### PR TITLE
fix: remove duplicate uniqueTags declaration in session-end.js

### DIFF
--- a/claude-hooks/core/session-end.js
+++ b/claude-hooks/core/session-end.js
@@ -288,10 +288,7 @@ function storeSessionMemory(endpoint, apiKey, content, projectContext, analysis)
         .filter(Boolean) // Remove any null/undefined values
         .map(tag => String(tag).toLowerCase()); // Normalize all to lowercase strings
 
-        // Deduplicate tags
-        const uniqueTags = [...new Set(tags)];
-
-        // Deduplicate case-insensitively
+        // Deduplicate tags case-insensitively
         const uniqueTags = [...new Set(tags.map(t => t.toLowerCase()))];
 
         const postData = JSON.stringify({


### PR DESCRIPTION
## Fix

Removes duplicate `const uniqueTags` declaration in `claude-hooks/core/session-end.js` (lines 292 and 295) that causes a `SyntaxError` on Node.js v24+:

```
SyntaxError: Identifier 'uniqueTags' has already been declared
```

The first declaration was redundant — the `tags` array is already lowercased on line 289, so the second declaration (with `.map(t => t.toLowerCase())`) handles both deduplication and normalization.

### Before
```javascript
// Deduplicate tags
const uniqueTags = [...new Set(tags)];

// Deduplicate case-insensitively
const uniqueTags = [...new Set(tags.map(t => t.toLowerCase()))];
```

### After
```javascript
// Deduplicate tags case-insensitively
const uniqueTags = [...new Set(tags.map(t => t.toLowerCase()))];
```

Fixes #477