### PR TITLE
chore: release v8.54.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [8.54.3] - 2025-12-25
+
+### Fixed
+- **Chunked Storage**: Fixed bug where storing content exceeding `max_content_length` would return `success: True` with "Successfully stored 0 memory chunks" when all chunks failed (e.g., due to duplicates)
+  - Now correctly returns `success: False` with descriptive error message when all chunks fail
+  - Added `failed_chunks` field to chunked success response for partial failures
+  - Includes failure reasons in error message (e.g., "Duplicate content detected")
+  - Added regression tests: `test_chunked_storage_all_chunks_fail` and `test_chunked_storage_partial_success`
+
 ## [8.54.2] - 2025-12-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop with SQLite-vec, Cloudflare, and Hybrid storage backends.
 
-> **🆕 v8.54.2**: **Offline Mode Fix** - Changed offline mode from always-on to opt-in to allow first-time installations to download models. Offline mode now only activates when `MCP_MEMORY_OFFLINE=1` is explicitly set, fixing "outgoing traffic has been disabled" error during fresh installs (#286). See [CHANGELOG.md](CHANGELOG.md) for full version history.
+> **🆕 v8.54.3**: **Chunked Storage Fix** - Fixed chunked storage to correctly return `success: False` when all chunks fail to store (e.g., due to duplicates), preventing confusing "Successfully stored 0 memory chunks" messages. Improved error reporting with failure reasons and partial success tracking. See [CHANGELOG.md](CHANGELOG.md) for full version history.
 >
 > **Note**: When releasing new versions, update this line with current version + brief description. Use `.claude/agents/github-release-manager.md` agent for complete release workflow.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.54.2"
+version = "8.54.3"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "8.54.2"
+__version__ = "8.54.3"

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -347,7 +347,7 @@ class MemoryService:
                     "memories": stored_memories,
                     "total_chunks": len(chunks),
                     "original_hash": content_hash,
-                    "failed_chunks": len(failed_chunks) if failed_chunks else 0
+                    "failed_chunks": len(failed_chunks)
                 }
             else:
                 # Store as single memory

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -8,6 +8,10 @@ all memory operations, eliminating the DRY violation and ensuring consistent beh
 
 import logging
 from typing import Dict, List, Optional, Any, Union, Tuple, TypedDict
+try:
+    from typing import NotRequired  # Python 3.11+
+except ImportError:
+    from typing_extensions import NotRequired  # Python 3.10
 from datetime import datetime
 
 from ..config import (
@@ -82,6 +86,7 @@ class StoreMemoryChunkedSuccess(TypedDict):
     memories: List[MemoryResult]
     total_chunks: int
     original_hash: str
+    failed_chunks: NotRequired[int]  # Number of chunks that failed to store
 
 
 class StoreMemoryFailure(TypedDict):
@@ -305,6 +310,7 @@ class MemoryService:
                     overlap=CONTENT_SPLIT_OVERLAP
                 )
                 stored_memories = []
+                failed_chunks = []
 
                 for i, chunk in enumerate(chunks):
                     chunk_hash = generate_content_hash(chunk)
@@ -324,12 +330,24 @@ class MemoryService:
                     success, message = await self.storage.store(memory)
                     if success:
                         stored_memories.append(self._format_memory_response(memory))
+                    else:
+                        failed_chunks.append({"index": i, "reason": message})
 
+                # If NO chunks were stored, return failure
+                if not stored_memories:
+                    reasons = ", ".join(set(fc["reason"] for fc in failed_chunks))
+                    return {
+                        "success": False,
+                        "error": f"Failed to store all {len(chunks)} chunks: {reasons}"
+                    }
+
+                # If SOME chunks were stored, return partial success
                 return {
                     "success": True,
                     "memories": stored_memories,
                     "total_chunks": len(chunks),
-                    "original_hash": content_hash
+                    "original_hash": content_hash,
+                    "failed_chunks": len(failed_chunks) if failed_chunks else 0
                 }
             else:
                 # Store as single memory

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "8.54.2"
+version = "8.54.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Fix chunked storage false success reporting when all chunks fail
- Improve error messages and partial failure tracking

## Bug Fix
**Issue**: Chunked storage (when content exceeds max_content_length) would return `success: True` with "Successfully stored 0 memory chunks" when all chunks failed to store (e.g., due to duplicates).

**Root Cause**: Code returned success=True even when stored_memories list was empty.

**Solution**:
- Track failed chunks with reasons
- Return `success: False` when all chunks fail
- Include descriptive error messages with failure reasons
- Add `failed_chunks` counter for partial failures

## Implementation Details

### Changes to `memory_service.py`
1. Added `NotRequired` import for Python 3.10 compatibility
2. Extended `StoreMemoryChunkedSuccess` TypedDict with `failed_chunks: NotRequired[int]` field
3. Fixed chunked storage logic (lines 297-346):
   - Track failed chunks with reasons
   - Return `success: False` when all chunks fail
   - Include failure reasons in error message
   - Add `failed_chunks` counter for partial failures

### Test Coverage
Added two regression tests in `test_memory_service.py`:
- `test_chunked_storage_all_chunks_fail` - Verifies correct error handling when all chunks fail
- `test_chunked_storage_partial_success` - Verifies partial failure tracking

Both tests PASS ✅

## Version Bump
PATCH bump: v8.54.2 → v8.54.3

**Files Updated**:
- `src/mcp_memory_service/_version.py`
- `pyproject.toml`
- `uv.lock`
- `CHANGELOG.md`
- `CLAUDE.md`

## Impact
- Users get clear error feedback when chunked storage fails
- Partial failures are transparently reported
- No more confusing "Successfully stored 0 memory chunks" messages

## Testing
```bash
pytest tests/unit/test_memory_service.py::test_chunked_storage_all_chunks_fail -v
pytest tests/unit/test_memory_service.py::test_chunked_storage_partial_success -v
```

All tests pass including new regression tests.

## Checklist
- [x] Bug fix implemented
- [x] Regression tests added (2 tests)
- [x] All tests passing
- [x] Version bumped (PATCH)
- [x] CHANGELOG.md updated
- [x] CLAUDE.md updated
- [ ] Gemini review requested
- [ ] Tests passing in CI
- [ ] Ready to merge

---

🤖 Generated with github-release-manager agent