### PR TITLE
feat: Add official lite distribution support (mcp-memory-service-lite)

### DIFF
--- a/.github/workflows/publish-dual.yml
+++ b/.github/workflows/publish-dual.yml
@@ -1,0 +1,116 @@
+name: Publish Dual Distribution (Main + Lite)
+
+# This workflow publishes both mcp-memory-service (full) and mcp-memory-service-lite (lightweight)
+# Both packages share the same codebase but have different dependencies
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 8.75.1)'
+        required: true
+        type: string
+
+jobs:
+  publish-main:
+    name: Publish Main Package (with PyTorch)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build hatchling twine
+
+    - name: Build main package
+      run: |
+        echo "Building mcp-memory-service (full version with PyTorch)"
+        python -m build
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m twine upload dist/* --skip-existing
+
+  publish-lite:
+    name: Publish Lite Package (ONNX only)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build hatchling twine
+
+    - name: Prepare lite package
+      run: |
+        echo "Preparing mcp-memory-service-lite (lightweight ONNX version)"
+        cp pyproject.toml pyproject-main.toml
+        cp pyproject-lite.toml pyproject.toml
+
+    - name: Build lite package
+      run: |
+        python -m build
+
+    - name: Publish lite to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m twine upload dist/* --skip-existing
+
+    - name: Restore original pyproject.toml
+      run: |
+        mv pyproject-main.toml pyproject.toml
+
+  verify-packages:
+    name: Verify Both Packages
+    runs-on: ubuntu-latest
+    needs: [publish-main, publish-lite]
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Wait for PyPI to update
+      run: sleep 60
+
+    - name: Test main package install
+      run: |
+        pip install mcp-memory-service --dry-run
+        echo "Main package available on PyPI"
+
+    - name: Test lite package install
+      run: |
+        pip install mcp-memory-service-lite --dry-run
+        echo "Lite package available on PyPI"

--- a/.github/workflows/publish-dual.yml
+++ b/.github/workflows/publish-dual.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Publish to PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         python -m twine upload dist/* --skip-existing
 
@@ -83,9 +83,12 @@ jobs:
     - name: Publish lite to PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         python -m twine upload dist/* --skip-existing
+
+    - name: Clean build artifacts
+      run: rm -rf dist/ build/ *.egg-info
 
     - name: Restore original pyproject.toml
       run: |
@@ -107,10 +110,12 @@ jobs:
 
     - name: Test main package install
       run: |
-        pip install mcp-memory-service --dry-run
-        echo "Main package available on PyPI"
+        python -m venv /tmp/test-main
+        /tmp/test-main/bin/pip install mcp-memory-service
+        /tmp/test-main/bin/python -c "import mcp_memory_service; print('Main package OK')"
 
     - name: Test lite package install
       run: |
-        pip install mcp-memory-service-lite --dry-run
-        echo "Lite package available on PyPI"
+        python -m venv /tmp/test-lite
+        /tmp/test-lite/bin/pip install mcp-memory-service-lite
+        /tmp/test-lite/bin/python -c "import mcp_memory_service; print('Lite package OK')"

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -1,0 +1,91 @@
+[build-system]
+requires = ["hatchling", "python-semantic-release", "build"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp-memory-service-lite"
+version = "8.75.1"
+description = "Lightweight MCP memory service with ONNX embeddings - no PyTorch required. 80% smaller install size."
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = [
+    "mcp", "model-context-protocol", "claude-desktop", "semantic-memory",
+    "vector-database", "ai-assistant", "sqlite-vec", "multi-client",
+    "semantic-search", "memory-consolidation", "ai-productivity", "vs-code",
+    "cursor", "continue", "fastapi", "developer-tools", "cross-platform",
+    "lightweight", "onnx"
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Database :: Database Engines/Servers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Framework :: FastAPI"
+]
+authors = [
+    { name = "Heinrich Krupp", email = "heinrich.krupp@gmail.com" }
+]
+maintainers = [
+    { name = "Sundeep G", email = "sundeepg98@gmail.com" }
+]
+license = { text = "Apache-2.0" }
+dependencies = [
+    "tokenizers==0.20.3",
+    "mcp>=1.8.0,<2.0.0",
+    "python-dotenv>=1.0.0",
+    "sqlite-vec>=0.1.0",
+    "build>=0.10.0",
+    "aiohttp>=3.8.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "python-multipart>=0.0.9",
+    "sse-starlette>=2.1.0",
+    "aiofiles>=23.2.1",
+    "psutil>=5.9.0",
+    "zeroconf>=0.130.0",
+    "pypdf2>=3.0.0",
+    "chardet>=5.0.0",
+    "click>=8.0.0",
+    "httpx>=0.24.0",
+    "authlib>=1.2.0",
+    "python-jose[cryptography]>=3.3.0",
+    "onnxruntime>=1.14.1",
+    "typing-extensions>=4.0.0; python_version < '3.11'",
+    "apscheduler>=3.11.0",
+]
+
+[project.optional-dependencies]
+# Machine learning dependencies for full torch-based embeddings
+ml = [
+    "sentence-transformers>=2.2.2",
+    "torch>=2.0.0"
+]
+# Full installation (lite + ml)
+full = [
+    "mcp-memory-service-lite[ml]"
+]
+
+[project.scripts]
+memory = "mcp_memory_service.cli.main:main"
+memory-server = "mcp_memory_service.cli.main:memory_server_main"
+mcp-memory-server = "mcp_memory_service.mcp_server:main"
+
+[project.urls]
+Homepage = "https://github.com/doobidoo/mcp-memory-service"
+Documentation = "https://github.com/doobidoo/mcp-memory-service#readme"
+Repository = "https://github.com/doobidoo/mcp-memory-service"
+Issues = "https://github.com/doobidoo/mcp-memory-service/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mcp_memory_service"]
+
+[tool.hatch.version]
+path = "src/mcp_memory_service/__init__.py"


### PR DESCRIPTION
## Summary
This PR adds support for publishing both `mcp-memory-service` (full) and `mcp-memory-service-lite` (lightweight) from the same codebase.

### Why?
- Many users need a lightweight installation without PyTorch (~175 MB vs ~880 MB)
- Current structure makes torch a hard requirement
- This follows the pattern used by Hugging Face transformers (torch as optional)

### Changes
- Add `pyproject-lite.toml` for lightweight ONNX-only distribution
- Add `publish-dual.yml` GitHub Action to publish both packages on release

### Package Comparison
| Package | Size | Embeddings | Use Case |
|---------|------|------------|----------|
| `mcp-memory-service` | ~880 MB | PyTorch + Sentence Transformers | Full ML capabilities |
| `mcp-memory-service-lite` | ~175 MB | ONNX Runtime | CLI tools, lightweight deployments |

### User Experience
```bash
# Full install (unchanged - default)
pip install mcp-memory-service

# Lightweight install (new option)
pip install mcp-memory-service-lite
```

### Benefits
- ✅ Default users get full PyTorch experience (unchanged)
- ✅ Lightweight users can `pip install mcp-memory-service-lite`
- ✅ Both packages receive same updates from same codebase
- ✅ CI publishes both on each release automatically
- ✅ No breaking changes for existing users

## Test plan
- [ ] Build main package: `python -m build`
- [ ] Build lite package: `cp pyproject-lite.toml pyproject.toml && python -m build`
- [ ] Verify lite package installs without torch
- [ ] Verify ONNX embeddings work in lite package

## Related
- Builds on PR #337 (ONNX support) to provide official lightweight distribution
- Follows industry standard pattern (like transformers, ray, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)