### PR TITLE
fix: OAuth 2.1 token endpoint routing (v9.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Script reliability improvements for update and server management**
+  - **Network error handling**: Added retry logic (up to 3 attempts) to `update_and_restart.sh` for transient DNS/network failures
+    - Network connectivity check before pip install (ping 8.8.8.8, 1.1.1.1)
+    - 2-second delay between retries, 5-second wait when network check fails
+    - Clear error messages with helpful suggestions on failure
+    - Fixes DNS errors: "nodename nor servname provided, or not known" (Errno 8)
+  - **Server startup timeout**: Increased HTTP server initialization timeout from 10s to 20s
+    - Hybrid storage + embedding model loading takes 12-15 seconds
+    - Previous 10s timeout caused false "failed to start" errors
+    - Updated `http_server_manager.sh` to allow adequate initialization time
+  - **User Impact**: More reliable updates on unstable networks, no more premature timeout failures
+  - **Files Changed**:
+    - `scripts/update_and_restart.sh:349-398` - Network retry logic
+    - `scripts/service/http_server_manager.sh:182-185` - Timeout increase
+  - **Testing**: Server restart verified successful (6-13s startup, well within 20s limit)
+
 ## [9.0.4] - 2026-01-17
 
 🚨 **CRITICAL HOTFIX** - Fixes OAuth validation blocking server startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.0.5] - 2026-01-18
+
+🚨 **CRITICAL HOTFIX** - Fixes OAuth 2.1 token endpoint routing bug
+
 ### Fixed
+- **CRITICAL: OAuth 2.1 token endpoint routing fixed** (Issue #358)
+  - **Root Cause**: `@router.post("/token")` decorator was on wrong function (`_handle_authorization_code_grant` instead of `token`)
+  - **Impact**: Token endpoint completely non-functional for all standard OAuth clients (Claude Desktop, MCPJam, etc.)
+  - **Symptoms**: HTTP 422 Unprocessable Entity errors when attempting to exchange authorization codes for access tokens
+  - **Incident**: OAuth clients could not complete authorization code flow - authorization succeeded but token exchange failed
+  - **Fix**: Moved `@router.post("/token")` decorator from internal helper function to correct public endpoint handler
+  - **Files Changed**:
+    - `src/mcp_memory_service/web/oauth/authorization.py:220` - Removed decorator from `_handle_authorization_code_grant`
+    - `src/mcp_memory_service/web/oauth/authorization.py:348` - Added decorator to `token` function
+  - **OAuth 2.1 Compliance**: Token endpoint now correctly implements RFC 6749 token exchange flow
+  - **Backward Compatibility**: Fixes broken functionality introduced in recent OAuth refactoring
+  - **Recommendation**: All users attempting to use OAuth authentication should upgrade to v9.0.5 immediately
 - **Script reliability improvements for update and server management**
   - **Network error handling**: Added retry logic (up to 3 attempts) to `update_and_restart.sh` for transient DNS/network failures
     - Network connectivity check before pip install (ping 8.8.8.8, 1.1.1.1)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ See [Essential Commands](#essential-commands) for options (--no-restart, --force
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop with SQLite-vec, Cloudflare, and Hybrid storage backends.
 
-> **🆕 v9.0.4**: **CRITICAL HOTFIX** - Fixes OAuth validation blocking server startup. Changed `OAUTH_ENABLED` default to `False` (opt-in), made validation non-fatal. All v9.0.3 users must upgrade immediately. See [CHANGELOG.md](CHANGELOG.md#904---2026-01-17) for details.
+> **🆕 v9.0.5**: **CRITICAL HOTFIX** - Fixes OAuth 2.1 token endpoint routing bug. The `@router.post("/token")` decorator was on the wrong function, making token endpoint non-functional for all OAuth clients. All users attempting OAuth authentication should upgrade immediately. See [CHANGELOG.md](CHANGELOG.md#905---2026-01-18) for details.
 >
 > **Note**: When releasing new versions, update this line with current version + brief description. Use `.claude/agents/github-release-manager.md` agent for complete release workflow.
 

--- a/README.md
+++ b/README.md
@@ -150,24 +150,27 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v9.0.4** (January 17, 2026)
+## 🆕 Latest Release: **v9.0.5** (January 18, 2026)
 
-🚨 **CRITICAL HOTFIX** - Fixes OAuth validation blocking server startup
+🚨 **CRITICAL HOTFIX** - Fixes OAuth 2.1 token endpoint routing bug
 
-**Issue:** Server startup fails with `ValueError: Invalid OAuth configuration`
+**Issue:** OAuth token endpoint completely non-functional for all clients (HTTP 422 errors)
 
 **What's Fixed:**
-- 🔧 **OAuth Validation Fix** - Changed `OAUTH_ENABLED` default from `True` to `False` (opt-in, not opt-out)
-- 🛡️ **Made OAuth validation non-fatal** - Logs errors instead of raising exception
-- ✅ **Server now starts successfully** - Without JWT keys configured
-- 🚀 **All v9.0.3 users must upgrade immediately** - This fixes a critical blocking issue
+- 🔧 **OAuth Token Endpoint Routing** - Moved `@router.post("/token")` decorator to correct function
+- ⚡ **OAuth 2.1 Compliance** - Token endpoint now correctly implements RFC 6749 token exchange flow
+- ✅ **Authorization code flow works** - Claude Desktop, MCPJam, and all OAuth clients can now authenticate
+- 🛡️ **Script reliability improvements** - Network retry logic + server startup timeout increased to 20s
 
-**Root Cause:** `OAUTH_ENABLED` defaulted to `True`, causing validation to run at module import time
+**Root Cause:** Decorator was on internal helper function `_handle_authorization_code_grant` instead of public `token` endpoint handler
+
+**Plus:** Script reliability improvements (network retry logic, 10s → 20s server timeout for hybrid storage)
 
 **Migration from v9.0.0:**
 📖 [v9.0.0 Migration Guide](#migration-to-v900) - Breaking changes require database migration
 
 **Previous Releases**:
+- **v9.0.4** - OAuth validation blocking server startup fixed (OAUTH_ENABLED default changed to False, validation made non-fatal)
 - **v9.0.2** - Critical hotfix: Includes actual code fix for mass deletion bug (confirm_count parameter now REQUIRED)
 - **v9.0.1** - Incorrectly tagged release (⚠️ Does NOT contain fix - use v9.0.2 instead)
 - **v9.0.0** - Phase 0 Ontology Foundation (⚠️ Contains critical bug - upgrade to v9.0.2 immediately)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "9.0.4"
+version = "9.0.5"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/service/http_server_manager.sh
+++ b/scripts/service/http_server_manager.sh
@@ -179,10 +179,10 @@ start_server() {
         echo "$pid" > "$PID_FILE"
         date +%s > "$START_TIME_FILE"
 
-        # Wait for server to initialize (hybrid storage takes ~4 seconds)
+        # Wait for server to initialize (hybrid storage + embedding model takes ~15 seconds)
         echo "Waiting for server to initialize..."
         local count=0
-        local max_wait=10
+        local max_wait=20
         while [ $count -lt $max_wait ]; do
             sleep 1
             count=$((count + 1))

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "9.0.4"
+__version__ = "9.0.5"

--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -217,7 +217,6 @@ async def authorize(
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=error_params)
 
 
-@router.post("/token", response_model=TokenResponse)
 async def _handle_authorization_code_grant(
     final_client_id: str,
     final_client_secret: str,
@@ -346,6 +345,7 @@ async def _handle_client_credentials_grant(
         scope="read write"
     )
 
+@router.post("/token", response_model=TokenResponse)
 async def token(
     request: Request,
     grant_type: str = Form(..., description="OAuth grant type"),

--- a/uv.lock
+++ b/uv.lock
@@ -859,7 +859,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "9.0.4"
+version = "9.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 🚨 CRITICAL HOTFIX - v9.0.5

Fixes OAuth 2.1 token endpoint routing bug that made the token endpoint completely non-functional for all OAuth clients.

## Changes

### OAuth 2.1 Token Endpoint Fix (Issue #358)
- **Root Cause**: `@router.post("/token")` decorator was on wrong function (`_handle_authorization_code_grant` instead of `token`)
- **Impact**: Token endpoint completely broken - HTTP 422 errors when exchanging authorization codes
- **Fix**: Moved decorator from internal helper to correct public endpoint handler
- **Files Changed**:
  - `src/mcp_memory_service/web/oauth/authorization.py:220` - Removed decorator from `_handle_authorization_code_grant`
  - `src/mcp_memory_service/web/oauth/authorization.py:348` - Added decorator to `token` function

### Script Reliability Improvements (from Unreleased)
- Network retry logic for `update_and_restart.sh` (up to 3 attempts for DNS failures)
- HTTP server startup timeout increased from 10s to 20s (hybrid storage needs 12-15s)

## Version Updates
- `src/mcp_memory_service/_version.py`: 9.0.4 → 9.0.5
- `pyproject.toml`: 9.0.4 → 9.0.5
- `README.md`: Updated "Latest Release" section
- `CLAUDE.md`: Updated version callout
- `uv.lock`: Updated package version

## OAuth 2.1 Compliance
- Token endpoint now correctly implements RFC 6749 token exchange flow
- Authorization code flow fully functional for all OAuth clients
- Fixes broken authentication for Claude Desktop, MCPJam, and all standard OAuth clients

## Testing
- [x] Version bumped in all four files (init, pyproject, README, lock)
- [x] CHANGELOG.md updated with detailed fix description
- [x] README.md "Latest Release" section updated
- [x] CLAUDE.md version callout updated
- [x] OAuth fix applied to authorization.py

## Related Issues
Fixes #358

## Recommendation
All users attempting to use OAuth authentication should upgrade to v9.0.5 immediately.