### PR TITLE
fix: resolve fatal Python error during shutdown (SIGTERM/SIGINT) (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Fatal Python error during shutdown** (#368)
+  - Fixed "database is locked" crash when Claude Desktop sends shutdown signal (SIGTERM/SIGINT)
+  - Changed signal handler to use `os._exit(0)` instead of `sys.exit(0)` to avoid buffered I/O lock deadlock
+  - Prevents "Fatal Python error: _enter_buffered_busy: could not acquire lock" during interpreter shutdown
+  - Server now shuts down cleanly without "Server disconnected" errors in Claude Desktop
+  - Root cause: `sys.exit(0)` in signal handler tried to flush buffered stdio streams while locks were held
+  - Solution: Use `os._exit(0)` to bypass I/O cleanup after `_cleanup_on_shutdown()` completes
+
 ## [9.3.0] - 2026-01-19
 
 ### Added

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -3193,7 +3193,11 @@ def main():
     def signal_handler(signum, frame):
         logger.info(f"Received signal {signum}, shutting down gracefully...")
         _cleanup_on_shutdown()
-        sys.exit(0)
+        # Use os._exit(0) instead of sys.exit(0) to avoid buffered I/O lock issues
+        # during shutdown. os._exit() bypasses Python's cleanup which is safe here
+        # because _cleanup_on_shutdown() has already performed necessary cleanup.
+        # See: https://github.com/doobidoo/mcp-memory-service/issues/368
+        os._exit(0)
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
## Summary

Fixes #368 - Fatal Python error during shutdown: `_enter_buffered_busy: could not acquire lock`

This PR resolves a critical bug where the MCP Memory Service crashed when receiving shutdown signals (SIGTERM/SIGINT) from Claude Desktop, causing "Server disconnected" errors.

## Problem

When Claude Desktop sent a shutdown signal, the server would crash with:
```
Fatal Python error: _enter_buffered_busy: could not acquire lock for <_io.BufferedReader name='<stdin>'> at interpreter shutdown
```

**Impact:**
- Server worked correctly during operation
- Crashed on every shutdown (closing Claude Desktop or switching conversations)
- Required reconnection after each crash

## Root Cause

The signal handler called `sys.exit(0)` which attempts to flush all buffered I/O streams during shutdown. Since the MCP server uses stdio for JSON-RPC communication, this created a deadlock:

1. Signal interrupts code that holds I/O locks on stdin/stdout
2. `sys.exit(0)` tries to acquire these same locks to flush buffers
3. Deadlock → Fatal Python error

## Solution

**Changed:** `sys.exit(0)` → `os._exit(0)` in signal handler

**Why this is safe:**
- `_cleanup_on_shutdown()` already performs all necessary cleanup (cache clearing, GC)
- `os._exit(0)` terminates immediately without I/O flush, avoiding the deadlock
- Consistent with KeyboardInterrupt handler pattern (line 3209-3211)

## Changes

- **server_impl.py**: Updated signal handler with `os._exit(0)` and detailed comment
- **CHANGELOG.md**: Documented fix in [Unreleased] section
- **docs/troubleshooting/general.md**: Added "Server Shutdown Issues" section

## Testing

- [x] Fix is consistent with existing KeyboardInterrupt handler
- [x] `_cleanup_on_shutdown()` already handles all resource cleanup
- [x] Documentation updated for users experiencing the issue

## Verification

After merging, users should:
```bash
cd path/to/mcp-memory-service
git pull origin main
pip install -e .
# Restart Claude Desktop
```

Server will now shut down cleanly without crashes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)