### PR TITLE
fix: tags displayed as individual characters in search results

### DIFF
--- a/src/mcp_memory_service/models/memory.py
+++ b/src/mcp_memory_service/models/memory.py
@@ -374,7 +374,8 @@ class Memory:
             "created_at_iso": self.created_at_iso,
             "updated_at": self.updated_at,
             "updated_at_iso": self.updated_at_iso,
-            **self.metadata
+            **self.metadata,
+            "tags": self.tags,  # override any leaked metadata["tags"]
         }
 
     @classmethod

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -355,11 +355,16 @@ class MemoryService:
             final_tags = normalize_tags(tags)
 
             # Extract and normalize metadata.tags if present
-            final_metadata = metadata or {}
+            final_metadata = dict(metadata) if metadata else {}
             if metadata and "tags" in metadata:
                 metadata_tags = normalize_tags(metadata.get("tags"))
                 # Merge with parameter tags (normalize_tags already deduplicates)
                 final_tags = normalize_tags(final_tags + metadata_tags)  # Re-normalize after merge
+
+            # Strip keys that have dedicated Memory fields to prevent
+            # them leaking through **self.metadata in to_dict()
+            for key in ("tags", "type"):
+                final_metadata.pop(key, None)
 
             # Apply hostname tagging if provided (for consistent source tracking)
             if client_hostname:


### PR DESCRIPTION
## Summary

- Tags in `memory_search` results display as individual characters (`[m, c, p, -, m, e, m, o, r, y, ...]`) instead of words (`[mcp-memory, bug-fix, ...]`)
- Root cause: `store_memory()` passes metadata dict with raw `tags` key to `Memory(metadata=...)` unchanged; `Memory.to_dict()` then spreads `**self.metadata`, leaking the raw string; handlers call `', '.join(tags_string)` which iterates characters
- Two-layer fix: strip `tags`/`type` keys from metadata copy at source, and add explicit `"tags": self.tags` override in `to_dict()` (handles existing corrupted data)

## Test plan

- [x] Added `test_store_memory_strips_tags_from_metadata` — verifies `tags` key removed from metadata before passing to Memory
- [x] Added `test_to_dict_tags_override_prevents_metadata_leak` — verifies `to_dict()` returns proper list even when metadata contains stale `tags` string
- [x] Verified manually: `memory_search` with tags shows `[mcp-memory, bug-fix, sqlite-vec, lessons-learned]` (words, not characters)
- [x] Verified manually: existing memories with corrupted metadata tags still display correctly via the `to_dict()` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)