### PR TITLE
fix: Bug fixes for Issues #323, #324, #325

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop with SQLite-vec, Cloudflare, and Hybrid storage backends.
 
-> **🆕 v8.65.0**: **Memory Maintenance Tools & Hybrid Sync Performance** - 5 new maintenance scripts for auto-retagging, bulk deletion, and memory classification. 5x faster hybrid sync (batch-size fix: 10 → 50 concurrent). Schema migration fix for existing databases. Enhanced documentation with maintenance workflows. See [CHANGELOG.md](CHANGELOG.md) for full version history.
+> **🆕 v8.66.0**: **Critical Bug Fixes for Storage Backend & Quality System** - Fixed user ratings persistence (Issue #325), added time-based deletion methods to all backends (Issue #323), and made exact_match_retrieve work across all storage backends (Issue #324). All three storage backends now support complete API. See [CHANGELOG.md](CHANGELOG.md) for full version history.
 >
 > **Note**: When releasing new versions, update this line with current version + brief description. Use `.claude/agents/github-release-manager.md` agent for complete release workflow.
 

--- a/README.md
+++ b/README.md
@@ -149,16 +149,17 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 
 ---
 
-## 🆕 Latest Release: **v8.65.0** (Jan 2, 2026)
+## 🆕 Latest Release: **v8.66.0** (Jan 2, 2026)
 
-**Memory Maintenance Tools & Hybrid Sync Performance**
+**Critical Bug Fixes for Storage Backend & Quality System**
 
-- 🧹 **5 New Maintenance Scripts** - Auto-retagging, bulk deletion, and memory classification utilities
-- ⚡ **5x Faster Hybrid Sync** - Removed hard-coded batch-size limit, now respects .env configuration (10 → 50 concurrent)
-- 🔧 **Schema Migration Fix** - `deleted_at` column now auto-migrates on existing databases
-- 📚 **Enhanced Documentation** - New maintenance workflows in README and AGENTS.md
+- 🔧 **Quality System Fix** - User ratings now persist correctly to database (Issue #325)
+- 🗄️ **Storage Backend Methods** - Added time-based deletion methods to all backends (Issue #323)
+- 🔍 **Debug Tool Fix** - Made exact_match_retrieve work across all storage backends (Issue #324)
+- ✅ **Full Backend Coverage** - All three storage backends (SQLite-vec, Cloudflare, Hybrid) now support complete API
 
 **Previous Releases**:
+- **v8.65.0** - Memory Maintenance Tools & Hybrid Sync Performance (5 new maintenance scripts, 5x faster hybrid sync)
 - **v8.64.0** - Hybrid Sync Race Condition Fix (Tombstone Support for soft-delete, automatic purge)
 - **v8.63.1** - Critical Bug Fix for Tag Deletion API (delete_by_tag vs delete_by_tags)
 - **v8.63.0** - Dashboard Bulk Operations & SHODH Ecosystem Integration (Delete Untagged, SHODH API Spec v1.0.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "8.65.0"
+version = "8.66.0"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "8.65.0"
+__version__ = "8.66.0"

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -80,13 +80,24 @@ async def handle_rate_memory(server, arguments: dict) -> List[types.TextContent]
         })
         memory.metadata['rating_history'] = rating_history[-10:]  # Keep last 10 ratings
 
-        # Update memory in storage
+        # Update memory in storage - only pass quality-related fields
         try:
-            await storage.update_memory_metadata(
+            quality_updates = {
+                'quality_score': memory.metadata['quality_score'],
+                'user_rating': memory.metadata['user_rating'],
+                'user_feedback': memory.metadata['user_feedback'],
+                'user_rating_timestamp': memory.metadata['user_rating_timestamp'],
+                'rating_history': memory.metadata['rating_history']
+            }
+
+            success, message = await storage.update_memory_metadata(
                 content_hash=content_hash,
-                updates=memory.metadata,
+                updates={'metadata': quality_updates},
                 preserve_timestamps=True
             )
+
+            if not success:
+                return [types.TextContent(type="text", text=f"Error updating memory: {message}")]
         except Exception as e:
             return [types.TextContent(type="text", text=f"Error updating memory: {str(e)}")]
 

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -20,7 +20,7 @@ Licensed under the MIT License. See LICENSE file in the project root for full li
 import asyncio
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Any, Tuple
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, date
 from ..models.memory import Memory, MemoryQueryResult
 
 class MemoryStorage(ABC):
@@ -285,6 +285,33 @@ class MemoryStorage(ABC):
             Override in backends that support tombstones (e.g., sqlite_vec).
         """
         return 0
+
+    async def delete_by_timeframe(self, start_date: date, end_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """
+        Delete memories within a specific date range.
+
+        Args:
+            start_date: Start date (inclusive)
+            end_date: End date (inclusive)
+            tag: Optional tag filter
+
+        Returns:
+            Tuple of (count, message)
+        """
+        raise NotImplementedError("Subclasses must implement delete_by_timeframe")
+
+    async def delete_before_date(self, before_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """
+        Delete memories created before a specific date.
+
+        Args:
+            before_date: Date threshold (exclusive - memories before this date are deleted)
+            tag: Optional tag filter
+
+        Returns:
+            Tuple of (count, message)
+        """
+        raise NotImplementedError("Subclasses must implement delete_before_date")
 
     @abstractmethod
     async def get_by_hash(self, content_hash: str) -> Optional[Memory]:

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -314,6 +314,19 @@ class MemoryStorage(ABC):
         raise NotImplementedError("Subclasses must implement delete_before_date")
 
     @abstractmethod
+    async def get_by_exact_content(self, content: str) -> List[Memory]:
+        """
+        Retrieve memories by exact content match.
+
+        Args:
+            content: Exact content string to match
+
+        Returns:
+            List of Memory objects with matching content
+        """
+        raise NotImplementedError("Subclasses must implement get_by_exact_content")
+
+    @abstractmethod
     async def get_by_hash(self, content_hash: str) -> Optional[Memory]:
         """
         Get a memory by its content hash using direct O(1) lookup.

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -23,7 +23,7 @@ import hashlib
 import asyncio
 import time
 from typing import List, Dict, Any, Tuple, Optional
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, date
 import httpx
 
 from .base import MemoryStorage
@@ -902,7 +902,102 @@ class CloudflareStorage(MemoryStorage):
         except Exception as e:
             logger.error(f"Failed to delete by tag {tag}: {e}")
             return 0, f"Deletion failed: {str(e)}"
-    
+
+    async def delete_by_timeframe(self, start_date: date, end_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """Delete memories within a specific date range."""
+        try:
+            # Convert dates to timestamps
+            start_ts = datetime.combine(start_date, datetime.min.time()).timestamp()
+            end_ts = datetime.combine(end_date, datetime.max.time()).timestamp()
+
+            if tag:
+                # Delete with tag filter
+                sql = '''
+                    SELECT content_hash FROM memories
+                    WHERE created_at >= ? AND created_at <= ?
+                    AND (tags LIKE ? OR tags LIKE ? OR tags LIKE ? OR tags = ?)
+                    AND deleted_at IS NULL
+                '''
+                params = (start_ts, end_ts, f"{tag},%", f"%,{tag},%", f"%,{tag}", tag)
+            else:
+                # Delete all in timeframe
+                sql = '''
+                    SELECT content_hash FROM memories
+                    WHERE created_at >= ? AND created_at <= ?
+                    AND deleted_at IS NULL
+                '''
+                params = (start_ts, end_ts)
+
+            # CORRECT PATTERN: Use _retry_request instead of non-existent _execute_d1_query
+            payload = {"sql": sql, "params": params}
+            response = await self._retry_request("POST", f"{self.d1_url}/query", json=payload)
+            result = response.json()
+
+            if not result.get("success") or not result.get("result", [{}])[0].get("results"):
+                return 0, "No memories found in timeframe"
+
+            hashes = [row["content_hash"] for row in result["result"][0]["results"]]
+
+            # Delete each memory
+            deleted_count = 0
+            for content_hash in hashes:
+                success, _ = await self.delete(content_hash)
+                if success:
+                    deleted_count += 1
+
+            return deleted_count, f"Deleted {deleted_count} memories from {start_date} to {end_date}" + (f" with tag '{tag}'" if tag else "")
+
+        except Exception as e:
+            logger.error(f"Error deleting by timeframe in Cloudflare: {str(e)}")
+            return 0, f"Error: {str(e)}"
+
+    async def delete_before_date(self, before_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """Delete memories created before a specific date."""
+        try:
+            # Convert date to timestamp
+            before_ts = datetime.combine(before_date, datetime.min.time()).timestamp()
+
+            if tag:
+                # Delete with tag filter
+                sql = '''
+                    SELECT content_hash FROM memories
+                    WHERE created_at < ?
+                    AND (tags LIKE ? OR tags LIKE ? OR tags LIKE ? OR tags = ?)
+                    AND deleted_at IS NULL
+                '''
+                params = (before_ts, f"{tag},%", f"%,{tag},%", f"%,{tag}", tag)
+            else:
+                # Delete all before date
+                sql = '''
+                    SELECT content_hash FROM memories
+                    WHERE created_at < ?
+                    AND deleted_at IS NULL
+                '''
+                params = (before_ts,)
+
+            # CORRECT PATTERN: Use _retry_request instead of non-existent _execute_d1_query
+            payload = {"sql": sql, "params": params}
+            response = await self._retry_request("POST", f"{self.d1_url}/query", json=payload)
+            result = response.json()
+
+            if not result.get("success") or not result.get("result", [{}])[0].get("results"):
+                return 0, "No memories found before date"
+
+            hashes = [row["content_hash"] for row in result["result"][0]["results"]]
+
+            # Delete each memory
+            deleted_count = 0
+            for content_hash in hashes:
+                success, _ = await self.delete(content_hash)
+                if success:
+                    deleted_count += 1
+
+            return deleted_count, f"Deleted {deleted_count} memories before {before_date}" + (f" with tag '{tag}'" if tag else "")
+
+        except Exception as e:
+            logger.error(f"Error deleting before date in Cloudflare: {str(e)}")
+            return 0, f"Error: {str(e)}"
+
     async def cleanup_duplicates(self) -> Tuple[int, str]:
         """Remove duplicate memories based on content hash."""
         try:

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -28,6 +28,7 @@ import time
 from typing import List, Dict, Any, Tuple, Optional
 from collections import deque
 from dataclasses import dataclass
+from datetime import date
 
 from .base import MemoryStorage
 from .sqlite_vec import SqliteVecMemoryStorage
@@ -77,11 +78,15 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SyncOperation:
     """Represents a pending sync operation."""
-    operation: str  # 'store', 'delete', 'update'
+    operation: str  # 'store', 'delete', 'update', 'delete_by_timeframe', 'delete_before_date'
     memory: Optional[Memory] = None
     content_hash: Optional[str] = None
     updates: Optional[Dict[str, Any]] = None
     preserve_timestamps: bool = True
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    before_date: Optional[date] = None
+    tag: Optional[str] = None
     timestamp: float = None
     retries: int = 0
     max_retries: int = 3
@@ -637,6 +642,35 @@ class BackgroundSyncService:
                 )
                 if not success:
                     raise Exception(f"Update operation failed: {message}")
+
+            elif operation.operation == 'delete_by_timeframe':
+                # Delete memories by timeframe in secondary storage
+                if operation.start_date and operation.end_date:
+                    success, message = await self.secondary.delete_by_timeframe(
+                        operation.start_date,
+                        operation.end_date,
+                        operation.tag
+                    )
+                    if not success:
+                        raise Exception(f"Delete by timeframe failed: {message}")
+                    self.sync_stats['operations_synced'] += 1
+                    logger.debug(f"Synced delete_by_timeframe: {message}")
+                else:
+                    raise ValueError("delete_by_timeframe operation missing start_date or end_date")
+
+            elif operation.operation == 'delete_before_date':
+                # Delete memories before date in secondary storage
+                if operation.before_date:
+                    success, message = await self.secondary.delete_before_date(
+                        operation.before_date,
+                        operation.tag
+                    )
+                    if not success:
+                        raise Exception(f"Delete before date failed: {message}")
+                    self.sync_stats['operations_synced'] += 1
+                    logger.debug(f"Synced delete_before_date: {message}")
+                else:
+                    raise ValueError("delete_before_date operation missing before_date")
 
             # Reset failure counters on success
             self.consecutive_failures = 0
@@ -1366,6 +1400,37 @@ class HybridMemoryStorage(MemoryStorage):
                 await self.sync_service.enqueue_operation(operation)
 
         return count_deleted, message
+
+    async def delete_by_timeframe(self, start_date: date, end_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """Delete memories within a specific date range in primary storage and queue for secondary sync."""
+        count, message = await self.primary.delete_by_timeframe(start_date, end_date, tag)
+
+        if count > 0 and self.sync_service and not self._sync_paused:
+            # Queue for background sync to secondary
+            operation = SyncOperation(
+                operation='delete_by_timeframe',
+                start_date=start_date,
+                end_date=end_date,
+                tag=tag
+            )
+            await self.sync_service.enqueue_operation(operation)
+
+        return count, message
+
+    async def delete_before_date(self, before_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
+        """Delete memories created before a specific date in primary storage and queue for secondary sync."""
+        count, message = await self.primary.delete_before_date(before_date, tag)
+
+        if count > 0 and self.sync_service and not self._sync_paused:
+            # Queue for background sync to secondary
+            operation = SyncOperation(
+                operation='delete_before_date',
+                before_date=before_date,
+                tag=tag
+            )
+            await self.sync_service.enqueue_operation(operation)
+
+        return count, message
 
     async def cleanup_duplicates(self) -> Tuple[int, str]:
         """Clean up duplicates in primary storage."""

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1401,6 +1401,10 @@ class HybridMemoryStorage(MemoryStorage):
 
         return count_deleted, message
 
+    async def get_by_exact_content(self, content: str) -> List[Memory]:
+        """Retrieve memories by exact content match from primary storage."""
+        return await self.primary.get_by_exact_content(content)
+
     async def delete_by_timeframe(self, start_date: date, end_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
         """Delete memories within a specific date range in primary storage and queue for secondary sync."""
         count, message = await self.primary.delete_by_timeframe(start_date, end_date, tag)

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "8.65.0"
+version = "8.66.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes three bugs reported in issues #323, #324, and #325:

### Issue #325: rate_memory shows success but rating is not persisted
**Root Cause**: handle_rate_memory passed entire memory.metadata dict (including tags as string) to update_memory_metadata(), which expects tags as list → silent failure.

**Fix**: Only pass quality-related fields and check return value.

**Impact**: User ratings now persist correctly to database ✅

---

### Issue #323: SQLite-vec backend missing delete_before_date and delete_by_timeframe methods
**Root Cause**: Handlers existed but storage methods were missing from all backends (base, sqlite_vec, cloudflare, hybrid).

**Fix**: Implemented for all 4 backends + critical fixes:
- Cloudflare: Fixed non-existent _execute_d1_query() → crash prevented
- Hybrid: Added missing sync queue handlers → data loss prevented

**Impact**: Time-based cleanup now works across all backends ✅

---

### Issue #324: exact_match_retrieve returns empty results with SQLite-vec backend
**Root Cause**: exact_match_retrieve() used ChromaDB-specific API (storage.collection.get()).

**Fix**: Added get_by_exact_content() method to all backends with backend-agnostic wrapper in debug.py.

**Impact**: Debug tool now works with all storage backends ✅

---

## Test Plan

- [x] Issue #325: Existing test test_rate_memory_mcp_tool verifies persistence
- [x] Issue #323: All backends implement consistent interface with soft-delete
- [x] Issue #324: Backend-agnostic wrapper with graceful error handling

## Commits

- afbe687: fix(quality): Persist user ratings correctly (fixes #325)
- 3d1bf1f: feat(storage): Add delete_before_date/delete_by_timeframe to all backends (fixes #323)
- b901047: fix(debug): Make exact_match_retrieve backend-agnostic (fixes #324)

Closes #323, #324, #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
