### PR TITLE
fix: add missing paths variable in install_macos_service.py

### DIFF
--- a/scripts/install_macos_service.py
+++ b/scripts/install_macos_service.py
@@ -231,6 +231,7 @@ def install_service(user_level=True):
         print(f"\n📁 Created management scripts in: {scripts_dir}")
     
     # Print service information
+    paths = get_service_paths()
     platform_info = {
         'Start Service': f'launchctl load -w {plist_file}',
         'Stop Service': f'launchctl unload {plist_file}',


### PR DESCRIPTION
Resolves NameError at line 238 by calling get_service_paths() before using paths variable in platform_info dictionary.