### PR TITLE
fix: v8.18.2 - Critical MCP retrieve_memory Tool Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [8.18.2] - 2025-11-06
+
 ### Fixed
 - **MCP Tool Handler Method Name** - Fixed critical bug where MCP tool handlers called non-existent `retrieve_memory()` method
   - **Root Cause**: Method name mismatch introduced in commit 36e9845 during MemoryService refactoring (Oct 28, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **MCP Tool Handler Method Name** - Fixed critical bug where MCP tool handlers called non-existent `retrieve_memory()` method
+  - **Root Cause**: Method name mismatch introduced in commit 36e9845 during MemoryService refactoring (Oct 28, 2025)
+  - **Symptom**: `'MemoryService' object has no attribute 'retrieve_memory'` error when using MCP retrieve_memory tool
+  - **Fix**: Updated handlers to call correct `retrieve_memories()` method (plural)
+  - **Files Modified**: `src/mcp_memory_service/server.py` (line 2153), `src/mcp_memory_service/mcp_server.py` (line 227)
+  - **Additional**: Removed unsupported `min_similarity` parameter from MCP tool definition
+  - **Impact**: MCP retrieve_memory tool now functions correctly
+  - **Issue**: [#207](https://github.com/doobidoo/mcp-memory-service/issues/207)
+
 ## [8.18.1] - 2025-11-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@
 
 ## 🚀 Quick Start (2 minutes)
 
-### 🆕 Latest Release: **v8.18.1** (Nov 5, 2025)
+### 🆕 Latest Release: **v8.18.2** (Nov 6, 2025)
 
-**Test Suite Import Fix** - Resolved critical import errors blocking all test collection.
+**MCP Retrieve Memory Fix** - Fixed critical bug preventing MCP memory retrieval.
 
 **What's New**:
-- 🔧 **Test Suite Restored** - Fixed import failures that prevented 190 tests from running
-- 📦 **MCP Client Update** - Migrated from deprecated `mcp` module to `mcp.client.session` (v1.1.2 API)
-- 🧹 **Architecture Cleanup** - Removed obsolete `CHROMA_PATH` constant from old storage backend
-- ✅ **Full Test Coverage** - All unit, integration, and E2E tests now collect and run successfully
+- 🐛 **Critical Bugfix** - Fixed 'MemoryService' object has no attribute 'retrieve_memory' error
+- ✅ **MCP Tool Restored** - MCP retrieve_memory tool now fully functional
+- 🔧 **Method Name Fix** - Corrected handler calls from `retrieve_memory()` to `retrieve_memories()`
+- 🧹 **Parameter Cleanup** - Removed unsupported `min_similarity` parameter
 
 **Technical Details**:
-- Updated test imports to use current MCP SDK API
-- Removed dependencies on deprecated storage constants
-- Verified test collection across all test suites
+- Root cause: Method name mismatch from Oct 28 refactoring (commit 36e9845)
+- Fixed server.py line 2153 and mcp_server.py line 227
+- All 4 retrieve-related tests pass
 
-**📖 Full Details**: [CHANGELOG.md](CHANGELOG.md#8181---2025-11-05) | [PR #205](https://github.com/doobidoo/mcp-memory-service/pull/205) | [Issue #204](https://github.com/doobidoo/mcp-memory-service/issues/204) | [All Releases](https://github.com/doobidoo/mcp-memory-service/releases)
+**📖 Full Details**: [CHANGELOG.md](CHANGELOG.md#8182---2025-11-06) | [Issue #207](https://github.com/doobidoo/mcp-memory-service/issues/207) | [All Releases](https://github.com/doobidoo/mcp-memory-service/releases)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.18.1"
+version = "8.18.2"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/__init__.py
+++ b/src/mcp_memory_service/__init__.py
@@ -47,7 +47,7 @@ def setup_offline_mode():
 # Setup offline mode immediately when this module is imported
 setup_offline_mode()
 
-__version__ = "8.18.1"
+__version__ = "8.18.2"
 
 from .models import Memory, MemoryQueryResult
 from .storage import MemoryStorage

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -208,8 +208,7 @@ async def store_memory(
 async def retrieve_memory(
     query: str,
     ctx: Context,
-    n_results: int = 5,
-    min_similarity: float = 0.0
+    n_results: int = 5
 ) -> Dict[str, Any]:
     """
     Retrieve memories based on semantic similarity to a query.
@@ -217,17 +216,15 @@ async def retrieve_memory(
     Args:
         query: Search query for semantic similarity
         n_results: Maximum number of results to return
-        min_similarity: Minimum similarity score threshold
 
     Returns:
         Dictionary with retrieved memories and metadata
     """
     # Delegate to shared MemoryService business logic
     memory_service = ctx.request_context.lifespan_context.memory_service
-    return await memory_service.retrieve_memory(
+    return await memory_service.retrieve_memories(
         query=query,
-        n_results=n_results,
-        min_similarity=min_similarity
+        n_results=n_results
     )
 
 @mcp.tool()

--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -2150,7 +2150,7 @@ class MemoryServer:
             start_time = time.time()
 
             # Call shared MemoryService business logic
-            result = await self.memory_service.retrieve_memory(
+            result = await self.memory_service.retrieve_memories(
                 query=query,
                 n_results=n_results
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12'",
@@ -816,7 +816,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "8.18.1"
+version = "8.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes
- Fixed critical bug: 'MemoryService' object has no attribute 'retrieve_memory'
- Updated MCP tool handlers to call correct `retrieve_memories()` method
- Removed unsupported `min_similarity` parameter from MCP tool definition

## Root Cause
Method name mismatch introduced in commit 36e9845 (Oct 28, 2025) during MemoryService refactoring.

## Testing
- ✅ All 4 retrieve-related unit tests pass
- ✅ test_retrieve_memories_basic
- ✅ test_retrieve_memories_with_filters
- ✅ test_retrieve_memories_error_handling
- ✅ test_store_and_retrieve_workflow

## Files Modified
- `src/mcp_memory_service/server.py` (line 2153)
- `src/mcp_memory_service/mcp_server.py` (lines 207-230)
- `src/mcp_memory_service/__init__.py` (version bump)
- `pyproject.toml` (version bump)
- `CHANGELOG.md` (release notes)
- `README.md` (latest release section)

## Related Issues
Fixes #207

## Severity
CRITICAL - MCP retrieve_memory tool was completely non-functional

## Release Checklist
- [x] Version bumped in __init__.py, pyproject.toml, and uv.lock
- [x] CHANGELOG.md updated with detailed bugfix entry
- [x] README.md "Latest Release" section updated
- [x] Tests pass (4/4 retrieve-related tests)
- [x] Documentation updated
- [x] Issue #207 created and referenced