### PR TITLE
chore: release v10.17.1 - hook fixes, root installer, GitNexus skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.17.0 - Default "untagged" tag for all tagless memories (Memory.__post_init__ enforcement); cleanup script for existing DBs - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.1 - Hook system bug fixes (session-end SyntaxError, MCP_HTTP_PORT detection, session-start retry backoff) + root-level install.py redirector + GitNexus skill files - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,17 +259,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.17.0** (February 20, 2026)
+## 🆕 Latest Release: **v10.17.1** (February 20, 2026)
 
-**Default "untagged" Tag for All Memories + Cleanup Tooling**
+**Hook System Bug Fixes + Root Installer + Session-Start Reliability**
 
 **What's New:**
-- **Universal "untagged" default**: Every new Memory with no tags automatically receives `["untagged"]` — enforced in `Memory.__post_init__`, the single creation point for all 5 entry-paths (MCP, REST API, ingestion, consolidation, CLI). Zero-tag memories are now impossible.
-- **`scripts/maintenance/tag_untagged_memories.py`**: One-shot migration script for existing databases. Run with `--dry-run` to preview, `--apply` to write. Handles document chunks (tagged `untagged,document`) and plain memories separately.
-- **3 new/updated tests** confirming default-tag enforcement, explicit-tag preservation, and `None`-input handling.
-- **306 production memories retroactively fixed**: 121 document chunks, 169 plain memories now discoverable via tag search.
+- **`session-end.js` SyntaxError fix**: Duplicate `uniqueTags` declaration caused a SyntaxError on Node.js v24, preventing the session-end hook from running entirely. Fixed by removing the redundant declaration (#477).
+- **Hook installer now reads `MCP_HTTP_PORT` from MCP config**: `install_hooks.py` previously ignored `MCP_HTTP_PORT` from `~/.claude.json`, always generating port 8000. Now reads the value from the server's `env` block (#478).
+- **Session-start retry backoff**: `session-start.js` now retries the HTTP connection up to 4 times (2 s, 4 s, 8 s back-off) before falling back to MCP-tool mode, resolving the race condition with Claude Code's lazy MCP server startup (#479).
+- **Root-level `install.py` dispatcher**: Users following the wiki guide who run `python install.py` from the repo root now get an interactive menu rather than a `No such file or directory` error. Supports `--package` and `--hooks` flags (#476).
+- **GitNexus skill files** added to `.claude/skills/gitnexus/` for architecture exploration, debugging, impact analysis, and refactoring workflows.
 
 **Previous Releases**:
+- **v10.17.0** - Default "untagged" Tag for All Tagless Memories + Cleanup Script (306 production memories retroactively fixed)
 - **v10.16.1** - Windows MCP Initialization Timeout Fix (`MCP_INIT_TIMEOUT` env override, 7 unit tests)
 - **v10.16.0** - Agentic AI Market Repositioning with REST API Integration Guides (LangGraph, CrewAI, AutoGen guides, X-Agent-ID header auto-tagging, agent: tag namespace)
 - **v10.15.1** - Stale Venv Detection for Moved/Renamed Projects (auto-recreate venv when pip shebang interpreter path is missing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.17.0"
+version = "10.17.1"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.17.0"
+__version__ = "10.17.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1104,7 +1104,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.17.0"
+version = "10.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.17.1

Patch release consolidating four bug fixes and internal tooling additions from PRs #481, #482, and #483.

## Changes

### Fixed
- **`session-end.js` SyntaxError on Node.js v24** (#477, PR #481): Duplicate `const uniqueTags` declaration in the same scope caused a strict SyntaxError that prevented the entire session-end hook from running. Removed the redundant first declaration; only the case-insensitive lowercasing version remains.
- **Hook installer ignores `MCP_HTTP_PORT` from MCP server config** (#478, PR #481): `scripts/install_hooks.py` detected the MCP server entry in `~/.claude.json` but did not read `MCP_HTTP_PORT` from its `env` block, so generated `config.json` always used port 8000. Added `_read_mcp_http_port_from_claude_json()` helper to extract the configured port.
- **Session-start race condition with lazy MCP server startup** (#479, PR #483): `session-start.js` tried to connect to the HTTP API before Claude Code had finished starting the MCP/HTTP server. Added `withRetry()` with exponential back-off (2 s, 4 s, 8 s; up to 4 attempts, ~14 s total) so the hook waits for the server rather than immediately falling back to MCP-tool mode.
- **Missing root-level `install.py` for wiki users** (#476, PR #482): Wiki installation guide instructs `python install.py` from the repo root; the file did not exist. Added a dispatcher that shows an interactive menu (no args), or delegates via `--package` / `--hooks`. Python 3.13 safetensors warning included.

### Added
- **GitNexus skill files** (`.claude/skills/gitnexus/`, PR #483): Four workflow guides -- `exploring/SKILL.md`, `debugging/SKILL.md`, `impact-analysis/SKILL.md`, `refactoring/SKILL.md` -- for using the GitNexus MCP knowledge graph.
- **`AGENTS.md`** (PR #483): Standard agent guidance file for AI coding tools (Amp, Codex, etc.).
- **`.gitnexus/` added to `.gitignore`** (PR #483): Prevents the ~102 MB kuzu binary graph database from being committed.

## Version Bump

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | 10.17.0 | 10.17.1 |
| `src/mcp_memory_service/_version.py` | 10.17.0 | 10.17.1 |
| `README.md` (Latest Release section) | v10.17.0 | v10.17.1 |
| `CLAUDE.md` (Current Version line) | v10.17.0 | v10.17.1 |
| `uv.lock` | updated | updated |

## Rationale for PATCH bump

All changes in PRs #481, #482, and #483 are either bug fixes (hook SyntaxError, port detection, race condition, missing installer) or internal/developer tooling (GitNexus skills, AGENTS.md, .gitignore entry). No new user-facing features or API changes. PATCH is appropriate.

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`, `CLAUDE.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with full details for all four fixes and three additions
- [x] `README.md` Latest Release section updated; v10.17.0 moved to Previous Releases
- [x] CHANGELOG structure validated: `[Unreleased]` -> `[10.17.1]` -> `[10.17.0]` (correct order, no duplicates)
- [x] No breaking changes

## Related PRs / Issues

Closes #476 (via PR #482), Closes #477 (via PR #481), Closes #478 (via PR #481), Closes #479 (via PR #483)
