### PR TITLE
refactor: use asyncio.to_thread in _execute_with_retry

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -289,7 +289,7 @@ class SqliteVecMemoryStorage(MemoryStorage):
         
         for attempt in range(max_retries + 1):
             try:
-                return operation()
+                return await asyncio.to_thread(operation)
             except sqlite3.OperationalError as e:
                 last_exception = e
                 error_msg = str(e).lower()


### PR DESCRIPTION
## Summary

- Replaces synchronous `operation()` call with `await asyncio.to_thread(operation)` in `_execute_with_retry` (line 292 of `sqlite_vec.py`)
- Blocking SQLite operations no longer stall the asyncio event loop, freeing it to service other coroutines during I/O

## Preconditions (already met)

- `check_same_thread=False` is already set on the SQLite connection (line 516), which is required since `asyncio.to_thread` dispatches to a thread pool
- SQLite's default serialized threading mode handles cross-thread access safely

## Caller audit

| Caller | Pattern | Safe? |
|--------|---------|-------|
| `_persist_access_metadata` | Single self-contained callback (includes `commit()`) | Yes |
| `store()` | `insert_memory` + `insert_embedding` + `commit` (3 calls) | Yes — interleaving already possible at `await` boundaries today |
| `retrieve()` | Single read-only callback | Yes |

## Test plan

- [x] Core sqlite_vec storage tests pass (51/52; the 1 `test_concurrent_operations` failure is a pre-existing test-isolation flake that passes when run individually)
- [x] Full suite: 1046 passed — all 61 failures are pre-existing (HTTP API, CLI, ONNX, graph analytics tests unrelated to this change)

Closes #433