### PR TITLE
fix: cast model to float32 before ONNX export

### DIFF
--- a/src/mcp_memory_service/quality/onnx_ranker.py
+++ b/src/mcp_memory_service/quality/onnx_ranker.py
@@ -232,6 +232,7 @@ class ONNXRankerModel:
                 model = AutoModelForSequenceClassification.from_pretrained(hf_model_name)
 
         model.eval()
+        model.float()  # Cast to float32 to prevent mixed fp16/fp32 ONNX export errors
 
         # Create dummy inputs based on model type
         if self.model_config['type'] == 'classifier':

--- a/src/mcp_memory_service/quality/onnx_ranker.py
+++ b/src/mcp_memory_service/quality/onnx_ranker.py
@@ -232,6 +232,7 @@ class ONNXRankerModel:
                 model = AutoModelForSequenceClassification.from_pretrained(hf_model_name)
 
         model.eval()
+        logger.info("Casting model to float32 for ONNX export compatibility.")
         model.float()  # Cast to float32 to prevent mixed fp16/fp32 ONNX export errors
 
         # Create dummy inputs based on model type


### PR DESCRIPTION
## Summary
- Adds `model.float()` after `model.eval()` in `_ensure_onnx_model()` to cast all DeBERTa parameters to float32 before ONNX export
- Fixes ONNX Runtime load failure caused by mixed float16/float32 `MatMul` nodes in the exported graph

## Problem
DeBERTa v3 (`microsoft/deberta-v3-base`) stores some weights in float16. When `torch.onnx.export()` serializes the model, it preserves these mixed types, producing an ONNX graph that ONNX Runtime rejects:

```
ONNXRuntimeError: Type parameter (T) of Optype (MatMul) bound to different
types (tensor(float16) and tensor(float) in node (node_MatMul_1566).
```

This affects GPUs that default to mixed precision (e.g., RTX 5050 Blackwell, and likely other Ampere+ cards).

## Fix
One line: `model.float()` casts all parameters to float32 before the ONNX export, producing a clean graph compatible with all ONNX Runtime providers (CPU, CUDA, TensorRT).

## Test plan
- [x] Verified on RTX 5050 Blackwell with PyTorch 2.10.0+cu128, ONNX Runtime 1.24.1
- [x] `ONNXRankerModel()` loads successfully with CUDAExecutionProvider
- [x] `score_quality()` returns expected scores (0.49 for test input)
- [x] No regression on CPU-only path (float32 is already the default there)