### PR TITLE
Fix: Prevent bloated tags from space-separated file paths in document upload

### DIFF
--- a/src/mcp_memory_service/web/api/documents.py
+++ b/src/mcp_memory_service/web/api/documents.py
@@ -88,8 +88,7 @@ def parse_and_validate_tags(tags: str) -> List[str]:
                        f"Please use shorter, more descriptive tags."
             )
 
-        if clean_tag:
-            tag_list.append(clean_tag)
+        tag_list.append(clean_tag)
 
     return tag_list
 

--- a/src/mcp_memory_service/web/api/documents.py
+++ b/src/mcp_memory_service/web/api/documents.py
@@ -41,6 +41,58 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Constants
+MAX_TAG_LENGTH = 100
+
+
+def parse_and_validate_tags(tags: str) -> List[str]:
+    """
+    Parse and validate tags from user input.
+
+    Handles comma-separated and space-separated tags, removes file:// prefixes,
+    sanitizes path separators, and validates tag lengths.
+
+    Args:
+        tags: Raw tag string (comma or space separated)
+
+    Returns:
+        List of cleaned and validated tags
+
+    Raises:
+        HTTPException: If any tag exceeds MAX_TAG_LENGTH
+    """
+    if not tags or not tags.strip():
+        return []
+
+    # Split by comma OR space
+    raw_tags = tags.replace(',', ' ').split()
+    tag_list = []
+
+    for tag in raw_tags:
+        clean_tag = tag.strip()
+        if not clean_tag:
+            continue
+
+        # Remove file:// protocol prefixes and extract filename
+        if clean_tag.startswith('file://'):
+            clean_tag = Path(clean_tag.replace('file://', '')).name
+
+        # Remove common path separators to create clean tag names
+        clean_tag = clean_tag.replace('/', '_').replace('\\', '_')
+
+        # Validate tag length - raise error instead of silently dropping
+        if len(clean_tag) > MAX_TAG_LENGTH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Tag '{clean_tag[:100]}...' exceeds maximum length of {MAX_TAG_LENGTH} characters. "
+                       f"Please use shorter, more descriptive tags."
+            )
+
+        if clean_tag:
+            tag_list.append(clean_tag)
+
+    return tag_list
+
 
 async def ensure_storage_initialized():
     """Ensure storage is initialized for web API usage."""
@@ -127,28 +179,8 @@ async def upload_document(
                 detail=f"Unsupported file type: .{file_ext}. Supported: {supported}"
             )
 
-        # Parse tags - split by comma OR space, remove file:// prefixes
-        raw_tags = tags.replace(',', ' ').split()
-        tag_list = []
-        for tag in raw_tags:
-            clean_tag = tag.strip()
-            # Remove file:// protocol prefixes
-            if clean_tag.startswith('file://'):
-                clean_tag = Path(clean_tag.replace('file://', '')).name
-            # Remove common path separators to create clean tag names
-            clean_tag = clean_tag.replace('/', '_').replace('\\', '_')
-            if clean_tag and len(clean_tag) <= 100:  # MAX_TAG_LENGTH = 100
-                tag_list.append(clean_tag)
-
-        # Validate tags - reject excessively long tags (likely user error/corruption)
-        MAX_TAG_LENGTH = 100
-        invalid_tags = [tag for tag in tag_list if len(tag) > MAX_TAG_LENGTH]
-        if invalid_tags:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Tags must be {MAX_TAG_LENGTH} characters or less. Found {len(invalid_tags)} invalid tag(s). "
-                       f"First invalid tag: {invalid_tags[0][:100]}..."
-            )
+        # Parse and validate tags
+        tag_list = parse_and_validate_tags(tags)
 
         # Create upload session
         upload_id = str(uuid.uuid4())
@@ -225,28 +257,8 @@ async def batch_upload_documents(
         if not files:
             raise HTTPException(status_code=400, detail="No files provided")
 
-        # Parse tags - split by comma OR space, remove file:// prefixes
-        raw_tags = tags.replace(',', ' ').split()
-        tag_list = []
-        for tag in raw_tags:
-            clean_tag = tag.strip()
-            # Remove file:// protocol prefixes
-            if clean_tag.startswith('file://'):
-                clean_tag = Path(clean_tag.replace('file://', '')).name
-            # Remove common path separators to create clean tag names
-            clean_tag = clean_tag.replace('/', '_').replace('\\', '_')
-            if clean_tag and len(clean_tag) <= 100:  # MAX_TAG_LENGTH = 100
-                tag_list.append(clean_tag)
-
-        # Validate tags - reject excessively long tags (likely user error/corruption)
-        MAX_TAG_LENGTH = 100
-        invalid_tags = [tag for tag in tag_list if len(tag) > MAX_TAG_LENGTH]
-        if invalid_tags:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Tags must be {MAX_TAG_LENGTH} characters or less. Found {len(invalid_tags)} invalid tag(s). "
-                       f"First invalid tag: {invalid_tags[0][:100]}..."
-            )
+        # Parse and validate tags
+        tag_list = parse_and_validate_tags(tags)
 
         # Create batch upload session
         batch_id = str(uuid.uuid4())

--- a/src/mcp_memory_service/web/api/documents.py
+++ b/src/mcp_memory_service/web/api/documents.py
@@ -127,8 +127,18 @@ async def upload_document(
                 detail=f"Unsupported file type: .{file_ext}. Supported: {supported}"
             )
 
-        # Parse tags
-        tag_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
+        # Parse tags - split by comma OR space, remove file:// prefixes
+        raw_tags = tags.replace(',', ' ').split()
+        tag_list = []
+        for tag in raw_tags:
+            clean_tag = tag.strip()
+            # Remove file:// protocol prefixes
+            if clean_tag.startswith('file://'):
+                clean_tag = Path(clean_tag.replace('file://', '')).name
+            # Remove common path separators to create clean tag names
+            clean_tag = clean_tag.replace('/', '_').replace('\\', '_')
+            if clean_tag and len(clean_tag) <= 100:  # MAX_TAG_LENGTH = 100
+                tag_list.append(clean_tag)
 
         # Validate tags - reject excessively long tags (likely user error/corruption)
         MAX_TAG_LENGTH = 100
@@ -215,8 +225,18 @@ async def batch_upload_documents(
         if not files:
             raise HTTPException(status_code=400, detail="No files provided")
 
-        # Parse tags
-        tag_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
+        # Parse tags - split by comma OR space, remove file:// prefixes
+        raw_tags = tags.replace(',', ' ').split()
+        tag_list = []
+        for tag in raw_tags:
+            clean_tag = tag.strip()
+            # Remove file:// protocol prefixes
+            if clean_tag.startswith('file://'):
+                clean_tag = Path(clean_tag.replace('file://', '')).name
+            # Remove common path separators to create clean tag names
+            clean_tag = clean_tag.replace('/', '_').replace('\\', '_')
+            if clean_tag and len(clean_tag) <= 100:  # MAX_TAG_LENGTH = 100
+                tag_list.append(clean_tag)
 
         # Validate tags - reject excessively long tags (likely user error/corruption)
         MAX_TAG_LENGTH = 100

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -4,6 +4,9 @@
  */
 
 class MemoryDashboard {
+    // Delay between individual file uploads to avoid overwhelming the server (ms)
+    static INDIVIDUAL_UPLOAD_DELAY = 500;
+
     // Static configuration for settings modal system information
     static SYSTEM_INFO_CONFIG = {
         settingsVersion: {
@@ -792,7 +795,7 @@ class MemoryDashboard {
 
                         // Small delay between individual uploads to avoid overwhelming the server
                         if (i < this.selectedFiles.length - 1) {
-                            await new Promise(resolve => setTimeout(resolve, 500));
+                            await new Promise(resolve => setTimeout(resolve, this.constructor.INDIVIDUAL_UPLOAD_DELAY));
                         }
                     } catch (error) {
                         console.error(`Failed to upload ${file.name}:`, error);
@@ -1218,11 +1221,7 @@ class MemoryDashboard {
     toggleProcessingModeHelp() {
         const helpSection = document.getElementById('processingModeHelpSection');
         if (helpSection) {
-            if (helpSection.style.display === 'none') {
-                helpSection.style.display = 'block';
-            } else {
-                helpSection.style.display = 'none';
-            }
+            helpSection.style.display = helpSection.style.display === 'block' ? 'none' : 'block';
         }
     }
 

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -75,6 +75,7 @@ class MemoryDashboard {
         // Documents upload state
         this.selectedFiles = [];
         this.documentsListenersSetup = false;
+        this.processingMode = 'batch'; // 'batch' or 'individual'
 
         // Bind methods
         this.handleSearch = this.handleSearch.bind(this);
@@ -569,10 +570,34 @@ class MemoryDashboard {
             });
         }
 
+        // Processing mode help info icon
+        const processingModeInfoIcon = document.querySelector('.info-icon-processing');
+        if (processingModeInfoIcon) {
+            processingModeInfoIcon.addEventListener('click', () => {
+                this.toggleProcessingModeHelp();
+            });
+        }
+
         if (chunkOverlapInput && chunkOverlapValue) {
             chunkOverlapInput.addEventListener('input', (e) => {
                 chunkOverlapValue.textContent = e.target.value;
                 this.updateUploadButton();
+            });
+        }
+
+        // Processing mode toggle buttons
+        const batchModeBtn = document.getElementById('batchModeBtn');
+        const individualModeBtn = document.getElementById('individualModeBtn');
+
+        if (batchModeBtn) {
+            batchModeBtn.addEventListener('click', () => {
+                this.setProcessingMode('batch');
+            });
+        }
+
+        if (individualModeBtn) {
+            individualModeBtn.addEventListener('click', () => {
+                this.setProcessingMode('individual');
             });
         }
 
@@ -702,6 +727,38 @@ class MemoryDashboard {
                 `Upload & Ingest ${this.selectedFiles.length} file${this.selectedFiles.length > 1 ? 's' : ''}` :
                 'Upload & Ingest';
         }
+
+        // Show/hide processing mode section based on file count
+        const processingModeSection = document.getElementById('processingModeSection');
+        if (processingModeSection) {
+            processingModeSection.style.display = (hasFiles && this.selectedFiles.length > 1) ? 'block' : 'none';
+        }
+    }
+
+    /**
+     * Set processing mode (batch or individual)
+     */
+    setProcessingMode(mode) {
+        this.processingMode = mode;
+
+        // Update button states
+        const batchBtn = document.getElementById('batchModeBtn');
+        const individualBtn = document.getElementById('individualModeBtn');
+        const modeDescription = document.getElementById('modeDescription');
+
+        if (batchBtn) {
+            batchBtn.classList.toggle('active', mode === 'batch');
+        }
+        if (individualBtn) {
+            individualBtn.classList.toggle('active', mode === 'individual');
+        }
+        if (modeDescription) {
+            modeDescription.innerHTML = mode === 'batch'
+                ? '<small>All selected files will be processed together with the same tags.</small>'
+                : '<small>Each file will be processed individually with the same tags.</small>';
+        }
+
+        console.log(`Processing mode set to: ${mode}`);
     }
 
     /**
@@ -721,14 +778,28 @@ class MemoryDashboard {
         try {
             this.setLoading(true);
 
-            if (this.selectedFiles.length === 1) {
-                // Single file upload
-                await this.uploadSingleDocument(this.selectedFiles[0], {
-                    tags,
-                    chunk_size: parseInt(chunkSize),
-                    chunk_overlap: parseInt(chunkOverlap),
-                    memory_type: memoryType
-                });
+            if (this.selectedFiles.length === 1 || this.processingMode === 'individual') {
+                // Individual file processing (single file or individual mode for multiple files)
+                for (let i = 0; i < this.selectedFiles.length; i++) {
+                    const file = this.selectedFiles[i];
+                    try {
+                        await this.uploadSingleDocument(file, {
+                            tags,
+                            chunk_size: parseInt(chunkSize),
+                            chunk_overlap: parseInt(chunkOverlap),
+                            memory_type: memoryType
+                        });
+
+                        // Small delay between individual uploads to avoid overwhelming the server
+                        if (i < this.selectedFiles.length - 1) {
+                            await new Promise(resolve => setTimeout(resolve, 500));
+                        }
+                    } catch (error) {
+                        console.error(`Failed to upload ${file.name}:`, error);
+                        this.showToast(`Failed to upload ${file.name}: ${error.message}`, 'error');
+                        // Continue with remaining files
+                    }
+                }
             } else {
                 // Batch upload
                 await this.uploadBatchDocuments(this.selectedFiles, {
@@ -1136,6 +1207,30 @@ class MemoryDashboard {
      */
     hideOverlapHelp() {
         const helpSection = document.getElementById('overlapHelpSection');
+        if (helpSection) {
+            helpSection.style.display = 'none';
+        }
+    }
+
+    /**
+     * Toggle processing mode help section visibility
+     */
+    toggleProcessingModeHelp() {
+        const helpSection = document.getElementById('processingModeHelpSection');
+        if (helpSection) {
+            if (helpSection.style.display === 'none') {
+                helpSection.style.display = 'block';
+            } else {
+                helpSection.style.display = 'none';
+            }
+        }
+    }
+
+    /**
+     * Hide processing mode help section
+     */
+    hideProcessingModeHelp() {
+        const helpSection = document.getElementById('processingModeHelpSection');
         if (helpSection) {
             helpSection.style.display = 'none';
         }

--- a/src/mcp_memory_service/web/static/index.html
+++ b/src/mcp_memory_service/web/static/index.html
@@ -350,10 +350,33 @@
 
                         <!-- Upload Configuration -->
                         <div class="upload-config">
-                            <div class="config-section">
-                                <label for="docTags">Tags (comma-separated)</label>
-                                <input type="text" id="docTags" placeholder="e.g., documentation, reference, manual" class="form-control">
-                            </div>
+                        <div class="config-section">
+                        <label for="docTags">Tags (comma-separated)</label>
+                        <input type="text" id="docTags" placeholder="e.g., documentation, reference, manual" class="form-control">
+                            <small class="form-help">Tags will be applied to all files. Use spaces or commas as separators.</small>
+                             </div>
+
+                             <!-- Processing Mode Toggle (shown when multiple files selected) -->
+                             <div class="config-section" id="processingModeSection" style="display: none;">
+                             <label>Processing Mode <span class="info-icon info-icon-processing" title="Click for processing mode explanation">ℹ️</span></label>
+                                 <div class="processing-mode-toggle">
+                                     <button type="button" id="batchModeBtn" class="mode-btn active" data-mode="batch">
+                                         <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
+                                             <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/>
+                                         </svg>
+                                         Batch Processing
+                                     </button>
+                                     <button type="button" id="individualModeBtn" class="mode-btn" data-mode="individual">
+                                         <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
+                                             <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
+                                         </svg>
+                                         Individual Processing
+                                     </button>
+                                 </div>
+                                 <div class="mode-description" id="modeDescription">
+                                     <small>All selected files will be processed together with the same tags.</small>
+                                 </div>
+                             </div>
                             <div class="config-row">
                                 <div class="config-section">
                                     <label for="chunkSize">
@@ -489,7 +512,54 @@
                                 </div>
                             </div>
 
-                            <div class="config-section">
+                            <!-- Processing Mode Help Section (collapsible) -->
+                             <div id="processingModeHelpSection" class="chunking-help processing-mode-help" style="display: none;">
+                                 <div class="help-header">
+                                     <strong>⚙️ Processing Mode Options</strong>
+                                     <button class="close-help" data-action="hideProcessingModeHelp">×</button>
+                                 </div>
+                                 <div class="help-content">
+                                     <p class="help-note">
+                                         <strong>When uploading multiple files,</strong> choose how they should be processed.
+                                         Both modes apply the same tags to all files.
+                                     </p>
+
+                                     <div class="help-recommendations">
+                                         <div class="help-option">
+                                             <div class="help-option-header">
+                                                 <strong>📦 Batch Processing</strong>
+                                                 <span class="help-tag">Default</span>
+                                             </div>
+                                             <p><strong>What it does:</strong> Uploads all files together as one operation</p>
+                                             <p><strong>Best for:</strong> Similar files, fast bulk processing, when you want files grouped together</p>
+                                             <p><strong>Pros:</strong> Faster, simpler, single progress indicator</p>
+                                             <p><strong>Cons:</strong> One file failure can affect the whole batch</p>
+                                         </div>
+
+                                         <div class="help-option">
+                                             <div class="help-option-header">
+                                                 <strong>🔄 Individual Processing</strong>
+                                             </div>
+                                             <p><strong>What it does:</strong> Uploads each file separately with individual API calls</p>
+                                             <p><strong>Best for:</strong> Mixed file types, when you want error isolation, or need individual progress tracking</p>
+                                             <p><strong>Pros:</strong> Better error handling, individual progress, more robust</p>
+                                             <p><strong>Cons:</strong> Slightly slower due to sequential processing</p>
+                                         </div>
+                                     </div>
+
+                                     <div class="help-tips">
+                                         <strong>💡 When to choose each mode:</strong>
+                                         <ul>
+                                             <li><strong>Batch mode:</strong> When files are similar and you want them processed quickly together</li>
+                                             <li><strong>Individual mode:</strong> When files might have different processing requirements or you want to ensure all files get processed even if some fail</li>
+                                             <li><strong>Single files:</strong> Always processed individually (no choice needed)</li>
+                                             <li>Both modes apply the same tags to all files</li>
+                                         </ul>
+                                     </div>
+                                 </div>
+                             </div>
+
+                             <div class="config-section">
                                 <label for="memoryType">Memory Type</label>
                                 <select id="memoryType" class="form-control">
                                     <option value="document">Document</option>

--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -2319,7 +2319,59 @@ body.dark-mode .footer-copyright {
 }
 
 .form-control[type="range"] {
+cursor: pointer;
+}
+
+/* Processing Mode Toggle */
+.processing-mode-toggle {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-2);
+}
+
+.mode-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--neutral-300);
+    border-radius: var(--radius-md);
+    background: var(--neutral-50);
+    color: var(--neutral-700);
+    font-size: var(--text-sm);
+    font-weight: 500;
     cursor: pointer;
+    transition: var(--transition-fast);
+    flex: 1;
+    justify-content: center;
+}
+
+.mode-btn:hover {
+    background: var(--neutral-100);
+    border-color: var(--neutral-400);
+}
+
+.mode-btn.active {
+    background: var(--primary);
+    border-color: var(--primary);
+    color: white;
+}
+
+.mode-btn.active:hover {
+    background: var(--primary-dark);
+}
+
+.mode-description {
+    font-size: var(--text-xs);
+    color: var(--neutral-500);
+    margin-top: var(--space-1);
+}
+
+.form-help {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--neutral-500);
+    margin-top: var(--space-1);
 }
 
 /* Upload Actions */


### PR DESCRIPTION
This PR implements the backend tag sanitization solution proposed in issue #174.

## Changes Made

- **Enhanced Tag Parsing**: Split tags by comma OR space instead of comma only
- **File Path Sanitization**: Remove  prefixes and extract filename only
- **Path Separator Cleanup**: Replace  and  with  for clean tag names
- **Maintained Validation**: Keep MAX_TAG_LENGTH validation to prevent excessively long tags

## Problem Solved

Previously, when uploading documents with space-separated file paths like:


This would create one massive 5000+ character tag instead of being properly separated.

## Solution

Now the same input produces clean, individual tags:
- 
-  
- 

## Testing

Created and ran test script to verify:
- ✅ Space-separated file paths are properly split
- ✅ File:// prefixes are removed and filenames extracted
- ✅ Comma-separated tags still work correctly
- ✅ Mixed comma+space input is handled properly
- ✅ Tag length validation prevents future bloated tags

Closes #174