### PR TITLE
Fix stale statusline with live API query and per-CWD injection tracking

### DIFF
--- a/claude-hooks/statusline.sh
+++ b/claude-hooks/statusline.sh
@@ -1,56 +1,136 @@
 #!/bin/bash
 
 # Claude Code Status Line Script
-# Displays session memory context in status line
-# Format: 🧠 8 (5 recent) memories | 📊 12 commits
+# Displays live memory count from mcp-memory-service HTTP API
+# with per-CWD injection tracking via injections.log
+#
+# Replaces stale session-cache.json approach with:
+# 1. Live API query for current memory count (30s cache TTL)
+# 2. Per-CWD injection log for accurate "injected this session" counts
+# 3. Rough token estimate for context awareness
+#
+# Fixes: https://github.com/doobidoo/mcp-memory-service/issues/408
 
-# Path to session cache file
-CACHE_FILE="$HOME/.claude/hooks/utilities/session-cache.json"
+# Read JSON input from Claude Code
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // empty')
 
-# ANSI color codes for styling
+# Configuration
+ENDPOINT="${MCP_MEMORY_ENDPOINT:-http://127.0.0.1:8000}"
+CACHE_FILE="$HOME/.claude/hooks/utilities/statusline-cache.json"
+INJECTION_LOG="$HOME/.claude/hooks/utilities/injections.log"
+CACHE_TTL=30  # seconds
+
+# ANSI color codes
 CYAN='\033[36m'
 GREEN='\033[32m'
 GRAY='\033[90m'
 RESET='\033[0m'
 
-# Check if cache file exists
-if [ ! -f "$CACHE_FILE" ]; then
-    # No cache file - session not started yet or hook failed
-    echo ""
-    exit 0
+# ── Live memory count with cache TTL ──
+
+refresh_cache() {
+    # Use curl (not PowerShell Invoke-WebRequest) for Windows compatibility
+    # Prefer curl.exe on Windows (MSYS2 curl can't reach Windows-bound localhost)
+    CURL_CMD="curl"
+    if command -v curl.exe >/dev/null 2>&1; then
+        CURL_CMD="curl.exe"
+    fi
+
+    local total=$($CURL_CMD -s --max-time 2 "${ENDPOINT}/api/memories?page_size=1" 2>/dev/null \
+        | jq -r '.total // 0' 2>/dev/null)
+    # Validate total is an integer to prevent command injection via heredoc
+    [[ "$total" =~ ^[0-9]+$ ]] || total=0
+
+    local now=$(date +%s)
+    mkdir -p "$(dirname "$CACHE_FILE")"
+    cat > "$CACHE_FILE" <<ENDJSON
+{"timestamp":${now},"total":${total}}
+ENDJSON
+    echo "$total"
+}
+
+read_cache() {
+    if [ ! -f "$CACHE_FILE" ]; then
+        return 1
+    fi
+    local cached_ts=$(jq -r '.timestamp // 0' "$CACHE_FILE" 2>/dev/null)
+    local now=$(date +%s)
+    local age=$((now - cached_ts))
+    if [ "$age" -gt "$CACHE_TTL" ]; then
+        return 1
+    fi
+    jq -r '.total // 0' "$CACHE_FILE" 2>/dev/null
+}
+
+# Get total stored count (with cache)
+TOTAL=$(read_cache)
+if [ -z "$TOTAL" ]; then
+    TOTAL=$(refresh_cache)
+fi
+TOTAL=${TOTAL:-0}
+
+# ── Per-CWD injection tracking ──
+# Count injections for this CWD from the injection log (last 6 hours)
+
+INJECTIONS=0
+INJECT_TOKENS=0
+SESSION_WINDOW=21600  # 6 hours
+
+if [ -n "$cwd" ] && [ -f "$INJECTION_LOG" ]; then
+    NOW=$(date +%s)
+    CUTOFF=$((NOW - SESSION_WINDOW))
+    # Normalize CWD for cross-platform comparison (backslash→slash, lowercase)
+    NORM_CWD=$(echo "$cwd" | tr '\\' '/' | tr '[:upper:]' '[:lower:]')
+
+    # Use awk for single-pass processing — faster than while-read on large logs
+    # and inherently safe from bash injection (awk treats non-numeric as 0)
+    read -r INJECTIONS INJECT_TOKENS <<< "$(awk -F'|' \
+        -v cutoff="$CUTOFF" \
+        -v norm_cwd="$NORM_CWD" \
+        'BEGIN { inj=0; tok=0 }
+        {
+            ts=$1; log_cwd=$2; count=$4; tokens=$5
+            if (ts+0 >= cutoff+0) {
+                gsub(/\\/, "/", log_cwd)
+                low_cwd = tolower(log_cwd)
+                if (low_cwd == norm_cwd) {
+                    inj += count+0
+                    tok += tokens+0
+                }
+            }
+        }
+        END { print inj, tok }' "$INJECTION_LOG")"
+    INJECTIONS=${INJECTIONS:-0}
+    INJECT_TOKENS=${INJECT_TOKENS:-0}
 fi
 
-# Read cache file and extract data
-MEMORIES=$(jq -r '.memoriesLoaded // 0' "$CACHE_FILE" 2>/dev/null)
-RECENT=$(jq -r '.recentCount // 0' "$CACHE_FILE" 2>/dev/null)
-GIT_COMMITS=$(jq -r '.gitCommits // 0' "$CACHE_FILE" 2>/dev/null)
+# ── Build status line ──
 
-# Handle jq errors
-if [ $? -ne 0 ]; then
-    echo ""
-    exit 0
-fi
-
-# Build status line output
 STATUS=""
 
-# Memory section
-if [ "$MEMORIES" -gt 0 ]; then
-    if [ "$RECENT" -gt 0 ]; then
-        STATUS="${CYAN}🧠 ${MEMORIES}${RESET} ${GREEN}(${RECENT} recent)${RESET} memories"
+if [ "$INJECTIONS" -gt 0 ]; then
+    # Show injection-based count (accurate per-session)
+    if [ "$INJECT_TOKENS" -ge 1000 ]; then
+        TOK_STR=$(awk "BEGIN {printf \"%.1fk\", $INJECT_TOKENS/1000}")
     else
-        STATUS="${CYAN}🧠 ${MEMORIES}${RESET} memories"
+        TOK_STR="$INJECT_TOKENS"
+    fi
+    STATUS="${CYAN}🧠 ${INJECTIONS} injected${RESET} ${GRAY}(~${TOK_STR} tok)${RESET}"
+elif [ "$TOTAL" -gt 0 ]; then
+    # Fallback: show total stored count from API
+    STATUS="${CYAN}🧠 ${TOTAL}${RESET} ${GRAY}stored${RESET}"
+fi
+
+# Fallback: check legacy session-cache.json for backwards compatibility
+if [ -z "$STATUS" ]; then
+    LEGACY_CACHE="$HOME/.claude/hooks/utilities/session-cache.json"
+    if [ -f "$LEGACY_CACHE" ]; then
+        MEMORIES=$(jq -r '.memoriesLoaded // 0' "$LEGACY_CACHE" 2>/dev/null)
+        if [[ "$MEMORIES" =~ ^[0-9]+$ ]] && [ "$MEMORIES" -gt 0 ]; then
+            STATUS="${CYAN}🧠 ${MEMORIES}${RESET} memories"
+        fi
     fi
 fi
 
-# Git section
-if [ "$GIT_COMMITS" -gt 0 ]; then
-    if [ -n "$STATUS" ]; then
-        STATUS="${STATUS} ${GRAY}|${RESET} ${CYAN}📊 ${GIT_COMMITS} commits${RESET}"
-    else
-        STATUS="${CYAN}📊 ${GIT_COMMITS} commits${RESET}"
-    fi
-fi
-
-# Output first line becomes status line
 echo -e "$STATUS"


### PR DESCRIPTION
## Summary

- Replace stale `session-cache.json` reads with live HTTP API queries
- Add 30-second file-based cache TTL to avoid process spawn overhead
- Support per-CWD injection tracking via `injections.log` for accurate per-session counts
- Add Windows compatibility (prefer `curl.exe` over MSYS2 `curl` for localhost)
- Fall back to legacy `session-cache.json` for backwards compatibility

## Problem

The current `statusline.sh` reads from `session-cache.json` written once at session start by `session-start.js`. This causes:
1. **Stale counts** that never update during the session
2. **Global scope** showing total stored memories (not per-project)
3. **Multi-session confusion** when running concurrent Claude Code sessions

## Solution

Query the live HTTP API (`GET /api/memories?page_size=1`) with a 30-second cache TTL. Also support an optional `injections.log` file for hooks that track actual memory injections per CWD, giving users accurate "X memories injected this session" counts instead of misleading global totals.

## Test plan

- [ ] Verify statusline shows live memory count (add a memory, wait 30s, count updates)
- [ ] Verify multi-session isolation (different CWDs show independent injection counts)
- [ ] Verify backwards compatibility (works without injections.log, falls back to session-cache.json)
- [ ] Verify Windows compatibility (`curl.exe` used when available)
- [ ] Verify graceful degradation when HTTP API is unavailable (shows nothing, no errors)

Fixes #408