### PR TITLE
fix: critical bugfix in check_database_health MCP tool (v8.54.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [8.54.4] - 2025-12-26
+
+### Fixed
+- **MCP Tools**: Fixed critical bug in `check_database_health` MCP tool that prevented it from working (#288)
+  - Corrected method call from non-existent `check_database_health()` to proper `health_check()` method
+  - Tool now properly returns database health status and statistics
+
 ## [8.54.3] - 2025-12-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop with SQLite-vec, Cloudflare, and Hybrid storage backends.
 
-> **🆕 v8.54.3**: **Chunked Storage Fix** - Fixed chunked storage to correctly return `success: False` when all chunks fail to store (e.g., due to duplicates), preventing confusing "Successfully stored 0 memory chunks" messages. Improved error reporting with failure reasons and partial success tracking. See [CHANGELOG.md](CHANGELOG.md) for full version history.
+> **🆕 v8.54.4**: **Critical MCP Tool Bugfix** - Fixed `check_database_health` MCP tool that was calling non-existent method, preventing database health status retrieval. Tool now properly returns health statistics. See [CHANGELOG.md](CHANGELOG.md) for full version history.
 >
 > **Note**: When releasing new versions, update this line with current version + brief description. Use `.claude/agents/github-release-manager.md` agent for complete release workflow.
 

--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ Choose from:
 
 ---
 
-## 🆕 Latest Release: **v8.54.3** (Dec 25, 2025)
+## 🆕 Latest Release: **v8.54.4** (Dec 26, 2025)
 
-**Chunked Storage Error Reporting Fix**
+**Critical MCP Tool Bugfix**
 
-- 🔧 **Accurate Error Messages** - Fixed confusing "Successfully stored 0 memory chunks" when all chunks fail
-- ✅ **Proper Failure Handling** - Returns `success: False` when no chunks can be stored (e.g., duplicates)
-- 📊 **Partial Success Tracking** - Added `failed_chunks` counter for transparency in mixed outcomes
-- 🐛 **Comprehensive Testing** - 2 new regression tests ensure bug won't reoccur
+- 🐛 **Database Health Check Fixed** - `check_database_health` MCP tool now works correctly
+- 🔧 **Method Call Correction** - Fixed critical method name mismatch preventing health status retrieval
+- ✅ **Restored Functionality** - Tool properly returns database health statistics and status
 
 **Previous Releases**:
+- **v8.54.3** - Chunked Storage Error Reporting Fix (accurate failure messages, partial success tracking)
 - **v8.54.2** - Offline Mode Fix (opt-in offline mode, first-time install support)
 - **v8.54.1** - UV Virtual Environment Support (installer compatibility fix)
 - **v8.54.0** - Smart Auto-Capture System (intelligent pattern detection, 6 memory types, bilingual support)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.54.3"
+version = "8.54.4"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "8.54.3"
+__version__ = "8.54.4"

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -428,7 +428,7 @@ async def check_database_health(ctx: Context) -> Dict[str, Any]:
     """
     # Delegate to shared MemoryService business logic
     memory_service = ctx.request_context.lifespan_context.memory_service
-    return await memory_service.check_database_health()
+    return await memory_service.health_check()
 
 @mcp.tool()
 async def list_memories(

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "8.54.3"
+version = "8.54.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes
- Fixed critical bug in check_database_health MCP tool (#288)
- Corrected method call from non-existent check_database_health() to proper health_check() method
- Version bump to v8.54.4 (patch release)
- Updated CHANGELOG.md, README.md, and CLAUDE.md

## Motivation
The check_database_health MCP tool was completely non-functional due to calling a method that does not exist on the MemoryService class. This prevented users from checking database health status via MCP.

## Testing
- Verified method name matches MemoryService implementation
- Confirmed all other health check endpoints use health_check() method

## Related Issues
Fixes #288

## Checklist
- [x] Version bumped in _version.py and pyproject.toml
- [x] CHANGELOG.md updated
- [x] README.md updated
- [x] CLAUDE.md updated
- [x] uv.lock updated