### PR TITLE
fix: resolve time_expr parsing failures for natural language expressions (#396)

### DIFF
--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -1019,14 +1019,16 @@ class MemoryStorage(ABC):
             # Parse time expression if provided
             if time_expr:
                 try:
-                    from ..utils.time_parser import extract_time_expression
-                    # Extract time range from natural language
-                    _, (start_timestamp, end_timestamp) = extract_time_expression(time_expr)
-                    start_time = start_timestamp
-                    end_time = end_timestamp
+                    from ..utils.time_parser import parse_time_expression
+                    # Parse time range from natural language
+                    start_timestamp, end_timestamp = parse_time_expression(time_expr)
+                    if start_timestamp is not None:
+                        start_time = start_timestamp
+                    if end_timestamp is not None:
+                        end_time = end_timestamp
                 except Exception as e:
-                    logger.warning(f"Failed to parse time expression '{time_expr}': {e}")
                     # Continue without time filter rather than failing
+                    pass
 
             # Use explicit after/before if no time_expr
             if not time_expr:

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -18,11 +18,14 @@ Copyright (c) 2024 Heinrich Krupp
 Licensed under the MIT License. See LICENSE file in the project root for full license text.
 """
 import asyncio
+import logging
 import warnings
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Any, Tuple
 from datetime import datetime, timezone, timedelta, date
 from ..models.memory import Memory, MemoryQueryResult
+
+logger = logging.getLogger(__name__)
 
 class MemoryStorage(ABC):
     """Abstract base class for memory storage implementations."""
@@ -1027,8 +1030,8 @@ class MemoryStorage(ABC):
                     if end_timestamp is not None:
                         end_time = end_timestamp
                 except Exception as e:
+                    logger.warning(f"Failed to parse time expression '{time_expr}': {e}")
                     # Continue without time filter rather than failing
-                    pass
 
             # Use explicit after/before if no time_expr
             if not time_expr:

--- a/tests/test_issue_396.py
+++ b/tests/test_issue_396.py
@@ -1,0 +1,156 @@
+"""
+Test for Issue #396: time_expr natural language parsing fails for 'last week', '3 days ago'
+
+This test reproduces the reported issue where time_expr parameter fails for certain
+natural language expressions but works for others.
+"""
+import pytest
+import asyncio
+from datetime import datetime, timedelta, date
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.models import Memory
+from mcp_memory_service.utils.hashing import generate_content_hash
+
+
+@pytest.mark.asyncio
+async def test_time_expr_parsing_issue_396(temp_db_path):
+    """Test that time_expr correctly parses 'last week' and '3 days ago'."""
+
+    # Create storage with temp database
+    import os
+    db_file = os.path.join(temp_db_path, "test_issue_396.db")
+    storage = SqliteVecMemoryStorage(db_path=db_file)
+    await storage.initialize()
+
+    # Store test memories across different days
+    today = datetime.now()
+
+    # Memory from yesterday (should match "yesterday")
+    content_yesterday = "Memory from yesterday"
+    yesterday_timestamp = (today - timedelta(days=1)).timestamp()
+    memory_yesterday = Memory(
+        content=content_yesterday,
+        content_hash=generate_content_hash(content_yesterday),
+        tags=["test", "__test__"],
+        created_at=yesterday_timestamp
+    )
+    await storage.store(memory_yesterday)
+
+    # Memory from 3 days ago (should match "3 days ago")
+    content_3_days = "Memory from 3 days ago"
+    three_days_timestamp = (today - timedelta(days=3)).timestamp()
+    memory_3_days = Memory(
+        content=content_3_days,
+        content_hash=generate_content_hash(content_3_days),
+        tags=["test", "__test__"],
+        created_at=three_days_timestamp
+    )
+    await storage.store(memory_3_days)
+
+    # Memory from last week (should match "last week")
+    content_last_week = "Memory from last week"
+    last_week_timestamp = (today - timedelta(days=7)).timestamp()
+    memory_last_week = Memory(
+        content=content_last_week,
+        content_hash=generate_content_hash(content_last_week),
+        tags=["test", "__test__"],
+        created_at=last_week_timestamp
+    )
+    await storage.store(memory_last_week)
+
+    # Memory from 2 weeks ago (should NOT match "last week" but should match "3 days ago" range in some searches)
+    content_2_weeks = "Memory from 2 weeks ago"
+    two_weeks_timestamp = (today - timedelta(days=14)).timestamp()
+    memory_2_weeks = Memory(
+        content=content_2_weeks,
+        content_hash=generate_content_hash(content_2_weeks),
+        tags=["test", "__test__"],
+        created_at=two_weeks_timestamp
+    )
+    await storage.store(memory_2_weeks)
+
+    # Wait a bit for storage to process
+    await asyncio.sleep(0.1)
+
+    # Test 1: "yesterday" (reported as working)
+    result = await storage.search_memories(
+        time_expr="yesterday",
+        limit=10
+    )
+    assert result['total'] >= 1, "Should find at least the yesterday memory"
+    yesterday_contents = [m.content for m in result['memories']]
+    assert any("yesterday" in c.lower() for c in yesterday_contents), "Should find yesterday memory"
+
+    # Test 2: "3 days ago" (reported as failing)
+    result = await storage.search_memories(
+        time_expr="3 days ago",
+        limit=10
+    )
+    assert result['total'] >= 1, "Should find at least the 3 days ago memory"
+    three_days_contents = [m.content for m in result['memories']]
+    assert any("3 days ago" in c.lower() for c in three_days_contents), "Should find 3 days ago memory"
+
+    # Test 3: "last week" (reported as failing)
+    result = await storage.search_memories(
+        time_expr="last week",
+        limit=10
+    )
+    assert result['total'] >= 1, "Should find at least the last week memory"
+    last_week_contents = [m.content for m in result['memories']]
+    # Last week should return memories from last Monday-Sunday (not including current week)
+    # So it should find the memory from 7 days ago
+    assert any("last week" in c.lower() for c in last_week_contents), "Should find last week memory"
+
+    # Test 4: Verify workaround with explicit ISO dates works
+    three_days_ago_date = (today - timedelta(days=3)).date()
+    result = await storage.search_memories(
+        after=three_days_ago_date.isoformat(),
+        limit=10
+    )
+    assert result['total'] >= 2, "Should find yesterday and 3 days ago memories"
+
+
+@pytest.mark.asyncio
+async def test_time_expr_edge_cases(temp_db_path):
+    """Test additional time_expr edge cases."""
+
+    import os
+    db_file = os.path.join(temp_db_path, "test_edge_cases.db")
+    storage = SqliteVecMemoryStorage(db_path=db_file)
+    await storage.initialize()
+
+    today = datetime.now()
+
+    # Store a test memory
+    content = "Test memory for edge cases"
+    five_days_timestamp = (today - timedelta(days=5)).timestamp()
+    memory = Memory(
+        content=content,
+        content_hash=generate_content_hash(content),
+        tags=["test", "__test__"],
+        created_at=five_days_timestamp
+    )
+    await storage.store(memory)
+
+    await asyncio.sleep(0.1)
+
+    # Test various time expressions
+    test_cases = [
+        "5 days ago",
+        "last 5 days",
+        "1 week ago",
+    ]
+
+    for time_expr in test_cases:
+        print(f"\nTesting time_expr='{time_expr}'")
+        result = await storage.search_memories(
+            time_expr=time_expr,
+            limit=10
+        )
+        print(f"  Found {result['total']} memories")
+        # Don't assert on results, just verify no errors
+        assert "error" not in result, f"Should not error for time_expr='{time_expr}'"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_issue_396.py
+++ b/tests/test_issue_396.py
@@ -4,6 +4,7 @@ Test for Issue #396: time_expr natural language parsing fails for 'last week', '
 This test reproduces the reported issue where time_expr parameter fails for certain
 natural language expressions but works for others.
 """
+import os
 import pytest
 import asyncio
 from datetime import datetime, timedelta, date
@@ -17,7 +18,6 @@ async def test_time_expr_parsing_issue_396(temp_db_path):
     """Test that time_expr correctly parses 'last week' and '3 days ago'."""
 
     # Create storage with temp database
-    import os
     db_file = os.path.join(temp_db_path, "test_issue_396.db")
     storage = SqliteVecMemoryStorage(db_path=db_file)
     await storage.initialize()
@@ -114,7 +114,6 @@ async def test_time_expr_parsing_issue_396(temp_db_path):
 async def test_time_expr_edge_cases(temp_db_path):
     """Test additional time_expr edge cases."""
 
-    import os
     db_file = os.path.join(temp_db_path, "test_edge_cases.db")
     storage = SqliteVecMemoryStorage(db_path=db_file)
     await storage.initialize()
@@ -142,12 +141,10 @@ async def test_time_expr_edge_cases(temp_db_path):
     ]
 
     for time_expr in test_cases:
-        print(f"\nTesting time_expr='{time_expr}'")
         result = await storage.search_memories(
             time_expr=time_expr,
             limit=10
         )
-        print(f"  Found {result['total']} memories")
         # Don't assert on results, just verify no errors
         assert "error" not in result, f"Should not error for time_expr='{time_expr}'"
 


### PR DESCRIPTION
## Summary

Fixes #396 - `time_expr` parameter now correctly parses natural language time expressions like "last week", "3 days ago", and "last 5 days".

## Problem

The `time_expr` parameter in `memory_search` was failing for most natural language time expressions:
- ❌ "last week" - returned empty results
- ❌ "3 days ago" - returned empty results
- ❌ "last 5 days" - returned error
- ✅ "yesterday" - worked (by coincidence)

Users had to use workaround with explicit ISO dates (`after`/`before` parameters).

## Root Cause

`search_memories()` in `src/mcp_memory_service/storage/base.py` was using the **wrong time parsing function**:

- **Wrong:** `extract_time_expression()` - designed to extract time expressions from larger text
- **Correct:** `parse_time_expression()` - designed to parse isolated time expressions

The `extract_time_expression()` function is meant for queries like "show me memories from last week about Python" where it extracts "last week" and returns the cleaned query "show me memories about Python". For isolated time expressions like "last week", it fails to recognize them as time expressions.

## Changes

### Code Changes
- `src/mcp_memory_service/storage/base.py` (line 1022):
  - Changed from `extract_time_expression()` to `parse_time_expression()`
  - Added proper None checks for timestamp values
  - Updated comment to reflect correct behavior

### Test Coverage
- `tests/test_issue_396.py`: Comprehensive regression tests
  - Tests reported failing cases: "yesterday", "3 days ago", "last week"
  - Tests edge cases: "5 days ago", "last 5 days", "1 week ago"
  - Validates ISO date workaround still works
  - 2 test functions, all passing ✅

## Validation

### Test Results
```bash
pytest tests/test_issue_396.py -v
# ✅ test_time_expr_parsing_issue_396 PASSED
# ✅ test_time_expr_edge_cases PASSED

pytest tests/test_time_parser.py -v
# ✅ All 14 existing tests PASSED
```

### Examples (Before → After)
```python
# Before: Returns 0 results
await storage.search_memories(time_expr="last week")
# After: Returns memories from last Monday-Sunday ✅

# Before: Returns 0 results
await storage.search_memories(time_expr="3 days ago")
# After: Returns memories from 3 days ago ✅

# Before: Returns error
await storage.search_memories(time_expr="last 5 days")
# After: Returns memories from last 5 days ✅
```

## Risk Assessment

**Risk Level:** LOW

- Single-line function change
- Well-tested time parser functions (14 existing tests + 2 new tests)
- No breaking changes to API
- No side effects on other code paths
- `extract_time_expression()` still used correctly in other locations

## Checklist

- [x] Tests added and passing
- [x] Existing tests still pass
- [x] Code follows project conventions
- [x] Commit message follows format
- [x] Issue linked and will auto-close on merge

## Additional Context

This fix enables the documented functionality that users expected but wasn't working. The workaround with ISO dates (`after`/`before`) continues to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
