### PR TITLE
feat(dashboard): add server management API and UI

### DIFF
--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -1,0 +1,381 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Server management endpoints for the HTTP interface.
+
+Provides server status, version checking, updates, and restart capabilities.
+"""
+
+import os
+import sys
+import time
+import asyncio
+import logging
+import platform
+import subprocess
+from typing import Optional, List, Dict, Any, Tuple
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks
+from pydantic import BaseModel, Field
+
+try:
+    from ... import __version__
+except (ImportError, AttributeError):
+    __version__ = "0.0.0.dev0"
+
+# OAuth authentication imports
+from ..oauth.middleware import require_read_access, require_admin_access, AuthenticationResult
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Constants
+RESTART_DELAY_SECONDS = 3
+GIT_TIMEOUT_SECONDS = 30
+PIP_TIMEOUT_SECONDS = 300
+
+# Track startup time for uptime calculation
+_startup_time = time.time()
+
+
+# Request/Response Models
+class ServerStatusResponse(BaseModel):
+    """Response model for server status."""
+    version: str
+    uptime_seconds: float
+    uptime_formatted: str
+    pid: int
+    platform: str
+    platform_version: str
+    python_version: str
+    timestamp: str
+
+
+class VersionCheckResponse(BaseModel):
+    """Response model for version check."""
+    current_version: str
+    commits_behind: int
+    update_available: bool
+    latest_commits: List[str]
+    check_timestamp: str
+    git_available: bool
+    error: Optional[str] = None
+
+
+class RestartRequest(BaseModel):
+    """Request model for server restart."""
+    confirm: bool = Field(..., description="Must be true to confirm restart")
+
+
+class RestartResponse(BaseModel):
+    """Response model for server restart."""
+    status: str
+    message: str
+    restart_in_seconds: int
+
+
+class UpdateRequest(BaseModel):
+    """Request model for server update."""
+    confirm: bool = Field(..., description="Must be true to confirm update")
+
+
+class UpdateResponse(BaseModel):
+    """Response model for server update."""
+    status: str
+    message: str
+    git_output: Optional[str] = None
+    pip_output: Optional[str] = None
+    restart_scheduled: bool
+
+
+# Helper functions
+def _get_project_root() -> str:
+    """Get the project root directory with git repository validation."""
+    # Navigate up from web/api/server.py to project root
+    current_file = os.path.abspath(__file__)
+    # Go up: server.py -> api -> web -> mcp_memory_service -> src -> project_root
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(current_file)))))
+
+    # Validate it's actually a git repository
+    if not os.path.isdir(os.path.join(project_root, '.git')):
+        raise ValueError(f"Not a valid git repository: {project_root}")
+
+    return project_root
+
+
+def _run_git_command(args: List[str], timeout: int = GIT_TIMEOUT_SECONDS) -> Tuple[str, bool]:
+    """
+    Run a git command and return output.
+
+    Returns:
+        Tuple of (output_string, success_boolean)
+    """
+    try:
+        result = subprocess.run(
+            ['git'] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=_get_project_root()
+        )
+        return result.stdout.strip(), result.returncode == 0
+    except FileNotFoundError:
+        return "Git command not found. Please install git.", False
+    except subprocess.TimeoutExpired:
+        return f"Git command timed out after {timeout} seconds", False
+    except Exception as e:
+        return f"Git command failed: {str(e)}", False
+
+
+def _run_pip_command(args: List[str], timeout: int = PIP_TIMEOUT_SECONDS) -> Tuple[str, bool]:
+    """
+    Run a pip command and return output.
+
+    Returns:
+        Tuple of (output_string, success_boolean)
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'pip'] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=_get_project_root()
+        )
+        return result.stdout.strip(), result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return f"Pip command timed out after {timeout} seconds", False
+    except Exception as e:
+        return f"Pip command failed: {str(e)}", False
+
+
+def _format_uptime(seconds: float) -> str:
+    """Format uptime in human-readable format."""
+    if seconds < 60:
+        return f"{seconds:.1f} seconds"
+    elif seconds < 3600:
+        return f"{seconds/60:.1f} minutes"
+    elif seconds < 86400:
+        return f"{seconds/3600:.1f} hours"
+    else:
+        return f"{seconds/86400:.1f} days"
+
+
+async def _restart_server_delayed():
+    """Restart the server after a delay to allow HTTP response to complete."""
+    await asyncio.sleep(RESTART_DELAY_SECONDS)
+
+    logger.warning("AUDIT: Server process restart initiated")
+
+    try:
+        if sys.platform == 'win32':
+            # Windows: Start a new process, then exit
+            subprocess.Popen(
+                [sys.executable] + sys.argv,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+            )
+        else:
+            # Linux/Mac: Replace process with execv
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+
+        # Exit current process (Windows only reaches here)
+        sys.exit(0)
+    except PermissionError:
+        logger.error("Failed to restart server: insufficient permissions")
+    except FileNotFoundError:
+        logger.error(f"Failed to restart server: executable not found: {sys.executable}")
+    except Exception as e:
+        logger.error(f"Failed to restart server: {type(e).__name__} - {e}")
+        sys.exit(1)
+
+
+# Endpoints
+@router.get("/status", response_model=ServerStatusResponse)
+async def get_server_status(
+    user: AuthenticationResult = Depends(require_read_access)
+):
+    """
+    Get server status information.
+
+    Returns current version, uptime, process ID, platform details, and Python version.
+    Requires read access.
+    """
+    uptime = time.time() - _startup_time
+
+    return ServerStatusResponse(
+        version=__version__,
+        uptime_seconds=uptime,
+        uptime_formatted=_format_uptime(uptime),
+        pid=os.getpid(),
+        platform=platform.system(),
+        platform_version=platform.version(),
+        python_version=platform.python_version(),
+        timestamp=datetime.now(timezone.utc).isoformat()
+    )
+
+
+@router.get("/version/check", response_model=VersionCheckResponse)
+async def check_for_updates(
+    user: AuthenticationResult = Depends(require_admin_access)
+):
+    """
+    Check for available updates from git repository.
+
+    Fetches latest changes and compares with current version.
+    Returns number of commits behind and list of commit messages.
+    Requires admin access.
+    """
+    # Try to fetch latest changes
+    fetch_output, fetch_success = _run_git_command(['fetch', 'origin'])
+
+    if not fetch_success:
+        return VersionCheckResponse(
+            current_version=__version__,
+            commits_behind=0,
+            update_available=False,
+            latest_commits=[],
+            check_timestamp=datetime.now(timezone.utc).isoformat(),
+            git_available=False,
+            error=fetch_output
+        )
+
+    # Count commits behind origin/main
+    count_output, count_success = _run_git_command(['rev-list', '--count', 'HEAD..origin/main'])
+
+    if not count_success:
+        return VersionCheckResponse(
+            current_version=__version__,
+            commits_behind=0,
+            update_available=False,
+            latest_commits=[],
+            check_timestamp=datetime.now(timezone.utc).isoformat(),
+            git_available=True,
+            error=count_output
+        )
+
+    try:
+        commits_behind = int(count_output)
+    except ValueError:
+        commits_behind = 0
+
+    # Get latest commit messages if behind
+    latest_commits = []
+    if commits_behind > 0:
+        log_output, log_success = _run_git_command([
+            'log', '--oneline', '--no-decorate', f'HEAD..origin/main', '-n', '5'
+        ])
+        if log_success and log_output:
+            latest_commits = [line.strip() for line in log_output.split('\n') if line.strip()]
+
+    return VersionCheckResponse(
+        current_version=__version__,
+        commits_behind=commits_behind,
+        update_available=commits_behind > 0,
+        latest_commits=latest_commits,
+        check_timestamp=datetime.now(timezone.utc).isoformat(),
+        git_available=True,
+        error=None
+    )
+
+
+@router.post("/restart", response_model=RestartResponse)
+async def restart_server(
+    request: RestartRequest,
+    background_tasks: BackgroundTasks,
+    user: AuthenticationResult = Depends(require_admin_access)
+):
+    """
+    Restart the server process.
+
+    Schedules a delayed restart to allow HTTP response to complete.
+    Returns 202 Accepted immediately.
+    Requires admin access and explicit confirmation.
+    """
+    if not request.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Restart confirmation required. Set 'confirm' to true."
+        )
+
+    logger.warning(f"AUDIT: Server restart requested by user: {user.client_id} (auth: {user.auth_method})")
+
+    # Schedule restart in background
+    background_tasks.add_task(_restart_server_delayed)
+
+    return RestartResponse(
+        status="accepted",
+        message=f"Server restarting in {RESTART_DELAY_SECONDS} seconds",
+        restart_in_seconds=RESTART_DELAY_SECONDS
+    )
+
+
+@router.post("/update", response_model=UpdateResponse)
+async def update_server(
+    request: UpdateRequest,
+    background_tasks: BackgroundTasks,
+    user: AuthenticationResult = Depends(require_admin_access)
+):
+    """
+    Update server from git and restart.
+
+    Performs git pull, pip install, and schedules restart.
+    Returns 202 Accepted with output from each step.
+    Requires admin access and explicit confirmation.
+    """
+    if not request.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail="Update confirmation required. Set 'confirm' to true."
+        )
+
+    logger.warning(f"AUDIT: Server update requested by user: {user.client_id} (auth: {user.auth_method})")
+
+    # Step 1: Git pull
+    git_output, git_success = _run_git_command(['pull', 'origin', 'main'])
+
+    if not git_success:
+        return UpdateResponse(
+            status="error",
+            message="Git pull failed",
+            git_output=git_output,
+            pip_output=None,
+            restart_scheduled=False
+        )
+
+    # Step 2: Pip install
+    pip_output, pip_success = _run_pip_command(['install', '-e', '.'])
+
+    if not pip_success:
+        return UpdateResponse(
+            status="error",
+            message="Pip install failed",
+            git_output=git_output,
+            pip_output=pip_output,
+            restart_scheduled=False
+        )
+
+    # Step 3: Schedule restart
+    background_tasks.add_task(_restart_server_delayed)
+
+    logger.warning(f"AUDIT: Server update completed by {user.client_id}, restart scheduled")
+
+    return UpdateResponse(
+        status="success",
+        message=f"Update completed successfully, server restarting in {RESTART_DELAY_SECONDS} seconds",
+        git_output=git_output,
+        pip_output=pip_output,
+        restart_scheduled=True
+    )

--- a/src/mcp_memory_service/web/app.py
+++ b/src/mcp_memory_service/web/app.py
@@ -60,6 +60,7 @@ from .api.mcp import router as mcp_router
 from .api.consolidation import router as consolidation_router
 from .api.backup import router as backup_router
 from .api.quality import router as quality_router
+from .api.server import router as server_router
 from .sse import sse_manager
 
 logger = logging.getLogger(__name__)
@@ -312,6 +313,10 @@ def create_app() -> FastAPI:
     # Include consolidation router
     app.include_router(consolidation_router, tags=["consolidation"])
     logger.info(f"✓ Included consolidation router with {len(consolidation_router.routes)} routes")
+
+    # Include server management router
+    app.include_router(server_router, prefix="/api/server", tags=["server-management"])
+    logger.info(f"✓ Included server router with {len(server_router.routes)} routes")
 
     # Include MCP protocol router
     app.include_router(mcp_router, tags=["mcp-protocol"])

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -3472,13 +3472,16 @@ class MemoryDashboard {
 
             if (data.update_available) {
                 if (statusEl) {
-                    statusEl.innerHTML = `<span style="color: var(--success, #10b981); font-weight: 600;">Yes - ${data.commits_behind} commit(s) available</span>`;
+                    statusEl.textContent = `Yes - ${data.commits_behind} commit(s) available`;
+                    statusEl.style.color = 'var(--success, #10b981)';
+                    statusEl.style.fontWeight = '600';
                 }
                 if (updateBtn) { updateBtn.style.display = 'inline-flex'; }
                 this.showToast(`${data.commits_behind} update(s) available!`, 'info');
             } else {
                 if (statusEl) {
-                    statusEl.innerHTML = '<span style="color: var(--text-secondary);">Up to date</span>';
+                    statusEl.textContent = 'Up to date';
+                    statusEl.style.color = 'var(--text-secondary)';
                 }
                 if (updateBtn) { updateBtn.style.display = 'none'; }
                 this.showToast('Already up to date.', 'success');

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -3508,10 +3508,7 @@ class MemoryDashboard {
         if (actionText) { actionText.textContent = 'Pulling updates and installing...'; }
 
         try {
-            const data = await this.apiCall('/server/update', {
-                method: 'POST',
-                body: JSON.stringify({ confirm: true })
-            });
+            const data = await this.apiCall('/server/update', 'POST', { confirm: true });
 
             if (actionText) { actionText.textContent = 'Update complete. Server restarting...'; }
             this.showRestartOverlay();
@@ -3530,10 +3527,7 @@ class MemoryDashboard {
         }
 
         try {
-            await this.apiCall('/server/restart', {
-                method: 'POST',
-                body: JSON.stringify({ confirm: true })
-            });
+            await this.apiCall('/server/restart', 'POST', { confirm: true });
             this.showRestartOverlay();
         } catch (error) {
             // Server may have already started shutting down

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -116,6 +116,7 @@ class MemoryDashboard {
         this.applyTheme();
         this.setupEventListeners();
         this.setupAuthListeners();
+        this.setupServerManagement();
         this.setupSSE();
 
         // Check for secure context
@@ -3414,6 +3415,187 @@ class MemoryDashboard {
                 window.location.href = '/oauth/authorize';
             });
         }
+    }
+
+    /**
+     * Setup server management event listeners
+     */
+    setupServerManagement() {
+        const checkBtn = document.getElementById('checkUpdatesBtn');
+        const updateBtn = document.getElementById('updateServerBtn');
+        const restartBtn = document.getElementById('restartServerBtn');
+
+        if (checkBtn) {
+            checkBtn.addEventListener('click', () => this.checkForUpdates());
+        }
+        if (updateBtn) {
+            updateBtn.addEventListener('click', () => this.updateAndRestart());
+        }
+        if (restartBtn) {
+            restartBtn.addEventListener('click', () => this.restartServer());
+        }
+
+        // Load server status when settings open
+        this.loadServerStatus();
+    }
+
+    /**
+     * Load server status information
+     */
+    async loadServerStatus() {
+        try {
+            const data = await this.apiCall('/server/status');
+            const pidEl = document.getElementById('settingsServerPid');
+            const platformEl = document.getElementById('settingsServerPlatform');
+            if (pidEl) pidEl.textContent = data.pid || '-';
+            if (platformEl) platformEl.textContent = `${data.platform || '-'} / Python ${data.python_version || '-'}`;
+        } catch (error) {
+            console.error('Failed to load server status:', error);
+        }
+    }
+
+    /**
+     * Check for available updates
+     */
+    async checkForUpdates() {
+        const statusEl = document.getElementById('settingsUpdateAvailable');
+        const updateBtn = document.getElementById('updateServerBtn');
+        const actionStatus = document.getElementById('serverActionStatus');
+        const actionText = document.getElementById('serverActionText');
+
+        if (actionStatus) { actionStatus.style.display = 'flex'; }
+        if (actionText) { actionText.textContent = 'Checking for updates...'; }
+
+        try {
+            const data = await this.apiCall('/server/version/check');
+            if (actionStatus) { actionStatus.style.display = 'none'; }
+
+            if (data.update_available) {
+                if (statusEl) {
+                    statusEl.innerHTML = `<span style="color: var(--success, #10b981); font-weight: 600;">Yes - ${data.commits_behind} commit(s) available</span>`;
+                }
+                if (updateBtn) { updateBtn.style.display = 'inline-flex'; }
+                this.showToast(`${data.commits_behind} update(s) available!`, 'info');
+            } else {
+                if (statusEl) {
+                    statusEl.innerHTML = '<span style="color: var(--text-secondary);">Up to date</span>';
+                }
+                if (updateBtn) { updateBtn.style.display = 'none'; }
+                this.showToast('Already up to date.', 'success');
+            }
+        } catch (error) {
+            if (actionStatus) { actionStatus.style.display = 'none'; }
+            if (statusEl) { statusEl.textContent = 'Check failed'; }
+            this.showToast('Failed to check for updates: ' + error.message, 'error');
+        }
+    }
+
+    /**
+     * Update and restart the server
+     */
+    async updateAndRestart() {
+        if (!confirm('This will pull the latest code, install dependencies, and restart the server. Continue?')) {
+            return;
+        }
+
+        const actionStatus = document.getElementById('serverActionStatus');
+        const actionText = document.getElementById('serverActionText');
+
+        if (actionStatus) { actionStatus.style.display = 'flex'; }
+        if (actionText) { actionText.textContent = 'Pulling updates and installing...'; }
+
+        try {
+            const data = await this.apiCall('/server/update', {
+                method: 'POST',
+                body: JSON.stringify({ confirm: true })
+            });
+
+            if (actionText) { actionText.textContent = 'Update complete. Server restarting...'; }
+            this.showRestartOverlay();
+        } catch (error) {
+            if (actionStatus) { actionStatus.style.display = 'none'; }
+            this.showToast('Update failed: ' + error.message, 'error');
+        }
+    }
+
+    /**
+     * Restart the server
+     */
+    async restartServer() {
+        if (!confirm('Are you sure you want to restart the server? This will temporarily disconnect all clients.')) {
+            return;
+        }
+
+        try {
+            await this.apiCall('/server/restart', {
+                method: 'POST',
+                body: JSON.stringify({ confirm: true })
+            });
+            this.showRestartOverlay();
+        } catch (error) {
+            // Server may have already started shutting down
+            if (error.message && error.message.includes('fetch')) {
+                this.showRestartOverlay();
+            } else {
+                this.showToast('Restart failed: ' + error.message, 'error');
+            }
+        }
+    }
+
+    /**
+     * Show restart overlay and poll for server recovery
+     */
+    showRestartOverlay() {
+        const overlay = document.getElementById('restartOverlay');
+        const countdownEl = document.getElementById('restartCountdown');
+        const statusEl = document.getElementById('restartStatus');
+
+        if (overlay) { overlay.style.display = 'flex'; }
+
+        let countdown = 5;
+        let attempts = 0;
+        const maxAttempts = 30;
+
+        const countdownInterval = setInterval(() => {
+            countdown--;
+            if (countdownEl) { countdownEl.textContent = countdown; }
+            if (countdown <= 0) {
+                clearInterval(countdownInterval);
+                this.pollServerHealth(statusEl, overlay, attempts, maxAttempts);
+            }
+        }, 1000);
+    }
+
+    /**
+     * Poll server health after restart
+     */
+    async pollServerHealth(statusEl, overlay, attempts, maxAttempts) {
+        if (attempts >= maxAttempts) {
+            if (statusEl) { statusEl.textContent = 'Server did not come back online. Please check manually.'; }
+            setTimeout(() => {
+                if (overlay) { overlay.style.display = 'none'; }
+            }, 5000);
+            return;
+        }
+
+        if (statusEl) { statusEl.textContent = `Attempt ${attempts + 1}/${maxAttempts} - Waiting for server...`; }
+
+        try {
+            const response = await fetch('/api/health');
+            if (response.ok) {
+                if (statusEl) { statusEl.textContent = 'Server is back online! Reloading...'; }
+                setTimeout(() => {
+                    window.location.reload();
+                }, 1500);
+                return;
+            }
+        } catch (e) {
+            // Server not ready yet
+        }
+
+        setTimeout(() => {
+            this.pollServerHealth(statusEl, overlay, attempts + 1, maxAttempts);
+        }, 2000);
     }
 
     /**

--- a/src/mcp_memory_service/web/static/index.html
+++ b/src/mcp_memory_service/web/static/index.html
@@ -1384,6 +1384,33 @@
                                 <button id="viewBackupsButton" class="btn btn-sm btn-secondary" data-i18n="modal.settings.viewBackups">View Backups</button>
                             </div>
                         </div>
+
+                        <hr class="settings-divider">
+
+                        <h4 class="settings-section-heading">Server Management</h4>
+                        <div class="server-management">
+                            <div class="info-row">
+                                <span class="info-label">Server PID:</span>
+                                <span class="info-value" id="settingsServerPid">-</span>
+                            </div>
+                            <div class="info-row">
+                                <span class="info-label">Platform:</span>
+                                <span class="info-value" id="settingsServerPlatform">-</span>
+                            </div>
+                            <div class="info-row">
+                                <span class="info-label">Update Available:</span>
+                                <span class="info-value" id="settingsUpdateAvailable">Checking...</span>
+                            </div>
+                            <div class="server-actions">
+                                <button id="checkUpdatesBtn" class="btn btn-sm btn-secondary">Check for Updates</button>
+                                <button id="updateServerBtn" class="btn btn-sm btn-primary" style="display:none;">Update &amp; Restart</button>
+                                <button id="restartServerBtn" class="btn btn-sm btn-warning">Restart Server</button>
+                            </div>
+                            <div id="serverActionStatus" class="server-action-status" style="display:none;">
+                                <div class="action-spinner"></div>
+                                <span id="serverActionText">Processing...</span>
+                            </div>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">
@@ -1397,6 +1424,16 @@
         <div id="loadingOverlay" class="loading-overlay">
             <div class="loading-spinner"></div>
             <p data-i18n="status.loading">Loading...</p>
+        </div>
+
+        <!-- Server Restart Overlay -->
+        <div id="restartOverlay" class="restart-overlay" style="display:none;">
+            <div class="restart-content">
+                <div class="restart-spinner"></div>
+                <h3>Server Restarting...</h3>
+                <p id="restartStatus">Waiting for server to come back online...</p>
+                <p class="restart-countdown">Reconnecting in <span id="restartCountdown">5</span>s</p>
+            </div>
         </div>
 
         <!-- Toast Notifications -->

--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -5256,3 +5256,100 @@ body.dark-mode .auth-footer code {
     background: var(--neutral-700);
     color: var(--primary);
 }
+
+/* Server Management */
+.server-management {
+    padding: var(--space-3) 0;
+}
+
+.server-actions {
+    display: flex;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.btn-warning {
+    background: var(--warning, #f59e0b);
+    color: #fff;
+    border: none;
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--radius-md, 6px);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: background 0.2s;
+}
+
+.btn-warning:hover {
+    background: #d97706;
+}
+
+.server-action-status {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-tertiary, #f0f4f8);
+    border-radius: var(--radius-md, 6px);
+    font-size: 0.875rem;
+    color: var(--text-secondary, #64748b);
+}
+
+.action-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border-color, #e2e8f0);
+    border-top-color: var(--primary, #3b82f6);
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+}
+
+/* Restart Overlay */
+.restart-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    backdrop-filter: blur(4px);
+}
+
+.restart-content {
+    text-align: center;
+    color: #fff;
+    padding: 3rem;
+}
+
+.restart-spinner {
+    width: 60px;
+    height: 60px;
+    border: 4px solid rgba(255, 255, 255, 0.2);
+    border-top-color: #3b82f6;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 1.5rem;
+}
+
+.restart-countdown {
+    margin-top: 1rem;
+    opacity: 0.7;
+    font-size: 0.875rem;
+}
+
+.update-badge {
+    display: inline-block;
+    background: #ef4444;
+    color: white;
+    font-size: 0.625rem;
+    padding: 1px 5px;
+    border-radius: 10px;
+    margin-left: 4px;
+    vertical-align: super;
+}


### PR DESCRIPTION
## Summary

- Add server management REST API (`/api/server/*`) with 4 endpoints: status, version check, update, and restart
- Add server management UI section in Dashboard Settings modal with real-time status display
- Implement git-based update detection and one-click update & restart workflow
- Include audit logging, git repo validation, and safe restart with confirmation dialogs
- Add reconnection overlay with health polling after server restart

## New Files

- `src/mcp_memory_service/web/api/server.py` - Backend API with 4 endpoints (admin-protected)

## Modified Files

- `src/mcp_memory_service/web/app.py` - Router registration
- `src/mcp_memory_service/web/static/index.html` - Server management UI section + restart overlay
- `src/mcp_memory_service/web/static/app.js` - 7 new methods for server management
- `src/mcp_memory_service/web/static/style.css` - Server management and restart overlay styles

## Security

- All destructive endpoints require `admin` scope via OAuth/API key
- Explicit `confirm: true` required for restart and update operations
- Audit logging (`logger.warning`) for all admin actions with user ID and auth method
- Git repository validation in `_get_project_root()` prevents path traversal
- No `shell=True` in subprocess calls

## Test plan

- [ ] Verify `/api/server/status` returns correct server info with API key
- [ ] Verify `/api/server/version/check` detects commits behind origin
- [ ] Verify restart/update endpoints require `confirm: true`
- [ ] Verify Dashboard Settings modal shows server management section
- [ ] Verify restart overlay appears and reconnects after server restart
- [ ] Verify endpoints return 401 without authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)