### PR TITLE
feat: add response size limiter to prevent context overflow

### DIFF
--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -257,7 +257,7 @@ async def handle_retrieve_memory(server, arguments: dict) -> List[types.TextCont
         truncated_response = _get_truncated_response_if_needed(
             memories,
             max_response_chars,
-            lambda m: _memories_to_dicts(m, score_key='similarity_score')
+            _memories_to_dicts
         )
         if truncated_response:
             return truncated_response

--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -164,7 +164,7 @@ def _get_truncated_response_if_needed(
             return truncated_response
         # ... continue with normal formatting
     """
-    if not (max_chars and max_chars > 0):
+    if max_chars <= 0:
         return None
 
     memory_dicts = to_dict_converter(memories)

--- a/src/mcp_memory_service/server/utils/__init__.py
+++ b/src/mcp_memory_service/server/utils/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Heinrich Krupp
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Server utility modules.
+"""
+
+from .response_limiter import (
+    truncate_memories,
+    format_truncated_response,
+    apply_response_limit,
+    safe_retrieve_response,
+    DEFAULT_MAX_CHARS,
+    MEMORY_OVERHEAD_CHARS,
+)
+
+__all__ = [
+    "truncate_memories",
+    "format_truncated_response",
+    "apply_response_limit",
+    "safe_retrieve_response",
+    "DEFAULT_MAX_CHARS",
+    "MEMORY_OVERHEAD_CHARS",
+]

--- a/src/mcp_memory_service/server/utils/response_limiter.py
+++ b/src/mcp_memory_service/server/utils/response_limiter.py
@@ -21,23 +21,25 @@ from typing import Any, Dict, List, Tuple
 
 # Default max response size (can be overridden by environment variable)
 # 0 = unlimited (for backward compatibility)
-try:
-    DEFAULT_MAX_CHARS = int(os.environ.get("MCP_MAX_RESPONSE_CHARS", "0"))
-    if DEFAULT_MAX_CHARS < 0:
+DEFAULT_MAX_CHARS = 0
+raw_value = os.environ.get("MCP_MAX_RESPONSE_CHARS")
+if raw_value:
+    try:
+        value = int(raw_value)
+        if value >= 0:
+            DEFAULT_MAX_CHARS = value
+        else:
+            print(
+                f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: {value}. "
+                "Must be non-negative. Using default 0 (unlimited).",
+                file=sys.stderr,
+            )
+    except ValueError:
         print(
-            f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: {DEFAULT_MAX_CHARS}. "
-            "Must be non-negative. Using default 0 (unlimited).",
-            file=sys.stderr
+            f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: '{raw_value}'. "
+            "Using default 0 (unlimited).",
+            file=sys.stderr,
         )
-        DEFAULT_MAX_CHARS = 0
-except ValueError:
-    print(
-        f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: "
-        f"'{os.environ.get('MCP_MAX_RESPONSE_CHARS')}'. "
-        "Using default 0 (unlimited).",
-        file=sys.stderr
-    )
-    DEFAULT_MAX_CHARS = 0
 
 # Estimated overhead per memory for metadata formatting.
 # Accounts for: "=== Memory N ===", "Timestamp:", "Content:", "Hash:",

--- a/src/mcp_memory_service/server/utils/response_limiter.py
+++ b/src/mcp_memory_service/server/utils/response_limiter.py
@@ -120,11 +120,6 @@ def truncate_memories(
         truncated.append(memory)
         current_chars += mem_size
 
-    # Ensure at least one memory if list wasn't empty (handles edge case)
-    if not truncated and memories:
-        truncated.append(memories[0])
-        current_chars = memory_sizes[0]
-
     shown_results = len(truncated)
 
     return truncated, {

--- a/src/mcp_memory_service/server/utils/response_limiter.py
+++ b/src/mcp_memory_service/server/utils/response_limiter.py
@@ -1,0 +1,263 @@
+"""
+Response size limiter for MCP Memory Service.
+
+Prevents context window overflow by truncating responses at memory boundaries.
+This module ensures that large memory retrieval operations don't crash Claude
+or other LLM clients by exceeding their context window limits.
+
+Example:
+    >>> from mcp_memory_service.server.utils.response_limiter import (
+    ...     truncate_memories,
+    ...     format_truncated_response,
+    ... )
+    >>> memories = [{"content": "test", "content_hash": "abc123"}]
+    >>> truncated, meta = truncate_memories(memories, max_chars=1000)
+    >>> response = format_truncated_response(truncated, meta)
+"""
+
+import os
+import sys
+from typing import Any, Dict, List, Tuple
+
+# Default max response size (can be overridden by environment variable)
+# 0 = unlimited (for backward compatibility)
+try:
+    DEFAULT_MAX_CHARS = int(os.environ.get("MCP_MAX_RESPONSE_CHARS", "0"))
+    if DEFAULT_MAX_CHARS < 0:
+        print(
+            f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: {DEFAULT_MAX_CHARS}. "
+            "Must be non-negative. Using default 0 (unlimited).",
+            file=sys.stderr
+        )
+        DEFAULT_MAX_CHARS = 0
+except ValueError:
+    print(
+        f"WARNING: Invalid MCP_MAX_RESPONSE_CHARS value: "
+        f"'{os.environ.get('MCP_MAX_RESPONSE_CHARS')}'. "
+        "Using default 0 (unlimited).",
+        file=sys.stderr
+    )
+    DEFAULT_MAX_CHARS = 0
+
+# Estimated overhead per memory for metadata formatting.
+# Accounts for: "=== Memory N ===", "Timestamp:", "Content:", "Hash:",
+# "Relevance Score:", "Tags:", separators, and newlines.
+MEMORY_OVERHEAD_CHARS = 200
+
+
+def truncate_memories(
+    memories: List[Dict[str, Any]],
+    max_chars: int = 0,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Truncate a list of memories to fit within max_chars limit.
+
+    Truncates at memory boundaries (never mid-content) to preserve integrity.
+    Always includes at least one memory if the input list is non-empty.
+
+    Args:
+        memories: List of memory dicts with "content", "content_hash", etc.
+        max_chars: Maximum total characters. 0 = unlimited.
+
+    Returns:
+        Tuple containing:
+            - truncated_memories: List of memories that fit within limit
+            - metadata: Dict with truncation details including:
+                - total_results: Original count
+                - shown_results: Count after truncation
+                - total_chars: Original estimated character count (content + overhead)
+                - shown_chars: Estimated character count after truncation
+                - truncated: Boolean indicating if truncation occurred
+                - omitted_count: Number of memories omitted
+
+    Example:
+        >>> memories = [{"content": "a" * 1000}, {"content": "b" * 1000}]
+        >>> truncated, meta = truncate_memories(memories, max_chars=1500)
+        >>> len(truncated)
+        1
+        >>> meta["truncated"]
+        True
+    """
+    empty_meta = {
+        "total_results": 0,
+        "shown_results": 0,
+        "total_chars": 0,
+        "shown_chars": 0,
+        "truncated": False,
+        "omitted_count": 0,
+    }
+
+    if not memories:
+        return [], empty_meta
+
+    # Calculate estimated size for each memory, including overhead
+    memory_sizes = [(len(m.get("content") or "") + MEMORY_OVERHEAD_CHARS) for m in memories]
+    total_estimated_chars = sum(memory_sizes)
+    total_results = len(memories)
+
+    # If no limit or under limit, return all
+    if max_chars <= 0 or total_estimated_chars <= max_chars:
+        return memories, {
+            "total_results": total_results,
+            "shown_results": total_results,
+            "total_chars": total_estimated_chars,
+            "shown_chars": total_estimated_chars,
+            "truncated": False,
+            "omitted_count": 0,
+        }
+
+    # Truncate at memory boundaries
+    truncated: List[Dict[str, Any]] = []
+    current_chars = 0
+
+    for i, memory in enumerate(memories):
+        mem_size = memory_sizes[i]
+
+        # Allow at least one memory to be returned, even if it exceeds the limit
+        if truncated and current_chars + mem_size > max_chars:
+            break
+
+        truncated.append(memory)
+        current_chars += mem_size
+
+    # Ensure at least one memory if list wasn't empty (handles edge case)
+    if not truncated and memories:
+        truncated.append(memories[0])
+        current_chars = memory_sizes[0]
+
+    shown_results = len(truncated)
+
+    return truncated, {
+        "total_results": total_results,
+        "shown_results": shown_results,
+        "total_chars": total_estimated_chars,
+        "shown_chars": current_chars,
+        "truncated": True,
+        "omitted_count": total_results - shown_results,
+    }
+
+
+def format_truncated_response(
+    memories: List[Dict[str, Any]],
+    meta: Dict[str, Any],
+) -> str:
+    """
+    Format memories into a response string with truncation warning if needed.
+
+    Args:
+        memories: List of memory dicts to format.
+        meta: Metadata dict from truncate_memories().
+
+    Returns:
+        Formatted string response with optional truncation header.
+
+    Example:
+        >>> memories = [{"content": "test", "content_hash": "abc123"}]
+        >>> meta = {"truncated": False, "total_results": 1, "shown_results": 1}
+        >>> response = format_truncated_response(memories, meta)
+        >>> "=== Memory 1 ===" in response
+        True
+    """
+    parts: List[str] = []
+
+    # Add truncation warning header if truncated
+    if meta.get("truncated"):
+        warning = (
+            f"[!] RESPONSE TRUNCATED: Showing {meta['shown_results']} of "
+            f"{meta['total_results']} results "
+            f"({meta['shown_chars']:,} of {meta['total_chars']:,} chars).\n"
+            f"{meta['omitted_count']} result(s) omitted to prevent context overflow.\n"
+            f"Use specific queries or hash-based retrieval for full content.\n"
+        )
+        parts.append(warning)
+        parts.append("")
+
+    # Format each memory
+    for i, memory in enumerate(memories, 1):
+        memory_lines = [f"=== Memory {i} ==="]
+
+        # Add timestamp if available
+        created_at = memory.get("created_at")
+        if created_at:
+            memory_lines.append(f"Timestamp: {created_at}")
+
+        # Add content
+        content = memory.get("content", "")
+        memory_lines.append(f"Content: {content}")
+
+        # Add hash
+        content_hash = memory.get("content_hash", "")
+        memory_lines.append(f"Hash: {content_hash}")
+
+        # Add relevance score if available
+        score = memory.get("relevance_score") or memory.get("similarity_score")
+        if score is not None:
+            memory_lines.append(f"Relevance Score: {score:.2f}")
+
+        # Add tags if available
+        tags = memory.get("tags", [])
+        if tags:
+            if isinstance(tags, list):
+                memory_lines.append(f"Tags: {', '.join(tags)}")
+            else:
+                memory_lines.append(f"Tags: {tags}")
+
+        memory_lines.append("---")
+        parts.append("\n".join(memory_lines))
+
+    return "\n".join(parts)
+
+
+def apply_response_limit(
+    memories: List[Dict[str, Any]],
+    max_chars: int = 0,
+    header: str = "",
+) -> str:
+    """
+    Convenience function: truncate and format in one call.
+
+    Args:
+        memories: List of memory dicts.
+        max_chars: Maximum response size. 0 = use env default or unlimited.
+        header: Optional header to prepend to the response.
+
+    Returns:
+        Formatted response string (truncated if needed).
+
+    Example:
+        >>> memories = [{"content": "test", "content_hash": "abc123"}]
+        >>> response = apply_response_limit(memories, max_chars=10000)
+        >>> isinstance(response, str)
+        True
+    """
+    # Use environment default if no limit specified
+    effective_max = max_chars if max_chars > 0 else DEFAULT_MAX_CHARS
+
+    truncated, meta = truncate_memories(memories, effective_max)
+    return header + format_truncated_response(truncated, meta)
+
+
+def safe_retrieve_response(
+    memories: List[Dict[str, Any]],
+    max_chars: int = 40000,
+) -> str:
+    """
+    Safe wrapper with sensible default limit.
+
+    Use this as a drop-in replacement for formatting retrieve results.
+    Default 40KB limit is safe for most context windows.
+
+    Args:
+        memories: List of memory dicts.
+        max_chars: Maximum response size (default: 40000).
+
+    Returns:
+        Formatted response string (truncated if needed).
+
+    Example:
+        >>> memories = [{"content": "important info", "content_hash": "hash1"}]
+        >>> response = safe_retrieve_response(memories)
+        >>> "important info" in response
+        True
+    """
+    return apply_response_limit(memories, max_chars)

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1293,6 +1293,10 @@ class MemoryServer:
                                     "type": "number",
                                     "default": 5,
                                     "description": "Maximum number of results to return."
+                                },
+                                "max_response_chars": {
+                                    "type": "number",
+                                    "description": "Maximum response size in characters. Truncates at memory boundaries to prevent context overflow. Recommended: 30000-50000. Default: unlimited."
                                 }
                             },
                             "required": ["query"]
@@ -1322,6 +1326,10 @@ class MemoryServer:
                                     "type": "number",
                                     "default": 5,
                                     "description": "Maximum number of results to return."
+                                },
+                                "max_response_chars": {
+                                    "type": "number",
+                                    "description": "Maximum response size in characters. Truncates at memory boundaries to prevent context overflow. Recommended: 30000-50000. Default: unlimited."
                                 }
                             },
                             "required": ["query"]
@@ -1374,6 +1382,10 @@ class MemoryServer:
                                     "minimum": 0.0,
                                     "maximum": 1.0,
                                     "description": "Quality score weight 0.0-1.0 (default 0.3 = 30% quality, 70% semantic)"
+                                },
+                                "max_response_chars": {
+                                    "type": "number",
+                                    "description": "Maximum response size in characters. Truncates at memory boundaries to prevent context overflow. Recommended: 30000-50000. Default: unlimited."
                                 }
                             },
                             "required": ["query"]
@@ -1408,6 +1420,10 @@ class MemoryServer:
                                         }
                                     ],
                                     "description": "List of tags to search for. Returns memories matching ANY of these tags. Accepts either an array of strings or a comma-separated string."
+                                },
+                                "max_response_chars": {
+                                    "type": "number",
+                                    "description": "Maximum response size in characters. Truncates at memory boundaries to prevent context overflow. Recommended: 30000-50000. Default: unlimited."
                                 }
                             },
                             "required": ["tags"]
@@ -1696,6 +1712,10 @@ class MemoryServer:
                                     "type": "number",
                                     "default": 5,
                                     "description": "Maximum number of results to return."
+                                },
+                                "max_response_chars": {
+                                    "type": "number",
+                                    "description": "Maximum response size in characters. Truncates at memory boundaries to prevent context overflow. Recommended: 30000-50000. Default: unlimited."
                                 }
                             },
                             "required": ["start_date"]

--- a/tests/test_response_limiter.py
+++ b/tests/test_response_limiter.py
@@ -1,0 +1,415 @@
+"""
+Tests for response size limiter functionality.
+
+Tests the response_limiter module which prevents context window overflow
+by truncating large memory retrieval responses at memory boundaries.
+"""
+
+import pytest
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+from mcp_memory_service.server.utils.response_limiter import (
+    truncate_memories,
+    format_truncated_response,
+    apply_response_limit,
+    safe_retrieve_response,
+    DEFAULT_MAX_CHARS,
+    MEMORY_OVERHEAD_CHARS,
+)
+
+
+# ============================================
+# Test Fixtures
+# ============================================
+
+
+@pytest.fixture
+def sample_memory() -> Dict[str, Any]:
+    """Single sample memory for testing."""
+    return {
+        "content": "This is test content for memory testing.",
+        "content_hash": "abc123def456",
+        "created_at": "2026-01-10T12:00:00Z",
+        "tags": ["test", "sample"],
+        "relevance_score": 0.85,
+    }
+
+
+@pytest.fixture
+def large_memories() -> List[Dict[str, Any]]:
+    """List of memories that exceeds typical limits."""
+    return [
+        {
+            "content": f"Memory content {i} " + "x" * 5000,
+            "content_hash": f"hash_{i}",
+            "created_at": f"2026-01-10T{i:02d}:00:00Z",
+            "tags": [f"tag_{i}"],
+            "relevance_score": 0.9 - (i * 0.1),
+        }
+        for i in range(20)
+    ]
+
+
+@pytest.fixture
+def small_memories() -> List[Dict[str, Any]]:
+    """List of small memories that fit within limits."""
+    return [
+        {
+            "content": f"Small content {i}",
+            "content_hash": f"hash_{i}",
+        }
+        for i in range(5)
+    ]
+
+
+# ============================================
+# truncate_memories() Tests
+# ============================================
+
+
+class TestTruncateMemories:
+    """Tests for truncate_memories function."""
+
+    def test_empty_list_returns_empty(self):
+        """Empty input should return empty list with zero metadata."""
+        result, meta = truncate_memories([])
+
+        assert result == []
+        assert meta["total_results"] == 0
+        assert meta["shown_results"] == 0
+        assert meta["truncated"] is False
+        assert meta["omitted_count"] == 0
+
+    def test_no_limit_returns_all(self, small_memories):
+        """With no limit (0), all memories should be returned."""
+        result, meta = truncate_memories(small_memories, max_chars=0)
+
+        assert len(result) == len(small_memories)
+        assert meta["truncated"] is False
+        assert meta["omitted_count"] == 0
+
+    def test_under_limit_returns_all(self, small_memories):
+        """Memories under the limit should all be returned."""
+        result, meta = truncate_memories(small_memories, max_chars=100000)
+
+        assert len(result) == len(small_memories)
+        assert meta["truncated"] is False
+
+    def test_over_limit_truncates(self, large_memories):
+        """Memories exceeding limit should be truncated."""
+        result, meta = truncate_memories(large_memories, max_chars=10000)
+
+        assert len(result) < len(large_memories)
+        assert meta["truncated"] is True
+        assert meta["omitted_count"] > 0
+        assert meta["total_results"] == len(large_memories)
+
+    def test_always_returns_at_least_one(self, large_memories):
+        """Even with tiny limit, at least one memory should be returned."""
+        result, meta = truncate_memories(large_memories, max_chars=1)
+
+        assert len(result) >= 1
+        assert meta["shown_results"] >= 1
+
+    def test_truncates_at_memory_boundaries(self, large_memories):
+        """Truncation should occur at memory boundaries, not mid-content."""
+        result, meta = truncate_memories(large_memories, max_chars=10000)
+
+        # Each returned memory should have complete content
+        for memory in result:
+            assert "content" in memory
+            # Content should not be cut off (original content intact)
+            original = next(
+                m for m in large_memories 
+                if m["content_hash"] == memory["content_hash"]
+            )
+            assert memory["content"] == original["content"]
+
+    def test_metadata_accuracy(self, large_memories):
+        """Metadata should accurately reflect truncation state."""
+        result, meta = truncate_memories(large_memories, max_chars=10000)
+
+        assert meta["total_results"] == len(large_memories)
+        assert meta["shown_results"] == len(result)
+        assert meta["omitted_count"] == meta["total_results"] - meta["shown_results"]
+        # shown_chars may exceed max_chars when at least one memory is returned
+        assert meta["shown_results"] == 1 or meta["shown_chars"] <= 10000
+
+    def test_preserves_memory_order(self, large_memories):
+        """Truncation should preserve the original order of memories."""
+        result, meta = truncate_memories(large_memories, max_chars=20000)
+
+        # First few memories should match original order
+        for i, memory in enumerate(result):
+            assert memory["content_hash"] == large_memories[i]["content_hash"]
+
+
+# ============================================
+# format_truncated_response() Tests
+# ============================================
+
+
+class TestFormatTruncatedResponse:
+    """Tests for format_truncated_response function."""
+
+    def test_formats_single_memory(self, sample_memory):
+        """Single memory should be formatted correctly."""
+        meta = {"truncated": False, "total_results": 1, "shown_results": 1}
+        result = format_truncated_response([sample_memory], meta)
+
+        assert "=== Memory 1 ===" in result
+        assert sample_memory["content"] in result
+        assert sample_memory["content_hash"] in result
+
+    def test_includes_timestamp_when_present(self, sample_memory):
+        """Timestamp should be included when available."""
+        meta = {"truncated": False}
+        result = format_truncated_response([sample_memory], meta)
+
+        assert "Timestamp:" in result
+        assert sample_memory["created_at"] in result
+
+    def test_includes_tags_when_present(self, sample_memory):
+        """Tags should be included when available."""
+        meta = {"truncated": False}
+        result = format_truncated_response([sample_memory], meta)
+
+        assert "Tags:" in result
+        assert "test" in result
+        assert "sample" in result
+
+    def test_includes_relevance_score(self, sample_memory):
+        """Relevance score should be formatted when present."""
+        meta = {"truncated": False}
+        result = format_truncated_response([sample_memory], meta)
+
+        assert "Relevance Score:" in result
+        assert "0.85" in result
+
+    def test_truncation_warning_header(self, small_memories):
+        """Truncation warning should appear when truncated."""
+        meta = {
+            "truncated": True,
+            "total_results": 10,
+            "shown_results": 5,
+            "total_chars": 10000,
+            "shown_chars": 5000,
+            "omitted_count": 5,
+        }
+        result = format_truncated_response(small_memories, meta)
+
+        assert "[!] RESPONSE TRUNCATED" in result
+        assert "5 of 10" in result
+        assert "omitted" in result.lower()
+
+    def test_no_warning_when_not_truncated(self, small_memories):
+        """No truncation warning when not truncated."""
+        meta = {"truncated": False}
+        result = format_truncated_response(small_memories, meta)
+
+        assert "TRUNCATED" not in result
+
+    def test_handles_missing_fields_gracefully(self):
+        """Should handle memories with missing optional fields."""
+        minimal_memory = {"content": "minimal", "content_hash": "hash1"}
+        meta = {"truncated": False}
+
+        result = format_truncated_response([minimal_memory], meta)
+
+        assert "minimal" in result
+        assert "hash1" in result
+        # Should not raise KeyError
+
+    def test_handles_string_tags(self):
+        """Should handle tags as string instead of list."""
+        memory = {
+            "content": "test",
+            "content_hash": "hash1",
+            "tags": "single-tag",
+        }
+        meta = {"truncated": False}
+
+        result = format_truncated_response([memory], meta)
+
+        assert "Tags: single-tag" in result
+
+
+# ============================================
+# apply_response_limit() Tests
+# ============================================
+
+
+class TestApplyResponseLimit:
+    """Tests for apply_response_limit convenience function."""
+
+    def test_combines_truncate_and_format(self, small_memories):
+        """Should truncate and format in one call."""
+        result = apply_response_limit(small_memories, max_chars=100000)
+
+        assert isinstance(result, str)
+        assert "=== Memory 1 ===" in result
+
+    def test_respects_max_chars(self, large_memories):
+        """Should respect the max_chars limit."""
+        result = apply_response_limit(large_memories, max_chars=5000)
+
+        # Result should be roughly within limit
+        assert len(result) < 10000  # Some buffer for formatting
+
+    def test_uses_env_default_when_zero(self, small_memories):
+        """Should use environment default when max_chars is 0.
+        
+        Note: DEFAULT_MAX_CHARS is read at module import time, so this test
+        verifies the function logic path rather than dynamic env var reading.
+        """
+        result = apply_response_limit(small_memories, max_chars=0)
+        assert isinstance(result, str)
+
+
+# ============================================
+# safe_retrieve_response() Tests
+# ============================================
+
+
+class TestSafeRetrieveResponse:
+    """Tests for safe_retrieve_response convenience function."""
+
+    def test_default_limit_is_40000(self, small_memories):
+        """Default limit should be 40000 characters."""
+        result = safe_retrieve_response(small_memories)
+
+        assert isinstance(result, str)
+        # Small memories should all fit
+        assert "=== Memory 1 ===" in result
+
+    def test_custom_limit_respected(self, large_memories):
+        """Custom limit should be respected."""
+        result = safe_retrieve_response(large_memories, max_chars=5000)
+
+        # Should be truncated
+        assert "TRUNCATED" in result
+
+
+# ============================================
+# Integration Tests
+# ============================================
+
+
+class TestResponseLimiterIntegration:
+    """Integration tests for full response limiting workflow."""
+
+    def test_full_workflow_small_response(self, small_memories):
+        """Full workflow with small response (no truncation)."""
+        # Truncate
+        truncated, meta = truncate_memories(small_memories, max_chars=100000)
+        
+        # Format
+        response = format_truncated_response(truncated, meta)
+
+        # Verify
+        assert len(truncated) == len(small_memories)
+        assert "TRUNCATED" not in response
+        for i, memory in enumerate(small_memories, 1):
+            assert f"=== Memory {i} ===" in response
+
+    def test_full_workflow_large_response(self, large_memories):
+        """Full workflow with large response (requires truncation)."""
+        max_chars = 10000
+        
+        # Truncate
+        truncated, meta = truncate_memories(large_memories, max_chars=max_chars)
+        
+        # Format
+        response = format_truncated_response(truncated, meta)
+
+        # Verify truncation occurred
+        assert len(truncated) < len(large_memories)
+        assert meta["truncated"] is True
+        assert "TRUNCATED" in response
+        
+        # Verify guidance for user
+        assert "specific queries" in response.lower() or "hash-based" in response.lower()
+
+    def test_response_size_within_limit(self, large_memories):
+        """Formatted response should be approximately within limit."""
+        max_chars = 20000
+        
+        truncated, meta = truncate_memories(large_memories, max_chars=max_chars)
+        response = format_truncated_response(truncated, meta)
+
+        # Response should be in reasonable range of limit
+        # (exact limit is on input content, not formatted output)
+        assert len(response) < max_chars * 2  # Allow for formatting overhead
+
+
+# ============================================
+# Edge Case Tests
+# ============================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_single_large_memory(self):
+        """Single memory larger than limit should still be returned."""
+        huge_memory = {
+            "content": "x" * 100000,
+            "content_hash": "huge_hash",
+        }
+        
+        result, meta = truncate_memories([huge_memory], max_chars=1000)
+
+        assert len(result) == 1
+        assert meta["shown_results"] == 1
+
+    def test_empty_content_memories(self):
+        """Memories with empty content should be handled."""
+        memories = [
+            {"content": "", "content_hash": "empty1"},
+            {"content": "", "content_hash": "empty2"},
+        ]
+        
+        result, meta = truncate_memories(memories, max_chars=1000)
+        response = format_truncated_response(result, meta)
+
+        assert len(result) == 2
+        assert "empty1" in response
+
+    def test_none_content_handling(self):
+        """Memories with None content should be handled gracefully."""
+        memories = [
+            {"content": None, "content_hash": "none1"},
+        ]
+        
+        result, meta = truncate_memories(memories, max_chars=1000)
+        
+        # Should not raise
+        assert len(result) == 1
+
+    def test_unicode_content(self):
+        """Unicode content should be handled correctly."""
+        memories = [
+            {"content": "日本語テスト 🎉 émojis", "content_hash": "unicode1"},
+        ]
+        
+        result, meta = truncate_memories(memories, max_chars=1000)
+        response = format_truncated_response(result, meta)
+
+        assert "日本語" in response
+        assert "🎉" in response
+
+    def test_special_characters_in_content(self):
+        """Special characters should not break formatting."""
+        memories = [
+            {
+                "content": "Test with <html> & \"quotes\" and 'apostrophes'",
+                "content_hash": "special1",
+            },
+        ]
+        
+        result, meta = truncate_memories(memories, max_chars=1000)
+        response = format_truncated_response(result, meta)
+
+        assert "<html>" in response
+        assert "&" in response


### PR DESCRIPTION
# Pull Request

## Description
Add response size limiting to prevent context window overflow when retrieving large numbers of memories. This feature adds a new `max_response_chars` parameter to retrieval MCP tools and an `MCP_MAX_RESPONSE_CHARS` environment variable for global configuration.

## Motivation
Users experienced crashes and unexpected behavior when retrieving many memories at once. Large MCP responses could exceed Claude's context window, causing session crashes, truncated responses with lost data, and compaction errors. This feature prevents those issues by automatically truncating responses at memory boundaries while providing clear feedback about omitted results.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## Changes
- Add `max_response_chars` parameter to retrieval tools (`retrieve_memory`, `recall_memory`, `search_by_tag`, `retrieve_with_quality_boost`)
- Add `MCP_MAX_RESPONSE_CHARS` environment variable for global default
- Add `server/utils/response_limiter.py` with truncation logic that preserves memory boundaries
- Add `server/handlers/safe_retrieval.py` with async handler wrappers
- Update README.md with new environment variable in all Claude Desktop config examples
- Update CHANGELOG.md with feature entry
- Fix syntax error in quality.py

**Breaking Changes** (if any):
- None. Default is unlimited (0) for backward compatibility.

## Testing

### How Has This Been Tested?
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version: 3.13.7
- OS: Windows
- Storage backend: sqlite_vec
- Installation method: uv

### Test Coverage
- [x] Added new tests
- [ ] Updated existing tests
- [x] Test coverage maintained/improved

48 new tests added:
- `tests/test_response_limiter.py` - 29 tests covering truncation logic, formatting, edge cases
- `tests/test_safe_retrieval.py` - 19 tests covering async handlers, error handling

## Related Issues
Fixes #
Closes #
Relates to #

## Screenshots
N/A

## Documentation
- [x] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [x] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [x] Updated code comments/docstrings
- [ ] Added API documentation
- [ ] No documentation needed

## Pre-submission Checklist
- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] ✅ Any dependent changes have been merged and published
- [x] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [ ] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes
Recommended `max_response_chars` values: 30000-50000 characters for safe operation with most LLM context windows. When truncation occurs, the response includes count of shown vs. total results and guidance for retrieving full content via specific queries or hash-based retrieval.