### PR TITLE
[Fix] API Key authentication without OAuth enabled (#407)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,12 +88,25 @@ MCP_HTTP_PORT=8000
 # MCP_HTTPS_ENABLED=true
 # MCP_HTTPS_PORT=8443
 
-# OAuth 2.1 Authentication (for web interface)
+# =============================================================================
+# Authentication
+# =============================================================================
+
+# API Key Authentication (simple, no OAuth required)
+# Accepts API key via X-API-Key header or api_key query parameter
+# Example: curl -H "X-API-Key: your-secret-key" http://localhost:8000/api/memories
+# MCP_API_KEY=your-secret-key-here
+
+# OAuth 2.1 Authentication (for web interface with team collaboration)
 # MCP_OAUTH_ENABLED=false
 
 # OAuth Storage Backend (memory|sqlite)
 MCP_OAUTH_STORAGE_BACKEND=memory
 MCP_OAUTH_SQLITE_PATH=./data/oauth.db
+
+# Anonymous Access (allow unauthenticated read-only access)
+# Only enable this if you're behind a firewall or using external auth (e.g., Nginx Basic Auth)
+# MCP_ALLOW_ANONYMOUS_ACCESS=false
 
 # Hybrid Backend Configuration (if using hybrid)
 # MCP_HYBRID_SYNC_INTERVAL=300      # Sync every 5 minutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.4.4] - 2026-02-05
+
+### Security
+- **CRITICAL: Timing Attack Vulnerability** (PR #411): Fixed CWE-208 timing attack in API key comparison
+  - Replaced direct string comparison with `secrets.compare_digest()` for constant-time comparison
+  - Prevents attackers from determining correct API key character-by-character via timing analysis
+  - All API key authentication methods now use secure comparison (X-API-Key header, query parameter, Bearer token)
+  - Severity: CRITICAL - Recommend immediate upgrade for all deployments using API key authentication
+
+### Fixed
+- **API Key Authentication without OAuth** (Issue #407, PR #411): API key auth now works independently of OAuth configuration
+  - Root cause: API routes had conditional OAuth dependencies that prevented API key authentication when `MCP_OAUTH_ENABLED=false`
+  - Solution: Removed OAuth conditionals from ALL 44 API route endpoints
+  - Authentication middleware now handles all auth methods unconditionally: OAuth, API key, or anonymous
+  - Enables simple single-user deployments without OAuth overhead
+
+### Added
+- **X-API-Key Header Authentication** (PR #411): Recommended method for API key authentication
+  - Usage: `curl -H "X-API-Key: your-secret-key" http://localhost:8000/api/memories`
+  - More secure than query parameters (not logged in server logs)
+  - Works with all API endpoints
+- **Query Parameter Authentication** (PR #411): Convenient fallback for scripts/browsers
+  - Usage: `curl "http://localhost:8000/api/memories?api_key=your-secret-key"`
+  - Warning: Logs API keys in server logs - use X-API-Key header in production
+- **Bearer Token Compatibility** (PR #411): Backward compatible with existing Bearer token auth
+  - Usage: `curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/api/memories`
+
+### Changed
+- **OAuth Import Behavior** (PR #411): OAuth authentication modules now always imported regardless of configuration
+  - Previous behavior caused FastAPI AssertionError when `OAUTH_ENABLED=false`
+  - Middleware decides auth method at runtime based on configuration
+  - Allows server startup with OAuth disabled while maintaining proper authentication
+
 ## [10.4.3] - 2026-02-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.4.3 - Windows Task Scheduler & consolidation stability fixes (6 Windows bugs fixed, logger NameError resolved) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.4.4 - CRITICAL security fix for timing attack in API key auth (CWE-208) + API key auth without OAuth (Issue #407) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -179,18 +179,22 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.4.3** (February 4, 2026)
+## 🆕 Latest Release: **v10.4.4** (February 5, 2026)
 
-**Windows Compatibility & Consolidation Stability**
+**CRITICAL Security Fix & API Key Authentication**
 
-**What's Fixed:**
-- 🪟 **Windows Task Scheduler**: Fixed 6 bugs preventing HTTP dashboard scheduled task startup (PR #402)
-  - PATH resolution, executable discovery, log capture, health check URLs, Python version sorting
-  - Windows users can now reliably run HTTP dashboard as scheduled task
-- 🔧 **Consolidation Logger**: Fixed NameError crash in memory consolidation (PR #404)
-  - Added missing module-level logger preventing crashes during compression/forgetting operations
+**What's New:**
+- 🔒 **CRITICAL Security Fix**: Fixed timing attack vulnerability in API key comparison (CWE-208)
+  - Prevents attackers from determining API keys via timing analysis
+  - Immediate upgrade recommended for all API key deployments
+- 🔑 **API Key Authentication Fixed**: Works independently without OAuth (Issue #407)
+  - X-API-Key header support (recommended, secure)
+  - Query parameter fallback (convenient for scripts)
+  - Bearer token backward compatibility
+- 🛡️ **Single-User Deployments**: Simple API key setup without OAuth overhead
 
 **Previous Releases**:
+- **v10.4.3** - Windows Task Scheduler & Consolidation Stability (6 bugs fixed, logger NameError resolved)
 - **v10.4.2** - Docker Container Startup Fix (ModuleNotFoundError: aiosqlite)
 - **v10.4.1** - Bug Fix: Time Expression Parsing (natural language time expressions fixed)
 - **v10.4.0** - Memory Hook Quality Improvements (semantic deduplication, tag normalization, budget optimization)

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -138,16 +138,34 @@ The OAuth system supports three scopes:
 - **`write`**: Access to create/update endpoints
 - **`admin`**: Access to administrative endpoints
 
-### Backward Compatibility
+### API Key Authentication (OAuth-Free)
 
-API key authentication continues to work:
+API key authentication works without OAuth enabled, perfect for single-user deployments or when you don't need team collaboration features:
 
 ```bash
-# Legacy API key authentication
-export MCP_API_KEY="your-api-key"
-curl -H "Authorization: Bearer $MCP_API_KEY" \
+# Configure API key
+export MCP_API_KEY="your-secret-key"
+export MCP_OAUTH_ENABLED=false  # OAuth not required
+export MCP_ALLOW_ANONYMOUS_ACCESS=false  # Require authentication
+
+# Start server
+python scripts/server/run_http_server.py
+
+# Option 1: X-API-Key header (recommended, more secure)
+curl -H "X-API-Key: your-secret-key" \
+     http://localhost:8000/api/memories
+
+# Option 2: Query parameter (convenient, less secure - avoid in production)
+curl "http://localhost:8000/api/memories?api_key=your-secret-key"
+
+# Option 3: Bearer token (backward compatible)
+curl -H "Authorization: Bearer your-secret-key" \
      http://localhost:8000/api/memories
 ```
+
+**When to use API Key vs OAuth:**
+- **API Key**: Single-user deployments, scripts, local development
+- **OAuth**: Team collaboration, Claude Code HTTP transport, multi-user access
 
 ## Security Considerations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.4.3"
+version = "10.4.4"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.4.2"
+__version__ = "10.4.4"

--- a/src/mcp_memory_service/web/api/analytics.py
+++ b/src/mcp_memory_service/web/api/analytics.py
@@ -376,7 +376,7 @@ class StorageStats(BaseModel):
 @router.get("/overview", response_model=AnalyticsOverview, tags=["analytics"])
 async def get_analytics_overview(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get overview analytics for the memory system.
@@ -458,7 +458,7 @@ def _generate_interval_label(date: datetime, period: PeriodType) -> str:
 async def get_memory_growth(
     period: PeriodType = Query(PeriodType.MONTH, description="Time period: week, month, quarter, year"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get memory growth data over time.
@@ -548,7 +548,7 @@ async def get_tag_usage_analytics(
     period: str = Query("all", description="Time period: week, month, all"),
     limit: int = Query(20, description="Maximum number of tags to return"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get tag usage analytics.
@@ -593,7 +593,7 @@ async def get_tag_usage_analytics(
 @router.get("/memory-types", response_model=MemoryTypeData, tags=["analytics"])
 async def get_memory_type_distribution(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get distribution of memories by type.
@@ -671,7 +671,7 @@ async def get_memory_type_distribution(
 @router.get("/relationship-types", response_model=Dict[str, int], tags=["analytics"])
 async def get_relationship_type_distribution(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get distribution of relationship types in the knowledge graph.
@@ -700,7 +700,7 @@ async def get_graph_visualization(
     limit: int = Query(100, description="Maximum number of nodes to include", ge=1, le=500),
     min_connections: int = Query(1, description="Minimum connections per node", ge=1),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get knowledge graph data for interactive visualization.
@@ -721,7 +721,7 @@ async def get_graph_visualization(
 
 @router.get("/search-analytics", response_model=SearchAnalytics, tags=["analytics"])
 async def get_search_analytics(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get search usage analytics.
@@ -742,7 +742,7 @@ async def get_search_analytics(
 @router.get("/performance", response_model=PerformanceMetrics, tags=["analytics"])
 async def get_performance_metrics(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get system performance metrics.
@@ -763,7 +763,7 @@ async def get_performance_metrics(
 async def get_activity_heatmap(
     days: int = Query(365, description="Number of days to include in heatmap"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get activity heatmap data for calendar view.
@@ -833,7 +833,7 @@ async def get_top_tags_report(
     period: str = Query("30d", description="Time period: 7d, 30d, 90d, all"),
     limit: int = Query(20, description="Maximum number of tags to return"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get enhanced top tags report with trends and co-occurrence patterns.
@@ -936,7 +936,7 @@ async def get_top_tags_report(
 async def get_activity_breakdown(
     granularity: str = Query("daily", description="Time granularity: hourly, daily, weekly"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get activity breakdown and patterns.
@@ -1003,7 +1003,7 @@ async def get_activity_breakdown(
 @router.get("/storage-stats", response_model=StorageStats, tags=["analytics"])
 async def get_storage_stats(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get storage statistics and largest memories.

--- a/src/mcp_memory_service/web/api/analytics.py
+++ b/src/mcp_memory_service/web/api/analytics.py
@@ -31,16 +31,11 @@ from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field
 
 from ...storage.base import MemoryStorage
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 from ..dependencies import get_storage
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, AuthenticationResult
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/api/backup.py
+++ b/src/mcp_memory_service/web/api/backup.py
@@ -26,14 +26,8 @@ from pydantic import BaseModel
 
 from mcp_memory_service.config import OAUTH_ENABLED
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
-    require_write_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
 
 router = APIRouter()
 

--- a/src/mcp_memory_service/web/api/backup.py
+++ b/src/mcp_memory_service/web/api/backup.py
@@ -79,7 +79,7 @@ class BackupListResponse(BaseModel):
 
 @router.get("/backup/status", response_model=BackupStatusResponse)
 async def get_backup_status(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get current backup service status.
@@ -110,7 +110,7 @@ async def get_backup_status(
 
 @router.post("/backup/now", response_model=BackupCreateResponse)
 async def trigger_backup(
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Manually trigger an immediate backup.
@@ -142,7 +142,7 @@ async def trigger_backup(
 
 @router.get("/backup/list", response_model=BackupListResponse)
 async def list_backups(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     List all available backups.

--- a/src/mcp_memory_service/web/api/events.py
+++ b/src/mcp_memory_service/web/api/events.py
@@ -6,17 +6,12 @@ from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
 from typing import Dict, Any, List, TYPE_CHECKING
 
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 from ..sse import create_event_stream, sse_manager
 from ..dependencies import get_storage
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, AuthenticationResult
 
 router = APIRouter()
 

--- a/src/mcp_memory_service/web/api/events.py
+++ b/src/mcp_memory_service/web/api/events.py
@@ -40,7 +40,7 @@ class SSEStatsResponse(BaseModel):
 @router.get("/events")
 async def events_endpoint(
     request: Request,
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Server-Sent Events endpoint for real-time updates.
@@ -58,7 +58,7 @@ async def events_endpoint(
 
 @router.get("/events/stats")
 async def get_sse_stats(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get statistics about current SSE connections.

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -33,15 +33,10 @@ try:
 except (ImportError, AttributeError):
     __version__ = "0.0.0.dev0"
 
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, AuthenticationResult
 
 router = APIRouter()
 

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -84,7 +84,7 @@ async def health_check():
 @router.get("/health/detailed", response_model=DetailedHealthResponse)
 async def detailed_health_check(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """Detailed health check with system and storage information."""
     
@@ -200,7 +200,7 @@ async def detailed_health_check(
 @router.get("/health/sync-status")
 async def sync_status(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """Get current initial sync status for hybrid storage."""
 
@@ -267,7 +267,7 @@ class ClearCachesResponse(BaseModel):
 
 @router.get("/memory-stats", response_model=MemoryStatsResponse)
 async def get_memory_stats(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get detailed memory usage statistics for the process.
@@ -311,7 +311,7 @@ async def get_memory_stats(
 
 @router.post("/clear-caches", response_model=ClearCachesResponse)
 async def clear_caches(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Clear all caches to free memory.

--- a/src/mcp_memory_service/web/api/manage.py
+++ b/src/mcp_memory_service/web/api/manage.py
@@ -26,17 +26,12 @@ from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field
 
 from ...storage.base import MemoryStorage
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 from ..dependencies import get_storage
 from .memories import MemoryResponse, memory_to_response
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_write_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_write_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_write_access, AuthenticationResult
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/api/manage.py
+++ b/src/mcp_memory_service/web/api/manage.py
@@ -90,7 +90,7 @@ class SystemOperationRequest(BaseModel):
 async def bulk_delete_memories(
     request: BulkDeleteRequest,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Perform bulk delete operations on memories.
@@ -186,7 +186,7 @@ async def bulk_delete_memories(
 @router.post("/cleanup-duplicates", response_model=BulkOperationResponse, tags=["management"])
 async def cleanup_duplicates(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Clean up duplicate memories in the database.
@@ -215,7 +215,7 @@ async def cleanup_duplicates(
 @router.get("/untagged/count", tags=["management"])
 async def count_untagged_memories(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Count memories without tags.
@@ -253,7 +253,7 @@ async def count_untagged_memories(
 async def delete_untagged_memories(
     confirm_count: int,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Delete all memories without tags.
@@ -334,7 +334,7 @@ async def delete_untagged_memories(
 @router.get("/tags/stats", response_model=TagStatsListResponse, tags=["management"])
 async def get_tag_statistics(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Get detailed statistics for all tags.
@@ -377,7 +377,7 @@ async def rename_tag(
     new_tag: str,
     confirm_count: Optional[int] = Query(None, description="Confirmation count"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Rename a tag across all memories.
@@ -414,7 +414,7 @@ async def rename_tag(
 async def perform_system_operation(
     operation: str,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Perform system maintenance operations.

--- a/src/mcp_memory_service/web/api/mcp.py
+++ b/src/mcp_memory_service/web/api/mcp.py
@@ -15,16 +15,10 @@ from pydantic import BaseModel, ConfigDict
 
 from ..dependencies import get_storage
 from ...utils.hashing import generate_content_hash
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 
 # Import OAuth dependencies only when needed
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
-    require_write_access = None
+from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/web/api/mcp.py
+++ b/src/mcp_memory_service/web/api/mcp.py
@@ -154,7 +154,7 @@ MCP_TOOLS = [
 @router.post("")
 async def mcp_endpoint(
     request: MCPRequest,
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """Main MCP protocol endpoint for processing MCP requests."""
     try:
@@ -398,7 +398,7 @@ async def handle_tool_call(storage, tool_name: str, arguments: Dict[str, Any]) -
 
 @router.get("/tools")
 async def list_mcp_tools(
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """List available MCP tools for discovery."""
     return {

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -138,7 +138,7 @@ async def store_memory(
     request: MemoryCreateRequest,
     http_request: Request,
     memory_service: MemoryService = Depends(get_memory_service),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Store a new memory.
@@ -234,7 +234,7 @@ async def list_memories(
     tag: Optional[str] = Query(None, description="Filter by tag"),
     memory_type: Optional[str] = Query(None, description="Filter by memory type"),
     memory_service: MemoryService = Depends(get_memory_service),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     List memories with pagination and optional filtering.
@@ -266,7 +266,7 @@ async def list_memories(
 async def get_memory(
     content_hash: str,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get a specific memory by its content hash.
@@ -292,7 +292,7 @@ async def get_memory(
 async def delete_memory(
     content_hash: str,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Delete a memory by its content hash.
@@ -326,7 +326,7 @@ async def update_memory(
     content_hash: str,
     request: MemoryUpdateRequest,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Update memory metadata (tags, type, metadata) without changing content or timestamps.
@@ -391,7 +391,7 @@ async def update_memory(
 @router.get("/tags", response_model=TagListResponse, tags=["tags"])
 async def get_tags(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get all tags with their usage counts.

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -28,18 +28,12 @@ from ...storage.base import MemoryStorage
 from ...models.memory import Memory
 from ...services.memory_service import MemoryService
 from ...utils.hashing import generate_content_hash
-from ...config import INCLUDE_HOSTNAME, OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 from ..dependencies import get_storage, get_memory_service
 from ..sse import sse_manager, create_memory_stored_event, create_memory_deleted_event
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
-    require_write_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/api/search.py
+++ b/src/mcp_memory_service/web/api/search.py
@@ -111,7 +111,7 @@ def memory_to_search_result(memory: Memory, reason: str = None) -> SearchResult:
 async def semantic_search(
     request: SemanticSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Perform semantic similarity search on memory content.
@@ -207,7 +207,7 @@ async def semantic_search(
 async def tag_search(
     request: TagSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Search memories by tags with optional time filtering.
@@ -289,7 +289,7 @@ async def tag_search(
 async def time_search(
     request: TimeSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Search memories by time-based queries.
@@ -359,7 +359,7 @@ async def find_similar(
     content_hash: str,
     n_results: int = Query(default=10, ge=1, le=100, description="Number of similar memories to find"),
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Find memories similar to a specific memory identified by its content hash.

--- a/src/mcp_memory_service/web/api/search.py
+++ b/src/mcp_memory_service/web/api/search.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel, Field
 
 from ...storage.base import MemoryStorage
 from ...models.memory import Memory, MemoryQueryResult
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 from ...utils.time_parser import parse_time_expression
 from ..dependencies import get_storage
 from .memories import MemoryResponse, memory_to_response
@@ -36,13 +36,8 @@ from ..sse import sse_manager, create_search_completed_event
 # Constants
 _TIME_SEARCH_CANDIDATE_POOL_SIZE = 100  # Number of candidates to retrieve for time filtering (reduced for performance)
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, AuthenticationResult
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/api/sync.py
+++ b/src/mcp_memory_service/web/api/sync.py
@@ -68,7 +68,7 @@ class SyncForceResponse(BaseModel):
 @router.get("/sync/status", response_model=SyncStatusResponse)
 async def get_sync_status(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_read_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """
     Get current sync status for hybrid backend.
@@ -141,7 +141,7 @@ async def get_sync_status(
 @router.post("/sync/force", response_model=SyncForceResponse)
 async def force_sync(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Manually trigger immediate bi-directional sync with Cloudflare.
@@ -222,7 +222,7 @@ class SyncPauseResponse(BaseModel):
 @router.post("/sync/pause", response_model=SyncPauseResponse)
 async def pause_sync(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Pause background sync operations.
@@ -258,7 +258,7 @@ async def pause_sync(
 @router.post("/sync/resume", response_model=SyncPauseResponse)
 async def resume_sync(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access) if OAUTH_ENABLED else None
+    user: AuthenticationResult = Depends(require_write_access)
 ):
     """
     Resume background sync operations.

--- a/src/mcp_memory_service/web/api/sync.py
+++ b/src/mcp_memory_service/web/api/sync.py
@@ -26,16 +26,10 @@ from pydantic import BaseModel
 
 from ...storage.base import MemoryStorage
 from ..dependencies import get_storage
-from ...config import OAUTH_ENABLED
+# OAuth config no longer needed - auth is always enabled
 
-# OAuth authentication imports (conditional)
-if OAUTH_ENABLED or TYPE_CHECKING:
-    from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
-else:
-    # Provide type stubs when OAuth is disabled
-    AuthenticationResult = None
-    require_read_access = None
-    require_write_access = None
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
 
 router = APIRouter()
 

--- a/src/mcp_memory_service/web/oauth/middleware.py
+++ b/src/mcp_memory_service/web/oauth/middleware.py
@@ -19,6 +19,7 @@ Provides Bearer token validation with fallback to API key authentication.
 """
 
 import logging
+import secrets
 from typing import Optional, Dict, Any
 from fastapi import HTTPException, status, Depends, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -271,8 +272,8 @@ def authenticate_api_key(api_key: str) -> AuthenticationResult:
             error="api_key_not_configured"
         )
 
-    # Validate API key
-    if api_key == API_KEY:
+    # Validate API key using constant-time comparison to prevent timing attacks
+    if secrets.compare_digest(api_key.encode(), API_KEY.encode()):
         logger.debug("API key authentication successful")
         return AuthenticationResult(
             authenticated=True,

--- a/src/mcp_memory_service/web/oauth/middleware.py
+++ b/src/mcp_memory_service/web/oauth/middleware.py
@@ -20,7 +20,7 @@ Provides Bearer token validation with fallback to API key authentication.
 
 import logging
 from typing import Optional, Dict, Any
-from fastapi import HTTPException, status, Depends
+from fastapi import HTTPException, status, Depends, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt, ExpiredSignatureError
 from jose.jwt import JWTClaimsError
@@ -290,6 +290,7 @@ def authenticate_api_key(api_key: str) -> AuthenticationResult:
 
 
 async def get_current_user(
+    request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer_scheme)
 ) -> AuthenticationResult:
     """

--- a/tests/web/test_middleware.py
+++ b/tests/web/test_middleware.py
@@ -1,0 +1,228 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for OAuth middleware and API key authentication.
+
+Validates X-API-Key header, query parameter, and Bearer token authentication methods.
+"""
+
+import pytest
+import pytest_asyncio
+from fastapi import Request
+from fastapi.testclient import TestClient
+import os
+
+@pytest_asyncio.fixture
+async def temp_storage(temp_db_path):
+    """Create and initialize temporary storage."""
+    from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+    from mcp_memory_service.web.dependencies import set_storage
+
+    db_path = os.path.join(temp_db_path, "test.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    await storage.initialize()
+    set_storage(storage)
+    yield storage
+    storage.close()
+
+
+@pytest.fixture
+def client(temp_storage, monkeypatch):
+    """Create FastAPI test client with initialized storage."""
+    # Set test environment variables
+    monkeypatch.setenv("MCP_API_KEY", "test-secret-key-12345")
+    monkeypatch.setenv("MCP_OAUTH_ENABLED", "false")
+    monkeypatch.setenv("MCP_ALLOW_ANONYMOUS_ACCESS", "false")
+
+    # Import app after storage is set
+    from mcp_memory_service.web.app import app
+
+    return TestClient(app)
+
+
+class TestAPIKeyAuthentication:
+    """Tests for API key authentication methods."""
+
+    @pytest.mark.asyncio
+    async def test_no_auth_returns_401(self, client):
+        """Test that requests without authentication return 401."""
+        response = client.get("/api/memories")
+        assert response.status_code == 401
+        assert "error_description" in response.json()["detail"]
+        assert "API key" in response.json()["detail"]["error_description"]
+
+    @pytest.mark.asyncio
+    async def test_x_api_key_header_success(self, client):
+        """Test successful authentication with X-API-Key header."""
+        response = client.get(
+            "/api/memories",
+            headers={"X-API-Key": "test-secret-key-12345"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "memories" in data or "total" in data
+
+    @pytest.mark.asyncio
+    async def test_x_api_key_header_wrong_key(self, client):
+        """Test that wrong API key returns 401."""
+        response = client.get(
+            "/api/memories",
+            headers={"X-API-Key": "wrong-key"}
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_query_parameter_success(self, client):
+        """Test successful authentication with query parameter."""
+        response = client.get("/api/memories?api_key=test-secret-key-12345")
+        assert response.status_code == 200
+        data = response.json()
+        assert "memories" in data or "total" in data
+
+    @pytest.mark.asyncio
+    async def test_query_parameter_wrong_key(self, client):
+        """Test that wrong query parameter returns 401."""
+        response = client.get("/api/memories?api_key=wrong-key")
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_fallback(self, client):
+        """Test backward compatible Bearer token authentication."""
+        response = client.get(
+            "/api/memories",
+            headers={"Authorization": "Bearer test-secret-key-12345"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "memories" in data or "total" in data
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_wrong_key(self, client):
+        """Test that wrong Bearer token returns 401."""
+        response = client.get(
+            "/api/memories",
+            headers={"Authorization": "Bearer wrong-key"}
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_case_sensitive_header(self, client):
+        """Test that X-API-Key header is case-insensitive (HTTP standard)."""
+        # FastAPI/Starlette normalizes headers to lowercase
+        response = client.get(
+            "/api/memories",
+            headers={"x-api-key": "test-secret-key-12345"}  # lowercase
+        )
+        assert response.status_code == 200
+
+
+class TestAuthenticationPriority:
+    """Tests for authentication method priority."""
+
+    @pytest.mark.asyncio
+    async def test_x_api_key_preferred_over_query_param(self, client):
+        """Test that X-API-Key header is checked before query parameter."""
+        # Send both, but header has correct key
+        response = client.get(
+            "/api/memories?api_key=wrong-key",
+            headers={"X-API-Key": "test-secret-key-12345"}
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_before_no_credentials(self, client):
+        """Test Bearer token is checked first if provided."""
+        response = client.get(
+            "/api/memories",
+            headers={"Authorization": "Bearer test-secret-key-12345"}
+        )
+        assert response.status_code == 200
+
+
+class TestMultipleEndpoints:
+    """Test that authentication works across different API endpoints."""
+
+    @pytest.mark.parametrize("endpoint,method", [
+        ("/api/health", "get"),
+        ("/api/memories", "get"),
+        ("/api/memories", "post"),
+    ])
+    @pytest.mark.asyncio
+    async def test_auth_on_various_endpoints(self, client, endpoint, method):
+        """Test authentication works on various endpoints."""
+        if method == "get":
+            response = client.get(
+                endpoint,
+                headers={"X-API-Key": "test-secret-key-12345"}
+            )
+        else:
+            response = client.post(
+                endpoint,
+                headers={"X-API-Key": "test-secret-key-12345"},
+                json={"content": "test", "tags": ["test"]}
+            )
+
+        # Health endpoint might not require auth, but others should work
+        assert response.status_code in [200, 201, 422]  # 422 = validation error, not auth
+
+
+class TestSecurityHeaders:
+    """Test security-related headers and responses."""
+
+    @pytest.mark.asyncio
+    async def test_401_includes_www_authenticate(self, client):
+        """Test that 401 responses include WWW-Authenticate header when Bearer used."""
+        response = client.get(
+            "/api/memories",
+            headers={"Authorization": "Bearer wrong-key"}
+        )
+        assert response.status_code == 401
+        # WWW-Authenticate header is added for Bearer token failures
+
+
+class TestAnonymousAccess:
+    """Test anonymous access behavior (when enabled)."""
+
+    @pytest.mark.asyncio
+    async def test_anonymous_disabled_by_default(self, client):
+        """Test that anonymous access is disabled by default in test env."""
+        response = client.get("/api/memories")
+        assert response.status_code == 401
+
+
+@pytest.mark.integration
+class TestIntegrationScenarios:
+    """Integration tests for real-world authentication scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_api_only_deployment(self, client):
+        """Test API-key-only deployment scenario (no OAuth)."""
+        # This is the main use case for Issue #407
+        response = client.get(
+            "/api/memories",
+            headers={"X-API-Key": "test-secret-key-12345"}
+        )
+        assert response.status_code == 200
+
+        # Verify WebUI dashboard is accessible (no auth required for HTML)
+        response = client.get("/")
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_script_access_with_query_param(self, client):
+        """Test convenient query parameter access for scripts."""
+        # Useful for quick scripts, though less secure
+        response = client.get("/api/memories?api_key=test-secret-key-12345")
+        assert response.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -924,7 +924,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.4.3"
+version = "10.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes #407 - API Key authentication now works independently of OAuth, enabling simple single-user deployments without OAuth overhead.

## Problem

Before this fix:
- API key auth only worked when 
- With , WebUI and API were inaccessible even with valid API key
- Root cause: API routes had conditional auth dependencies ()

## Solution

**1. Middleware Enhancement** (a5cbd16, b49a76f):
- Added X-API-Key header support (recommended, secure)
- Added query parameter `api_key` support (convenient, less secure)
- Backward compatible Bearer token support
- API key checked BEFORE anonymous access fallback

**2. Route Refactoring** (ce7bd73, ff34e11):
- Removed OAuth conditional from ALL API route dependencies
- Auth middleware now runs unconditionally
- Middleware decides auth method based on configuration (OAuth, API key, or anonymous)

**3. Documentation** (b6b037f):
- Updated `.env.example` with API key configuration
- Updated `docs/oauth-setup.md` with API-key-only deployment examples
- Documented three auth methods and usage guidelines

## Authentication Methods

Users can now choose:

```bash
# Method 1: X-API-Key header (recommended)
curl -H "X-API-Key: your-secret-key" http://localhost:8000/api/memories

# Method 2: Query parameter (convenient for scripts)
curl "http://localhost:8000/api/memories?api_key=your-secret-key"

# Method 3: Bearer token (backward compatible)
curl -H "Authorization: Bearer your-secret-key" http://localhost:8000/api/memories
```

## Configuration

```bash
# API-key-only deployment (no OAuth)
export MCP_API_KEY="your-secret-key"
export MCP_OAUTH_ENABLED=false
export MCP_ALLOW_ANONYMOUS_ACCESS=false

python scripts/server/run_http_server.py
```

## Manual Testing

✅ All authentication methods tested and working:

```bash
# Test 1: No auth → 401
curl -s http://localhost:8000/api/memories
# ❌ 401 Unauthorized: "Authorization required. Provide valid API key via X-API-Key header..."

# Test 2: X-API-Key header → 200 OK
curl -s -H "X-API-Key: test-secret-key-12345" http://localhost:8000/api/memories
# ✅ 200 OK, returns memories

# Test 3: Wrong API key → 401
curl -s -H "X-API-Key: wrong-key" http://localhost:8000/api/memories
# ❌ 401 Unauthorized

# Test 4: Query parameter → 200 OK
curl -s "http://localhost:8000/api/memories?api_key=test-secret-key-12345"
# ✅ 200 OK, returns memories
```

## Breaking Changes

None - fully backward compatible:
- OAuth deployments work unchanged
- Bearer token auth continues working
- Anonymous access behavior unchanged

## TODO

- [ ] Add unit tests for middleware (tests/web/test_middleware.py needs temp_db_path fixture)
- [ ] Consider adding X-API-Key to frontend for browser-based auth

## Closes

#407

---

**🛡️ Security:** API keys should be kept secret. Query parameter method logs keys in server logs - use X-API-Key header in production.