### PR TITLE
chore: release v10.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.6.0] - 2026-02-07
+
+### Added
+- **Server Management Dashboard** (PR #421): Complete server administration from Dashboard Settings
+  - **REST API**: 4 new endpoints at `/api/server/*` (admin-protected):
+    - `GET /api/server/status` - Real-time server status (version, uptime, platform info)
+    - `GET /api/server/version/check` - Git-based update detection (commits behind origin)
+    - `POST /api/server/update` - One-click git pull + pip install workflow
+    - `POST /api/server/restart` - Safe server restart with 3-second delay
+  - **Dashboard UI**: Server management section in Settings modal
+  - **Security**: Admin-only access, explicit confirmation required, full audit logging
+
 ## [10.5.1] - 2026-02-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.5.1 - Test Environment Safety Scripts to prevent production data loss (Issue #419, PR #418) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.6.0 - Server Management Dashboard for complete server administration (PR #421) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -179,24 +179,23 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.5.1** (February 6, 2026)
+## 🆕 Latest Release: **v10.6.0** (February 7, 2026)
 
-**Test Environment Safety: Prevent Production Data Loss**
+**Server Management Dashboard: Complete Server Administration**
 
 **What's New:**
-- 🛡️ **Test Environment Safety Scripts** (Issue #419, PR #418): 4 critical scripts (524 lines) to prevent production database testing
-  - Mandatory backup before testing with date-stamped archives
-  - Isolated test environment setup (port 8001, separate data directory)
-  - Safe test data cleanup with environment verification
-  - Comprehensive testing workflow documentation (250 lines)
-  - **CRITICAL**: Prevents data loss incidents from running tests against production databases
+- ⚙️ **Server Management Dashboard** (PR #421): Complete server administration from Dashboard Settings
+  - 4 new REST API endpoints (`/api/server/*`) for real-time status, update detection, git pull workflow, and safe restart
+  - Dashboard UI with server management section in Settings modal
+  - Admin-only access with explicit confirmation and full audit logging
+  - One-click server updates with automatic dependency installation
 
 **Previous Releases**:
+- **v10.5.1** - Test Environment Safety: 4 critical scripts to prevent production database testing
 - **v10.5.0** - Dashboard Authentication UI: Graceful user experience (authentication modal, API key/OAuth flows)
 - **v10.4.6** - Documentation Enhancement: HTTP dashboard authentication requirements clarified (authentication setup examples)
 - **v10.4.5** - Unified CLI Interface: `memory server --http` flag (easier UX, single command)
 - **v10.4.4** - CRITICAL Security Fix: Timing attack vulnerability in API key comparison (CWE-208) + API Key Auth without OAuth
-- **v10.4.3** - Windows Task Scheduler & Consolidation Stability (6 bugs fixed, logger NameError resolved)
 - **v10.4.2** - Docker Container Startup Fix (ModuleNotFoundError: aiosqlite)
 - **v10.4.1** - Bug Fix: Time Expression Parsing (natural language time expressions fixed)
 - **v10.4.0** - Memory Hook Quality Improvements (semantic deduplication, tag normalization, budget optimization)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.5.1"
+version = "10.6.0"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.5.1"
+__version__ = "10.6.0"


### PR DESCRIPTION
## Summary
Release version 10.6.0 with Server Management Dashboard feature.

## Changes
- **Version bump**: 10.5.1 → 10.6.0
- **CHANGELOG.md**: Added v10.6.0 entry with Server Management Dashboard details (PR #421)
- **README.md**: Updated Latest Release section with v10.6.0 highlights
- **CLAUDE.md**: Updated current version reference to v10.6.0
- **_version.py**: Updated version string
- **pyproject.toml**: Updated version field

## CHANGELOG Entry
```markdown
## [10.6.0] - 2026-02-07

### Added
- **Server Management Dashboard** (PR #421): Complete server administration from Dashboard Settings
  - **REST API**: 4 new endpoints at `/api/server/*` (admin-protected)
  - **Dashboard UI**: Server management section in Settings modal
  - **Security**: Admin-only access, explicit confirmation required, full audit logging
```

## Checklist
- [x] Version bumped in _version.py and pyproject.toml
- [x] CHANGELOG.md updated with v10.6.0 entry
- [x] README.md Latest Release section updated
- [x] CLAUDE.md version reference updated
- [x] Previous version (v10.5.1) moved to Previous Releases in README

## Related
- Follows merged PR #421 (Server Management Dashboard)
- Semantic version: MINOR bump for new feature (server management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)