### PR TITLE
Hotfix v8.36.1: Fix HTTP server crash from forward reference error

### DIFF
--- a/src/mcp_memory_service/web/api/analytics.py
+++ b/src/mcp_memory_service/web/api/analytics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """
 Analytics endpoints for the HTTP interface.
 
@@ -19,7 +21,7 @@ Provides usage statistics, trends, and performance metrics for the memory system
 """
 
 import logging
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from typing import List, Optional, Dict, Any, TYPE_CHECKING, Tuple
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 from dataclasses import dataclass


### PR DESCRIPTION
## Critical Hotfix for v8.36.0

**Fixes:** #247
**Type:** Bug fix (hotfix)
**Priority:** Critical
**Impact:** HTTP server fails to start in v8.36.0

## Problem
v8.36.0 (PR #244) introduced a critical regression preventing HTTP server startup:

```
Error starting server: name 'TagUsageStats' is not defined
systemd: mcp-memory-http.service: Failed with result 'exit-code'
```

**Root Cause:** PR #244 refactored analytics.py, introducing helper functions with forward references to Pydantic models defined later in the file, without enabling PEP 563.

## Solution
```diff
+from __future__ import annotations

 import logging
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from typing import List, Optional, Dict, Any, TYPE_CHECKING, Tuple
```

**Changes:**
1. Added `from __future__ import annotations` (line 15) - enables PEP 563 forward references
2. Added `Tuple` to typing imports (line 24) - missing import for return type hint

## Testing
- [x] HTTP server starts successfully
- [x] Health endpoint returns v8.36.0
- [x] No import errors in analytics module
- [x] All refactored functions work correctly

## Coordination
User is working on issue #246 (Phase 2 refactoring) on another machine. This hotfix should be merged and released as v8.36.1 before continuing #246 work.

## Recommendation
Fast-track merge → release v8.36.1 immediately to unblock users on broken v8.36.0.