### PR TITLE
chore: release v10.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.7.2] - 2026-02-07
+
+### Fixed
+- **Server Management buttons cause page reload** (PR #429): Added `type="button"` to Check for Updates, Update & Restart, and Restart Server buttons in Settings modal. Without explicit type, buttons inside `<form>` default to `type="submit"`, causing unintended form submission and page reload.
+
 ## [10.7.1] - 2026-02-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.7.1 - Dashboard API authentication fix for all endpoints (commit 5bf4834) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.7.2 - Server Management button fix in Settings modal (PR #429) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.7.1"
+version = "10.7.2"
 description = "Universal MCP memory service with semantic search, multi-client support, and autonomous consolidation for Claude Desktop, VS Code, and 13+ AI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.7.1"
+__version__ = "10.7.2"


### PR DESCRIPTION
## Summary
- Version bump to v10.7.2
- Includes fix from PR #429: Server Management buttons in Settings modal caused page reload due to missing `type="button"` attribute

## Changes
- `_version.py`: 10.7.1 → 10.7.2
- `pyproject.toml`: 10.7.1 → 10.7.2
- `CHANGELOG.md`: Added v10.7.2 entry
- `CLAUDE.md`: Updated current version reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)