### PR TITLE
fix: use uv pip show for version verification when uv is available

### DIFF
--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -249,9 +249,14 @@ if ($UseUv) {
 
 Write-SuccessLog "Dependencies installed"
 
-# Verify installation
+# Verify installation - use same tool that was used for installation
 try {
-    $PipShow = pip show mcp-memory-service 2>&1 | Out-String
+    if ($UseUv) {
+        $PipShow = uv pip show mcp-memory-service 2>&1 | Out-String
+    } else {
+        $PipShow = pip show mcp-memory-service 2>&1 | Out-String
+    }
+
     if ($PipShow -match 'Version:\s+(.+)') {
         $InstalledVersion = $Matches[1].Trim()
     } else {
@@ -261,10 +266,18 @@ try {
     if ($InstalledVersion -ne $NewVersion) {
         Write-WarningLog "Installation version mismatch! Expected: $NewVersion, Got: $InstalledVersion"
         Write-WarningLog "Retrying installation..."
-        & pip install -e . --force-reinstall --quiet 2>&1 | Out-Null
+        if ($UseUv) {
+            & uv pip install -e . --reinstall --quiet 2>&1 | Out-Null
+        } else {
+            & pip install -e . --force-reinstall --quiet 2>&1 | Out-Null
+        }
 
         # Re-check
-        $PipShow = pip show mcp-memory-service 2>&1 | Out-String
+        if ($UseUv) {
+            $PipShow = uv pip show mcp-memory-service 2>&1 | Out-String
+        } else {
+            $PipShow = pip show mcp-memory-service 2>&1 | Out-String
+        }
         if ($PipShow -match 'Version:\s+(.+)') {
             $InstalledVersion = $Matches[1].Trim()
         }


### PR DESCRIPTION
## Summary
- Fix version mismatch error in Windows update script when using uv
- The script now uses `uv pip show` to verify installation when uv was used for installation
- Previously it always used `pip show` which could find an old version in system Python site-packages

## Test plan
- [x] Verified `uv pip show mcp-memory-service` returns correct version 10.3.0
- [x] Removed old 8.71.0 from system Python to confirm issue was dual installation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)