### PR TITLE
fix: add type=button to server management buttons

### DIFF
--- a/src/mcp_memory_service/web/static/index.html
+++ b/src/mcp_memory_service/web/static/index.html
@@ -1403,9 +1403,9 @@
                                 <span class="info-value" id="settingsUpdateAvailable">Checking...</span>
                             </div>
                             <div class="server-actions">
-                                <button id="checkUpdatesBtn" class="btn btn-sm btn-secondary">Check for Updates</button>
-                                <button id="updateServerBtn" class="btn btn-sm btn-primary" style="display:none;">Update &amp; Restart</button>
-                                <button id="restartServerBtn" class="btn btn-sm btn-warning">Restart Server</button>
+                                <button type="button" id="checkUpdatesBtn" class="btn btn-sm btn-secondary">Check for Updates</button>
+                                <button type="button" id="updateServerBtn" class="btn btn-sm btn-primary" style="display:none;">Update &amp; Restart</button>
+                                <button type="button" id="restartServerBtn" class="btn btn-sm btn-warning">Restart Server</button>
                             </div>
                             <div id="serverActionStatus" class="server-action-status" style="display:none;">
                                 <div class="action-spinner"></div>


### PR DESCRIPTION
## Summary
- Server management buttons (Check for Updates, Update & Restart, Restart Server) inside the settings `<form>` were missing `type="button"`, defaulting to `type="submit"`
- This caused the form to submit and the page to reload/jump to Dashboard when any button was clicked
- Added `type="button"` to all three buttons to prevent unintended form submission

## Test plan
- [ ] Open dashboard Settings modal
- [ ] Click "Check for Updates" - should show result without page reload
- [ ] Verify "Restart Server" button doesn't cause page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)