### PR TITLE
feat: conversation_id parameter for incremental conversation saves (closes #463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **`conversation_id` parameter for `memory_store` and REST API**: Pass `conversation_id` when storing memories from the same conversation to allow incremental saves without being blocked by semantic deduplication. Exact hash deduplication is always enforced. The `conversation_id` is stored in memory metadata for future retrieval/grouping. Applies to both the MCP `memory_store` tool and the `POST /api/memories` REST endpoint. Closes #463.
+
 ### Fixed
 - **CI: update hash assertion in integration test**: `test_store_memory_success` was asserting `"..." in text` (truncated hash), but commit `978af00` intentionally changed responses to show the full 64-character content hash. Updated assertion to `re.search(r'[0-9a-f]{64}', text)` to match current behaviour.
 

--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -188,6 +188,7 @@ async def handle_store_memory(server, arguments: dict) -> List[types.TextContent
         tags = metadata.get("tags", "")
         memory_type = metadata.get("type", "note")  # HTTP server uses metadata.type
         client_hostname = arguments.get("client_hostname")
+        conversation_id = arguments.get("conversation_id")
 
         # Call shared MemoryService business logic
         result = await server.memory_service.store_memory(
@@ -195,7 +196,8 @@ async def handle_store_memory(server, arguments: dict) -> List[types.TextContent
             tags=tags,
             memory_type=memory_type,
             metadata=metadata,
-            client_hostname=client_hostname
+            client_hostname=client_hostname,
+            conversation_id=conversation_id,
         )
 
         # Convert MemoryService result to MCP response format

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1257,6 +1257,9 @@ class MemoryServer:
                         - Array: ["tag1", "tag2"]
                         - String: "tag1,tag2"
 
+                        Use `conversation_id` to bypass semantic deduplication when saving
+                        incremental memories from the same conversation.
+
                        Examples:
                         # Using array format:
                         {
@@ -1274,6 +1277,15 @@ class MemoryServer:
                                 "tags": "important,reference",
                                 "type": "note"
                             }
+                        }
+
+                        # Using conversation_id to save incremental notes:
+                        {
+                            "content": "User prefers dark mode",
+                            "conversation_id": "conv_abc123",
+                            "metadata": {
+                                "tags": "preference,ui"
+                            }
                         }""",
                         inputSchema={
                             "type": "object",
@@ -1281,6 +1293,10 @@ class MemoryServer:
                                 "content": {
                                     "type": "string",
                                     "description": "The memory content to store, such as a fact, note, or piece of information."
+                                },
+                                "conversation_id": {
+                                    "type": "string",
+                                    "description": "Optional conversation identifier. When provided, semantic deduplication is skipped, allowing multiple incremental memories from the same conversation to be stored even if their content is topically similar. Exact duplicate hashes are still rejected."
                                 },
                                 "metadata": {
                                     "type": "object",

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -59,8 +59,14 @@ class MemoryStorage(ABC):
         pass
     
     @abstractmethod
-    async def store(self, memory: Memory) -> Tuple[bool, str]:
-        """Store a memory. Returns (success, message)."""
+    async def store(self, memory: Memory, skip_semantic_dedup: bool = False) -> Tuple[bool, str]:
+        """Store a memory. Returns (success, message).
+
+        Args:
+            memory: The Memory object to store.
+            skip_semantic_dedup: If True, bypass semantic similarity check.
+                Exact hash deduplication is always enforced.
+        """
         pass
 
     async def store_batch(self, memories: List[Memory]) -> List[Tuple[bool, str]]:

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -522,8 +522,15 @@ class CloudflareStorage(MemoryStorage):
                 raise ValueError(f"R2 bucket '{self.r2_bucket}' not found")
             raise
     
-    async def store(self, memory: Memory) -> Tuple[bool, str]:
-        """Store a memory in Cloudflare storage."""
+    async def store(self, memory: Memory, skip_semantic_dedup: bool = False) -> Tuple[bool, str]:
+        """Store a memory in Cloudflare storage.
+
+        Args:
+            memory: The Memory object to store.
+            skip_semantic_dedup: Accepted for interface compatibility; Cloudflare
+                storage does not implement semantic deduplication, so this flag
+                has no effect.
+        """
         try:
             # Generate embedding for the content
             embedding = await self._generate_embedding(memory.content)

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1301,10 +1301,16 @@ class HybridMemoryStorage(MemoryStorage):
             "progress_percentage": round((self.initial_sync_completed / max(self.initial_sync_total, 1)) * 100, 1) if self.initial_sync_total > 0 else 0
         }
 
-    async def store(self, memory: Memory) -> Tuple[bool, str]:
-        """Store a memory in primary storage and queue for secondary sync."""
+    async def store(self, memory: Memory, skip_semantic_dedup: bool = False) -> Tuple[bool, str]:
+        """Store a memory in primary storage and queue for secondary sync.
+
+        Args:
+            memory: The Memory object to store.
+            skip_semantic_dedup: If True, bypass semantic similarity check on primary storage.
+                Exact hash deduplication is always enforced.
+        """
         # Always store in primary first for immediate availability
-        success, message = await self.primary.store(memory)
+        success, message = await self.primary.store(memory, skip_semantic_dedup=skip_semantic_dedup)
 
         if success and self.sync_service:
             # Queue for background sync to secondary

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1167,7 +1167,7 @@ SOLUTIONS:
 
         return False, None
 
-    async def store(self, memory: Memory) -> Tuple[bool, str]:
+    async def store(self, memory: Memory, skip_semantic_dedup: bool = False) -> Tuple[bool, str]:
         """Store a memory in the SQLite-vec database."""
         try:
             if not self.conn:
@@ -1181,8 +1181,8 @@ SOLUTIONS:
             if cursor.fetchone():
                 return False, "Duplicate content detected (exact match)"
 
-            # Check for semantic duplicates within configured time window (only if enabled)
-            if self.semantic_dedup_enabled:
+            # Check for semantic duplicates (skipped when caller signals incremental save)
+            if self.semantic_dedup_enabled and not skip_semantic_dedup:
                 is_duplicate, existing_hash = await self._check_semantic_duplicate(
                     memory.content,
                     time_window_hours=self.semantic_dedup_time_window,

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1168,7 +1168,13 @@ SOLUTIONS:
         return False, None
 
     async def store(self, memory: Memory, skip_semantic_dedup: bool = False) -> Tuple[bool, str]:
-        """Store a memory in the SQLite-vec database."""
+        """Store a memory in the SQLite-vec database.
+
+        Args:
+            memory: The Memory object to store.
+            skip_semantic_dedup: If True, bypass semantic similarity check.
+                Exact hash deduplication is always enforced.
+        """
         try:
             if not self.conn:
                 return False, "Database not initialized"

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -48,6 +48,7 @@ class MemoryCreateRequest(BaseModel):
     memory_type: Optional[str] = Field(None, description="Type of memory (e.g., 'note', 'reminder', 'fact')")
     metadata: Dict[str, Any] = Field(default={}, description="Additional metadata for the memory")
     client_hostname: Optional[str] = Field(None, description="Client machine hostname for source tracking")
+    conversation_id: Optional[str] = Field(None, description="Optional conversation identifier. When provided, semantic deduplication is skipped, allowing multiple incremental memories from the same conversation to be stored even if their content is topically similar.")
 
 
 class MemoryUpdateRequest(BaseModel):
@@ -159,10 +160,11 @@ async def store_memory(
         # Use injected MemoryService for consistent business logic (hostname tagging handled internally)
         result = await memory_service.store_memory(
             content=request.content,
-        tags=request.tags,
-        memory_type=request.memory_type,
-        metadata=request.metadata,
-        client_hostname=client_hostname
+            tags=request.tags,
+            memory_type=request.memory_type,
+            metadata=request.metadata,
+            client_hostname=client_hostname,
+            conversation_id=request.conversation_id,
         )
 
         if result["success"]:

--- a/tests/integration/test_server_handlers.py
+++ b/tests/integration/test_server_handlers.py
@@ -131,6 +131,30 @@ class TestHandleStoreMemory:
         assert "successfully" in text.lower()
 
 
+    @pytest.mark.asyncio
+    async def test_store_memory_with_conversation_id(self, unique_content):
+        """Storing with conversation_id allows semantically similar saves."""
+        server = MemoryServer()
+        await server._ensure_storage_initialized()
+        server.storage.semantic_dedup_enabled = True
+
+        content1 = unique_content("Claude Code is a powerful CLI tool for software engineering.")
+        result1 = await server.handle_store_memory({
+            "content": content1,
+            "conversation_id": "test-conv-001",
+            "metadata": {"tags": ["test"], "type": "note"}
+        })
+        assert "successfully" in result1[0].text.lower()
+
+        content2 = unique_content("The Claude Code CLI is an excellent software development tool.")
+        result2 = await server.handle_store_memory({
+            "content": content2,
+            "conversation_id": "test-conv-001",
+            "metadata": {"tags": ["test"], "type": "note"}
+        })
+        assert "successfully" in result2[0].text.lower(), f"Expected success, got: {result2[0].text}"
+
+
 class TestHandleRetrieveMemory:
     """Test suite for handle_retrieve_memory MCP handler."""
 

--- a/tests/services/test_memory_service.py
+++ b/tests/services/test_memory_service.py
@@ -1,0 +1,60 @@
+"""Tests for MemoryService.store_memory() — Task 2: conversation_id threading."""
+import os
+import tempfile
+import pytest
+
+# Ensure sqlite_vec backend and a fresh test DB for this module
+os.environ['MCP_MEMORY_STORAGE_BACKEND'] = 'sqlite_vec'
+_test_db_dir = tempfile.mkdtemp(prefix='mcp-service-test-')
+os.environ['MCP_MEMORY_SQLITE_PATH'] = os.path.join(_test_db_dir, 'test.db')
+os.environ['MCP_SEMANTIC_DEDUP_ENABLED'] = 'false'  # off by default; tests override
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../src'))
+
+from mcp_memory_service.services.memory_service import MemoryService
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+
+@pytest.fixture
+async def memory_service(tmp_path):
+    """Create a fresh MemoryService backed by a temp SQLite-Vec database."""
+    db_path = str(tmp_path / "test_service.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    await storage.initialize()
+    service = MemoryService(storage=storage)
+    yield service
+    await storage.close()
+
+
+class TestStoreMemory:
+    """Tests for MemoryService.store_memory()."""
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_bypasses_semantic_dedup(self, memory_service):
+        """Storing with conversation_id skips semantic dedup."""
+        # Enable semantic dedup on the storage backend
+        memory_service.storage.semantic_dedup_enabled = True
+
+        result1 = await memory_service.store_memory(
+            content="Claude Code is a powerful CLI tool for software engineering.",
+            tags=["test"],
+            conversation_id="conv-abc"
+        )
+        assert result1["success"]
+
+        # Similar content, same conversation — should succeed (dedup skipped)
+        result2 = await memory_service.store_memory(
+            content="The Claude Code CLI is an excellent software development tool.",
+            tags=["test"],
+            conversation_id="conv-abc"
+        )
+        assert result2["success"], f"Expected success with conversation_id, got: {result2.get('error')}"
+
+        # Similar content, NO conversation_id — should be rejected by semantic dedup
+        result3 = await memory_service.store_memory(
+            content="Claude Code CLI is a top-tier software engineering tool.",
+            tags=["test"]
+        )
+        assert not result3["success"]
+        assert "semantically similar" in result3.get("error", "").lower()

--- a/tests/services/test_memory_service.py
+++ b/tests/services/test_memory_service.py
@@ -55,3 +55,19 @@ class TestStoreMemory:
         )
         assert not result3["success"]
         assert "semantically similar" in result3.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_conversation_id_persisted_in_metadata(self, memory_service):
+        """conversation_id is stored in memory metadata for future grouping/retrieval."""
+        result = await memory_service.store_memory(
+            content="A memory tagged with a conversation ID for retrieval.",
+            tags=["test"],
+            conversation_id="conv-persist-check"
+        )
+        assert result["success"]
+        content_hash = result["memory"]["content_hash"]
+
+        # Retrieve the stored memory and verify conversation_id is in metadata
+        memory = await memory_service.storage.get_by_hash(content_hash)
+        assert memory is not None
+        assert memory.metadata.get("conversation_id") == "conv-persist-check"

--- a/tests/services/test_memory_service.py
+++ b/tests/services/test_memory_service.py
@@ -9,9 +9,6 @@ _test_db_dir = tempfile.mkdtemp(prefix='mcp-service-test-')
 os.environ['MCP_MEMORY_SQLITE_PATH'] = os.path.join(_test_db_dir, 'test.db')
 os.environ['MCP_SEMANTIC_DEDUP_ENABLED'] = 'false'  # off by default; tests override
 
-import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../src'))
-
 from mcp_memory_service.services.memory_service import MemoryService
 from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
 


### PR DESCRIPTION
## Summary

- Adds optional `conversation_id` parameter to `memory_store` MCP tool and `POST /api/memories` REST endpoint
- When `conversation_id` is provided, semantic deduplication is bypassed — allowing multiple related saves from the same conversation without false-positive rejection
- Exact hash deduplication is always preserved (true duplicates are still rejected)
- `conversation_id` is stored in memory `metadata` for future grouping/retrieval

## Problem

Semantic dedup checks all memories in a 24-hour window and rejects any with cosine similarity ≥ 0.85 to an existing one. This incorrectly blocks incremental saves from long conversations — e.g. saving "Excalidraw log issue" then "Express auto-start script" can be rejected as similar because both are AI-generated prose with related vocabulary (#463).

## Changes

| File | Change |
|------|--------|
| `storage/base.py` | Add `skip_semantic_dedup: bool = False` to abstract `store()` |
| `storage/sqlite_vec.py` | Honour `skip_semantic_dedup` flag in concrete `store()` |
| `storage/cloudflare.py` | Accept flag for interface compatibility (no-op; Cloudflare has no semantic dedup) |
| `storage/hybrid.py` | Forward flag to `primary.store()` |
| `services/memory_service.py` | Add `conversation_id` param; pass `skip_semantic_dedup=bool(conversation_id)` to storage |
| `server/handlers/memory.py` | Extract `conversation_id` from MCP tool arguments |
| `server_impl.py` | Add `conversation_id` to `memory_store` tool `inputSchema` + description |
| `web/api/memories.py` | Add `conversation_id` to `MemoryCreateRequest` + pass to service |
| `tests/test_sqlite_vec_storage.py` | Test: similar content stored with `skip_semantic_dedup=True` |
| `tests/services/test_memory_service.py` | Tests: dedup bypass behaviour + metadata persistence |
| `tests/integration/test_server_handlers.py` | Integration test: two semantically similar stores via MCP handler with `conversation_id` |

## Usage

**MCP tool:**
```json
{
  "content": "Express auto-start script added to project",
  "conversation_id": "conv-session-abc123",
  "metadata": { "tags": ["devops"], "type": "note" }
}
```

**REST API:**
```bash
curl -X POST http://localhost:8000/api/memories   -H "Content-Type: application/json"   -d '{"content": "...", "conversation_id": "conv-session-abc123", "tags": ["note"]}'
```

## Test Plan

- [x] `tests/test_sqlite_vec_storage.py::TestSemanticDeduplication` — 10/10 pass
- [x] `tests/services/test_memory_service.py` — 2/2 pass (dedup bypass + metadata persistence)
- [x] `tests/integration/test_server_handlers.py` — 158 pass, 6 skip
- [x] Full suite: 1168 passed, 43 skipped, 23 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)