### PR TITLE
fix: HTTP dashboard now respects MCP_MEMORY_STORAGE_BACKEND configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,95 @@
+# Cloudflare Configuration for MCP Memory Service
+# ================================================
+# Copy this file to .env and replace with your actual credentials
+#
+# Setup Instructions:
+# 1. Copy this file: cp .env.example .env
+# 2. Create Cloudflare API Token at: https://dash.cloudflare.com/profile/api-tokens
+# 3. Replace placeholder values below with your actual credentials
+# 4. Never commit your .env file to git (it's already in .gitignore)
+
+# =============================================================================
+# REQUIRED: Cloudflare API Token
+# =============================================================================
+# Create at: https://dash.cloudflare.com/profile/api-tokens
+# Required permissions:
+#   - Account: Cloudflare Workers:Edit
+#   - Zone Resources: Include All zones
+#   - Account Resources: Include All accounts
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token-here
+
+# =============================================================================
+# REQUIRED: Cloudflare Account ID
+# =============================================================================
+# Find in: Cloudflare Dashboard > Right sidebar under "Account ID"
+# Example: be0e35a26715043ef8df90253268c33f
+CLOUDFLARE_ACCOUNT_ID=your-account-id-here
+
+# =============================================================================
+# REQUIRED: D1 Database ID
+# =============================================================================
+# Create with: wrangler d1 create mcp-memory-database
+# Or find existing: wrangler d1 list
+# Example: f745e9b4-ba8e-4d47-b38f-12af91060d5a
+CLOUDFLARE_D1_DATABASE_ID=your-d1-database-id-here
+
+# =============================================================================
+# REQUIRED: Vectorize Index Name
+# =============================================================================
+# Create with: wrangler vectorize create mcp-memory-index --dimensions=384
+# Or find existing: wrangler vectorize list
+# Example: mcp-memory-index
+CLOUDFLARE_VECTORIZE_INDEX=your-vectorize-index-name
+
+# =============================================================================
+# OPTIONAL: R2 Bucket for Large Content Storage
+# =============================================================================
+# Create with: wrangler r2 bucket create mcp-memory-content
+# Only needed if you plan to store large content (>1MB)
+# CLOUDFLARE_R2_BUCKET=mcp-memory-content
+
+# =============================================================================
+# STORAGE BACKEND CONFIGURATION
+# =============================================================================
+# Options: sqlite_vec | cloudflare | hybrid | chromadb
+# - sqlite_vec: Fast local storage (development)
+# - cloudflare: Cloud storage with Cloudflare (production)
+# - hybrid: Best of both - local speed + cloud persistence (recommended)
+# - chromadb: Local ChromaDB storage (team environments)
+MCP_MEMORY_STORAGE_BACKEND=cloudflare
+
+# =============================================================================
+# OPTIONAL: Advanced Configuration
+# =============================================================================
+
+# Cloudflare embedding model (default is recommended)
+# CLOUDFLARE_EMBEDDING_MODEL=@cf/baai/bge-base-en-v1.5
+
+# Large content threshold for R2 storage (bytes)
+# CLOUDFLARE_LARGE_CONTENT_THRESHOLD=1048576
+
+# HTTP Interface (Web Dashboard)
+# MCP_HTTP_ENABLED=true
+# MCP_HTTP_PORT=8888
+# MCP_HTTPS_ENABLED=true
+# MCP_HTTPS_PORT=8443
+
+# OAuth 2.1 Authentication (for web interface)
+# MCP_OAUTH_ENABLED=false
+
+# Hybrid Backend Configuration (if using hybrid)
+# MCP_HYBRID_SYNC_INTERVAL=300      # Sync every 5 minutes
+# MCP_HYBRID_BATCH_SIZE=50          # Sync 50 operations at a time
+# MCP_HYBRID_SYNC_ON_STARTUP=true   # Initial sync on startup
+
+# =============================================================================
+# TROUBLESHOOTING
+# =============================================================================
+# Common issues:
+# 1. "Invalid API Token" - Check token permissions and expiry
+# 2. "Database not found" - Verify D1 database ID is correct
+# 3. "Vectorize index not found" - Check index name and dimensions (384)
+# 4. "Account access denied" - Ensure API token has account permissions
+#
+# Documentation: https://github.com/doobidoo/mcp-memory-service/wiki
+# Support: https://github.com/doobidoo/mcp-memory-service/issues

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,12 @@ __pypackages__/
 
 # Virtual Environment activation files (redundant due to .venv/ but explicit if needed)
 .env
-.env.*
+.env.local
+.env.development
+.env.test
+.env.production
+# But include template files
+!.env.example
 
 # IDEs & Editors
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ For older releases, see [CHANGELOG-HISTORIC.md](./CHANGELOG-HISTORIC.md).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.1] - 2025-10-03
+
+### 🐛 **Bug Fixes**
+
+#### 🔧 **HTTP Dashboard Backend Selection**
+- **Fixed HTTP dashboard backend selection** - Dashboard now properly respects `MCP_MEMORY_STORAGE_BACKEND` configuration
+- **Universal backend support** - Web interface works with all backends: SQLite-vec, Cloudflare, ChromaDB, and Hybrid
+- **Tags functionality restored** - Fixed broken browse by tags feature for all storage backends
+- **Shared factory pattern** - Eliminated code duplication between MCP server and web interface initialization
+
+#### 🛠️ **Code Quality Improvements**
+- **Extracted fallback logic** - Centralized SQLite-vec fallback handling for better maintainability
+- **Enhanced type safety** - Improved type hints throughout web interface components
+- **Gemini Code Assistant feedback** - Addressed all code review suggestions for better robustness
+
+### 🔗 **References**
+- Closes #136: HTTP Dashboard doesn't use Cloudflare backend despite configuration
+- PR #138: Complete universal storage backend support for HTTP dashboard
+
 ## [7.3.0] - 2025-10-02
 
 ### 🎉 **API Documentation Restoration**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "7.3.0"
+version = "7.3.1"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/__init__.py
+++ b/src/mcp_memory_service/__init__.py
@@ -47,7 +47,7 @@ def setup_offline_mode():
 # Setup offline mode immediately when this module is imported
 setup_offline_mode()
 
-__version__ = "7.3.0"
+__version__ = "7.3.1"
 
 from .models import Memory, MemoryQueryResult
 from .storage import MemoryStorage

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -442,7 +442,7 @@ MDNS_SERVICE_TYPE = os.getenv('MCP_MDNS_SERVICE_TYPE', '_mcp-memory._tcp.local.'
 MDNS_DISCOVERY_TIMEOUT = int(os.getenv('MCP_MDNS_DISCOVERY_TIMEOUT', '5'))
 
 # Database path for HTTP interface (use SQLite-vec by default)
-if STORAGE_BACKEND == 'sqlite_vec' and SQLITE_VEC_PATH:
+if (STORAGE_BACKEND in ['sqlite_vec', 'hybrid']) and SQLITE_VEC_PATH:
     DATABASE_PATH = SQLITE_VEC_PATH
 else:
     # Fallback to a default SQLite-vec path for HTTP interface

--- a/src/mcp_memory_service/storage/factory.py
+++ b/src/mcp_memory_service/storage/factory.py
@@ -1,0 +1,159 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared storage backend factory for the MCP Memory Service.
+
+This module provides a single, shared factory function for creating storage backends,
+eliminating code duplication between the MCP server and web interface initialization.
+"""
+
+import logging
+from typing import Type
+
+from .base import MemoryStorage
+
+logger = logging.getLogger(__name__)
+
+
+def get_storage_backend_class() -> Type[MemoryStorage]:
+    """
+    Get storage backend class based on configuration.
+
+    Returns:
+        Storage backend class
+    """
+    from ..config import STORAGE_BACKEND
+
+    backend = STORAGE_BACKEND.lower()
+
+    if backend == "sqlite-vec" or backend == "sqlite_vec":
+        from .sqlite_vec import SqliteVecMemoryStorage
+        return SqliteVecMemoryStorage
+    elif backend == "chroma":
+        try:
+            from .chroma import ChromaStorage
+            return ChromaStorage
+        except ImportError as e:
+            logger.error(f"ChromaDB not installed. Install with: pip install mcp-memory-service[chromadb]")
+            logger.error(f"Import error: {str(e)}")
+            logger.warning("Falling back to SQLite-vec storage")
+            from .sqlite_vec import SqliteVecMemoryStorage
+            return SqliteVecMemoryStorage
+    elif backend == "cloudflare":
+        try:
+            from .cloudflare import CloudflareStorage
+            return CloudflareStorage
+        except ImportError as e:
+            logger.error(f"Failed to import Cloudflare storage: {e}")
+            raise
+    elif backend == "hybrid":
+        try:
+            from .hybrid import HybridMemoryStorage
+            return HybridMemoryStorage
+        except ImportError as e:
+            logger.error(f"Failed to import Hybrid storage: {e}")
+            logger.warning("Falling back to SQLite-vec storage")
+            from .sqlite_vec import SqliteVecMemoryStorage
+            return SqliteVecMemoryStorage
+    else:
+        logger.warning(f"Unknown storage backend '{backend}', defaulting to SQLite-vec")
+        from .sqlite_vec import SqliteVecMemoryStorage
+        return SqliteVecMemoryStorage
+
+
+async def create_storage_instance(sqlite_path: str) -> MemoryStorage:
+    """
+    Create and initialize storage backend instance based on configuration.
+
+    Args:
+        sqlite_path: Path to SQLite database file (used for SQLite-vec and Hybrid backends)
+
+    Returns:
+        Initialized storage backend instance
+    """
+    from ..config import (
+        EMBEDDING_MODEL_NAME,
+        CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID,
+        CLOUDFLARE_R2_BUCKET, CLOUDFLARE_EMBEDDING_MODEL,
+        CLOUDFLARE_LARGE_CONTENT_THRESHOLD, CLOUDFLARE_MAX_RETRIES,
+        CLOUDFLARE_BASE_DELAY, CHROMA_PATH, COLLECTION_METADATA,
+        HYBRID_SYNC_INTERVAL, HYBRID_BATCH_SIZE
+    )
+
+    logger.info(f"Creating storage backend instance (sqlite_path: {sqlite_path})...")
+
+    # Get storage class based on configuration
+    StorageClass = get_storage_backend_class()
+
+    # Create storage instance based on backend type
+    if StorageClass.__name__ == "SqliteVecMemoryStorage":
+        storage = StorageClass(
+            db_path=sqlite_path,
+            embedding_model=EMBEDDING_MODEL_NAME
+        )
+        logger.info(f"Initialized SQLite-vec storage at {sqlite_path}")
+
+    elif StorageClass.__name__ == "CloudflareStorage":
+        storage = StorageClass(
+            api_token=CLOUDFLARE_API_TOKEN,
+            account_id=CLOUDFLARE_ACCOUNT_ID,
+            vectorize_index=CLOUDFLARE_VECTORIZE_INDEX,
+            d1_database_id=CLOUDFLARE_D1_DATABASE_ID,
+            r2_bucket=CLOUDFLARE_R2_BUCKET,
+            embedding_model=CLOUDFLARE_EMBEDDING_MODEL,
+            large_content_threshold=CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
+            max_retries=CLOUDFLARE_MAX_RETRIES,
+            base_delay=CLOUDFLARE_BASE_DELAY
+        )
+        logger.info(f"Initialized Cloudflare storage with vectorize index: {CLOUDFLARE_VECTORIZE_INDEX}")
+
+    elif StorageClass.__name__ == "HybridMemoryStorage":
+        # Prepare Cloudflare configuration dict
+        cloudflare_config = None
+        if all([CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID]):
+            cloudflare_config = {
+                'api_token': CLOUDFLARE_API_TOKEN,
+                'account_id': CLOUDFLARE_ACCOUNT_ID,
+                'vectorize_index': CLOUDFLARE_VECTORIZE_INDEX,
+                'd1_database_id': CLOUDFLARE_D1_DATABASE_ID,
+                'r2_bucket': CLOUDFLARE_R2_BUCKET,
+                'embedding_model': CLOUDFLARE_EMBEDDING_MODEL,
+                'large_content_threshold': CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
+                'max_retries': CLOUDFLARE_MAX_RETRIES,
+                'base_delay': CLOUDFLARE_BASE_DELAY
+            }
+
+        storage = StorageClass(
+            sqlite_db_path=sqlite_path,
+            embedding_model=EMBEDDING_MODEL_NAME,
+            cloudflare_config=cloudflare_config,
+            sync_interval=HYBRID_SYNC_INTERVAL,
+            batch_size=HYBRID_BATCH_SIZE
+        )
+        logger.info(f"Initialized hybrid storage with SQLite at {sqlite_path}")
+
+    else:  # ChromaStorage
+        storage = StorageClass(
+            path=str(CHROMA_PATH),
+            collection_name=COLLECTION_METADATA.get("name", "memories")
+        )
+        logger.info(f"Initialized ChromaDB storage at {CHROMA_PATH}")
+
+    # Initialize storage backend
+    await storage.initialize()
+    logger.info(f"Storage backend {StorageClass.__name__} initialized successfully")
+
+    return storage

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -888,6 +888,10 @@ class HybridMemoryStorage(MemoryStorage):
 
         return stats
 
+    async def get_all_tags_with_counts(self) -> List[Dict[str, Any]]:
+        """Get all tags with their usage counts from primary storage."""
+        return await self.primary.get_all_tags_with_counts()
+
     async def get_all_tags(self) -> List[str]:
         """Get all unique tags from primary storage."""
         return self.primary.get_all_tags()

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -41,7 +41,8 @@ try:
         CLOUDFLARE_VECTORIZE_MAX_VECTORS,
         CLOUDFLARE_MAX_METADATA_SIZE_KB,
         CLOUDFLARE_WARNING_THRESHOLD_PERCENT,
-        CLOUDFLARE_CRITICAL_THRESHOLD_PERCENT
+        CLOUDFLARE_CRITICAL_THRESHOLD_PERCENT,
+        HYBRID_SYNC_ON_STARTUP
     )
 except ImportError:
     # Fallback values if config doesn't have them
@@ -50,6 +51,7 @@ except ImportError:
     CLOUDFLARE_MAX_METADATA_SIZE_KB = 10
     CLOUDFLARE_WARNING_THRESHOLD_PERCENT = 80
     CLOUDFLARE_CRITICAL_THRESHOLD_PERCENT = 95
+    HYBRID_SYNC_ON_STARTUP = True
 
 logger = logging.getLogger(__name__)
 
@@ -571,6 +573,12 @@ class HybridMemoryStorage(MemoryStorage):
         self.batch_size = batch_size
         self.initialized = False
 
+        # Initial sync status tracking
+        self.initial_sync_in_progress = False
+        self.initial_sync_total = 0
+        self.initial_sync_completed = 0
+        self.initial_sync_finished = False
+
     async def initialize(self) -> None:
         """Initialize the hybrid storage system."""
         logger.info("Initializing hybrid memory storage...")
@@ -595,12 +603,173 @@ class HybridMemoryStorage(MemoryStorage):
                 await self.sync_service.start()
                 logger.info("Background sync service started")
 
+                # Schedule initial sync to run after server startup (non-blocking)
+                if HYBRID_SYNC_ON_STARTUP:
+                    asyncio.create_task(self._perform_initial_sync_after_startup())
+                    logger.info("Initial sync scheduled to run after server startup")
+
             except Exception as e:
                 logger.warning(f"Failed to initialize secondary storage: {e}")
                 self.secondary = None
 
         self.initialized = True
         logger.info("Hybrid memory storage initialization completed")
+
+    async def _perform_initial_sync_after_startup(self) -> None:
+        """
+        Wrapper for initial sync that waits for server startup to complete.
+        This allows the web server to be accessible during the sync process.
+        """
+        # Wait a bit for server to fully start up
+        await asyncio.sleep(2)
+        logger.info("Starting initial sync in background (server is now accessible)")
+        await self._perform_initial_sync()
+
+    async def _perform_initial_sync(self) -> None:
+        """
+        Perform initial sync from Cloudflare to SQLite if enabled.
+
+        This downloads all memories from Cloudflare that are missing in local SQLite,
+        providing immediate access to existing cloud memories.
+        """
+        if not HYBRID_SYNC_ON_STARTUP or not self.secondary:
+            return
+
+        logger.info("Starting initial sync from Cloudflare to SQLite...")
+
+        self.initial_sync_in_progress = True
+        self.initial_sync_completed = 0
+        self.initial_sync_finished = False
+
+        try:
+            # Get memory count from both storages to compare
+            primary_stats = self.primary.get_stats()
+            secondary_stats = await self.secondary.get_stats()
+
+            primary_count = primary_stats.get('total_memories', 0)
+            secondary_count = secondary_stats.get('total_memories', 0)
+
+            logger.info(f"Memory count comparison - Local SQLite: {primary_count}, Cloudflare: {secondary_count}")
+
+            if secondary_count <= primary_count:
+                logger.info("Local SQLite has same or more memories than Cloudflare, skipping initial sync")
+                self.initial_sync_finished = True
+                return
+
+            # Get all memories from Cloudflare to sync missing ones
+            missing_count = secondary_count - primary_count
+            self.initial_sync_total = missing_count
+            logger.info(f"Found {missing_count} memories in Cloudflare that need to be synced to local SQLite")
+
+            # Get all Cloudflare memories using cursor-based pagination to avoid D1 OFFSET limitations
+            synced_count = 0
+            batch_size = min(100, self.batch_size * 2)  # Use larger batch for initial sync
+            cursor = None  # Start from most recent (no cursor)
+            processed_count = 0
+
+            while True:
+                try:
+                    # Get batch of memories from Cloudflare using cursor-based pagination
+                    logger.debug(f"Fetching batch from Cloudflare with cursor-based pagination: cursor={cursor}, batch_size={batch_size}")
+
+                    # Try cursor-based pagination first, fallback to offset if not supported
+                    if hasattr(self.secondary, 'get_all_memories_cursor'):
+                        cloudflare_memories = await self.secondary.get_all_memories_cursor(
+                            limit=batch_size,
+                            cursor=cursor
+                        )
+                    else:
+                        # Fallback for backends without cursor support
+                        cloudflare_memories = await self.secondary.get_all_memories(
+                            limit=batch_size,
+                            offset=processed_count
+                        )
+
+                    if not cloudflare_memories:
+                        logger.debug(f"No more memories returned from Cloudflare at cursor {cursor}")
+                        break
+
+                    logger.debug(f"Processing batch of {len(cloudflare_memories)} memories from Cloudflare")
+                    batch_checked = 0
+                    batch_missing = 0
+                    batch_synced = 0
+
+                    # Check which memories are missing in primary storage
+                    for cf_memory in cloudflare_memories:
+                        batch_checked += 1
+                        processed_count += 1
+                        try:
+                            # Check if memory exists in primary storage
+                            existing = await self.primary.get_by_hash(cf_memory.content_hash)
+                            if not existing:
+                                batch_missing += 1
+                                # Memory doesn't exist locally, sync it
+                                success, message = await self.primary.store(cf_memory)
+                                if success:
+                                    batch_synced += 1
+                                    synced_count += 1
+                                    self.initial_sync_completed = synced_count
+                                    if synced_count % 10 == 0:  # Log progress every 10 memories
+                                        logger.info(f"Initial sync progress: {synced_count}/{missing_count} memories synced")
+                                else:
+                                    logger.warning(f"Failed to sync memory {cf_memory.content_hash}: {message}")
+                        except Exception as e:
+                            logger.warning(f"Error checking/syncing memory {cf_memory.content_hash}: {e}")
+                            continue
+
+                    logger.debug(f"Batch complete: checked={batch_checked}, missing={batch_missing}, synced={batch_synced}")
+
+                    # Update cursor to the oldest timestamp from this batch for next iteration
+                    if cloudflare_memories and hasattr(self.secondary, 'get_all_memories_cursor'):
+                        # Get the oldest created_at timestamp from this batch for next cursor
+                        cursor = min(memory.created_at for memory in cloudflare_memories if memory.created_at)
+                        logger.debug(f"Next cursor set to: {cursor}")
+
+                    # If we've processed a significant number of memories and found none missing,
+                    # it's likely that all memories already exist (count mismatch issue)
+                    if processed_count >= 100 and synced_count == 0:
+                        logger.info(f"No missing memories found after checking {processed_count} memories - all Cloudflare memories already exist locally")
+                        break
+
+                    # Yield control to avoid blocking
+                    await asyncio.sleep(0.01)
+
+                except Exception as e:
+                    # Handle Cloudflare D1 errors (like 400 Bad Request from OFFSET limitations)
+                    if "400" in str(e) and not hasattr(self.secondary, 'get_all_memories_cursor'):
+                        logger.error(f"D1 OFFSET limitation hit at processed_count={processed_count}: {e}")
+                        logger.warning("Cloudflare D1 OFFSET limits reached - sync incomplete due to backend limitations")
+                        break
+                    else:
+                        logger.error(f"Error during cursor-based sync: {e}")
+                        break
+
+            logger.info(f"Initial sync completed: {synced_count} memories downloaded from Cloudflare to local SQLite")
+
+            # Update sync tracking to reflect actual sync completion
+            if synced_count == 0:
+                # All memories were already present - this is a successful "no-op" sync
+                self.initial_sync_completed = self.initial_sync_total
+                logger.info(f"Sync completed successfully: All {self.initial_sync_total} memories were already present locally")
+
+            self.initial_sync_finished = True
+
+        except Exception as e:
+            logger.error(f"Initial sync failed: {e}")
+            # Don't fail initialization if initial sync fails
+            logger.warning("Continuing with hybrid storage despite initial sync failure")
+        finally:
+            self.initial_sync_in_progress = False
+
+    def get_initial_sync_status(self) -> Dict[str, Any]:
+        """Get current initial sync status for monitoring."""
+        return {
+            "in_progress": self.initial_sync_in_progress,
+            "total": self.initial_sync_total,
+            "completed": self.initial_sync_completed,
+            "finished": self.initial_sync_finished,
+            "progress_percentage": round((self.initial_sync_completed / max(self.initial_sync_total, 1)) * 100, 1) if self.initial_sync_total > 0 else 0
+        }
 
     async def store(self, memory: Memory) -> Tuple[bool, str]:
         """Store a memory in primary storage and queue for secondary sync."""

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -25,7 +25,7 @@ from typing import Dict, Any, TYPE_CHECKING
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from ...storage.sqlite_vec import SqliteVecMemoryStorage
+from ...storage.base import MemoryStorage
 from ..dependencies import get_storage
 from ... import __version__
 from ...config import OAUTH_ENABLED
@@ -78,7 +78,7 @@ async def health_check():
 
 @router.get("/health/detailed", response_model=DetailedHealthResponse)
 async def detailed_health_check(
-    storage: SqliteVecMemoryStorage = Depends(get_storage),
+    storage: MemoryStorage = Depends(get_storage),
     user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
 ):
     """Detailed health check with system and storage information."""

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -184,6 +184,33 @@ async def detailed_health_check(
     )
 
 
+@router.get("/health/sync-status")
+async def sync_status(
+    storage: MemoryStorage = Depends(get_storage),
+    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+):
+    """Get current initial sync status for hybrid storage."""
+
+    # Check if this is a hybrid storage that supports sync status
+    if hasattr(storage, 'get_initial_sync_status'):
+        sync_status = storage.get_initial_sync_status()
+        return {
+            "sync_supported": True,
+            "status": sync_status
+        }
+    else:
+        return {
+            "sync_supported": False,
+            "status": {
+                "in_progress": False,
+                "total": 0,
+                "completed": 0,
+                "finished": True,
+                "progress_percentage": 100
+            }
+        }
+
+
 def format_uptime(seconds: float) -> str:
     """Format uptime in human-readable format."""
     if seconds < 60:

--- a/src/mcp_memory_service/web/api/search.py
+++ b/src/mcp_memory_service/web/api/search.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field
 
-from ...storage.sqlite_vec import SqliteVecMemoryStorage
+from ...storage.base import MemoryStorage
 from ...models.memory import Memory, MemoryQueryResult
 from ...config import OAUTH_ENABLED
 from ..dependencies import get_storage
@@ -102,7 +102,7 @@ def memory_to_search_result(memory: Memory, reason: str = None) -> SearchResult:
 @router.post("/search", response_model=SearchResponse, tags=["search"])
 async def semantic_search(
     request: SemanticSearchRequest,
-    storage: SqliteVecMemoryStorage = Depends(get_storage),
+    storage: MemoryStorage = Depends(get_storage),
     user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
 ):
     """
@@ -164,7 +164,7 @@ async def semantic_search(
 @router.post("/search/by-tag", response_model=SearchResponse, tags=["search"])
 async def tag_search(
     request: TagSearchRequest,
-    storage: SqliteVecMemoryStorage = Depends(get_storage),
+    storage: MemoryStorage = Depends(get_storage),
     user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
 ):
     """
@@ -234,7 +234,7 @@ async def tag_search(
 @router.post("/search/by-time", response_model=SearchResponse, tags=["search"])
 async def time_search(
     request: TimeSearchRequest,
-    storage: SqliteVecMemoryStorage = Depends(get_storage),
+    storage: MemoryStorage = Depends(get_storage),
     user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
 ):
     """
@@ -304,7 +304,7 @@ async def time_search(
 async def find_similar(
     content_hash: str,
     n_results: int = Query(default=10, ge=1, le=100, description="Number of similar memories to find"),
-    storage: SqliteVecMemoryStorage = Depends(get_storage),
+    storage: MemoryStorage = Depends(get_storage),
     user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
 ):
     """

--- a/src/mcp_memory_service/web/app.py
+++ b/src/mcp_memory_service/web/app.py
@@ -51,7 +51,7 @@ from .sse import sse_manager
 logger = logging.getLogger(__name__)
 
 # Global storage instance
-storage = None
+storage: Optional["MemoryStorage"] = None
 
 # Global mDNS advertiser instance
 mdns_advertiser: Optional[Any] = None

--- a/src/mcp_memory_service/web/app.py
+++ b/src/mcp_memory_service/web/app.py
@@ -40,8 +40,7 @@ from ..config import (
     HTTPS_ENABLED,
     OAUTH_ENABLED
 )
-from ..storage.sqlite_vec import SqliteVecMemoryStorage
-from .dependencies import set_storage, get_storage
+from .dependencies import set_storage, get_storage, create_storage_backend
 from .api.health import router as health_router
 from .api.memories import router as memories_router
 from .api.search import router as search_router
@@ -52,7 +51,7 @@ from .sse import sse_manager
 logger = logging.getLogger(__name__)
 
 # Global storage instance
-storage: Optional[SqliteVecMemoryStorage] = None
+storage = None
 
 # Global mDNS advertiser instance
 mdns_advertiser: Optional[Any] = None
@@ -91,13 +90,8 @@ async def lifespan(app: FastAPI):
     # Startup
     logger.info("Starting MCP Memory Service HTTP interface...")
     try:
-        storage = SqliteVecMemoryStorage(
-            db_path=DATABASE_PATH,
-            embedding_model=EMBEDDING_MODEL_NAME
-        )
-        await storage.initialize()
+        storage = await create_storage_backend()
         set_storage(storage)  # Set the global storage instance
-        logger.info(f"SQLite-vec storage initialized at {DATABASE_PATH}")
         
         # Start SSE manager
         await sse_manager.start()

--- a/src/mcp_memory_service/web/dependencies.py
+++ b/src/mcp_memory_service/web/dependencies.py
@@ -16,23 +16,110 @@
 FastAPI dependencies for the HTTP interface.
 """
 
+import logging
 from typing import Optional
 from fastapi import HTTPException
 
-from ..storage.sqlite_vec import SqliteVecMemoryStorage
+from ..storage.base import MemoryStorage
+
+logger = logging.getLogger(__name__)
 
 # Global storage instance
-_storage: Optional[SqliteVecMemoryStorage] = None
+_storage: Optional[MemoryStorage] = None
 
 
-def set_storage(storage: SqliteVecMemoryStorage) -> None:
+def set_storage(storage: MemoryStorage) -> None:
     """Set the global storage instance."""
     global _storage
     _storage = storage
 
 
-def get_storage() -> SqliteVecMemoryStorage:
+def get_storage() -> MemoryStorage:
     """Get the global storage instance."""
     if _storage is None:
         raise HTTPException(status_code=503, detail="Storage not initialized")
     return _storage
+
+
+async def create_storage_backend() -> MemoryStorage:
+    """
+    Create and initialize storage backend for web interface based on configuration.
+
+    Returns:
+        Initialized storage backend
+    """
+    from ..mcp_server import get_storage_backend
+    from ..config import (
+        SQLITE_VEC_PATH, EMBEDDING_MODEL_NAME, DATABASE_PATH,
+        CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
+        CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID,
+        CLOUDFLARE_R2_BUCKET, CLOUDFLARE_EMBEDDING_MODEL,
+        CLOUDFLARE_LARGE_CONTENT_THRESHOLD, CLOUDFLARE_MAX_RETRIES,
+        CLOUDFLARE_BASE_DELAY, CHROMA_PATH, COLLECTION_METADATA,
+        HYBRID_SYNC_INTERVAL, HYBRID_BATCH_SIZE
+    )
+
+    logger.info("Creating storage backend for web interface...")
+
+    # Get storage class based on configuration
+    StorageClass = get_storage_backend()
+
+    if StorageClass.__name__ == "SqliteVecMemoryStorage":
+        # For HTTP interface, use DATABASE_PATH which is configured for web interface
+        storage = StorageClass(
+            db_path=DATABASE_PATH,
+            embedding_model=EMBEDDING_MODEL_NAME
+        )
+        logger.info(f"Initialized SQLite-vec storage at {DATABASE_PATH}")
+
+    elif StorageClass.__name__ == "CloudflareStorage":
+        storage = StorageClass(
+            api_token=CLOUDFLARE_API_TOKEN,
+            account_id=CLOUDFLARE_ACCOUNT_ID,
+            vectorize_index=CLOUDFLARE_VECTORIZE_INDEX,
+            d1_database_id=CLOUDFLARE_D1_DATABASE_ID,
+            r2_bucket=CLOUDFLARE_R2_BUCKET,
+            embedding_model=CLOUDFLARE_EMBEDDING_MODEL,
+            large_content_threshold=CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
+            max_retries=CLOUDFLARE_MAX_RETRIES,
+            base_delay=CLOUDFLARE_BASE_DELAY
+        )
+        logger.info(f"Initialized Cloudflare storage with vectorize index: {CLOUDFLARE_VECTORIZE_INDEX}")
+
+    elif StorageClass.__name__ == "HybridMemoryStorage":
+        # Prepare Cloudflare configuration dict
+        cloudflare_config = None
+        if all([CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID]):
+            cloudflare_config = {
+                'api_token': CLOUDFLARE_API_TOKEN,
+                'account_id': CLOUDFLARE_ACCOUNT_ID,
+                'vectorize_index': CLOUDFLARE_VECTORIZE_INDEX,
+                'd1_database_id': CLOUDFLARE_D1_DATABASE_ID,
+                'r2_bucket': CLOUDFLARE_R2_BUCKET,
+                'embedding_model': CLOUDFLARE_EMBEDDING_MODEL,
+                'large_content_threshold': CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
+                'max_retries': CLOUDFLARE_MAX_RETRIES,
+                'base_delay': CLOUDFLARE_BASE_DELAY
+            }
+
+        storage = StorageClass(
+            sqlite_db_path=DATABASE_PATH,  # Use DATABASE_PATH for web interface
+            embedding_model=EMBEDDING_MODEL_NAME,
+            cloudflare_config=cloudflare_config,
+            sync_interval=HYBRID_SYNC_INTERVAL,
+            batch_size=HYBRID_BATCH_SIZE
+        )
+        logger.info(f"Initialized hybrid storage with SQLite at {DATABASE_PATH}")
+
+    else:  # ChromaStorage
+        storage = StorageClass(
+            path=str(CHROMA_PATH),
+            collection_name=COLLECTION_METADATA.get("name", "memories")
+        )
+        logger.info(f"Initialized ChromaDB storage at {CHROMA_PATH}")
+
+    # Initialize storage backend
+    await storage.initialize()
+    logger.info(f"Storage backend {StorageClass.__name__} initialized successfully")
+
+    return storage

--- a/src/mcp_memory_service/web/dependencies.py
+++ b/src/mcp_memory_service/web/dependencies.py
@@ -41,45 +41,6 @@ def get_storage() -> MemoryStorage:
     return _storage
 
 
-def _get_storage_backend_class() -> type:
-    """Get storage backend class based on configuration (web-only version)."""
-    from ..config import STORAGE_BACKEND
-
-    backend = STORAGE_BACKEND.lower()
-
-    if backend == "sqlite-vec" or backend == "sqlite_vec":
-        from ..storage.sqlite_vec import SqliteVecMemoryStorage
-        return SqliteVecMemoryStorage
-    elif backend == "chroma":
-        try:
-            from ..storage.chroma import ChromaStorage
-            return ChromaStorage
-        except ImportError as e:
-            logger.error(f"ChromaDB not installed. Install with: pip install mcp-memory-service[chromadb]")
-            logger.error(f"Import error: {str(e)}")
-            logger.warning("Falling back to SQLite-vec storage")
-            from ..storage.sqlite_vec import SqliteVecMemoryStorage
-            return SqliteVecMemoryStorage
-    elif backend == "cloudflare":
-        try:
-            from ..storage.cloudflare import CloudflareStorage
-            return CloudflareStorage
-        except ImportError as e:
-            logger.error(f"Failed to import Cloudflare storage: {e}")
-            raise
-    elif backend == "hybrid":
-        try:
-            from ..storage.hybrid import HybridMemoryStorage
-            return HybridMemoryStorage
-        except ImportError as e:
-            logger.error(f"Failed to import Hybrid storage: {e}")
-            logger.warning("Falling back to SQLite-vec storage")
-            from ..storage.sqlite_vec import SqliteVecMemoryStorage
-            return SqliteVecMemoryStorage
-    else:
-        logger.warning(f"Unknown storage backend '{backend}', defaulting to SQLite-vec")
-        from ..storage.sqlite_vec import SqliteVecMemoryStorage
-        return SqliteVecMemoryStorage
 
 
 async def create_storage_backend() -> MemoryStorage:
@@ -89,77 +50,10 @@ async def create_storage_backend() -> MemoryStorage:
     Returns:
         Initialized storage backend
     """
-    from ..config import (
-        SQLITE_VEC_PATH, EMBEDDING_MODEL_NAME, DATABASE_PATH,
-        CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
-        CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID,
-        CLOUDFLARE_R2_BUCKET, CLOUDFLARE_EMBEDDING_MODEL,
-        CLOUDFLARE_LARGE_CONTENT_THRESHOLD, CLOUDFLARE_MAX_RETRIES,
-        CLOUDFLARE_BASE_DELAY, CHROMA_PATH, COLLECTION_METADATA,
-        HYBRID_SYNC_INTERVAL, HYBRID_BATCH_SIZE
-    )
+    from ..config import DATABASE_PATH
+    from ..storage.factory import create_storage_instance
 
     logger.info("Creating storage backend for web interface...")
 
-    # Get storage class based on configuration
-    StorageClass = _get_storage_backend_class()
-
-    if StorageClass.__name__ == "SqliteVecMemoryStorage":
-        # For HTTP interface, use DATABASE_PATH which is configured for web interface
-        storage = StorageClass(
-            db_path=DATABASE_PATH,
-            embedding_model=EMBEDDING_MODEL_NAME
-        )
-        logger.info(f"Initialized SQLite-vec storage at {DATABASE_PATH}")
-
-    elif StorageClass.__name__ == "CloudflareStorage":
-        storage = StorageClass(
-            api_token=CLOUDFLARE_API_TOKEN,
-            account_id=CLOUDFLARE_ACCOUNT_ID,
-            vectorize_index=CLOUDFLARE_VECTORIZE_INDEX,
-            d1_database_id=CLOUDFLARE_D1_DATABASE_ID,
-            r2_bucket=CLOUDFLARE_R2_BUCKET,
-            embedding_model=CLOUDFLARE_EMBEDDING_MODEL,
-            large_content_threshold=CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
-            max_retries=CLOUDFLARE_MAX_RETRIES,
-            base_delay=CLOUDFLARE_BASE_DELAY
-        )
-        logger.info(f"Initialized Cloudflare storage with vectorize index: {CLOUDFLARE_VECTORIZE_INDEX}")
-
-    elif StorageClass.__name__ == "HybridMemoryStorage":
-        # Prepare Cloudflare configuration dict
-        cloudflare_config = None
-        if all([CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_VECTORIZE_INDEX, CLOUDFLARE_D1_DATABASE_ID]):
-            cloudflare_config = {
-                'api_token': CLOUDFLARE_API_TOKEN,
-                'account_id': CLOUDFLARE_ACCOUNT_ID,
-                'vectorize_index': CLOUDFLARE_VECTORIZE_INDEX,
-                'd1_database_id': CLOUDFLARE_D1_DATABASE_ID,
-                'r2_bucket': CLOUDFLARE_R2_BUCKET,
-                'embedding_model': CLOUDFLARE_EMBEDDING_MODEL,
-                'large_content_threshold': CLOUDFLARE_LARGE_CONTENT_THRESHOLD,
-                'max_retries': CLOUDFLARE_MAX_RETRIES,
-                'base_delay': CLOUDFLARE_BASE_DELAY
-            }
-
-        storage = StorageClass(
-            sqlite_db_path=DATABASE_PATH,  # Use DATABASE_PATH for web interface
-            embedding_model=EMBEDDING_MODEL_NAME,
-            cloudflare_config=cloudflare_config,
-            sync_interval=HYBRID_SYNC_INTERVAL,
-            batch_size=HYBRID_BATCH_SIZE
-        )
-        logger.info(f"Initialized hybrid storage with SQLite at {DATABASE_PATH}")
-
-    else:  # ChromaStorage
-        storage = StorageClass(
-            path=str(CHROMA_PATH),
-            collection_name=COLLECTION_METADATA.get("name", "memories")
-        )
-        logger.info(f"Initialized ChromaDB storage at {CHROMA_PATH}")
-
-    # Initialize storage backend
-    await storage.initialize()
-    logger.info(f"Storage backend {StorageClass.__name__} initialized successfully")
-
-    return storage
+    # Use shared factory with DATABASE_PATH for web interface
+    return await create_storage_instance(DATABASE_PATH)

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "7.2.2"
+version = "7.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Fixes issue #136 where the HTTP dashboard interface hardcoded SQLite-vec storage initialization even when Cloudflare backend was explicitly configured.

## Problem
- HTTP dashboard ignored MCP_MEMORY_STORAGE_BACKEND environment variable
- Created discrepancy between MCP protocol (using Cloudflare) and HTTP interface (using SQLite-vec)
- Users couldn't access Cloudflare-stored memories through web dashboard

## Solution
- Updated web/dependencies.py to support all storage backends using generic MemoryStorage interface
- Added create_storage_backend() factory function for dynamic backend selection (similar to MCP server)
- Modified web/app.py to use storage factory instead of hardcoded SQLite-vec initialization  
- Updated API endpoint type hints to use generic MemoryStorage interface
- Ensured HTTP and MCP interfaces use the same storage backend

## Testing
- Configuration correctly detects Cloudflare backend: Storage Backend: cloudflare
- Cloudflare storage imports successfully
- Storage factory function imported without errors
- All syntax checks pass

## Impact
- Users can now access their Cloudflare-stored memories through the web dashboard
- HTTP and MCP interfaces show consistent memory counts
- Health endpoints display correct backend information

Closes #136