### PR TITLE
feat: Enable PyPI Publishing

### DIFF
--- a/.github/workflows/publish-and-test.yml
+++ b/.github/workflows/publish-and-test.yml
@@ -154,8 +154,41 @@ jobs:
           SKIP_MODEL_DOWNLOAD=true
         outputs: type=registry
 
+  publish-pypi:
+    needs: [test-uvx-compatibility, test-docker-build]
+    runs-on: ubuntu-latest
+    name: Publish to PyPI
+    if: github.event_name != 'pull_request'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        twine upload dist/*
+
   update-documentation:
-    needs: [publish-docker]
+    needs: [publish-docker, publish-pypi]
     runs-on: ubuntu-latest
     name: Update documentation
     if: github.event_name != 'pull_request'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ changelog_file = "CHANGELOG.md"
 build_command = "pip install build && python -m build"
 build_command_env = []
 dist_path = "dist/"
-upload_to_pypi = false
+upload_to_pypi = true
 upload_to_release = true
 commit_message = "chore(release): bump version to {version}"
 


### PR DESCRIPTION
## Summary

Enables automated PyPI publishing for mcp-memory-service package.

## Changes

**Clean cherry-pick from feature branch - PyPI changes only**

### Workflow Configuration
- ✅ **`.github/workflows/publish-and-test.yml`**: Added `publish-pypi` job
  - Runs after tests pass
  - Uses `PYPI_TOKEN` secret for authentication
  - Publishes via twine on tag push (v*.*.*)

### Project Configuration  
- ✅ **`pyproject.toml`**: Set `upload_to_pypi = true`

## Workflow Sequence

On tag push (v*.*.*):
1. ✅ Tests (uvx compatibility, Docker build)
2. ✅ **NEW**: Publishes to PyPI via twine
3. ✅ Publishes Docker image to GHCR
4. ✅ Updates documentation

## Testing

Already tested and working:
- ✅ Package successfully published to PyPI as v8.24.0
- ✅ Verified installation: `pip install mcp-memory-service`
- ✅ Package URL: https://pypi.org/project/mcp-memory-service/
- ✅ PYPI_TOKEN secret configured

## Impact

**Resolves installation issues** where users couldn't install via `pip install mcp-memory-service` because package wasn't on PyPI.

**Next release** (v8.26.0 or later) will automatically publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>