### PR TITLE
fix(hooks): cap score inflation in memory-scorer, preserve cross-project technology sharing

### DIFF
--- a/claude-hooks/utilities/memory-scorer.js
+++ b/claude-hooks/utilities/memory-scorer.js
@@ -482,7 +482,7 @@ function calculateRelevanceScore(memory, projectContext, options = {}) {
             breakdown.projectAffinity = 'none (filtered)';
         } else if (!hasProjectTag) {
             // Some tag relevance but no project tag - might be related
-            finalScore *= 0.25; // Tighter penalty to prevent cross-project leakage
+            finalScore = Math.min(1.0, finalScore) * 0.25; // Cap then penalize to guarantee < minRelevanceScore (0.3)
             breakdown.projectAffinity = 'low';
         } else {
             breakdown.projectAffinity = 'high';

--- a/claude-hooks/utilities/memory-scorer.js
+++ b/claude-hooks/utilities/memory-scorer.js
@@ -482,7 +482,7 @@ function calculateRelevanceScore(memory, projectContext, options = {}) {
             breakdown.projectAffinity = 'none (filtered)';
         } else if (!hasProjectTag) {
             // Some tag relevance but no project tag - might be related
-            finalScore = Math.min(1.0, finalScore) * 0.25; // Cap then penalize to guarantee < minRelevanceScore (0.3)
+            finalScore = Math.min(1.0, finalScore) * 0.5; // Cap to prevent bonus inflation, moderate penalty preserves cross-project technology sharing
             breakdown.projectAffinity = 'low';
         } else {
             breakdown.projectAffinity = 'high';

--- a/claude-hooks/utilities/memory-scorer.js
+++ b/claude-hooks/utilities/memory-scorer.js
@@ -482,7 +482,7 @@ function calculateRelevanceScore(memory, projectContext, options = {}) {
             breakdown.projectAffinity = 'none (filtered)';
         } else if (!hasProjectTag) {
             // Some tag relevance but no project tag - might be related
-            finalScore *= 0.5; // Moderate penalty
+            finalScore *= 0.25; // Tighter penalty to prevent cross-project leakage
             breakdown.projectAffinity = 'low';
         } else {
             breakdown.projectAffinity = 'high';


### PR DESCRIPTION
## Summary

The `finalScore` in `memory-scorer.js` can exceed 1.0 due to unweighted bonuses (`typeBonus` up to +0.3, `recencyBonus` up to +0.15), inflating the effective score through the Case 2 penalty path. This adds a `Math.min(1.0, finalScore)` cap before the penalty multiplier is applied.

The penalty multiplier itself stays at **0.5** — Case 2 (no project tag, but tagScore ≥ 0.3) represents memories that share **real technology overlap** (language, frameworks, tools), which is the desirable cross-pollination path.

### Before (uncapped)
```
typeBonus=0.3, recencyBonus=0.15 → base 1.45 × 0.5 = 0.725
```
Score inflated well above what the weighted components warranted.

### After (capped)
```
Math.min(1.0, 1.45) × 0.5 = 0.50
```
Bonuses still influence ranking within the 0–1 range, but can't inflate past it.

## Why 0.5 (not 0.25)

`calculateTagRelevance()` only counts technology overlap — project name, language, frameworks, and tools. Generic activity tags like "debugging", "implementation", "testing" **do not contribute** to `tagScore`. This means:

- **Case 1** (`tagScore < 0.3`, no project tag): Catches generic activity-only noise → hard zero. Already working correctly.
- **Case 2** (`tagScore ≥ 0.3`, no project tag): Represents memories sharing actual technologies (react, sqlite, pytorch) across projects. This is [cross-project knowledge sharing](https://github.com/doobidoo/mcp-memory-service#-key-features) — the feature should be preserved, not blocked.
- **Case 3** (has project tag): Same-project memory → no penalty.

A 0.25 multiplier would guarantee all Case 2 scores fall below the 0.3 `minRelevanceScore` threshold (`max 1.0 × 0.25 = 0.25 < 0.3`), mathematically eliminating all cross-project technology sharing.

### Desirable vs undesirable cross-pollination

| Type | Examples | Cross-pollinate? | Handled by |
|---|---|---|---|
| Technology/stack tags | `react`, `pytorch`, `sqlite`, `vite` | Yes — framework patterns transfer across projects | Case 2 at 0.5x (this path) |
| Generic activity tags | `debug`, `implementation`, `architecture`, `testing` | No — every session has these | Case 1 hard zero (tagScore < 0.3) |

Session summary analysis confirms: **12/12 auto-generated summaries have only generic activity tags, zero technology-specific tags** — so Case 1's hard zero already blocks these. Case 2 doesn't need to be tightened further.

## Changes

- `claude-hooks/utilities/memory-scorer.js` line 485: Add `Math.min(1.0, finalScore)` cap before 0.5x penalty

## Test plan
- [x] Verified: max possible Case 2 score = min(1.45, 1.0) × 0.5 = 0.5 (was 0.725 uncapped)
- [x] Verified: Case 1 hard zero still catches all generic-only memories
- [x] Verified: Case 2 at 0.5x preserves technology cross-pollination above 0.3 threshold
- [x] Database analysis: 12/12 session summaries have 100% generic activity tags, 0% technology-specific
- [x] Gemini Code Assist review: implemented score cap suggestion
- [ ] Integration test: cross-project technology memories still injected; generic-only memories filtered