### PR TITLE
fix: resolve Windows Task Scheduler HTTP dashboard startup failures

### DIFF
--- a/scripts/service/windows/install_scheduled_task.ps1
+++ b/scripts/service/windows/install_scheduled_task.ps1
@@ -72,8 +72,13 @@ if ($ExistingTask) {
 
 Write-Host "[INFO] Creating scheduled task..." -ForegroundColor Green
 
-# Create the action
-$Action = New-ScheduledTaskAction -Execute "powershell.exe" `
+# Create the action (use full path — Task Scheduler has minimal PATH)
+$PowerShellPath = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+if (-not (Test-Path $PowerShellPath)) {
+    # Fallback: resolve from current session
+    $PowerShellPath = (Get-Command powershell.exe).Source
+}
+$Action = New-ScheduledTaskAction -Execute $PowerShellPath `
     -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$WrapperScript`"" `
     -WorkingDirectory $ProjectRoot
 

--- a/scripts/service/windows/manage_service.ps1
+++ b/scripts/service/windows/manage_service.ps1
@@ -221,7 +221,7 @@ function Start-Server {
                 UseBasicParsing = $true
                 ErrorAction = 'SilentlyContinue'
             }
-                $Response = Invoke-WebRequest @params
+            $Response = Invoke-WebRequest @params
             if ($Response.StatusCode -eq 200) {
                 Write-Host "[SUCCESS] Server started successfully!" -ForegroundColor Green
                 Write-Host "Dashboard: http://127.0.0.1:8000/" -ForegroundColor Cyan

--- a/scripts/service/windows/manage_service.ps1
+++ b/scripts/service/windows/manage_service.ps1
@@ -45,30 +45,8 @@ $ErrorActionPreference = "Stop"
 $TaskName = "MCPMemoryHTTPServer"
 $LogFile = Join-Path $env:LOCALAPPDATA "mcp-memory\logs\http-server.log"
 $PidFile = Join-Path $env:LOCALAPPDATA "mcp-memory\http-server.pid"
-# HTTPS is enabled by default
-$HealthUrl = "https://127.0.0.1:8000/api/health"
-
-# Skip SSL certificate validation for self-signed certificates
-# Compatible with both PowerShell 5.1 and 7+
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-
-# Check if we're on PowerShell 7+ (has -SkipCertificateCheck parameter)
-$Script:SkipCertCheckSupported = $PSVersionTable.PSVersion.Major -ge 7
-
-# For PowerShell 5.1, use callback approach (ICertificatePolicy exists in .NET Framework)
-if (-not $Script:SkipCertCheckSupported) {
-    if (-not ("TrustAllCertsPolicy" -as [type])) {
-        Add-Type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) { return true; }
-}
-"@
-    }
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-}
+# HTTP server (default configuration — no TLS)
+$HealthUrl = "http://127.0.0.1:8000/api/health"
 
 function Show-Help {
     Write-Host ""
@@ -124,7 +102,6 @@ function Get-ServerStatus {
             UseBasicParsing = $true
             ErrorAction = 'SilentlyContinue'
         }
-        if ($Script:SkipCertCheckSupported) { $params['SkipCertificateCheck'] = $true }
         $Response = Invoke-WebRequest @params
         if ($Response.StatusCode -eq 200) {
             $HttpHealthy = $true
@@ -193,7 +170,7 @@ function Show-Status {
     if ($Status.HttpHealthy) {
         Write-Host "  Status:  " -NoNewline
         Write-Host "HEALTHY" -ForegroundColor Green
-        Write-Host "  URL:     https://127.0.0.1:8000/"
+        Write-Host "  URL:     http://127.0.0.1:8000/"
         if ($Status.HealthResponse) {
             Write-Host "  Version: $($Status.HealthResponse.version)"
             Write-Host "  Backend: $($Status.HealthResponse.storage_backend)"
@@ -244,11 +221,10 @@ function Start-Server {
                 UseBasicParsing = $true
                 ErrorAction = 'SilentlyContinue'
             }
-            if ($Script:SkipCertCheckSupported) { $params['SkipCertificateCheck'] = $true }
-            $Response = Invoke-WebRequest @params
+                $Response = Invoke-WebRequest @params
             if ($Response.StatusCode -eq 200) {
                 Write-Host "[SUCCESS] Server started successfully!" -ForegroundColor Green
-                Write-Host "Dashboard: https://127.0.0.1:8000/" -ForegroundColor Cyan
+                Write-Host "Dashboard: http://127.0.0.1:8000/" -ForegroundColor Cyan
                 return
             }
         } catch {
@@ -324,7 +300,6 @@ function Check-Health {
             TimeoutSec = 5
             UseBasicParsing = $true
         }
-        if ($Script:SkipCertCheckSupported) { $params['SkipCertificateCheck'] = $true }
         $Response = Invoke-WebRequest @params
         Write-Host "[SUCCESS] Server is healthy!" -ForegroundColor Green
         Write-Host ""

--- a/scripts/service/windows/run_http_server_background.ps1
+++ b/scripts/service/windows/run_http_server_background.ps1
@@ -161,8 +161,8 @@ while ($RestartCount -lt $MaxRestarts) {
                     "C:\Python3*\python.exe"
                 )
                 foreach ($Pattern in $PythonCandidates) {
-                    $Match = Get-Item $Pattern -ErrorAction SilentlyContinue | Select-Object -First 1
-                    if ($Match) { $PythonPath = $Match.FullName; break }
+                    $Matches = Get-Item $Pattern -ErrorAction SilentlyContinue
+                    if ($Matches) { $PythonPath = ($Matches | Sort-Object Name -Descending | Select-Object -First 1).FullName; break }
                 }
             }
 

--- a/scripts/service/windows/run_http_server_background.ps1
+++ b/scripts/service/windows/run_http_server_background.ps1
@@ -162,7 +162,7 @@ while ($RestartCount -lt $MaxRestarts) {
                 )
                 foreach ($Pattern in $PythonCandidates) {
                     $Matches = Get-Item $Pattern -ErrorAction SilentlyContinue
-                    if ($Matches) { $PythonPath = ($Matches | Sort-Object Name -Descending | Select-Object -First 1).FullName; break }
+                    if ($Matches) { $PythonPath = ($Matches | Sort-Object DirectoryName -Descending | Select-Object -First 1).FullName; break }
                 }
             }
 

--- a/scripts/service/windows/run_http_server_background.ps1
+++ b/scripts/service/windows/run_http_server_background.ps1
@@ -60,6 +60,34 @@ function Load-EnvFile {
     }
 }
 
+# Find uv executable (Task Scheduler has a minimal PATH)
+function Find-Executable {
+    # Common install locations for uv on Windows
+    $Candidates = @(
+        (Join-Path $env:USERPROFILE ".local\bin\uv.exe"),
+        (Join-Path $env:LOCALAPPDATA "uv\uv.exe"),
+        (Join-Path $env:USERPROFILE ".cargo\bin\uv.exe"),
+        "C:\ProgramData\uv\uv.exe"
+    )
+
+    foreach ($Path in $Candidates) {
+        if (Test-Path $Path) {
+            Write-Log "Found uv at: $Path"
+            return $Path
+        }
+    }
+
+    # Try PATH resolution (works in interactive shells, may fail in Task Scheduler)
+    $PathResolved = Get-Command uv -ErrorAction SilentlyContinue
+    if ($PathResolved) {
+        Write-Log "Found uv on PATH: $($PathResolved.Source)"
+        return $PathResolved.Source
+    }
+
+    Write-Log "uv not found, will fall back to python directly" "WARN"
+    return $null
+}
+
 # Check if server is already running
 function Test-ServerRunning {
     if (Test-Path $PidFile) {
@@ -109,23 +137,36 @@ while ($RestartCount -lt $MaxRestarts) {
     Write-Log "Starting HTTP server (attempt $($RestartCount + 1)/$MaxRestarts)..."
 
     try {
-        # Start the server process
+        # Resolve executable (uv or python fallback)
+        $UvPath = Find-Executable
         $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
-        $ProcessInfo.FileName = "uv"
-        $ProcessInfo.Arguments = "run python scripts/server/run_http_server.py"
+        if ($UvPath) {
+            $ProcessInfo.FileName = $UvPath
+            $ProcessInfo.Arguments = "run python scripts/server/run_http_server.py"
+        } else {
+            # Fallback: run python directly
+            $PythonPath = (Get-Command python -ErrorAction SilentlyContinue).Source
+            if (-not $PythonPath) { $PythonPath = "python" }
+            $ProcessInfo.FileName = $PythonPath
+            $ProcessInfo.Arguments = "scripts/server/run_http_server.py"
+        }
         $ProcessInfo.WorkingDirectory = $ProjectRoot
         $ProcessInfo.UseShellExecute = $false
         $ProcessInfo.RedirectStandardOutput = $true
         $ProcessInfo.RedirectStandardError = $true
         $ProcessInfo.CreateNoWindow = $true
 
+        Write-Log "Executable: $($ProcessInfo.FileName) $($ProcessInfo.Arguments)"
+
         $Process = New-Object System.Diagnostics.Process
         $Process.StartInfo = $ProcessInfo
 
         # Event handlers for output
+        # NOTE: $using: scope does NOT work in .NET event handlers (only in PS jobs/runspaces).
+        # Use $script: scope which is captured by the closure.
         $OutputHandler = {
             if (-not [String]::IsNullOrEmpty($EventArgs.Data)) {
-                Add-Content -Path $using:LogFile -Value "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] [SERVER] $($EventArgs.Data)"
+                Add-Content -Path $script:LogFile -Value "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] [SERVER] $($EventArgs.Data)"
             }
         }
 

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -48,30 +48,8 @@ $StartTime = Get-Date
 # Configuration
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
 $ManageServiceScript = Join-Path $PSScriptRoot "manage_service.ps1"
-# HTTPS is enabled by default - use https and skip certificate validation for self-signed certs
-$HealthUrl = "https://127.0.0.1:8000/api/health"
-
-# Skip SSL certificate validation for self-signed certificates
-# Compatible with both PowerShell 5.1 and 7+
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-
-# Check if we're on PowerShell 7+ (has -SkipCertificateCheck parameter)
-$Script:SkipCertCheckSupported = $PSVersionTable.PSVersion.Major -ge 7
-
-# For PowerShell 5.1, use callback approach
-if (-not $Script:SkipCertCheckSupported) {
-    if (-not ("TrustAllCertsPolicy" -as [type])) {
-        Add-Type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) { return true; }
-}
-"@
-    }
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-}
+# HTTP server (default configuration — no TLS)
+$HealthUrl = "http://127.0.0.1:8000/api/health"
 
 # Color helpers
 function Write-InfoLog { param($Message) Write-Host "[i] $Message" -ForegroundColor Cyan }
@@ -102,7 +80,6 @@ function Get-ServerVersion {
             TimeoutSec = 3
             ErrorAction = 'SilentlyContinue'
         }
-        if ($Script:SkipCertCheckSupported) { $params['SkipCertificateCheck'] = $true }
         $Response = Invoke-RestMethod @params
         return $Response.version
     } catch {
@@ -330,8 +307,7 @@ if ($NoRestart) {
                 TimeoutSec = 2
                 ErrorAction = 'SilentlyContinue'
             }
-            if ($Script:SkipCertCheckSupported) { $params['SkipCertificateCheck'] = $true }
-            $HealthResponse = Invoke-RestMethod @params
+                $HealthResponse = Invoke-RestMethod @params
             $ServerVersion = $HealthResponse.version
 
             if ($ServerVersion -eq $NewVersion) {
@@ -368,8 +344,8 @@ Write-Host ""
 Write-SuccessLog "Version: $CurrentVersion -> $NewVersion"
 Write-SuccessLog "Total time: ${TotalTime}s"
 Write-Host ""
-Write-InfoLog "Dashboard: https://localhost:8000"
-Write-InfoLog "API Docs:  https://localhost:8000/api/docs"
+Write-InfoLog "Dashboard: http://localhost:8000"
+Write-InfoLog "API Docs:  http://localhost:8000/api/docs"
 Write-Host ""
 
 if ($CurrentVersion -ne $NewVersion) {

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -307,7 +307,7 @@ if ($NoRestart) {
                 TimeoutSec = 2
                 ErrorAction = 'SilentlyContinue'
             }
-                $HealthResponse = Invoke-RestMethod @params
+            $HealthResponse = Invoke-RestMethod @params
             $ServerVersion = $HealthResponse.version
 
             if ($ServerVersion -eq $NewVersion) {


### PR DESCRIPTION
## Summary

Fixes #401 — the `MCPMemoryHTTPServer` Windows Scheduled Task fails to start with error 0x80070002 (FILE_NOT_FOUND) due to 6 interrelated bugs in the Windows service scripts.

**Changes:**

- **`install_scheduled_task.ps1`**: Use full path to `powershell.exe` (resolved via `$env:SystemRoot`) instead of bare name — Task Scheduler's minimal PATH can't find it
- **`run_http_server_background.ps1`**: Add `Find-Executable` function that probes known `uv.exe` install locations (`~\.local\bin`, `%LOCALAPPDATA%\uv`, `.cargo\bin`) with automatic `python` fallback; fix `$using:LogFile` → `$script:LogFile` in .NET event handlers (the `$using:` scope only works in PS jobs/runspaces, not CLR delegates — was silently dropping all server output); add executable path logging for diagnostics
- **`manage_service.ps1`**: Change `https://` → `http://` in health check URL and display URLs; remove unused `TrustAllCertsPolicy` SSL bypass code
- **`update_and_restart.ps1`**: Same HTTPS → HTTP fix and SSL bypass removal

## Test plan

- [x] Manual run of `run_http_server_background.ps1` — server starts, logs show `uv.exe` path resolution
- [x] `curl http://localhost:8000/api/health` returns `{"status":"healthy","version":"10.4.2"}`
- [x] Scheduled task starts server via full `powershell.exe` path — confirmed via Windows Event Log
- [x] `manage_service.ps1 status` shows HTTP Endpoint as HEALTHY with `http://` URL
- [x] Log file shows `.env` loaded, executable path logged, PID recorded