### PR TITLE
fix: use Memory field access instead of dict attribute access in prompts

### DIFF
--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1074,8 +1074,8 @@ class MemoryServer:
             if memories:
                 for mem in memories:
                     prompt_text += f"- {mem.content}\n"
-                    if mem.metadata.tags:
-                        prompt_text += f"  Tags: {', '.join(mem.metadata.tags)}\n"
+                    if mem.tags:
+                        prompt_text += f"  Tags: {', '.join(mem.tags)}\n"
             else:
                 prompt_text += "No memories found for this time period."
             
@@ -1108,9 +1108,9 @@ class MemoryServer:
             tag_counts = {}
             type_counts = {}
             for mem in memories:
-                for tag in mem.metadata.tags:
+                for tag in mem.tags:
                     tag_counts[tag] = tag_counts.get(tag, 0) + 1
-                mem_type = mem.metadata.memory_type
+                mem_type = mem.memory_type
                 type_counts[mem_type] = type_counts.get(mem_type, 0) + 1
             
             analysis_text += f"Total memories analyzed: {len(memories)}\n\n"
@@ -1148,14 +1148,14 @@ class MemoryServer:
             
             if format_type == "markdown":
                 for mem in memories:
-                    export_text += f"## {mem.metadata.created_at_iso}\n"
+                    export_text += f"## {mem.created_at_iso}\n"
                     export_text += f"{mem.content}\n"
-                    if mem.metadata.tags:
-                        export_text += f"*Tags: {', '.join(mem.metadata.tags)}*\n"
+                    if mem.tags:
+                        export_text += f"*Tags: {', '.join(mem.tags)}*\n"
                     export_text += "\n"
             elif format_type == "text":
                 for mem in memories:
-                    export_text += f"[{mem.metadata.created_at_iso}] {mem.content}\n"
+                    export_text += f"[{mem.created_at_iso}] {mem.content}\n"
             else:  # json
                 import json
                 export_data = [m.to_dict() for m in memories]


### PR DESCRIPTION
## Summary

- Prompt handler functions (`_prompt_memory_review`, `_prompt_memory_analysis`, `_prompt_knowledge_export`) use `mem.metadata.tags`, `mem.metadata.memory_type`, and `mem.metadata.created_at_iso` — dot attribute access on a `Dict[str, Any]`
- Python dicts don't support dot-notation attribute access, so these throw `AttributeError` when any prompt is invoked
- Changed to use the proper Memory field attributes: `mem.tags`, `mem.memory_type`, `mem.created_at_iso`

### Sites fixed (8 total in `server_impl.py`)

| Line | Before | After |
|------|--------|-------|
| 1077-1078 | `mem.metadata.tags` | `mem.tags` |
| 1111 | `mem.metadata.tags` | `mem.tags` |
| 1113 | `mem.metadata.memory_type` | `mem.memory_type` |
| 1151 | `mem.metadata.created_at_iso` | `mem.created_at_iso` |
| 1153-1154 | `mem.metadata.tags` | `mem.tags` |
| 1158 | `mem.metadata.created_at_iso` | `mem.created_at_iso` |

## Test plan

- [x] Verified: `grep -n 'mem.metadata\.\(tags\|memory_type\|created_at_iso\)' server_impl.py` returns no matches after fix
- [x] All replaced attributes (`tags`, `memory_type`, `created_at_iso`) are proper fields on the `Memory` model class

🤖 Generated with [Claude Code](https://claude.com/claude-code)