### PR TITLE
fix: add module-level logger to consolidator.py

### DIFF
--- a/src/mcp_memory_service/consolidation/consolidator.py
+++ b/src/mcp_memory_service/consolidation/consolidator.py
@@ -32,6 +32,8 @@ from ..storage.graph import GraphStorage
 from ..config import GRAPH_STORAGE_MODE
 from .relationship_inference import RelationshipInferenceEngine
 
+logger = logging.getLogger(__name__)
+
 
 # Protocol for storage backend interface
 class StorageProtocol(Protocol):


### PR DESCRIPTION
## Bug Fix: Missing Module-Level Logger in Consolidator

### Problem
Memory consolidation operations logged warnings with `NameError: name 'logger' is not defined` during compression and forgetting phases.

### Root Cause
Two methods in `consolidator.py` used bare `logger.warning()` calls:
- `_handle_compression_results()` (line 699)
- `_apply_forgetting_results()` (line 716)

However, no module-level logger was defined. The class has `self.logger` but these specific warnings were attempting to use a module-level logger that didn't exist.

### Solution
Added module-level logger definition after imports:
```python
logger = logging.getLogger(__name__)
```

### Testing
- Consolidation operations now complete successfully without NameError
- Warning messages are properly logged when compression/forgetting operations fail

### Type
- [x] Bug fix (non-breaking change that fixes an issue)

---
🤖 Generated with [Claude Code](https://claude.ai/code)