### PR TITLE
fix: update session-end hook for new config structure

### DIFF
--- a/claude-hooks/core/session-end.js
+++ b/claude-hooks/core/session-end.js
@@ -6,6 +6,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const https = require('https');
+const http = require('http');
 
 // Import utilities
 const { detectProjectContext } = require('../utilities/project-detector');
@@ -23,8 +24,10 @@ async function loadConfig() {
         console.warn('[Memory Hook] Using default configuration:', error.message);
         return {
             memoryService: {
-                endpoint: 'https://narrowbox.local:8443',
-                apiKey: 'test-key-123',
+                http: {
+                    endpoint: 'http://127.0.0.1:8000',
+                    apiKey: 'test-key-123'
+                },
                 defaultTags: ['claude-code', 'auto-generated'],
                 enableSessionConsolidation: true
             },
@@ -210,7 +213,9 @@ function analyzeConversation(conversationData) {
 async function storeSessionMemory(endpoint, apiKey, content, projectContext, analysis) {
     return new Promise((resolve, reject) => {
         const url = new URL('/api/memories', endpoint);
-        
+        const isHttps = url.protocol === 'https:';
+        const requestModule = isHttps ? https : http;
+
         // Generate tags based on analysis and project context
         const tags = [
             'claude-code-session',
@@ -221,7 +226,7 @@ async function storeSessionMemory(endpoint, apiKey, content, projectContext, ana
             ...projectContext.frameworks.slice(0, 2), // Top 2 frameworks
             `confidence:${Math.round(analysis.confidence * 100)}`
         ].filter(Boolean);
-        
+
         const postData = JSON.stringify({
             content: content,
             tags: tags,
@@ -248,18 +253,22 @@ async function storeSessionMemory(endpoint, apiKey, content, projectContext, ana
 
         const options = {
             hostname: url.hostname,
-            port: url.port || 8443,
+            port: url.port || (isHttps ? 8443 : 8000),
             path: url.pathname,
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(postData),
                 'Authorization': `Bearer ${apiKey}`
-            },
-            rejectUnauthorized: false // For self-signed certificates
+            }
         };
 
-        const req = https.request(options, (res) => {
+        // Only set rejectUnauthorized for HTTPS
+        if (isHttps) {
+            options.rejectUnauthorized = false; // For self-signed certificates
+        }
+
+        const req = requestModule.request(options, (res) => {
             let data = '';
             res.on('data', (chunk) => {
                 data += chunk;
@@ -326,11 +335,15 @@ async function onSessionEnd(context) {
         
         // Format session consolidation
         const consolidation = formatSessionConsolidation(analysis, projectContext);
-        
+
+        // Get endpoint and apiKey from new config structure
+        const endpoint = config.memoryService.http?.endpoint || config.memoryService.endpoint || 'http://127.0.0.1:8000';
+        const apiKey = config.memoryService.http?.apiKey || config.memoryService.apiKey || 'default-key';
+
         // Store to memory service
         const result = await storeSessionMemory(
-            config.memoryService.endpoint,
-            config.memoryService.apiKey,
+            endpoint,
+            apiKey,
             consolidation,
             projectContext,
             analysis

--- a/claude-hooks/core/session-end.js
+++ b/claude-hooks/core/session-end.js
@@ -210,7 +210,7 @@ function analyzeConversation(conversationData) {
 /**
  * Store session consolidation to memory service
  */
-async function storeSessionMemory(endpoint, apiKey, content, projectContext, analysis) {
+function storeSessionMemory(endpoint, apiKey, content, projectContext, analysis) {
     return new Promise((resolve, reject) => {
         const url = new URL('/api/memories', endpoint);
         const isHttps = url.protocol === 'https:';
@@ -337,8 +337,8 @@ async function onSessionEnd(context) {
         const consolidation = formatSessionConsolidation(analysis, projectContext);
 
         // Get endpoint and apiKey from new config structure
-        const endpoint = config.memoryService.http?.endpoint || config.memoryService.endpoint || 'http://127.0.0.1:8000';
-        const apiKey = config.memoryService.http?.apiKey || config.memoryService.apiKey || 'default-key';
+        const endpoint = config.memoryService?.http?.endpoint || config.memoryService?.endpoint || 'http://127.0.0.1:8000';
+        const apiKey = config.memoryService?.http?.apiKey || config.memoryService?.apiKey || 'test-key-123';
 
         // Store to memory service
         const result = await storeSessionMemory(


### PR DESCRIPTION
## Summary

Fixes the SessionEnd hook to work with the new nested configuration structure introduced in the environment detection updates.

## Problem

The SessionEnd hook was failing with "Invalid URL" error because:
1. It only supported HTTPS protocol
2. It read from old flat config structure (`config.memoryService.endpoint`)
3. New config uses nested structure (`config.memoryService.http.endpoint`)

## Changes

✅ **Added HTTP protocol support** - Hook now works with both HTTP and HTTPS endpoints  
✅ **Updated config reading** - Reads from new `http.endpoint` structure with fallback to old format  
✅ **Fixed protocol detection** - Auto-selects `http` or `https` module based on endpoint URL  
✅ **Updated default fallback** - Uses HTTP port 8000 instead of HTTPS port 8443  
✅ **Backward compatible** - Still works with old config format

## Technical Details

### Before:
```javascript
const result = await storeSessionMemory(
    config.memoryService.endpoint,  // ❌ Doesn't exist in new config
    config.memoryService.apiKey,     // ❌ Doesn't exist in new config
    ...
);
```

### After:
```javascript
const endpoint = config.memoryService.http?.endpoint || config.memoryService.endpoint || 'http://127.0.0.1:8000';
const apiKey = config.memoryService.http?.apiKey || config.memoryService.apiKey || 'default-key';

const result = await storeSessionMemory(endpoint, apiKey, ...);
```

## Testing

✅ Manual test passed - Hook successfully stored session consolidation:
- Memory hash: `a5075bf0...`
- Tags: `claude-code-session`, `session-consolidation`, `mcp-memory-service`
- Protocol: HTTP on port 8000
- Content includes: topics (4), decisions (1), insights (1), code changes (1), next steps (1)

✅ Verified memory retrieval:
```bash
curl http://localhost:8000/api/search/by-tag -d '{"tags":["session-consolidation"]}'
```

## Impact

- **SessionEnd hook now functional** with latest config structure
- **Session summaries automatically stored** when closing Claude Code
- **No breaking changes** - backward compatible with old config

## Related

- Follows environment detection PR #157
- Part of hooks configuration standardization

🤖 Generated with [Claude Code](https://claude.com/claude-code)