### PR TITLE
Fix memory injection filtering for empty/new projects

### DIFF
--- a/claude-hooks/core/session-start.js
+++ b/claude-hooks/core/session-start.js
@@ -939,11 +939,13 @@ async function executeSessionStart(context) {
                 // tag OR mention the project name in content. This prevents generic
                 // "architecture" tags from pulling in unrelated project memories.
                 const projectScoped = (importantMemories || []).filter(mem => {
+                    if (!projectTag) {
+                        return false;
+                    }
+                    const projectTagLower = projectTag.toLowerCase();
                     const tags = (mem.tags || []).map(t => t.toLowerCase());
-                    if (tags.includes(projectTag.toLowerCase())) return true;
                     const content = (mem.content || mem.preview || '').toLowerCase();
-                    if (content.includes(projectTag.toLowerCase())) return true;
-                    return false;
+                    return tags.includes(projectTagLower) || content.includes(projectTagLower);
                 });
 
                 // Filter out duplicates using similarity-based deduplication (80% threshold)

--- a/claude-hooks/core/session-start.js
+++ b/claude-hooks/core/session-start.js
@@ -945,9 +945,9 @@ async function executeSessionStart(context) {
                 // Filter to require project affinity: memory must have the project
                 // tag OR mention the project name in content. This prevents generic
                 // "architecture" tags from pulling in unrelated project memories.
+                const projectTagLower = projectTag?.toLowerCase();
                 const projectScoped = (importantMemories || []).filter(mem => {
-                    if (!projectTag) return false;
-                    const projectTagLower = projectTag.toLowerCase();
+                    if (!projectTagLower) return false;
                     const tags = (mem.tags || []).map(t => t.toLowerCase());
                     const content = (mem.content || mem.preview || '').toLowerCase();
                     return tags.includes(projectTagLower) || content.includes(projectTagLower);

--- a/claude-hooks/core/session-start.js
+++ b/claude-hooks/core/session-start.js
@@ -322,10 +322,10 @@ async function queryMemoryServiceViaCode(query, config) {
     const enableMetrics = config?.codeExecution?.enableMetrics !== false;
 
     try {
-        const { execSync } = require('child_process');
+        const { execFileSync } = require('child_process');
 
-        // Escape query strings for safe shell execution
-        const escapeForPython = (str) => str.replace(/"/g, '\\"').replace(/\n/g, '\\n');
+        // Sanitize inputs to prevent injection via project names or queries
+        const sanitize = (str) => String(str || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
         // Build Python code for memory search
         // Use v8.19.0+ Code Execution Interface API for optimal performance
@@ -338,7 +338,7 @@ from mcp_memory_service.api import search
 
 try:
     # Execute search with semantic query and limit (time filtering done server-side)
-    results = search("${escapeForPython(query.semanticQuery || '')}", limit=${query.limit || 8})
+    results = search('${sanitize(query.semanticQuery || '')}', limit=${parseInt(query.limit, 10) || 8})
 
     # Format compact output
     output = {
@@ -370,8 +370,8 @@ except Exception as e:
         const pythonPath = config?.codeExecution?.pythonPath || 'python3';
         const timeout = config?.codeExecution?.timeout || 5000;
 
-        // Execute Python code with timeout (suppress warnings to avoid stderr failures)
-        const result = execSync(`${pythonPath} -W ignore -c "${pythonCode.replace(/"/g, '\\"')}"`, {
+        // Use execFileSync with args array to avoid shell injection
+        const result = execFileSync(pythonPath, ['-W', 'ignore', '-c', pythonCode], {
             encoding: 'utf-8',
             timeout: timeout,
             stdio: ['pipe', 'pipe', 'pipe']
@@ -501,6 +501,13 @@ function calculateContentSimilarity(str1, str2) {
  * Check if a new memory is a duplicate of any existing memory
  * Uses 80% similarity threshold and never deduplicates cluster memories
  */
+/** Strip ANSI escape sequences and control characters to prevent terminal/log injection */
+function sanitizeForLog(str) {
+    if (!str) return '';
+    // eslint-disable-next-line no-control-regex
+    return String(str).replace(/[\x00-\x1f\x7f-\x9f]/g, '').replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+}
+
 function isDuplicateMemory(newMemory, existingMemories) {
     if (!newMemory || !newMemory.content) return false;
 
@@ -927,7 +934,7 @@ async function executeSessionStart(context) {
                 const timeFilter = 'last-2-weeks';
 
                 if (verbose && showMemoryDetails && showPhaseDetails && !cleanMode) {
-                    console.log(`${CONSOLE_COLORS.BLUE}🎯 Phase 2${CONSOLE_COLORS.RESET} ${CONSOLE_COLORS.DIM}→${CONSOLE_COLORS.RESET} Searching important tagged memories (${remainingForTags} slots, project: ${projectTag})`);
+                    console.log(`${CONSOLE_COLORS.BLUE}🎯 Phase 2${CONSOLE_COLORS.RESET} ${CONSOLE_COLORS.DIM}→${CONSOLE_COLORS.RESET} Searching important tagged memories (${remainingForTags} slots, project: ${sanitizeForLog(projectTag)})`);
                 }
 
                 // Use new tag-time filtering method for efficient recency prioritization
@@ -939,9 +946,7 @@ async function executeSessionStart(context) {
                 // tag OR mention the project name in content. This prevents generic
                 // "architecture" tags from pulling in unrelated project memories.
                 const projectScoped = (importantMemories || []).filter(mem => {
-                    if (!projectTag) {
-                        return false;
-                    }
+                    if (!projectTag) return false;
                     const projectTagLower = projectTag.toLowerCase();
                     const tags = (mem.tags || []).map(t => t.toLowerCase());
                     const content = (mem.content || mem.preview || '').toLowerCase();


### PR DESCRIPTION
## Summary

Two bugs in session-start.js cause irrelevant memories to be injected into empty/new project sessions:

- **Bug 1: minRelevanceScore threshold not applied.** The config value (default 0.3) is loaded at line 814 but the filter at line 1123 compared against `> 0` instead of `>= minRelevanceScore`. The memory-scorer applies an 85% penalty to cross-project matches (reducing them to ~12% relevance), but without the threshold these low-relevance memories still passed through.

- **Bug 2: Phase 2 tag search lacks project scoping.** The tag-based search queries generic tags (`architecture`, `key-decisions`, `claude-code-reference`) via the `/api/search/by-tag` endpoint which uses OR logic. Any memory tagged with "architecture" from *any* project gets returned. Without client-side project filtering, these unrelated memories consume injection slots.

## Changes

1. Change `scoredMemories.filter(m => m.relevanceScore > 0)` to `scoredMemories.filter(m => m.relevanceScore >= minRelevanceScore)` — enforces the configured threshold
2. Add project-affinity filter after Phase 2 tag results — memories must have the project tag or mention the project name in content
3. Replace `execSync` with `execFileSync` in `queryMemoryServiceViaCode` to prevent command injection via project names (per Gemini review)
4. Add `sanitizeForLog()` to strip ANSI/control characters from logged project names (per Gemini review)
5. Guard against null/empty `projectTag` in affinity filter (per Gemini review)

## Test plan
- [x] Syntax check passes (`node -c`)
- [x] New session in empty/unrelated project directory shows zero injected memories (verified via `cm-count.js` with nonexistent project returning 0 observations)
- [x] Existing project sessions still load relevant memories normally (verified via `cm-count.js` with temp project returning 31 observations)
- [x] Cluster memories (dedicated query path with `['cluster']` tag) unaffected — cluster search uses a separate `queryMemoriesByTagsAndTime(['cluster'], ...)` call that does not pass through the project-affinity filter