### PR TITLE
fix: Accept both string and array formats for tags metadata

### DIFF
--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -1329,7 +1329,11 @@ class MemoryServer:
                                                     "description": "Tags as comma-separated string"
                                                 }
                                             ],
-                                            "description": "Tags to categorize the memory. Accepts either an array of strings or a comma-separated string."
+                                            "description": "Tags to categorize the memory. Accepts either an array of strings or a comma-separated string.",
+                                            "examples": [
+                                                "tag1,tag2,tag3",
+                                                ["tag1", "tag2", "tag3"]
+                                            ]
                                         },
                                         "type": {
                                             "type": "string",

--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -1318,9 +1318,18 @@ class MemoryServer:
                                     "description": "Optional metadata about the memory, including tags and type.",
                                     "properties": {
                                         "tags": {
-                                            "type": "array",
-                                            "items": {"type": "string"},
-                                            "description": "Tags to categorize the memory as an array of strings. If you have a comma-separated string, convert it to an array before calling."
+                                            "oneOf": [
+                                                {
+                                                    "type": "array",
+                                                    "items": {"type": "string"},
+                                                    "description": "Tags as an array of strings"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "description": "Tags as comma-separated string"
+                                                }
+                                            ],
+                                            "description": "Tags to categorize the memory. Accepts either an array of strings or a comma-separated string."
                                         },
                                         "type": {
                                             "type": "string",


### PR DESCRIPTION
## Problem

The `store_memory` tool's JSON schema validation rejects string format for tags metadata, even though:
1. The tool description claims to support both formats
2. The handler code (`handle_store_memory`) includes logic to convert strings to arrays

This causes validation errors:
```
Input validation error: 'postgresql,indexing,...' is not of type 'array'
```

## Root Cause

The `inputSchema` definition uses:
```python
"tags": {
    "type": "array",
    "items": {"type": "string"},
    ...
}
```

This causes MCP client-side validation to reject string inputs before they even reach the server's string-to-array conversion code.

## Solution

Changed the schema to accept both formats using `oneOf`:
```python
"tags": {
    "oneOf": [
        {"type": "array", "items": {"type": "string"}, ...},
        {"type": "string", ...}
    ],
    ...
}
```

Now the schema validation passes for both formats, allowing the existing conversion logic in `handle_store_memory()` (lines 2542-2547) to work as originally intended.

## Testing

Verified both formats work correctly:
- String format: `{"tags": "tag1,tag2,tag3"}` ✅
- Array format: `{"tags": ["tag1", "tag2", "tag3"]}` ✅

Both are properly parsed and stored.

## Impact

- Fixes misleading documentation
- No breaking changes (array format continues to work)
- Enables the documented string format to actually work
- Aligns schema validation with handler implementation