### PR TITLE
fix(mcp): enforce JSON-RPC 2.0 compliance by excluding null fields

### DIFF
--- a/src/mcp_memory_service/web/api/mcp.py
+++ b/src/mcp_memory_service/web/api/mcp.py
@@ -161,7 +161,7 @@ async def mcp_endpoint(
         storage = get_storage()
 
         if request.method == "initialize":
-            return MCPResponse(
+            response = MCPResponse(
                 id=request.id,
                 result={
                     "protocolVersion": "2024-11-05",
@@ -174,14 +174,16 @@ async def mcp_endpoint(
                     }
                 }
             )
+            return JSONResponse(content=response.model_dump(exclude_none=True))
 
         elif request.method == "tools/list":
-            return MCPResponse(
+            response = MCPResponse(
                 id=request.id,
                 result={
                     "tools": [tool.model_dump() for tool in MCP_TOOLS]
                 }
             )
+            return JSONResponse(content=response.model_dump(exclude_none=True))
 
         elif request.method == "tools/call":
             tool_name = request.params.get("name") if request.params else None
@@ -189,7 +191,7 @@ async def mcp_endpoint(
 
             result = await handle_tool_call(storage, tool_name, arguments)
 
-            return MCPResponse(
+            response = MCPResponse(
                 id=request.id,
                 result={
                     "content": [
@@ -200,25 +202,28 @@ async def mcp_endpoint(
                     ]
                 }
             )
+            return JSONResponse(content=response.model_dump(exclude_none=True))
 
         else:
-            return MCPResponse(
+            response = MCPResponse(
                 id=request.id,
                 error={
                     "code": -32601,
                     "message": f"Method not found: {request.method}"
                 }
             )
+            return JSONResponse(content=response.model_dump(exclude_none=True))
 
     except Exception as e:
         logger.error(f"MCP endpoint error: {e}")
-        return MCPResponse(
+        response = MCPResponse(
             id=request.id,
             error={
                 "code": -32603,
                 "message": f"Internal error: {str(e)}"
             }
         )
+        return JSONResponse(content=response.model_dump(exclude_none=True))
 
 
 async def handle_tool_call(storage, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

PR #236 attempted to fix JSON-RPC 2.0 compliance by adding `ConfigDict(exclude_none=True)` to the MCPResponse Pydantic model, but **FastAPI ignores this configuration** when directly returning Pydantic models.

**Result**: HTTP MCP responses still contained `"error": null` (in success responses) or `"result": null` (in error responses), violating JSON-RPC 2.0 spec and causing Claude Code/Desktop to reject all MCP communications.

## Root Cause

FastAPI's automatic JSON serialization doesn't respect Pydantic's `model_config` when models are returned directly. The `response_model_exclude_none=True` decorator parameter also doesn't work without an explicit `response_model`.

## Solution

Explicitly serialize MCPResponse using `JSONResponse` with `.model_dump(exclude_none=True)`:

```python
response = MCPResponse(id=request.id, result={...})
return JSONResponse(content=response.model_dump(exclude_none=True))
```

This ensures:
- ✅ Success responses contain **ONLY**: `jsonrpc`, `id`, `result`
- ✅ Error responses contain **ONLY**: `jsonrpc`, `id`, `error`

## Testing

Verified both response types comply with JSON-RPC 2.0 spec:

```bash
# Success response
curl -X POST http://localhost:8000/mcp -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | python3 -m json.tool

# Response keys: ['jsonrpc', 'id', 'result']
# ✓ NO "error" field

# Error response
curl -X POST http://localhost:8000/mcp -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"invalid"}' | python3 -m json.tool

# Response keys: ['jsonrpc', 'id', 'error']
# ✓ NO "result" field
```

## Impact

- Fixes Claude Code/Desktop MCP HTTP transport connectivity
- Ensures 100% JSON-RPC 2.0 spec compliance
- Properly completes the fix started in PR #236

Fixes #236

Co-authored-by: Tim Knauff <timothy.knauff@gmail.com>
Co-authored-by: Claude <noreply@anthropic.com>