### PR TITLE
fix: show full content hash in user-facing tool responses

### DIFF
--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -207,11 +207,11 @@ async def handle_store_memory(server, arguments: dict) -> List[types.TextContent
             # Chunked response - multiple memories created
             num_chunks = len(result["memories"])
             original_hash = result.get("original_hash", "unknown")
-            message = f"Successfully stored {num_chunks} memory chunks (original hash: {original_hash[:8]}...)"
+            message = f"Successfully stored {num_chunks} memory chunks (original hash: {original_hash})"
         else:
             # Single memory response
             memory_hash = result["memory"]["content_hash"]
-            message = f"Memory stored successfully (hash: {memory_hash[:8]}...)"
+            message = f"Memory stored successfully (hash: {memory_hash})"
 
         return [types.TextContent(type="text", text=message)]
 
@@ -382,7 +382,7 @@ async def handle_retrieve_with_quality_boost(server, arguments: dict) -> List[ty
                 f"- Semantic: {semantic_score:.3f}",
                 f"- Quality: {quality_score:.3f}",
                 f"- Timestamp: {timestamp_str}",
-                f"- Hash: {memory.content_hash[:12]}...",
+                f"- Hash: {memory.content_hash}",
                 f"- Content: {memory.content[:200]}{'...' if len(memory.content) > 200 else ''}",
             ]
 
@@ -532,7 +532,7 @@ async def handle_delete_memory(server, arguments: dict) -> List[types.TextConten
 
         # Handle response based on success/failure format
         if result["success"]:
-            return [types.TextContent(type="text", text=f"Memory deleted successfully: {result['content_hash'][:16]}...")]
+            return [types.TextContent(type="text", text=f"Memory deleted successfully: {result['content_hash']}")]
         else:
             return [types.TextContent(type="text", text=f"Failed to delete memory: {result.get('error', 'Unknown error')}")]
     except Exception as e:
@@ -656,7 +656,7 @@ async def handle_memory_delete(server, arguments: dict) -> List[types.TextConten
             if result.get("dry_run"):
                 response += f"\n\nWould delete {result['deleted_count']} memories"
                 if result['deleted_count'] > 0:
-                    response += f"\nHashes: {', '.join(h[:16] + '...' for h in result['deleted_hashes'][:5])}"
+                    response += f"\nHashes: {', '.join(result['deleted_hashes'][:5])}"
                     if result['deleted_count'] > 5:
                         response += f" ... and {result['deleted_count'] - 5} more"
             else:
@@ -764,7 +764,7 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
 
             formatted_results.append(
                 f"{idx}. {memory.get('content', '')}\n"
-                f"   Hash: {content_hash[:16]}...\n"
+                f"   Hash: {content_hash}\n"
                 f"   Created: {created_at}{tags_display}"
             )
 

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -167,7 +167,7 @@ async def handle_rate_memory(server, arguments: dict) -> List[types.TextContent]
         rating_text = {-1: "thumbs down", 0: "neutral", 1: "thumbs up"}[rating]
         response = [
             f"✅ Memory rated successfully: {rating_text}",
-            f"Content hash: {content_hash[:16]}...",
+            f"Content hash: {content_hash}",
             f"New quality score: {new_quality_score:.3f} (was {existing_score:.3f})",
         ]
         if feedback:
@@ -217,7 +217,7 @@ async def handle_get_memory_quality(server, arguments: dict) -> List[types.TextC
 
         # Format as readable text
         response_lines = [
-            f"🔍 Quality Metrics for Memory: {content_hash[:16]}...",
+            f"🔍 Quality Metrics for Memory: {content_hash}",
             "",
             f"Quality Score: {quality_data['quality_score']:.3f} / 1.0",
             f"Quality Provider: {quality_data['quality_provider']}",

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1188,7 +1188,7 @@ SOLUTIONS:
                     similarity_threshold=self.semantic_dedup_threshold
                 )
                 if is_duplicate:
-                    return False, f"Duplicate content detected (semantically similar to {existing_hash[:8]}...)"
+                    return False, f"Duplicate content detected (semantically similar to {existing_hash})"
 
             # Generate and validate embedding
             try:


### PR DESCRIPTION
## Summary

- Hash IDs were truncated to 8-16 characters in tool responses (e.g. `46e08af4...`), making it impossible to copy-paste them for subsequent operations
- The typical MCP workflow of `memory_search` → copy hash → `memory_delete` or `memory_quality` was broken because truncated hashes can't match the full 64-character SHA256 in storage
- Removes hash slicing (`[:8]`, `[:12]`, `[:16]`) from 9 user-facing response sites across memory handlers, quality handlers, and storage duplicate detection messages
- Internal logging truncations left unchanged (standard practice for log readability)

### Sites fixed

| File | Count | Details |
|------|-------|---------|
| `server/handlers/memory.py` | 6 | store, retrieve, delete, delete-by-tag, search responses |
| `server/handlers/quality.py` | 2 | rate and get-quality responses |
| `storage/sqlite_vec.py` | 1 | semantic duplicate detection message |

## Test plan

- [x] Verified manually: `memory_store` returns full 64-char hash (e.g. `2261e868d8782e803330358b6f98efc660e2af8c957dded3455d9a0358315001`)
- [x] Verified manually: `memory_search` results show full hash, enabling copy-paste to `memory_delete`
- [x] Verified manually: `memory_delete` response shows full hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)