### PR TITLE
Fix: Consistent timestamp metadata across retrieval methods (#126)

### DIFF
--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -2739,13 +2739,10 @@ class MemoryServer:
             
             formatted_results = []
             for i, result in enumerate(results):
-                memory_info = [
-                    f"Memory {i+1}:",
-                ]
-
-                # Add timestamp if available
-                if hasattr(result.memory, 'timestamp') and result.memory.timestamp:
-                    memory_info.append(f"Timestamp: {result.memory.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
+                memory_info = [f"Memory {i+1}:"]
+                timestamp = getattr(result.memory, "timestamp", None)
+                if timestamp:
+                    memory_info.append(f"Timestamp: {timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
 
                 memory_info.extend([
                     f"Content: {result.memory.content}",
@@ -2785,13 +2782,10 @@ class MemoryServer:
             
             formatted_results = []
             for i, memory in enumerate(memories):
-                memory_info = [
-                    f"Memory {i+1}:",
-                ]
-
-                # Add timestamp if available
-                if hasattr(memory, 'timestamp') and memory.timestamp:
-                    memory_info.append(f"Timestamp: {memory.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
+                memory_info = [f"Memory {i+1}:"]
+                timestamp = getattr(memory, "timestamp", None)
+                if timestamp:
+                    memory_info.append(f"Timestamp: {timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
 
                 memory_info.extend([
                     f"Content: {memory.content}",

--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -2741,10 +2741,17 @@ class MemoryServer:
             for i, result in enumerate(results):
                 memory_info = [
                     f"Memory {i+1}:",
+                ]
+
+                # Add timestamp if available
+                if hasattr(result.memory, 'timestamp') and result.memory.timestamp:
+                    memory_info.append(f"Timestamp: {result.memory.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
+
+                memory_info.extend([
                     f"Content: {result.memory.content}",
                     f"Hash: {result.memory.content_hash}",
                     f"Relevance Score: {result.relevance_score:.2f}"
-                ]
+                ])
                 if result.memory.tags:
                     memory_info.append(f"Tags: {', '.join(result.memory.tags)}")
                 memory_info.append("---")
@@ -2780,10 +2787,17 @@ class MemoryServer:
             for i, memory in enumerate(memories):
                 memory_info = [
                     f"Memory {i+1}:",
+                ]
+
+                # Add timestamp if available
+                if hasattr(memory, 'timestamp') and memory.timestamp:
+                    memory_info.append(f"Timestamp: {memory.timestamp.strftime('%Y-%m-%d %H:%M:%S')}")
+
+                memory_info.extend([
                     f"Content: {memory.content}",
                     f"Hash: {memory.content_hash}",
                     f"Tags: {', '.join(memory.tags)}"
-                ]
+                ])
                 if memory.memory_type:
                     memory_info.append(f"Type: {memory.memory_type}")
                 memory_info.append("---")


### PR DESCRIPTION
## Summary

This PR resolves the inconsistent timestamp metadata across memory retrieval methods reported in issue #126.

### Problem
- ✅ recall_memory: Shows timestamps correctly
- ❌ retrieve_memory: No timestamp information displayed  
- ❌ search_by_tag: No timestamp information displayed

This inconsistency created orphaned memories that were difficult to discover using natural language time queries.

### Solution
- Added timestamp display to handle_retrieve_memory method (server.py:2747-2748)
- Added timestamp display to handle_search_by_tag method (server.py:2793-2794)
- Maintains exact format consistency with existing recall_memory implementation
- Uses same timestamp access pattern: memory.timestamp.strftime('%Y-%m-%d %H:%M:%S')

### Files Changed
- src/mcp_memory_service/server.py: Added timestamp display to both retrieval handlers

Fixes #126

/gemini review