### PR TITLE
fix: hybrid storage proxy methods + timezone-aware datetime in consolidation

### DIFF
--- a/src/mcp_memory_service/consolidation/base.py
+++ b/src/mcp_memory_service/consolidation/base.py
@@ -141,7 +141,10 @@ class ConsolidationBase(ABC):
             created_dt = datetime.fromtimestamp(memory.created_at, tz=timezone.utc)
             return (ref_time - created_dt).days
         elif memory.timestamp:
-            return (ref_time - memory.timestamp).days
+            ts = memory.timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return (ref_time - ts).days
         else:
             self.logger.warning(f"Memory {memory.content_hash} has no timestamp")
             return 0

--- a/src/mcp_memory_service/consolidation/base.py
+++ b/src/mcp_memory_service/consolidation/base.py
@@ -17,7 +17,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 from ..models.memory import Memory
@@ -133,10 +133,12 @@ class ConsolidationBase(ABC):
     
     def _get_memory_age_days(self, memory: Memory, reference_time: Optional[datetime] = None) -> int:
         """Get the age of a memory in days."""
-        ref_time = reference_time or datetime.now()
+        ref_time = reference_time or datetime.now(timezone.utc)
+        if ref_time.tzinfo is None:
+            ref_time = ref_time.replace(tzinfo=timezone.utc)
         
         if memory.created_at:
-            created_dt = datetime.utcfromtimestamp(memory.created_at)
+            created_dt = datetime.fromtimestamp(memory.created_at, tz=timezone.utc)
             return (ref_time - created_dt).days
         elif memory.timestamp:
             return (ref_time - memory.timestamp).days

--- a/src/mcp_memory_service/consolidation/clustering.py
+++ b/src/mcp_memory_service/consolidation/clustering.py
@@ -275,7 +275,10 @@ class SemanticClusteringEngine(ConsolidationBase):
                 age_days = (now - created_dt).days
                 ages.append(age_days)
             elif memory.timestamp:
-                age_days = (now - memory.timestamp).days
+                ts = memory.timestamp
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                age_days = (now - ts).days
                 ages.append(age_days)
         
         return sum(ages) / len(ages) if ages else 0.0

--- a/src/mcp_memory_service/consolidation/clustering.py
+++ b/src/mcp_memory_service/consolidation/clustering.py
@@ -17,7 +17,7 @@
 import uuid
 import numpy as np
 from typing import List, Dict, Any, Optional, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import Counter
 import re
 
@@ -266,12 +266,12 @@ class SemanticClusteringEngine(ConsolidationBase):
     
     def _calculate_average_age(self, memories: List[Memory]) -> float:
         """Calculate average age of memories in days."""
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         ages = []
         
         for memory in memories:
             if memory.created_at:
-                created_dt = datetime.utcfromtimestamp(memory.created_at)
+                created_dt = datetime.fromtimestamp(memory.created_at, tz=timezone.utc)
                 age_days = (now - created_dt).days
                 ages.append(age_days)
             elif memory.timestamp:

--- a/src/mcp_memory_service/consolidation/compression.py
+++ b/src/mcp_memory_service/consolidation/compression.py
@@ -357,8 +357,8 @@ class SemanticCompressionEngine(ConsolidationBase):
             'end_time': end_time,
             'span_days': span_days,
             'span_description': span_description,
-            'start_iso': datetime.fromtimestamp(start_time, tz=timezone.utc).isoformat() + 'Z',
-            'end_iso': datetime.fromtimestamp(end_time, tz=timezone.utc).isoformat() + 'Z'
+            'start_iso': datetime.fromtimestamp(start_time, tz=timezone.utc).isoformat().replace('+00:00', 'Z'),
+            'end_iso': datetime.fromtimestamp(end_time, tz=timezone.utc).isoformat().replace('+00:00', 'Z')
         }
     
     def _aggregate_tags(self, memories: List[Memory]) -> List[str]:

--- a/src/mcp_memory_service/consolidation/compression.py
+++ b/src/mcp_memory_service/consolidation/compression.py
@@ -17,7 +17,7 @@
 import asyncio
 import numpy as np
 from typing import List, Dict, Any, Optional, Tuple, Set
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from collections import Counter
 import re
@@ -357,8 +357,8 @@ class SemanticCompressionEngine(ConsolidationBase):
             'end_time': end_time,
             'span_days': span_days,
             'span_description': span_description,
-            'start_iso': datetime.utcfromtimestamp(start_time).isoformat() + 'Z',
-            'end_iso': datetime.utcfromtimestamp(end_time).isoformat() + 'Z'
+            'start_iso': datetime.fromtimestamp(start_time, tz=timezone.utc).isoformat() + 'Z',
+            'end_iso': datetime.fromtimestamp(end_time, tz=timezone.utc).isoformat() + 'Z'
         }
     
     def _aggregate_tags(self, memories: List[Memory]) -> List[str]:

--- a/src/mcp_memory_service/consolidation/consolidator.py
+++ b/src/mcp_memory_service/consolidation/consolidator.py
@@ -117,7 +117,7 @@ def filter_memories_by_age(
     return [
         m
         for m in memories
-        if m.created_at and datetime.utcfromtimestamp(m.created_at) < cutoff_date
+        if m.created_at and datetime.fromtimestamp(m.created_at, tz=timezone.utc) < cutoff_date
     ]
 
 
@@ -875,7 +875,7 @@ class DreamInspiredConsolidator:
             memory_types = {}
             total_size = 0
             old_memories = 0
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
 
             for memory in memories:
                 memory_type = memory.memory_type or "standard"
@@ -883,7 +883,7 @@ class DreamInspiredConsolidator:
                 total_size += len(memory.content)
 
                 if memory.created_at:
-                    age_days = (now - datetime.utcfromtimestamp(memory.created_at)).days
+                    age_days = (now - datetime.fromtimestamp(memory.created_at, tz=timezone.utc)).days
                     if age_days > 30:
                         old_memories += 1
 

--- a/src/mcp_memory_service/consolidation/decay.py
+++ b/src/mcp_memory_service/consolidation/decay.py
@@ -224,7 +224,7 @@ class ExponentialDecayCalculator(ConsolidationBase):
         if not last_accessed:
             # Check memory's own updated_at timestamp
             if memory.updated_at:
-                last_accessed = datetime.utcfromtimestamp(memory.updated_at)
+                last_accessed = datetime.fromtimestamp(memory.updated_at, tz=timezone.utc)
             else:
                 return 1.0  # No access data available
 

--- a/src/mcp_memory_service/consolidation/forgetting.py
+++ b/src/mcp_memory_service/consolidation/forgetting.py
@@ -158,6 +158,8 @@ class ControlledForgettingEngine(ConsolidationBase):
                 last_accessed = datetime.fromtimestamp(memory.updated_at, tz=timezone.utc)
 
             if last_accessed:
+                if last_accessed.tzinfo is None:
+                    last_accessed = last_accessed.replace(tzinfo=timezone.utc)
                 days_since_access = (current_time - last_accessed).days
 
                 # Quality-based retention thresholds

--- a/src/mcp_memory_service/consolidation/forgetting.py
+++ b/src/mcp_memory_service/consolidation/forgetting.py
@@ -18,7 +18,7 @@ import os
 import json
 import shutil
 from typing import List, Dict, Any, Optional, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 import hashlib
@@ -130,7 +130,7 @@ class ControlledForgettingEngine(ConsolidationBase):
         )
 
         candidates = []
-        current_time = datetime.now()
+        current_time = datetime.now(timezone.utc)
 
         for memory in memories:
             # Skip protected memories
@@ -155,7 +155,7 @@ class ControlledForgettingEngine(ConsolidationBase):
             # Access pattern check with quality-based thresholds
             last_accessed = access_patterns.get(memory.content_hash)
             if not last_accessed and memory.updated_at:
-                last_accessed = datetime.utcfromtimestamp(memory.updated_at)
+                last_accessed = datetime.fromtimestamp(memory.updated_at, tz=timezone.utc)
 
             if last_accessed:
                 days_since_access = (current_time - last_accessed).days

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -28,7 +28,7 @@ import time
 from typing import List, Dict, Any, Tuple, Optional
 from collections import deque
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 
 from .base import MemoryStorage
 from .sqlite_vec import SqliteVecMemoryStorage
@@ -1869,14 +1869,9 @@ class HybridMemoryStorage(MemoryStorage):
     async def delete_memory(self, content_hash: str) -> bool:
         """Delete a memory by content hash (consolidation protocol).
 
-        Proxies to primary storage's delete() method and enqueues
-        the deletion for secondary (Cloudflare) sync.
+        Delegates to delete() to avoid duplicating sync logic.
         """
-        success, message = await self.primary.delete(content_hash)
-        if success and self.sync_service:
-            await self.sync_service.enqueue_operation(
-                SyncOperation(operation='delete', content_hash=content_hash)
-            )
+        success, _ = await self.delete(content_hash)
         return success
 
     async def get_memory_connections(self) -> Dict[str, int]:

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1864,7 +1864,7 @@ class HybridMemoryStorage(MemoryStorage):
     # These methods are required by the DreamInspiredConsolidator's
     # StorageProtocol but were missing from HybridMemoryStorage,
     # causing consolidation forgetting/archival to fail silently.
-    # See: https://github.com/doobidoo/mcp-memory-service/issues/TBD
+    # See the project issue tracker for related consolidation bug details.
 
     async def delete_memory(self, content_hash: str) -> bool:
         """Delete a memory by content hash (consolidation protocol).

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1886,7 +1886,7 @@ class HybridMemoryStorage(MemoryStorage):
         """
         return await self.primary.get_memory_connections()
 
-    async def get_access_patterns(self) -> Dict[str, Any]:
+    async def get_access_patterns(self) -> Dict[str, datetime]:
         """Get memory access pattern statistics (consolidation protocol).
 
         Proxies to primary storage.


### PR DESCRIPTION
## Summary

Two bugs that cause consolidation to fail when using the hybrid storage backend.

### Bug 1: Missing StorageProtocol proxy methods in HybridMemoryStorage

**File:** `src/mcp_memory_service/storage/hybrid.py`

`HybridMemoryStorage` was missing three methods required by the `DreamInspiredConsolidator`'s `StorageProtocol` interface:

- `delete_memory()`
- `get_memory_connections()`  
- `get_access_patterns()`

Without these, the consolidator's forgetting phase (step 6) fails silently when using the hybrid backend, because these methods are called on the storage object but `AttributeError` is swallowed. Each method now delegates to `self.primary`, consistent with other proxy methods in the class.

### Bug 2: Deprecated `utcfromtimestamp()` causes TypeError in consolidation

**Files:** 6 files in `src/mcp_memory_service/consolidation/`

The entire consolidation module used `datetime.utcfromtimestamp()` which creates **naive** (timezone-unaware) datetimes. However, `get_access_patterns()` returns **aware** datetimes. This mismatch causes `TypeError: can't compare offset-naive and offset-aware datetimes` crashes during quarterly and yearly consolidation.

**Fix pattern applied consistently:**
- `datetime.utcfromtimestamp(x)` -> `datetime.fromtimestamp(x, tz=timezone.utc)`
- `datetime.now()` -> `datetime.now(timezone.utc)` (where compared with aware datetimes)
- Added `from datetime import timezone` import where missing

### Testing

Verified on Windows 11 with hybrid backend (SQLite + Cloudflare D1/Vectorize):
- Weekly consolidation: 69 associations, 138 graph edges ✅
- Quarterly consolidation: 386 memories processed, zero warnings ✅  
- Yearly consolidation: correctly returns 0 (no memories old enough yet) ✅

### Files Changed

**Commit 1** — Hybrid proxy fix (1 file):
- `storage/hybrid.py`: +33 lines (3 new proxy methods)

**Commit 2** — Timezone fix (6 files):
- `consolidation/consolidator.py`
- `consolidation/forgetting.py`
- `consolidation/decay.py`
- `consolidation/base.py`
- `consolidation/clustering.py`
- `consolidation/compression.py`
