### PR TITLE
fix: Use EMBEDDING_MODEL_NAME from config instead of hardcoded value

### DIFF
--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -3784,7 +3784,6 @@ Memories Archived: {report.memories_archived}"""
             result["storage_cache"]["keys"] = list(_STORAGE_CACHE.keys())
             result["backend_info"] = {
                 "storage_backend": STORAGE_BACKEND,
-    EMBEDDING_MODEL_NAME,
                 "sqlite_path": SQLITE_VEC_PATH
             }
 

--- a/src/mcp_memory_service/server.py
+++ b/src/mcp_memory_service/server.py
@@ -182,6 +182,7 @@ from .config import (
     SERVER_NAME,
     SERVER_VERSION,
     STORAGE_BACKEND,
+    EMBEDDING_MODEL_NAME,
     SQLITE_VEC_PATH,
     CONSOLIDATION_ENABLED,
     CONSOLIDATION_CONFIG,
@@ -628,7 +629,7 @@ class MemoryServer:
                         import importlib
                         storage_module = importlib.import_module('mcp_memory_service.storage.sqlite_vec')
                         SqliteVecMemoryStorage = storage_module.SqliteVecMemoryStorage
-                        self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH)
+                        self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH, embedding_model=EMBEDDING_MODEL_NAME)
                         logger.info(f"✅ EAGER INIT: HTTP server auto-start failed, using direct SQLite-vec storage")
                 else:
                     # Import sqlite-vec storage module (supports dynamic class replacement)
@@ -636,7 +637,7 @@ class MemoryServer:
                     import importlib
                     storage_module = importlib.import_module('mcp_memory_service.storage.sqlite_vec')
                     SqliteVecMemoryStorage = storage_module.SqliteVecMemoryStorage
-                    self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH)
+                    self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH, embedding_model=EMBEDDING_MODEL_NAME)
                     logger.info(f"✅ EAGER INIT: Using direct SQLite-vec storage at {SQLITE_VEC_PATH}")
             elif STORAGE_BACKEND == 'cloudflare':
                 # Initialize Cloudflare storage
@@ -680,7 +681,7 @@ class MemoryServer:
 
                 self.storage = HybridMemoryStorage(
                     sqlite_db_path=SQLITE_VEC_PATH,
-                    embedding_model="all-MiniLM-L6-v2",
+                    embedding_model=EMBEDDING_MODEL_NAME,
                     cloudflare_config=cloudflare_config,
                     sync_interval=HYBRID_SYNC_INTERVAL or 300,
                     batch_size=HYBRID_BATCH_SIZE or 50
@@ -804,14 +805,14 @@ class MemoryServer:
                             import importlib
                             storage_module = importlib.import_module('mcp_memory_service.storage.sqlite_vec')
                             SqliteVecMemoryStorage = storage_module.SqliteVecMemoryStorage
-                            self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH)
+                            self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH, embedding_model=EMBEDDING_MODEL_NAME)
                             logger.info(f"✅ LAZY INIT: HTTP server auto-start failed, using direct SQLite-vec storage at: {SQLITE_VEC_PATH}")
                     else:
                         # Use direct SQLite-vec storage (with WAL mode for concurrent access)
                         import importlib
                         storage_module = importlib.import_module('mcp_memory_service.storage.sqlite_vec')
                         SqliteVecMemoryStorage = storage_module.SqliteVecMemoryStorage
-                        self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH)
+                        self.storage = SqliteVecMemoryStorage(SQLITE_VEC_PATH, embedding_model=EMBEDDING_MODEL_NAME)
                         logger.info(f"✅ LAZY INIT: Created SQLite-vec storage at: {SQLITE_VEC_PATH}")
                 elif STORAGE_BACKEND == 'cloudflare':
                     # Cloudflare backend using Vectorize, D1, and R2
@@ -856,7 +857,7 @@ class MemoryServer:
                     logger.info(f"🔄 LAZY INIT: Creating HybridMemoryStorage instance...")
                     self.storage = HybridMemoryStorage(
                         sqlite_db_path=SQLITE_VEC_PATH,
-                        embedding_model="all-MiniLM-L6-v2",
+                        embedding_model=EMBEDDING_MODEL_NAME,
                         cloudflare_config=cloudflare_config,
                         sync_interval=HYBRID_SYNC_INTERVAL or 300,
                         batch_size=HYBRID_BATCH_SIZE or 50
@@ -3783,6 +3784,7 @@ Memories Archived: {report.memories_archived}"""
             result["storage_cache"]["keys"] = list(_STORAGE_CACHE.keys())
             result["backend_info"] = {
                 "storage_backend": STORAGE_BACKEND,
+    EMBEDDING_MODEL_NAME,
                 "sqlite_path": SQLITE_VEC_PATH
             }
 


### PR DESCRIPTION
## Summary

- Fixes the `MCP_EMBEDDING_MODEL` environment variable being ignored in `server.py`
- Adds `EMBEDDING_MODEL_NAME` import from `.config`
- Replaces hardcoded `"all-MiniLM-L6-v2"` with `EMBEDDING_MODEL_NAME` in storage instantiation

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line ~684, ~860 (HybridMemoryStorage) | `embedding_model="all-MiniLM-L6-v2"` | `embedding_model=EMBEDDING_MODEL_NAME` |
| Lines ~632, ~640, ~808, ~815 (SqliteVecMemoryStorage) | `SqliteVecMemoryStorage(SQLITE_VEC_PATH)` | `SqliteVecMemoryStorage(SQLITE_VEC_PATH, embedding_model=EMBEDDING_MODEL_NAME)` |

## Test Plan

- [x] Verified `MCP_EMBEDDING_MODEL` environment variable is now respected
- [x] Tested with `paraphrase-multilingual-mpnet-base-v2` model
- [x] Confirmed storage initializes with correct embedding model and dimension (768 for multilingual vs 384 for MiniLM)
- [x] Tested both `sqlite_vec` and `hybrid` backends

## Related Issue

Fixes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)