### PR TITLE
chore: release v10.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.17.5] - 2026-02-22
+
+### Security
+
+- **Upgrade vulnerable dependencies (38 Dependabot security alerts)**: Bumped minimum version constraints in `pyproject.toml` and regenerated `uv.lock` to address all open Dependabot alerts.
+  - **CRITICAL**: h11 0.14.0 → 0.16.0 (malformed chunked-encoding bypass)
+  - **HIGH**: pillow 11.0.0 → 12.1.1 (OOB write in image processing)
+  - **HIGH**: cryptography 46.0.1 → 46.0.5 (subgroup attack on DSA/DH)
+  - **HIGH**: protobuf 5.29.2 → 6.33.5 (JSON recursion DoS)
+  - **HIGH**: python-multipart 0.0.20 → 0.0.22 (arbitrary file write)
+  - **HIGH**: pyasn1 0.6.1 → 0.6.2 (DoS in DER/BER decoder)
+  - **HIGH**: urllib3 2.3.0 → 2.6.3 (decompression bomb DoS)
+  - **HIGH**: aiohttp 3.12.14 → 3.13.3 (CRLF injection, path traversal, multiple CVEs)
+  - **HIGH**: starlette 0.41.3 → 0.52.1 (DoS via Range header)
+  - **HIGH**: authlib 1.6.4 → 1.6.8 (DoS + account takeover via JWT)
+  - **HIGH**: setuptools 75.6.0 → 82.0.0 (path traversal via crafted wheel)
+  - **HIGH**: fastapi 0.115.6 → 0.129.2 (upgraded to resolve starlette constraint)
+  - **MEDIUM**: filelock 3.16.1 → 3.24.3 (TOCTOU symlink attack)
+  - **MEDIUM**: requests 2.32.3 → 2.32.5 (.netrc credential leak)
+  - **MEDIUM**: jinja2 3.1.5 → 3.1.6 (sandbox breakout)
+  - Note: `ecdsa` and `PyPDF2` have no fix available and were skipped.
+
 ## [10.17.4] - 2026-02-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.17.4 - Resolve all remaining CodeQL alerts (21 alerts: unused import, empty-except, catch-base-exception) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.5 - Security patch: upgrade 15 vulnerable dependencies to address 38 Dependabot alerts (h11, aiohttp, starlette, cryptography, pillow, protobuf, and more) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.17.4"
+version = "10.17.5"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.17.4"
+__version__ = "10.17.5"

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.17.4"
+version = "10.17.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Version bump from v10.17.4 to v10.17.5
- Updates `pyproject.toml`, `_version.py`, `CHANGELOG.md`, and `CLAUDE.md`
- This is a security patch release following PR #491 which upgraded 15 vulnerable dependencies

## Changes

See CHANGELOG.md for the full list of security fixes included in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)