### PR TITLE
fix: increase retry budget for concurrent write contention

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -269,7 +269,7 @@ class SqliteVecMemoryStorage(MemoryStorage):
             logger.error(f"JSON type error in {context}: {e}")
             return {}
 
-    async def _execute_with_retry(self, operation: Callable, max_retries: int = 3, initial_delay: float = 0.1):
+    async def _execute_with_retry(self, operation: Callable, max_retries: int = 5, initial_delay: float = 0.2):
         """
         Execute a database operation with exponential backoff retry logic.
         


### PR DESCRIPTION
## Summary

- Bumps `_execute_with_retry` defaults: `max_retries` 3→5, `initial_delay` 0.1s→0.2s
- Fixes `test_two_clients_concurrent_write` which failed consistently on `main`

## Problem

When multiple connections contend for SQLite's RESERVED write lock under WAL mode, the old retry budget (3 retries, ~0.7s total exponential backoff) was insufficient. The second writer would exhaust all retries and fail with `database is locked`.

This was exposed by the `test_two_clients_concurrent_write` integration test, which runs two `SqliteVecMemoryStorage` instances writing 10 memories each concurrently to the same database file.

## Fix

| Parameter | Before | After |
|-----------|--------|-------|
| `max_retries` | 3 | 5 |
| `initial_delay` | 0.1s | 0.2s |
| Total backoff | ~0.7s | ~6.2s (0.2+0.4+0.8+1.6+3.2) |

The increased budget provides adequate headroom for concurrent writers while keeping worst-case latency reasonable (6.2s backoff + SQLite `busy_timeout` waits).

## Test plan

- [x] `test_two_clients_concurrent_write` now passes (was consistently failing)
- [x] All 6 concurrent client tests pass
- [x] All 51 core sqlite_vec storage tests pass
- [x] 57 total tests passed, 0 failed

```
$ python -m pytest tests/integration/test_concurrent_clients.py tests/test_sqlite_vec_storage.py -v
===================== 57 passed in 10.46s ======================
```

Related: #434 (noted this as a pre-existing failure in CI analysis)