### PR TITLE
fix: add MCP_INIT_TIMEOUT env override for Windows session reconnect issue (v10.16.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,12 @@ MCP_OAUTH_SQLITE_PATH=./data/oauth.db
                                     # Note: Models must be pre-cached before enabling
                                     # First install downloads models automatically
 
+# Initialization Timeout (Windows users may need to increase this)
+# Controls the eager storage initialization timeout in seconds
+# Default: 30s on Windows, 15s on other platforms (auto-doubled on first run or missing deps)
+# Increase if you see "Storage initialization timed out" in logs on every startup
+# MCP_INIT_TIMEOUT=120              # Set to 120s for slow Windows systems
+
 # =============================================================================
 # OPTIONAL: External Embedding API (vLLM, Ollama, TEI, OpenAI)
 # =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.16.1] - 2026-02-19
+
+### Fixed
+- **`MCP_INIT_TIMEOUT` environment variable override for Windows initialization timeout** (#474): The eager storage initialization timeout (30s on Windows, 15s on other platforms) was sometimes insufficient for ONNX model loading on slower Windows machines. On these systems the server would fall back to lazy loading, causing the MCP client to treat the initial connection as failed — requiring a manual reconnect on every new session. Users can now set `MCP_INIT_TIMEOUT=120` (or any positive number) in their MCP server environment to override the automatically computed timeout. Invalid, zero, or negative values are logged as warnings and fall through to automatic detection. Documented in `.env.example` and `CLAUDE.md` Common Issues table.
+
+### Added
+- **7 unit tests** for `get_recommended_timeout()` covering env override (integer, float), invalid values (non-numeric, zero, negative, empty string), and no-override path (`tests/unit/test_dependency_check.py`).
+
 ## [10.16.0] - 2026-02-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.16.0 - Agentic AI market repositioning with REST API integration guides for LangGraph, CrewAI, AutoGen; X-Agent-ID header auto-tagging - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.16.1 - Windows MCP initialization timeout fix via `MCP_INIT_TIMEOUT` env var; 7 unit tests for override logic - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 
@@ -279,6 +279,10 @@ export MCP_CONSOLIDATION_ENABLED=true
 
 # SQLite Concurrent Access (CRITICAL for HTTP + MCP servers)
 export MCP_MEMORY_SQLITE_PRAGMAS=journal_mode=WAL,busy_timeout=15000,cache_size=20000
+
+# Initialization Timeout (Windows users may need to increase this)
+# Default: 30s on Windows, 15s on Linux/macOS (auto-doubled on first run)
+# export MCP_INIT_TIMEOUT=120        # Increase for slow Windows systems
 ```
 
 **Configuration Precedence:** Environment variables > .env file > Global Claude Config > defaults
@@ -466,6 +470,7 @@ memory.memory_type or ''
 | Schema validation errors after PR merge | Run `/mcp` in Claude Code to reconnect with new schema |
 | Database lock errors | Add `journal_mode=WAL` to `MCP_MEMORY_SQLITE_PRAGMAS` in `.env`, restart servers |
 | Tests failing after git pull | Run `./scripts/update_and_restart.sh` (installs deps, restarts server) |
+| MCP fails on every session (Windows) | Set `MCP_INIT_TIMEOUT=120` in your MCP server env config (issue #474) |
 
 **Comprehensive troubleshooting:** [docs/troubleshooting/hooks-quick-reference.md](docs/troubleshooting/hooks-quick-reference.md)
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.16.0** (February 18, 2026)
+## 🆕 Latest Release: **v10.16.1** (February 19, 2026)
 
-**Agentic AI Market Repositioning with REST API Integration Guides**
+**Windows MCP Initialization Timeout Fix**
 
 **What's New:**
-- **Agent framework integration guides**: Five new guides in `docs/agents/` — LangGraph StateGraph memory nodes, CrewAI BaseTool implementations, AutoGen 0.4+ FunctionTool schema, and generic HTTP examples covering all 15 REST endpoints.
-- **`X-Agent-ID` header auto-tagging**: Send `X-Agent-ID: my-agent` in any `POST /api/memories` request to automatically scope memories to that agent identity — no client-side tag management required.
-- **`agent:` tag namespace**: New `NAMESPACE_AGENT` entry in tag taxonomy for agent-scoped memory isolation and retrieval.
-- **README overhaul**: New hero section "Persistent Shared Memory for AI Agent Pipelines", "Why Agents Need This" comparison table, competitor comparison (vs Mem0/Zep/DIY), and LangGraph/CrewAI/AutoGen framework badges.
-- **PyPI discoverability**: Updated description and keywords to target the multi-agent and agentic AI ecosystem.
+- **`MCP_INIT_TIMEOUT` environment variable**: Set `MCP_INIT_TIMEOUT=120` in your MCP server env to override the auto-computed initialization timeout — solves "fails on every new session" on slow Windows machines (#474).
+- **Automatic detection preserved**: Invalid, zero, or negative values fall back to platform-aware auto-detection (30s Windows / 15s other, doubled on first run or missing deps).
+- **7 unit tests** covering all edge cases for the new override logic.
+- **Documentation**: Documented in `.env.example` and added Windows troubleshooting entry to CLAUDE.md.
 
 **Previous Releases**:
+- **v10.16.0** - Agentic AI Market Repositioning with REST API Integration Guides (LangGraph, CrewAI, AutoGen guides, X-Agent-ID header auto-tagging, agent: tag namespace)
 - **v10.15.1** - Stale Venv Detection for Moved/Renamed Projects (auto-recreate venv when pip shebang interpreter path is missing)
 - **v10.15.0** - Config Validation & Safe Environment Parsing (`validate_config()` at startup, `safe_get_int_env()`, 8 new robustness tests)
 - **v10.14.0** - `conversation_id` Support for Incremental Conversation Saves (semantic dedup bypass, metadata storage, all backends)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.16.0"
+version = "10.16.1"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.16.0"
+__version__ = "10.16.1"

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -231,6 +231,7 @@ def get_recommended_timeout() -> float:
             if override > 0:
                 logger.info(f"Using MCP_INIT_TIMEOUT override: {override}s")
                 return override
+            logger.warning(f"MCP_INIT_TIMEOUT must be a positive number, got '{env_timeout}'. Using automatic detection.")
         except ValueError:
             logger.warning(f"Invalid MCP_INIT_TIMEOUT value '{env_timeout}', using automatic detection")
 

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -219,24 +219,38 @@ def is_first_run() -> bool:
 def get_recommended_timeout() -> float:
     """
     Get the recommended timeout based on system and dependencies.
+
+    Can be overridden via MCP_INIT_TIMEOUT environment variable.
+    Useful for Windows systems where ONNX model initialization takes longer.
     """
+    # Allow explicit override via environment variable
+    env_timeout = os.getenv('MCP_INIT_TIMEOUT')
+    if env_timeout:
+        try:
+            override = float(env_timeout)
+            if override > 0:
+                logger.info(f"Using MCP_INIT_TIMEOUT override: {override}s")
+                return override
+        except ValueError:
+            logger.warning(f"Invalid MCP_INIT_TIMEOUT value '{env_timeout}', using automatic detection")
+
     # Check if dependencies are missing
     all_installed, missing = check_critical_dependencies()
-    
+
     # Check if it's first run (models need downloading)
     first_run = is_first_run()
-    
+
     # Base timeout
     timeout = 30.0 if platform.system() == "Windows" else 15.0
-    
+
     # Extend timeout if dependencies are missing
     if not all_installed:
         timeout *= 2  # Double the timeout
         logger.warning(f"Dependencies missing, extending timeout to {timeout}s")
-    
+
     # Extend timeout if it's first run
     if first_run:
         timeout *= 2  # Double the timeout
         logger.warning(f"First run detected, extending timeout to {timeout}s")
-    
+
     return timeout

--- a/tests/test_tag_optimization_performance.py
+++ b/tests/test_tag_optimization_performance.py
@@ -26,7 +26,7 @@ class TestTagValidationOptimization:
         assert isinstance(TagTaxonomy.VALID_NAMESPACES, set)
 
         # Verify all namespaces are present
-        assert len(TagTaxonomy.VALID_NAMESPACES) == 6
+        assert len(TagTaxonomy.VALID_NAMESPACES) == 7
 
         # Verify fast membership testing works
         assert "q:" in TagTaxonomy.VALID_NAMESPACES

--- a/tests/test_tag_taxonomy.py
+++ b/tests/test_tag_taxonomy.py
@@ -19,6 +19,7 @@ NAMESPACE_PROJECT = tag_taxonomy.NAMESPACE_PROJECT
 NAMESPACE_TOPIC = tag_taxonomy.NAMESPACE_TOPIC
 NAMESPACE_TEMPORAL = tag_taxonomy.NAMESPACE_TEMPORAL
 NAMESPACE_USER = tag_taxonomy.NAMESPACE_USER
+NAMESPACE_AGENT = tag_taxonomy.NAMESPACE_AGENT
 parse_tag = tag_taxonomy.parse_tag
 validate_tag = tag_taxonomy.validate_tag
 add_namespace = tag_taxonomy.add_namespace
@@ -177,17 +178,18 @@ class TestBurst26TagTaxonomyClass:
         """VALID_NAMESPACES class attribute should be exposed for efficient access"""
         assert hasattr(TagTaxonomy, 'VALID_NAMESPACES')
         assert isinstance(TagTaxonomy.VALID_NAMESPACES, set)
-        assert len(TagTaxonomy.VALID_NAMESPACES) == 6
+        assert len(TagTaxonomy.VALID_NAMESPACES) == 7
 
     def test_valid_namespaces_contains_all_namespaces(self):
-        """VALID_NAMESPACES should contain all 6 namespace constants"""
+        """VALID_NAMESPACES should contain all 7 namespace constants"""
         expected_namespaces = {
             NAMESPACE_SYSTEM,
             NAMESPACE_QUALITY,
             NAMESPACE_PROJECT,
             NAMESPACE_TOPIC,
             NAMESPACE_TEMPORAL,
-            NAMESPACE_USER
+            NAMESPACE_USER,
+            NAMESPACE_AGENT
         }
         assert TagTaxonomy.VALID_NAMESPACES == expected_namespaces
 

--- a/tests/unit/test_dependency_check.py
+++ b/tests/unit/test_dependency_check.py
@@ -1,0 +1,59 @@
+"""Tests for dependency_check.py - especially get_recommended_timeout."""
+import os
+import pytest
+
+
+class TestGetRecommendedTimeout:
+    """Tests for the get_recommended_timeout function."""
+
+    def test_env_override_takes_precedence(self, monkeypatch):
+        """MCP_INIT_TIMEOUT env var should override automatic detection."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', '120')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert result == 120.0
+
+    def test_env_override_float_value(self, monkeypatch):
+        """MCP_INIT_TIMEOUT should accept float values."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', '45.5')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert result == 45.5
+
+    def test_env_override_invalid_value_falls_back(self, monkeypatch):
+        """Invalid MCP_INIT_TIMEOUT should fall back to automatic detection."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', 'not-a-number')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        # Should not raise, should return a positive value from automatic detection
+        result = get_recommended_timeout()
+        assert isinstance(result, float)
+        assert result > 0
+
+    def test_env_override_zero_falls_back(self, monkeypatch):
+        """Zero MCP_INIT_TIMEOUT should fall back to automatic detection."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', '0')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert result > 0
+
+    def test_env_override_negative_falls_back(self, monkeypatch):
+        """Negative MCP_INIT_TIMEOUT should fall back to automatic detection."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', '-10')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert result > 0
+
+    def test_no_env_override_returns_positive(self, monkeypatch):
+        """Without env override, should return a positive timeout."""
+        monkeypatch.delenv('MCP_INIT_TIMEOUT', raising=False)
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert isinstance(result, float)
+        assert result > 0
+
+    def test_env_override_empty_string_falls_back(self, monkeypatch):
+        """Empty MCP_INIT_TIMEOUT should fall back to automatic detection."""
+        monkeypatch.setenv('MCP_INIT_TIMEOUT', '')
+        from mcp_memory_service.dependency_check import get_recommended_timeout
+        result = get_recommended_timeout()
+        assert result > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1104,7 +1104,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.16.0"
+version = "10.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes the Windows-specific issue where the MCP server fails to connect on every new session, requiring a manual reconnect (#474).

**Root cause:** The eager storage initialization timeout (30s on Windows, 15s elsewhere) was sometimes insufficient for ONNX model loading on slower Windows machines. When initialization timed out, the server fell back to lazy loading mode — and the MCP client treated the initial connection as failed.

**Fix:** `get_recommended_timeout()` in `dependency_check.py` now checks `MCP_INIT_TIMEOUT` as the first step. Users on slow Windows machines can add `MCP_INIT_TIMEOUT=120` to their MCP server environment config to guarantee enough headroom without touching any server code.

## Changes

- **`src/mcp_memory_service/dependency_check.py`**: `get_recommended_timeout()` reads `MCP_INIT_TIMEOUT` env var first; returns the override immediately if it is a positive float. Invalid (non-numeric), zero, or negative values log a warning and fall through to the existing automatic detection logic — no silent failures.
- **`tests/unit/test_dependency_check.py`** (new): 7 unit tests covering integer override, float override, non-numeric fallback, zero fallback, negative fallback, no-override positive result, and empty-string fallback.
- **`.env.example`**: New documented block for `MCP_INIT_TIMEOUT` with recommended value and context about when to use it.
- **`CLAUDE.md`**: Added `MCP_INIT_TIMEOUT` to the environment variable quick reference; added a Windows troubleshooting entry to the Common Issues table.
- **`CHANGELOG.md`**: v10.16.1 entry with full description.
- **`README.md`**: Updated Latest Release to v10.16.1; previous v10.16.0 moved to Previous Releases list.
- **`_version.py`, `pyproject.toml`, `uv.lock`**: Bumped to 10.16.1.

## Testing

- 7 new unit tests in `tests/unit/test_dependency_check.py` — all passing (118 total tests passed, 7 expected failures).
- Manual validation: `MCP_INIT_TIMEOUT=120 python -c "from mcp_memory_service.dependency_check import get_recommended_timeout; print(get_recommended_timeout())"` returns `120.0`.

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`, `uv.lock`
- [x] `CHANGELOG.md` updated with v10.16.1 entry (validated structure: no duplicates, correct order)
- [x] `README.md` Latest Release section updated; previous version added to Previous Releases
- [x] `CLAUDE.md` updated with new env var and troubleshooting entry
- [x] 7 unit tests added and passing
- [x] `.env.example` documented

Fixes #474