### PR TITLE
fix(windows): Add PowerShell 7+ SSL compatibility to manage_service.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Windows PowerShell 7+ compatibility**: Fixed SSL certificate validation in `manage_service.ps1`
+  - Extends previous fix from `update_and_restart.ps1` to `manage_service.ps1`
+  - PowerShell 5.1: Uses `ICertificatePolicy` (.NET Framework)
+  - PowerShell 7+: Uses `-SkipCertificateCheck` parameter on `Invoke-WebRequest`
+  - Error was: `CS0246: The type or namespace name 'ICertificatePolicy' was not found`
+
 ## [10.1.1] - 2026-01-27
 
 ### Fixed


### PR DESCRIPTION
## Summary                                                      
- Extends PowerShell 7+ SSL certificate validation fix to
`manage_service.ps1`
- Previous commit (2f23eb0) fixed `update_and_restart.ps1`, this
completes the fix for all Windows service scripts

## Problem
Running `update_and_restart.ps1` on PowerShell 7+ caused:       
CS0246: The type or namespace name 'ICertificatePolicy' was not 
found
`ICertificatePolicy` exists only in .NET Framework, not in .NET 
Core (PowerShell 7+).

## Solution
Scripts now detect PowerShell version and use appropriate SSL   
handling:
- **PowerShell 5.1**: Uses `ICertificatePolicy` (.NET Framework)
- **PowerShell 7+**: Uses `-SkipCertificateCheck` parameter on  
`Invoke-WebRequest`

## Files Changed
- `scripts/service/windows/manage_service.ps1` - SSL
compatibility fix
- `CHANGELOG.md` - Added entry under Unreleased

## Test Plan
- [x] Run `.\scripts\service\windows\manage_service.ps1 status` 
on PowerShell 7+
- [x] Verify no `CS0246` error occurs