### PR TITLE
fix: correct SqliteVecMemoryStorage class name and initialization

### DIFF
--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -49,8 +49,8 @@ def get_storage_backend():
     
     if backend == "sqlite-vec" or backend == "sqlite_vec":
         try:
-            from .storage.sqlite_vec import SqliteVecStorage
-            return SqliteVecStorage
+            from .storage.sqlite_vec import SqliteVecMemoryStorage
+            return SqliteVecMemoryStorage
         except ImportError as e:
             logger.error(f"Failed to import SQLite-vec storage: {e}")
             raise
@@ -76,8 +76,8 @@ def get_storage_backend():
     else:
         logger.warning(f"Unknown storage backend '{backend}', defaulting to SQLite-vec")
         try:
-            from .storage.sqlite_vec import SqliteVecStorage
-            return SqliteVecStorage
+            from .storage.sqlite_vec import SqliteVecMemoryStorage
+            return SqliteVecMemoryStorage
         except ImportError as e:
             logger.error(f"Failed to import default SQLite-vec storage: {e}")
             raise
@@ -100,10 +100,11 @@ async def mcp_server_lifespan(server: FastMCP) -> AsyncIterator[MCPServerContext
     # Initialize storage backend based on configuration and availability
     StorageClass = get_storage_backend()
     
-    if StorageClass.__name__ == "SqliteVecStorage":
+    if StorageClass.__name__ == "SqliteVecMemoryStorage":
+        from ..config import SQLITE_VEC_PATH, EMBEDDING_MODEL_NAME
         storage = StorageClass(
-            db_path=CHROMA_PATH / "memory.db",
-            embedding_manager=None  # Will be set after creation
+            db_path=SQLITE_VEC_PATH,
+            embedding_model=EMBEDDING_MODEL_NAME
         )
     elif StorageClass.__name__ == "CloudflareStorage":
         storage = StorageClass(


### PR DESCRIPTION
## Summary
Fixes multiple critical issues that completely prevented MCP server initialization with the `sqlite_vec` backend.

## Problem
The MCP server initialization was completely broken for sqlite_vec backend due to multiple interconnected issues:
- Wrong class name: trying to import non-existent `SqliteVecStorage` instead of `SqliteVecMemoryStorage`
- Wrong constructor parameters: using `embedding_manager=None` instead of `embedding_model` 
- Wrong database path: using `CHROMA_PATH / "memory.db"` instead of `SQLITE_VEC_PATH`
- Wrong configuration imports: missing `SQLITE_VEC_PATH` and `EMBEDDING_MODEL_NAME`

This resulted in:
- Server initialization failures (import errors)
- "No embedding model available" errors during memory operations  
- Complete inability to use sqlite_vec backend (the default backend)

## Root Cause
The MCP server sqlite_vec integration was never properly implemented or tested end-to-end. The storage class was always named `SqliteVecMemoryStorage` and always used `db_path`/`embedding_model` parameters, but the MCP server code was written assuming different names and parameters that never existed.

This bug went undetected because:
- Existing tests directly import `SqliteVecMemoryStorage` (bypassing the broken dynamic backend selection)
- No integration tests cover `get_storage_backend()` function or `mcp_server_lifespan()` initialization
- CI tests focus on package imports and direct storage functionality rather than MCP server integration

## Changes
- Fix class import: `SqliteVecStorage` → `SqliteVecMemoryStorage` in `get_storage_backend()`
- Fix class name check: `"SqliteVecStorage"` → `"SqliteVecMemoryStorage"` in `mcp_server_lifespan()`
- Fix constructor call: Use correct `db_path` and `embedding_model` parameters
- Add missing imports: `SQLITE_VEC_PATH` and `EMBEDDING_MODEL_NAME` from config
- Fix database path: Use `SQLITE_VEC_PATH` instead of hardcoded ChromaDB path

## Testing
- MCP server now initializes correctly with sqlite_vec backend
- Memory storage operations work (store/search/retrieve)
- Embedding model loads and generates embeddings successfully  
- Search functionality returns proper relevance scoring
- Completely resolves "No embedding model available" error

## Impact
**This essentially implements sqlite_vec MCP server support for the first time.** The previous code would never have worked due to the multiple fundamental issues. This fix enables:
- Default sqlite_vec backend functionality in MCP server
- Claude Desktop integration with memory operations
- Proper embedding-based memory search and storage

## Suggested Follow-up
Consider adding integration tests that verify MCP server initialization with different storage backends to prevent similar issues and ensure all backends are actually functional.