### PR TITLE
fix: preserve memory_type during Cloudflare-to-SQLite sync (v8.27.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [8.27.2] - 2025-11-18
+
+### Fixed
+- **Memory Type Loss During Cloudflare-to-SQLite Sync** - Fixed `memory_type` not being preserved in sync script
+  - **Problem**: `scripts/sync/sync_memory_backends.py` did not extract or pass `memory_type` when syncing from Cloudflare to SQLite-vec
+  - **Impact**: All memories synced via `--direction cf-to-sqlite` showed as "untyped" (100%) in dashboard analytics
+  - **Root Cause**: Missing `memory_type` field in both memory dict extraction (line 85) and Memory object creation (line 153)
+  - **Solution**:
+    - Added `memory_type` to memory dictionary extraction from source
+    - Added `memory_type` parameter when creating Memory objects for target storage
+  - **Files Modified**:
+    - `scripts/sync/sync_memory_backends.py` - Added memory_type handling (lines 85, 153)
+  - **Affected Users**: Users who ran `python scripts/sync/sync_memory_backends.py --direction cf-to-sqlite`
+  - **Recovery**: Re-run sync from Cloudflare to restore memory types (Cloudflare preserves original types)
+
 ## [8.27.1] - 2025-11-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Memory Type Loss During Cloudflare-to-SQLite Sync** - Fixed `memory_type` not being preserved in sync script
   - **Problem**: `scripts/sync/sync_memory_backends.py` did not extract or pass `memory_type` when syncing from Cloudflare to SQLite-vec
   - **Impact**: All memories synced via `--direction cf-to-sqlite` showed as "untyped" (100%) in dashboard analytics
-  - **Root Cause**: Missing `memory_type` field in both memory dict extraction (line 85) and Memory object creation (line 153)
+  - **Root Cause**: Missing `memory_type` field in both memory dict extraction and Memory object creation
   - **Solution**:
     - Added `memory_type` to memory dictionary extraction from source
-    - Added `memory_type` parameter when creating Memory objects for target storage
+    - Added `memory_type` and `updated_at` parameters when creating Memory objects for target storage
   - **Files Modified**:
-    - `scripts/sync/sync_memory_backends.py` - Added memory_type handling (lines 85, 153)
+    - `scripts/sync/sync_memory_backends.py` - Added memory_type and updated_at handling
   - **Affected Users**: Users who ran `python scripts/sync/sync_memory_backends.py --direction cf-to-sqlite`
   - **Recovery**: Re-run sync from Cloudflare to restore memory types (Cloudflare preserves original types)
 

--- a/README.md
+++ b/README.md
@@ -23,28 +23,17 @@
 
 ## 🚀 Quick Start (2 minutes)
 
-### 🆕 Latest Release: **v8.27.1** (Nov 18, 2025)
+### 🆕 Latest Release: **v8.27.2** (Nov 18, 2025)
 
-**🚨 CRITICAL HOTFIX: Timestamp Regression** 🔧
+**Bug Fix: Memory Type Preservation in Sync Script**
 
-- 🐛 **Fixed timestamp corruption bug** - `created_at` timestamps no longer reset during metadata sync
-- 🔧 **Affected versions**: v8.25.0-v8.27.0 (hybrid backend users with drift detection)
-- 🛡️ **Data integrity restored** - All timestamp preservation tests passing
-- 🔄 **Recovery tools included** - Script to restore timestamps from Cloudflare backup
-- ✅ **Zero breaking changes** - Drop-in fix for affected installations
-
-**If you're on v8.25.0-v8.27.0 with hybrid backend:**
-```bash
-# Check for corrupted timestamps
-python scripts/validation/validate_timestamp_integrity.py
-
-# Recover from Cloudflare (if needed)
-python scripts/maintenance/recover_timestamps_from_cloudflare.py --dry-run
-python scripts/maintenance/recover_timestamps_from_cloudflare.py --apply
-```
+- 🐛 **Fixed memory_type loss** - Sync script now preserves `memory_type` during cf-to-sqlite sync
+- 📊 **Dashboard analytics restored** - No more 100% "untyped" memories after sync
+- 🔄 **Recovery**: Re-run sync from Cloudflare to restore memory types
+- ✅ **Zero breaking changes** - Drop-in fix for sync script users
 
 **Previous Releases**:
-- **v8.27.0** - Hybrid Storage Performance (3-5x faster sync, real-time progress, bidirectional sync)
+- **v8.27.1** - Critical Hotfix: Timestamp Regression (created_at preservation during metadata sync)
 - **v8.26.0** - Revolutionary MCP Performance (534,628x faster tools, 90%+ cache hit rate)
 - **v8.25.0** - Hybrid Backend Drift Detection (automatic metadata sync, bidirectional awareness)
 - **v8.24.4** - Code Quality Improvements from Gemini Code Assist (regex sanitization, DOM caching)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.27.1"
+version = "8.27.2"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/sync/sync_memory_backends.py
+++ b/scripts/sync/sync_memory_backends.py
@@ -82,6 +82,7 @@ class MemorySync:
                     'content': memory.content,
                     'metadata': memory.metadata,
                     'tags': memory.tags,
+                    'memory_type': memory.memory_type,
                     'created_at': memory.created_at,
                     'created_at_iso': memory.created_at_iso,
                     'updated_at': memory.updated_at,
@@ -149,6 +150,7 @@ class MemorySync:
                         content_hash=source_memory['content_hash'],
                         tags=source_memory.get('tags', []),
                         metadata=source_memory.get('metadata', {}),
+                        memory_type=source_memory.get('memory_type'),
                         created_at=source_memory.get('created_at'),
                     )
                     success, message = await target_storage.store(memory_obj)

--- a/scripts/sync/sync_memory_backends.py
+++ b/scripts/sync/sync_memory_backends.py
@@ -152,6 +152,7 @@ class MemorySync:
                         metadata=source_memory.get('metadata', {}),
                         memory_type=source_memory.get('memory_type'),
                         created_at=source_memory.get('created_at'),
+                        updated_at=source_memory.get('updated_at'),
                     )
                     success, message = await target_storage.store(memory_obj)
                     if success:

--- a/src/mcp_memory_service/__init__.py
+++ b/src/mcp_memory_service/__init__.py
@@ -47,7 +47,7 @@ def setup_offline_mode():
 # Setup offline mode immediately when this module is imported
 setup_offline_mode()
 
-__version__ = "8.27.1"
+__version__ = "8.27.2"
 
 from .models import Memory, MemoryQueryResult
 from .storage import MemoryStorage


### PR DESCRIPTION
## Summary

- Fixed `memory_type` not being preserved when syncing memories from Cloudflare to SQLite-vec
- All memories synced via `--direction cf-to-sqlite` were showing as "untyped" (100%) in dashboard analytics
- Bumped version to v8.27.2 (patch release)

## Changes

### Bug Fix
- Added `memory_type` to memory dict extraction in `scripts/sync/sync_memory_backends.py` (line 85)
- Added `memory_type` parameter to Memory object creation (line 153)

### Documentation
- Updated CHANGELOG.md with detailed bug fix entry
- Updated README.md Latest Release section for v8.27.2

### Version Bump
- Updated `src/mcp_memory_service/__init__.py` to 8.27.2
- Updated `pyproject.toml` to 8.27.2

## Motivation

Users who ran `python scripts/sync/sync_memory_backends.py --direction cf-to-sqlite` had all their `memory_type` values lost, causing dashboard analytics to show 100% "untyped" memories instead of the natural distribution of types.

## Testing

- Verified the sync script logic manually
- The fix ensures `memory_type` is extracted from source memory and passed to target Memory object

## Recovery

Users affected by this bug can restore memory types by re-running the sync from Cloudflare (which preserves original types):

```bash
python scripts/sync/sync_memory_backends.py --direction cf-to-sqlite
```

## Related Issues

None directly reported, but this was discovered during dashboard analytics review.

## Checklist

- [x] Version bumped in __init__.py and pyproject.toml
- [x] CHANGELOG.md updated
- [x] README.md updated
- [x] Tests: N/A (script fix, manual verification)
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)