### PR TITLE
Fix datetime timezone mismatch in decay calculator

### DIFF
--- a/src/mcp_memory_service/consolidation/decay.py
+++ b/src/mcp_memory_service/consolidation/decay.py
@@ -189,10 +189,8 @@ class ExponentialDecayCalculator(ConsolidationBase):
                 return 1.0  # No access data available
 
         # Normalize both datetimes to UTC timezone-aware
-        if current_time.tzinfo is None:
-            current_time = current_time.replace(tzinfo=timezone.utc)
-        if last_accessed.tzinfo is None:
-            last_accessed = last_accessed.replace(tzinfo=timezone.utc)
+        current_time = current_time.replace(tzinfo=timezone.utc) if current_time.tzinfo is None else current_time.astimezone(timezone.utc)
+        last_accessed = last_accessed.replace(tzinfo=timezone.utc) if last_accessed.tzinfo is None else last_accessed.astimezone(timezone.utc)
 
         days_since_access = (current_time - last_accessed).days
         

--- a/src/mcp_memory_service/consolidation/decay.py
+++ b/src/mcp_memory_service/consolidation/decay.py
@@ -16,7 +16,7 @@
 
 import math
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 
 from .base import ConsolidationBase, ConsolidationConfig
@@ -187,7 +187,13 @@ class ExponentialDecayCalculator(ConsolidationBase):
                 last_accessed = datetime.utcfromtimestamp(memory.updated_at)
             else:
                 return 1.0  # No access data available
-        
+
+        # Normalize both datetimes to UTC timezone-aware
+        if current_time.tzinfo is None:
+            current_time = current_time.replace(tzinfo=timezone.utc)
+        if last_accessed.tzinfo is None:
+            last_accessed = last_accessed.replace(tzinfo=timezone.utc)
+
         days_since_access = (current_time - last_accessed).days
         
         if days_since_access <= 1:


### PR DESCRIPTION
Fixes issue #167 by normalizing both current_time and last_accessed to UTC timezone-aware before subtraction in the _calculate_access_boost method.

The problem was that datetime.now() creates offset-naive datetime while database timestamps are offset-aware, causing TypeError when subtracting.

Solution: Add timezone normalization to ensure both datetimes are UTC timezone-aware.

Closes #167