### PR TITLE
fix: MCP Resource Handler AttributeError (v8.42.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [8.42.1] - 2025-11-29
+
+### Fixed
+- **MCP Resource Handler AttributeError** - Fixed `AttributeError: 'AnyUrl' object has no attribute 'startswith'` in `handle_read_resource` function (issue #254)
+  - Added automatic URI string conversion at function start to handle both plain strings and Pydantic AnyUrl objects
+  - MCP SDK may pass AnyUrl objects instead of strings, causing AttributeError when using `.startswith()` method
+  - Fix converts AnyUrl to string using `str()` before processing, maintaining backward compatibility
+
 ## [8.42.0] - 2025-11-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@
 
 ## 🚀 Quick Start (2 minutes)
 
-### 🆕 Latest Release: **v8.42.0** (Nov 27, 2025)
+### 🆕 Latest Release: **v8.42.1** (Nov 29, 2025)
 
-**Memory Awareness Enhancements**
+**Bug Fix Release**
 
-- 👁️ **Visible Memory Injection** - Users now see top 3 memories at session start with relevance scores, age, and tags
-- 🎯 **Quality Session Summaries** - Raised quality thresholds (200 char min, 0.5 confidence) to prevent generic boilerplate
-- 🤖 **LLM-Powered Summarization** - Optional Gemini CLI integration for intelligent session analysis
-- 🧹 **Database Quality** - Cleaned 167 generic summaries (3352 → 3185 memories)
+- 🐛 **MCP Resource Handler Fix** - Fixed `AttributeError: 'AnyUrl' object has no attribute 'startswith'` in `handle_read_resource` (issue #254)
+- 🔧 **Pydantic Compatibility** - Added automatic URI string conversion to handle both string and AnyUrl inputs from MCP SDK
 
 **Previous Releases**:
+- **v8.42.0** - Memory Awareness Enhancements (visible memory injection, quality session summaries, LLM-powered summarization)
 - **v8.41.2** - Hook Installer Utility File Deployment (ALL 14 utilities copied, future-proof glob pattern)
 - **v8.41.1** - Context Formatter Memory Sorting (recency sorting within categories, newest first)
 - **v8.41.0** - Session Start Hook Reliability Improvements (error suppression, clean output, memory filtering, classification fixes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.42.0"
+version = "8.42.1"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/__init__.py
+++ b/src/mcp_memory_service/__init__.py
@@ -47,7 +47,7 @@ def setup_offline_mode():
 # Setup offline mode immediately when this module is imported
 setup_offline_mode()
 
-__version__ = "8.42.0"
+__version__ = "8.42.1"
 
 from .models import Memory, MemoryQueryResult
 from .storage import MemoryStorage

--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -1122,10 +1122,15 @@ class MemoryServer:
         async def handle_read_resource(uri: str) -> str:
             """Read a specific memory resource."""
             await self._ensure_storage_initialized()
-            
+
             import json
             from urllib.parse import unquote
-            
+
+            # Convert AnyUrl to string if necessary (fix for issue #254)
+            # MCP SDK may pass Pydantic AnyUrl objects instead of plain strings
+            if hasattr(uri, '__str__'):
+                uri = str(uri)
+
             try:
                 if uri == "memory://stats":
                     # Get memory statistics

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "8.42.0"
+version = "8.42.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes #254

This PR addresses the `AttributeError: 'AnyUrl' object has no attribute 'startswith'` bug in the `handle_read_resource` function. The MCP SDK sometimes passes Pydantic `AnyUrl` objects instead of plain strings, causing the error when string methods are called.

## Changes

- **Bug Fix** (commit d494015): Added automatic URI string conversion at the beginning of `handle_read_resource`
- **Version Bump** (commit 179aee7): Updated version to 8.42.1 in all four required files
- **Dependency Lock** (commit 30f81c8): Updated `uv.lock` for v8.42.1

### Files Modified
- `src/mcp_memory_service/server.py` - Added AnyUrl to string conversion
- `src/mcp_memory_service/__init__.py` - Version bump to 8.42.1
- `pyproject.toml` - Version bump to 8.42.1
- `CHANGELOG.md` - Added v8.42.1 entry with bug fix details
- `README.md` - Updated Latest Release section
- `uv.lock` - Dependency lock update

## Technical Details

The fix uses a safe conversion approach:
```python
# Convert AnyUrl to string if necessary (fix for issue #254)
# MCP SDK may pass Pydantic AnyUrl objects instead of plain strings
if hasattr(uri, '__str__'):
    uri = str(uri)
```

This ensures compatibility with both string and AnyUrl inputs while maintaining backward compatibility.

## Testing

Manual testing confirms the fix resolves the AttributeError when using `fetch_mcp_resource`:
```python
print(default_api.fetch_mcp_resource(server="user-memory", uri="memory://stats"))
```

Expected behavior: Successfully returns memory statistics in JSON format without errors.

## Checklist

- [x] Bug fix implemented and tested
- [x] Version bumped in __init__.py, pyproject.toml, README.md
- [x] CHANGELOG.md updated with bug fix details  
- [x] uv.lock updated
- [x] No breaking changes
- [x] Backward compatible with existing code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>