### PR TITLE
fix: retrieve_memories reads tags/memory_type from wrong field

### DIFF
--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -514,13 +514,13 @@ class MemoryService:
                 for query_result in memories:
                     # Filter by tags if specified
                     if tags:
-                        memory_tags = query_result.memory.metadata.get('tags', [])
+                        memory_tags = query_result.memory.tags or []
                         if not any(tag in memory_tags for tag in tags):
                             continue
 
                     # Filter by memory_type if specified
                     if memory_type:
-                        mem_type = query_result.memory.metadata.get('memory_type', '')
+                        mem_type = query_result.memory.memory_type or ''
                         if mem_type != memory_type:
                             continue
 


### PR DESCRIPTION
## Summary

`MemoryService.retrieve_memories()` post-filters search results by tags and memory_type, but reads them from the wrong location:

```python
# Bug: reads from metadata dict (always empty for these fields)
memory_tags = query_result.memory.metadata.get('tags', [])
mem_type = query_result.memory.metadata.get('memory_type', '')

# Fix: reads from top-level Memory dataclass fields
memory_tags = query_result.memory.tags or []
mem_type = query_result.memory.memory_type or ''
```

`tags` and `memory_type` are top-level fields on the `Memory` dataclass, not nested in `metadata`. The metadata dict doesn't contain these keys, so the filter silently matches nothing and returns 0 results.

## Impact

Any consumer calling `retrieve_memories(tags=..., memory_type=...)` gets 0 results. The `memory_search` MCP tool is not affected (it uses `search_memories()` instead), but the REST API and any direct `MemoryService` consumers are.

## Test plan
- [x] Existing `test_retrieve_memories_with_filters` passes (test sets both `memory.tags` and `memory.metadata["tags"]`, so it works with both old and new code)
- [x] Code inspection confirms `Memory` dataclass has `tags: List[str]` and `memory_type: Optional[str]` as top-level fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)