### PR TITLE
fix: cap tag search candidates at sqlite-vec k=4096 limit

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -73,7 +73,8 @@ from ..config import SQLITEVEC_MAX_CONTENT_LENGTH
 logger = logging.getLogger(__name__)
 
 # Module-level constants for vector search and tag filtering
-_MAX_TAG_SEARCH_CANDIDATES = 10000  # Maximum vector candidates when filtering by tags (DoS protection)
+_SQLITE_VEC_MAX_KNN_K = 4096        # sqlite-vec hard limit for k in KNN queries
+_MAX_TAG_SEARCH_CANDIDATES = _SQLITE_VEC_MAX_KNN_K  # Cap at sqlite-vec limit (was 10000, which exceeds k limit)
 _MAX_TAGS_FOR_SEARCH = 100          # Maximum number of tags to process in a single search (DoS protection)
 
 # Global model cache for performance optimization


### PR DESCRIPTION
## Summary

- `_MAX_TAG_SEARCH_CANDIDATES` was set to 10,000 but sqlite-vec enforces a hard limit of `k=4096` for KNN queries
- Once a database exceeds 4096 memories, any tag-filtered `memory_search` silently returns 0 results due to a caught `OperationalError: k value in knn query too large`
- Fix: set `_MAX_TAG_SEARCH_CANDIDATES = 4096` (extracted as `_SQLITE_VEC_MAX_KNN_K` constant)

## Root Cause

In PR #460, we introduced SQL-level tag filtering with `k_value = min(embedding_count, _MAX_TAG_SEARCH_CANDIDATES)`. The intent was correct (scan enough candidates to find tagged results), but the cap of 10,000 exceeds sqlite-vec's hard KNN limit of 4096.

The error `k value in knn query too large, provided N and the limit is 4096` is caught by the exception handler in `retrieve()`, which returns an empty list — making tag filtering appear silently broken.

## Verification

Binary-searched the actual sqlite-vec limit on a database with 4,691 memories:
```
k=4096: OK
k=4097: OperationalError: k value in knn query too large
```

After fix: tag-filtered searches return correct results.

## Test plan
- [x] Existing `test_retrieve_k_value_capping_without_tags` still passes (updated comment)
- [x] Existing `test_retrieve_all_invalid_tags_returns_empty` still passes
- [x] Manual verification: `memory_search` with `tags=["development"]` returns results on 4,691-memory database

🤖 Generated with [Claude Code](https://claude.com/claude-code)