### PR TITLE
fix(install): support uv venvs without pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ For older releases, see [CHANGELOG-HISTORIC.md](./CHANGELOG-HISTORIC.md).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Installer now supports `uv` virtual environments that don’t include `pip` by falling back to `uv pip` (targeting the active interpreter).
 
 ## [8.54.0] - 2025-12-23
 
@@ -2024,4 +2026,3 @@ The fallback implementation remains available for experimentation, but MS-MARCO'
 - `670fb74` - Phase 1: Automated detection (check_dev_setup.py, pre-commit hook, CLAUDE.md)
 - `9537259` - Phase 2: Runtime warnings (server.py) + developer documentation
 - `a17bcc7` - Phase 3: Interactive onboarding (install.py) + CI/CD validation
-

--- a/scripts/installation/install.py
+++ b/scripts/installation/install.py
@@ -13,6 +13,7 @@ import shutil
 from pathlib import Path
 from typing import Tuple, Dict, Any, Optional
 import re
+import importlib.util
 
 def is_python_version_at_least(major, minor):
     """Check if current Python version is at least the specified version.
@@ -192,7 +193,15 @@ def install_package_safe(package, success_msg=None, error_msg=None, fallback_in_
     Returns:
         bool: True if installation succeeded OR if fallback was applied (see warning messages)
     """
-    cmd = [sys.executable, '-m', 'pip', 'install', package]
+    pip_module_available = importlib.util.find_spec("pip") is not None
+    uv_path = shutil.which("uv")
+    if pip_module_available:
+        cmd = [sys.executable, '-m', 'pip', 'install', package]
+    elif uv_path:
+        # uv environments commonly omit pip; use uv to install into the current interpreter
+        cmd = [uv_path, 'pip', 'install', '--python', sys.executable, package]
+    else:
+        cmd = [sys.executable, '-m', 'pip', 'install', package]
     default_success = success_msg or f"{package} installed successfully"
     default_error = error_msg or f"Failed to install {package}"
 
@@ -348,7 +357,7 @@ def check_dependencies():
             if in_venv:
                 print_warning("pip could not be detected, but you're in a virtual environment. "
                             "If you're using uv or another alternative package manager, this is normal. "
-                            "Continuing installation...")
+                            "Continuing installation (will use uv where needed)...")
                 pip_installed = True  # Proceed anyway
             else:
                 print_error("pip is not installed. Please install pip first.")
@@ -1090,7 +1099,10 @@ def _setup_storage_and_gpu_environment(args, system_info, gpu_info, env):
             
             # First try to install without ML dependencies
             try:
-                cmd = installer_cmd + ['install', '--no-deps'] + install_mode + ['.']
+                cmd = installer_cmd + ['install']
+                if len(installer_cmd) >= 2 and Path(installer_cmd[0]).stem == "uv" and installer_cmd[1] == "pip":
+                    cmd += ['--python', sys.executable]
+                cmd += ['--no-deps'] + install_mode + ['.']
                 success, _ = run_command_safe(
                     cmd,
                     success_msg="Package installed with --no-deps successfully",
@@ -1114,7 +1126,14 @@ def _setup_storage_and_gpu_environment(args, system_info, gpu_info, env):
                     dependencies.append("chromadb==0.5.23")
                 
                 # Install dependencies
-                cmd = [sys.executable, '-m', 'pip', 'install'] + dependencies
+                pip_module_available = importlib.util.find_spec("pip") is not None
+                uv_path = shutil.which("uv")
+                if pip_module_available:
+                    cmd = [sys.executable, '-m', 'pip', 'install'] + dependencies
+                elif uv_path:
+                    cmd = [uv_path, 'pip', 'install', '--python', sys.executable] + dependencies
+                else:
+                    cmd = [sys.executable, '-m', 'pip', 'install'] + dependencies
                 success, _ = run_command_safe(
                     cmd,
                     success_msg="Core dependencies installed successfully",
@@ -1167,7 +1186,10 @@ def _setup_storage_and_gpu_environment(args, system_info, gpu_info, env):
             print_info("Installing lightweight version (no ML dependencies by default)")
             print_info("For full functionality, use --with-ml flag or install with: pip install mcp-memory-service[ml]")
 
-        cmd = installer_cmd + ['install'] + install_mode + install_target
+        cmd = installer_cmd + ['install']
+        if len(installer_cmd) >= 2 and Path(installer_cmd[0]).stem == "uv" and installer_cmd[1] == "pip":
+            cmd += ['--python', sys.executable]
+        cmd += install_mode + install_target
         success, _ = run_command_safe(
             cmd,
             success_msg="MCP Memory Service installed successfully",

--- a/tests/unit/test_uv_no_pip_installer_fallback.py
+++ b/tests/unit/test_uv_no_pip_installer_fallback.py
@@ -80,3 +80,13 @@ def test_scripts_installer_uses_uv_when_pip_module_missing(monkeypatch):
     assert "--python" in recorded["cmd"]
     assert sys.executable in recorded["cmd"]
     assert "sqlite-vec" in recorded["cmd"]
+
+
+def test_scripts_installer_returns_false_when_no_pip_and_no_uv(monkeypatch):
+    from scripts.installation import install as scripts_install
+
+    monkeypatch.setattr(scripts_install.importlib.util, "find_spec", lambda name: None)
+    monkeypatch.setattr(scripts_install.shutil, "which", lambda name: None)
+
+    ok = scripts_install.install_package_safe("sqlite-vec", fallback_in_venv=False)
+    assert ok is False

--- a/tests/unit/test_uv_no_pip_installer_fallback.py
+++ b/tests/unit/test_uv_no_pip_installer_fallback.py
@@ -1,0 +1,82 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_install_py_module(monkeypatch, base_dir: Path):
+    repo_root = Path(__file__).resolve().parents[2]
+    # Avoid touching user-global app support directories during import.
+    monkeypatch.setenv("MCP_MEMORY_BASE_DIR", str(base_dir))
+    install_py = repo_root / "install.py"
+    spec = importlib.util.spec_from_file_location("mcp_memory_service_install_py", install_py)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_install_py_uses_pip_when_available(monkeypatch, tmp_path):
+    install_module = _load_install_py_module(monkeypatch, tmp_path)
+
+    recorded = {}
+
+    def fake_check_call(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(install_module, "_pip_available", lambda: True)
+    monkeypatch.setattr(install_module, "subprocess", install_module.subprocess)
+    monkeypatch.setattr(install_module.subprocess, "check_call", fake_check_call)
+
+    install_module._install_python_packages(["sqlite-vec"], extra_args=["--no-deps"], silent=True)
+
+    assert recorded["cmd"][:4] == [sys.executable, "-m", "pip", "install"]
+    assert "--no-deps" in recorded["cmd"]
+    assert "sqlite-vec" in recorded["cmd"]
+    assert "stdout" in recorded["kwargs"]
+    assert "stderr" in recorded["kwargs"]
+
+
+def test_install_py_uses_uv_when_pip_missing(monkeypatch, tmp_path):
+    install_module = _load_install_py_module(monkeypatch, tmp_path)
+
+    recorded = {}
+
+    def fake_check_call(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(install_module, "_pip_available", lambda: False)
+    monkeypatch.setattr(install_module, "_uv_executable", lambda: "/opt/homebrew/bin/uv")
+    monkeypatch.setattr(install_module.subprocess, "check_call", fake_check_call)
+
+    install_module._install_python_packages(["sqlite-vec"])
+
+    assert recorded["cmd"][:3] == ["/opt/homebrew/bin/uv", "pip", "install"]
+    assert "--python" in recorded["cmd"]
+    assert sys.executable in recorded["cmd"]
+    assert "sqlite-vec" in recorded["cmd"]
+
+
+def test_scripts_installer_uses_uv_when_pip_module_missing(monkeypatch):
+    from scripts.installation import install as scripts_install
+
+    recorded = {}
+
+    def fake_run_command_safe(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["kwargs"] = kwargs
+        return True, None
+
+    monkeypatch.setattr(scripts_install.importlib.util, "find_spec", lambda name: None)
+    monkeypatch.setattr(scripts_install.shutil, "which", lambda name: "/opt/homebrew/bin/uv")
+    monkeypatch.setattr(scripts_install, "run_command_safe", fake_run_command_safe)
+
+    ok = scripts_install.install_package_safe("sqlite-vec", fallback_in_venv=False)
+    assert ok is True
+    assert recorded["cmd"][:3] == ["/opt/homebrew/bin/uv", "pip", "install"]
+    assert "--python" in recorded["cmd"]
+    assert sys.executable in recorded["cmd"]
+    assert "sqlite-vec" in recorded["cmd"]


### PR DESCRIPTION
  # Pull Request

  ## Description
  Fix installer failure in `uv`-created virtual environments that don’t include `pip` by falling back to `uv pip` for package installation
  (including sqlite-vec backend install).

  ## Motivation
  `uv venv` environments may omit `pip`, causing `python -m pip install sqlite-vec` to fail with `No module named pip` during installer step
  [3c]. This prevents sqlite-vec installs even though `uv` is detected earlier.

  ## Type of Change
  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [x] 🧪 Test improvement
  - [ ] ♻️ Code refactoring (no functional changes)
  - [ ] ⚡ Performance improvement
  - [ ] 🔧 Configuration change
  - [ ] 🎨 UI/UX improvement

  ## Changes
  - Use `uv pip install --python <sys.executable>` when `python -m pip` is unavailable in `install.py` and `scripts/installation/install.py`.
  - Ensure `uv pip install` calls target the current interpreter to avoid installing into the wrong environment.
  - Add unit tests covering pip-present vs pip-missing (uv fallback) behavior.
  - Add CHANGELOG entry under `[Unreleased]`.

  **Breaking Changes** (if any):
  - None

  ## Testing

  ### How Has This Been Tested?
  - [x] Unit tests
  - [ ] Integration tests
  - [x] Manual testing
  - [ ] MCP Inspector validation

  **Test Configuration**:
  - Python version: 3.12.x
  - uv 0.9.18 (Homebrew 2025-12-16)
  - OS: macOS (Apple Silicon)
  - Storage backend: sqlite_vec
  - Installation method: `uv venv` + `python install.py`

  Commands:
  - `python -m pytest tests/unit/test_uv_no_pip_installer_fallback.py -q`

  Manual repro:
  - `uv venv .venv`
  - `.venv/bin/python3 -c "import pip"` (fails as expected)
  - `.venv/bin/python3 install.py --storage-backend sqlite_vec` (no longer fails on sqlite-vec install step)

  ### Test Coverage
  - [x] Added new tests
  - [ ] Updated existing tests
  - [ ] Test coverage maintained/improved

  ## Related Issues
  Fixes #284
  Closes #
  Relates to #

  ## Screenshots

  ## Documentation
  - [ ] Updated README.md
  - [ ] Updated CLAUDE.md
  - [ ] Updated AGENTS.md
  - [x] Updated CHANGELOG.md
  - [ ] Updated Wiki pages
  - [ ] Updated code comments/docstrings
  - [ ] Added API documentation
  - [ ] No documentation needed

  ## Pre-submission Checklist
  - [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
  - [x] ✅ I have performed a self-review of my code
  - [ ] ✅ I have commented my code, particularly in hard-to-understand areas
  - [ ] ✅ I have made corresponding changes to the documentation
  - [ ] ✅ My changes generate no new warnings
  - [x] ✅ I have added tests that prove my fix is effective or that my feature works
  - [x] ✅ New and existing unit tests pass locally with my changes
  - [ ] ✅ Any dependent changes have been merged and published
  - [x] ✅ I have updated CHANGELOG.md following Keep a Changelog format
  - [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
  - [ ] ✅ I have verified this works with all supported storage backends (if applicable)

  ## Additional Notes
  Some integration tests require additional optional test dependencies (e.g. `pytest-asyncio`, `python-dotenv`) and were not run here; this PR
  focuses on installer fallback behavior and includes targeted unit coverage.