### PR TITLE
feat: default "untagged" tag for tagless memories + cleanup script (v10.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.17.0] - 2026-02-20
+
+### Added
+- **Default "untagged" tag for memories without tags** (`Memory.__post_init__`): All Memory objects now receive a default `["untagged"]` tag when no tags are supplied at creation time. The enforcement point is the `Memory` dataclass `__post_init__` method — universal across all 5 entry-points (MCP tools, REST API, document ingestion, consolidation, CLI). Previously, 306 production memories had empty tag lists, making them unretrievable via tag-based search and invisible in tag-faceted dashboards.
+- **`scripts/maintenance/tag_untagged_memories.py`**: New one-shot cleanup script for existing databases with untagged memories. Supports `--dry-run` (preview counts by category) and `--apply` (write changes). Applied to production DB: 16 test artifacts soft-deleted, 121 document chunks tagged `untagged,document`, 169 real memories tagged `untagged`, 0 untagged memories remaining.
+
+### Fixed
+- **3 tests updated** to reflect new default-tag behaviour: `test_empty_tags_gets_untagged_default` (updated assertion), `test_explicit_tags_not_adds_untagged` (new — verifies explicit tags are preserved), `test_none_tags_gets_untagged_default` (new — verifies `None` tags input is handled correctly).
+- **`tests/unit/test_memory_service.py`**: Updated `test_empty_tags_list_gets_untagged_default` to assert `["untagged"]` rather than `[]`.
+
 ## [10.16.1] - 2026-02-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.16.1 - Windows MCP initialization timeout fix via `MCP_INIT_TIMEOUT` env var; 7 unit tests for override logic - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.0 - Default "untagged" tag for all tagless memories (Memory.__post_init__ enforcement); cleanup script for existing DBs - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,17 +259,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.16.1** (February 19, 2026)
+## 🆕 Latest Release: **v10.17.0** (February 20, 2026)
 
-**Windows MCP Initialization Timeout Fix**
+**Default "untagged" Tag for All Memories + Cleanup Tooling**
 
 **What's New:**
-- **`MCP_INIT_TIMEOUT` environment variable**: Set `MCP_INIT_TIMEOUT=120` in your MCP server env to override the auto-computed initialization timeout — solves "fails on every new session" on slow Windows machines (#474).
-- **Automatic detection preserved**: Invalid, zero, or negative values fall back to platform-aware auto-detection (30s Windows / 15s other, doubled on first run or missing deps).
-- **7 unit tests** covering all edge cases for the new override logic.
-- **Documentation**: Documented in `.env.example` and added Windows troubleshooting entry to CLAUDE.md.
+- **Universal "untagged" default**: Every new Memory with no tags automatically receives `["untagged"]` — enforced in `Memory.__post_init__`, the single creation point for all 5 entry-paths (MCP, REST API, ingestion, consolidation, CLI). Zero-tag memories are now impossible.
+- **`scripts/maintenance/tag_untagged_memories.py`**: One-shot migration script for existing databases. Run with `--dry-run` to preview, `--apply` to write. Handles document chunks (tagged `untagged,document`) and plain memories separately.
+- **3 new/updated tests** confirming default-tag enforcement, explicit-tag preservation, and `None`-input handling.
+- **306 production memories retroactively fixed**: 121 document chunks, 169 plain memories now discoverable via tag search.
 
 **Previous Releases**:
+- **v10.16.1** - Windows MCP Initialization Timeout Fix (`MCP_INIT_TIMEOUT` env override, 7 unit tests)
 - **v10.16.0** - Agentic AI Market Repositioning with REST API Integration Guides (LangGraph, CrewAI, AutoGen guides, X-Agent-ID header auto-tagging, agent: tag namespace)
 - **v10.15.1** - Stale Venv Detection for Moved/Renamed Projects (auto-recreate venv when pip shebang interpreter path is missing)
 - **v10.15.0** - Config Validation & Safe Environment Parsing (`validate_config()` at startup, `safe_get_int_env()`, 8 new robustness tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.16.1"
+version = "10.17.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/maintenance/tag_untagged_memories.py
+++ b/scripts/maintenance/tag_untagged_memories.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Tag Untagged Memories - Cleanup Script
+
+Finds all memories with empty tags in the production database and:
+- Soft-deletes test artifacts
+- Tags document chunks as "untagged,document"
+- Tags real memories as "untagged"
+
+Usage:
+    python scripts/maintenance/tag_untagged_memories.py --dry-run   # Preview (default)
+    python scripts/maintenance/tag_untagged_memories.py --apply      # Apply changes
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+from datetime import datetime
+
+DEFAULT_DB = Path.home() / ".local" / "share" / "mcp-memory" / "sqlite_vec.db"
+
+TEST_PATTERNS = [
+    "test content for hash length",
+    "this is a test memory",
+    "test content",
+    "test memory for",
+    "backup test",
+    "__test__",
+]
+
+
+def find_untagged(conn):
+    """Find all non-deleted memories with empty or NULL tags."""
+    cursor = conn.execute(
+        "SELECT content_hash, content, memory_type, tags "
+        "FROM memories "
+        "WHERE deleted_at IS NULL AND (tags IS NULL OR tags = '')"
+    )
+    return cursor.fetchall()
+
+
+def classify(content, memory_type):
+    """Classify a memory as test, document, or real."""
+    content_lower = content.lower()
+    for pattern in TEST_PATTERNS:
+        if pattern in content_lower:
+            return "test"
+    if memory_type == "document":
+        return "document"
+    return "real"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tag untagged memories in production DB")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="Path to SQLite database")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dry-run", action="store_true", help="Preview changes only")
+    group.add_argument("--apply", action="store_true", help="Apply changes to database")
+    args = parser.parse_args()
+
+    if not args.db.exists():
+        print(f"Database not found: {args.db}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(args.db))
+    rows = find_untagged(conn)
+    print(f"Found {len(rows)} untagged memories\n")
+
+    if not rows:
+        print("Nothing to do.")
+        conn.close()
+        return
+
+    # Classify
+    test_rows = []
+    doc_rows = []
+    real_rows = []
+
+    for content_hash, content, memory_type, tags in rows:
+        cat = classify(content, memory_type)
+        if cat == "test":
+            test_rows.append((content_hash, content))
+        elif cat == "document":
+            doc_rows.append((content_hash, content))
+        else:
+            real_rows.append((content_hash, content))
+
+    print(f"Classification:")
+    print(f"  Test artifacts (soft-delete):  {len(test_rows)}")
+    print(f"  Document chunks (tag):         {len(doc_rows)}")
+    print(f"  Real memories (tag):           {len(real_rows)}")
+    print()
+
+    if args.dry_run:
+        print("--- DRY RUN (no changes) ---\n")
+        if test_rows:
+            print("Would SOFT-DELETE:")
+            for h, c in test_rows[:5]:
+                print(f"  {h[:12]}... | {c[:60]}")
+            if len(test_rows) > 5:
+                print(f"  ... and {len(test_rows) - 5} more")
+            print()
+        if doc_rows:
+            print("Would TAG as 'untagged,document':")
+            for h, c in doc_rows[:5]:
+                print(f"  {h[:12]}... | {c[:60]}")
+            if len(doc_rows) > 5:
+                print(f"  ... and {len(doc_rows) - 5} more")
+            print()
+        if real_rows:
+            print("Would TAG as 'untagged':")
+            for h, c in real_rows[:5]:
+                print(f"  {h[:12]}... | {c[:60]}")
+            if len(real_rows) > 5:
+                print(f"  ... and {len(real_rows) - 5} more")
+            print()
+        print("Run with --apply to execute.")
+        conn.close()
+        return
+
+    # Apply changes
+    now = datetime.utcnow().isoformat() + "Z"
+    deleted = 0
+    tagged = 0
+
+    for content_hash, _ in test_rows:
+        conn.execute(
+            "UPDATE memories SET deleted_at = ? WHERE content_hash = ?",
+            (now, content_hash),
+        )
+        deleted += 1
+
+    for content_hash, _ in doc_rows:
+        conn.execute(
+            "UPDATE memories SET tags = ? WHERE content_hash = ?",
+            ("untagged,document", content_hash),
+        )
+        tagged += 1
+
+    for content_hash, _ in real_rows:
+        conn.execute(
+            "UPDATE memories SET tags = ? WHERE content_hash = ?",
+            ("untagged", content_hash),
+        )
+        tagged += 1
+
+    conn.commit()
+    conn.close()
+
+    print(f"Done:")
+    print(f"  Soft-deleted: {deleted}")
+    print(f"  Tagged:       {tagged}")
+
+    # Verify
+    conn2 = sqlite3.connect(str(args.db))
+    remaining = conn2.execute(
+        "SELECT COUNT(*) FROM memories "
+        "WHERE deleted_at IS NULL AND (tags IS NULL OR tags = '')"
+    ).fetchone()[0]
+    conn2.close()
+    print(f"  Remaining untagged: {remaining}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/maintenance/tag_untagged_memories.py
+++ b/scripts/maintenance/tag_untagged_memories.py
@@ -124,26 +124,26 @@ def main():
     deleted = 0
     tagged = 0
 
-    for content_hash, _ in test_rows:
-        conn.execute(
+    if test_rows:
+        conn.executemany(
             "UPDATE memories SET deleted_at = ? WHERE content_hash = ?",
-            (now, content_hash),
+            [(now, h) for h, _ in test_rows],
         )
-        deleted += 1
+        deleted = len(test_rows)
 
-    for content_hash, _ in doc_rows:
-        conn.execute(
+    if doc_rows:
+        conn.executemany(
             "UPDATE memories SET tags = ? WHERE content_hash = ?",
-            ("untagged,document", content_hash),
+            [("untagged,document", h) for h, _ in doc_rows],
         )
-        tagged += 1
+        tagged += len(doc_rows)
 
-    for content_hash, _ in real_rows:
-        conn.execute(
+    if real_rows:
+        conn.executemany(
             "UPDATE memories SET tags = ? WHERE content_hash = ?",
-            ("untagged", content_hash),
+            [("untagged", h) for h, _ in real_rows],
         )
-        tagged += 1
+        tagged += len(real_rows)
 
     conn.commit()
     conn.close()

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.16.1"
+__version__ = "10.17.0"

--- a/src/mcp_memory_service/models/memory.py
+++ b/src/mcp_memory_service/models/memory.py
@@ -72,6 +72,10 @@ class Memory:
                 )
                 self.memory_type = "observation"  # Default to base type
 
+        # Default tag when no tags provided
+        if not self.tags:
+            self.tags = ["untagged"]
+
         # Validate tags using taxonomy (soft validation)
         if self.tags:
             invalid_tags = []

--- a/tests/test_memory_ontology_integration.py
+++ b/tests/test_memory_ontology_integration.py
@@ -178,8 +178,8 @@ class TestBurstI2TagValidation:
         assert "sys:core" not in caplog.text  # Valid, not logged
         assert "python" not in caplog.text    # Legacy, not logged
 
-    def test_empty_tags_no_validation(self):
-        """Empty tags list should not trigger validation"""
+    def test_empty_tags_gets_untagged_default(self):
+        """Empty tags list should get 'untagged' default tag"""
         content = "Test content"
         content_hash = hashlib.sha256(content.encode()).hexdigest()
 
@@ -189,4 +189,30 @@ class TestBurstI2TagValidation:
             tags=[]
         )
 
-        assert memory.tags == []
+        assert memory.tags == ["untagged"]
+
+    def test_explicit_tags_not_adds_untagged(self):
+        """Memory with explicit tags should NOT get 'untagged' added"""
+        content = "Test content with tags"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        memory = Memory(
+            content=content,
+            content_hash=content_hash,
+            tags=["python", "testing"]
+        )
+
+        assert memory.tags == ["python", "testing"]
+        assert "untagged" not in memory.tags
+
+    def test_none_tags_gets_untagged_default(self):
+        """Memory created without tags param should get 'untagged' default"""
+        content = "Test content no tags"
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+        memory = Memory(
+            content=content,
+            content_hash=content_hash,
+        )
+
+        assert memory.tags == ["untagged"]

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -590,8 +590,8 @@ async def test_list_memories_database_level_filtering(memory_service, mock_stora
 
 
 @pytest.mark.asyncio
-async def test_empty_tags_list_stored_correctly(memory_service, mock_storage):
-    """Test that empty or None tags are handled correctly."""
+async def test_empty_tags_list_gets_untagged_default(memory_service, mock_storage):
+    """Test that empty or None tags get 'untagged' default."""
     mock_storage.store.return_value = None
 
     # Store with None tags
@@ -599,7 +599,7 @@ async def test_empty_tags_list_stored_correctly(memory_service, mock_storage):
 
     stored_memory = mock_storage.store.call_args.args[0]
     assert isinstance(stored_memory.tags, list)
-    assert len(stored_memory.tags) == 0
+    assert "untagged" in stored_memory.tags
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1104,7 +1104,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.16.1"
+version = "10.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **Universal default tag enforcement** (`src/mcp_memory_service/models/memory.py`): Added 2 lines in `Memory.__post_init__()` — `if not self.tags: self.tags = [\"untagged\"]`. Because every storage entry-point (MCP tools, REST API, document ingestion, consolidation, CLI) constructs a `Memory` object, this single enforcement point covers the entire surface area. Memories with explicit tags are unaffected.
- **Cleanup script** (`scripts/maintenance/tag_untagged_memories.py`): New one-shot migration utility for databases created before this fix. Supports `--dry-run` (preview counts by category) and `--apply` (write changes). Already applied to production: 16 test artifacts soft-deleted, 121 document chunks tagged `untagged,document`, 169 plain memories tagged `untagged`, 0 untagged remaining.
- **4 tests updated/added**:
  - `tests/test_memory_ontology_integration.py`: Updated `test_empty_tags_gets_untagged_default`; added `test_explicit_tags_not_adds_untagged` and `test_none_tags_gets_untagged_default`.
  - `tests/unit/test_memory_service.py`: Updated `test_empty_tags_list_gets_untagged_default` to assert `["untagged"]`.

## Motivation

306 production memories had empty tag lists, making them invisible to tag-based search and tag-faceted dashboard views. Tags were optional everywhere with no layer setting a default. This fix closes the gap at the model layer — the only point guaranteed to run for every memory regardless of how it enters the system.

## Testing

- 1157 tests passed, 3 pre-existing benchmark failures (unrelated to this change), 0 regressions.
- Cleanup script tested with `--dry-run` before `--apply` on production database.

## Checklist

- [x] Version bumped in `_version.py` (10.16.1 → 10.17.0) and `pyproject.toml`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new `[10.17.0]` section immediately after `[Unreleased]`)
- [x] `README.md` "Latest Release" section updated; v10.16.1 moved to Previous Releases
- [x] `CLAUDE.md` Current Version line updated
- [x] Tests added/updated (4 tests)
- [x] CHANGELOG structure validated (versions in reverse chronological order, no duplicates)