### PR TITLE
fix: resolve 100 CodeQL import alerts (unused/repeated/cyclic)

### DIFF
--- a/src/mcp_memory_service/cli/ingestion.py
+++ b/src/mcp_memory_service/cli/ingestion.py
@@ -21,13 +21,13 @@ import logging
 import sys
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import click
 
 from ..ingestion import get_loader_for_file, is_supported_file, SUPPORTED_FORMATS
 from ..models.memory import Memory
-from ..utils import create_memory_from_chunk, _process_and_store_chunk
+from ..utils import _process_and_store_chunk
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/consolidation/consolidator.py
+++ b/src/mcp_memory_service/consolidation/consolidator.py
@@ -14,8 +14,7 @@
 
 """Main dream-inspired consolidation orchestrator."""
 
-import asyncio
-from typing import List, Dict, Any, Optional, Protocol, Tuple
+from typing import List, Dict, Any, Protocol, Tuple
 from datetime import datetime, timedelta, timezone
 import logging
 import time

--- a/src/mcp_memory_service/consolidation/decay.py
+++ b/src/mcp_memory_service/consolidation/decay.py
@@ -15,7 +15,7 @@
 """Exponential decay scoring for memory relevance calculation."""
 
 import math
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from datetime import datetime, timezone
 from dataclasses import dataclass
 

--- a/src/mcp_memory_service/consolidation/health.py
+++ b/src/mcp_memory_service/consolidation/health.py
@@ -14,7 +14,6 @@
 
 """Health monitoring and error handling for consolidation system."""
 
-import asyncio
 import logging
 from typing import Dict, Any, List, Optional
 from datetime import datetime, timedelta

--- a/src/mcp_memory_service/consolidation/relationship_inference.py
+++ b/src/mcp_memory_service/consolidation/relationship_inference.py
@@ -14,11 +14,9 @@ This enables rich knowledge graphs with meaningful relationship types beyond "re
 import re
 import logging
 from typing import Tuple, Optional, List
-from datetime import datetime
 
 from ..models.ontology import (
     get_parent_type,
-    validate_memory_type,
     validate_relationship,
 )
 

--- a/src/mcp_memory_service/consolidation/scheduler.py
+++ b/src/mcp_memory_service/consolidation/scheduler.py
@@ -14,10 +14,9 @@
 
 """APScheduler integration for autonomous consolidation operations."""
 
-import asyncio
 import logging
-from typing import Dict, Any, Optional, Callable, Awaitable
-from datetime import datetime, timedelta
+from typing import Dict, Any, Optional
+from datetime import datetime
 
 try:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -31,7 +30,6 @@ except ImportError:
     APSCHEDULER_AVAILABLE = False
 
 from .consolidator import DreamInspiredConsolidator
-from .base import ConsolidationConfig
 
 class ConsolidationScheduler:
     """

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -4,7 +4,6 @@ This prevents runtime downloads during server initialization that cause timeouts
 """
 
 import sys
-import subprocess
 import platform
 import logging
 import os

--- a/src/mcp_memory_service/discovery/mdns_service.py
+++ b/src/mcp_memory_service/discovery/mdns_service.py
@@ -22,9 +22,9 @@ network using mDNS (Multicast DNS) and discover other MCP Memory Service instanc
 import asyncio
 import logging
 import socket
-from typing import Dict, List, Optional, Callable, Any
+from typing import Dict, List, Optional, Callable
 from dataclasses import dataclass
-from zeroconf import Zeroconf, ServiceInfo, ServiceBrowser, ServiceListener
+from zeroconf import Zeroconf, ServiceInfo, ServiceListener
 from zeroconf.asyncio import AsyncZeroconf, AsyncServiceBrowser
 
 from ..config import (

--- a/src/mcp_memory_service/embeddings/onnx_embeddings.py
+++ b/src/mcp_memory_service/embeddings/onnx_embeddings.py
@@ -5,9 +5,7 @@ Based on ONNXMiniLM_L6_V2 implementation.
 """
 
 import hashlib
-import json
 import logging
-import os
 import tarfile
 from pathlib import Path
 from typing import List, Optional, Union

--- a/src/mcp_memory_service/ingestion/csv_loader.py
+++ b/src/mcp_memory_service/ingestion/csv_loader.py
@@ -19,7 +19,7 @@ CSV document loader for tabular data files.
 import csv
 import logging
 from pathlib import Path
-from typing import AsyncGenerator, Dict, Any, List, Optional
+from typing import AsyncGenerator, List, Optional
 import asyncio
 import io
 

--- a/src/mcp_memory_service/ingestion/json_loader.py
+++ b/src/mcp_memory_service/ingestion/json_loader.py
@@ -19,7 +19,7 @@ JSON document loader for structured data files.
 import json
 import logging
 from pathlib import Path
-from typing import AsyncGenerator, Dict, Any, Union, List
+from typing import AsyncGenerator, Any
 import asyncio
 
 from .base import DocumentLoader, DocumentChunk

--- a/src/mcp_memory_service/ingestion/pdf_loader.py
+++ b/src/mcp_memory_service/ingestion/pdf_loader.py
@@ -18,7 +18,7 @@ PDF document loader for extracting text content from PDF files.
 
 import logging
 from pathlib import Path
-from typing import AsyncGenerator, Dict, Any, Optional
+from typing import AsyncGenerator, Optional
 import asyncio
 
 from .base import DocumentLoader, DocumentChunk

--- a/src/mcp_memory_service/ingestion/semtools_loader.py
+++ b/src/mcp_memory_service/ingestion/semtools_loader.py
@@ -23,7 +23,7 @@ import logging
 import asyncio
 import os
 from pathlib import Path
-from typing import AsyncGenerator, Dict, Any, Optional
+from typing import AsyncGenerator, Optional
 import shutil
 
 from .base import DocumentLoader, DocumentChunk

--- a/src/mcp_memory_service/ingestion/text_loader.py
+++ b/src/mcp_memory_service/ingestion/text_loader.py
@@ -20,7 +20,7 @@ import logging
 import re
 import chardet
 from pathlib import Path
-from typing import AsyncGenerator, Dict, Any, Optional
+from typing import AsyncGenerator, Optional
 import asyncio
 
 from .base import DocumentLoader, DocumentChunk

--- a/src/mcp_memory_service/lm_studio_compat.py
+++ b/src/mcp_memory_service/lm_studio_compat.py
@@ -8,8 +8,7 @@ This module provides a monkey patch to handle LM Studio's non-standard
 import logging
 import sys
 import platform
-from typing import Any, Dict, Union
-from pydantic import BaseModel, Field
+from typing import Any, Union
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +43,8 @@ def add_windows_timeout_handling():
 
 def create_cancelled_notification_class():
     """Create a proper CancelledNotification class if it doesn't exist."""
-    from pydantic import BaseModel
-    
+    from pydantic import BaseModel, Field
+
     class CancelledNotificationParams(BaseModel):
         """Parameters for cancelled notification."""
         requestId: Any = Field(default=None, alias="requestId")

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -17,7 +17,6 @@ Features:
 import asyncio
 import logging
 import os
-import socket
 import sys
 import time
 from collections.abc import AsyncIterator
@@ -61,19 +60,13 @@ except ImportError:
     FastMCP = _DummyFastMCP  # type: ignore
     Context = None  # type: ignore
 
-from mcp.types import TextContent, ToolAnnotations
+from mcp.types import ToolAnnotations
 
 # Import existing memory service components
 from .config import (
     STORAGE_BACKEND,
-    CONSOLIDATION_ENABLED, EMBEDDING_MODEL_NAME, INCLUDE_HOSTNAME,
+    EMBEDDING_MODEL_NAME,
     SQLITE_VEC_PATH,
-    CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_VECTORIZE_INDEX,
-    CLOUDFLARE_D1_DATABASE_ID, CLOUDFLARE_R2_BUCKET, CLOUDFLARE_EMBEDDING_MODEL,
-    CLOUDFLARE_LARGE_CONTENT_THRESHOLD, CLOUDFLARE_MAX_RETRIES, CLOUDFLARE_BASE_DELAY,
-    HYBRID_SYNC_INTERVAL, HYBRID_BATCH_SIZE, HYBRID_MAX_QUEUE_SIZE,
-    HYBRID_SYNC_ON_STARTUP, HYBRID_FALLBACK_TO_PRIMARY,
-    CONTENT_PRESERVE_BOUNDARIES, CONTENT_SPLIT_OVERLAP, ENABLE_AUTO_SPLIT
 )
 from .storage.base import MemoryStorage
 from .services.memory_service import MemoryService

--- a/src/mcp_memory_service/quality/metadata_codec.py
+++ b/src/mcp_memory_service/quality/metadata_codec.py
@@ -19,7 +19,7 @@ Reduces metadata size by 60% compared to JSON while maintaining readability.
 Used for Cloudflare sync to stay under 10KB D1 metadata limit.
 """
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/quality/onnx_ranker.py
+++ b/src/mcp_memory_service/quality/onnx_ranker.py
@@ -5,7 +5,6 @@ Uses ms-marco-MiniLM-L-6-v2 model for relevance scoring.
 Exports the model from transformers to ONNX format on first use.
 """
 
-import json
 import logging
 import os
 import threading

--- a/src/mcp_memory_service/server/environment.py
+++ b/src/mcp_memory_service/server/environment.py
@@ -21,10 +21,7 @@ and performance optimizations for the MCP server.
 
 import sys
 import os
-import logging
-import subprocess
 from importlib.metadata import version as pkg_version
-from importlib.util import find_spec
 
 from .logging_config import logger
 

--- a/src/mcp_memory_service/server/handlers/documents.py
+++ b/src/mcp_memory_service/server/handlers/documents.py
@@ -20,7 +20,6 @@ Extracted from server_impl.py Phase 2.4 refactoring.
 """
 
 import logging
-import traceback
 from typing import List
 
 from mcp import types

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -200,7 +200,6 @@ async def handle_get_memory_quality(server, arguments: dict) -> List[types.TextC
             return [types.TextContent(type="text", text=f"Error retrieving memory: {str(e)}")]
 
         # Extract quality metrics
-        import json
         from datetime import datetime
 
         quality_data = {

--- a/src/mcp_memory_service/server/handlers/utility.py
+++ b/src/mcp_memory_service/server/handlers/utility.py
@@ -19,7 +19,6 @@ Database health checks, cache statistics, and monitoring utilities.
 Extracted from server_impl.py Phase 2.3 refactoring.
 """
 
-import os
 import json
 import logging
 import traceback

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -27,27 +27,18 @@ import json
 import platform
 import logging
 from collections import deque
-from typing import List, Dict, Any, Optional, Tuple
-from datetime import datetime, timedelta
+from typing import List, Dict, Any, Optional
+from datetime import datetime
 
 # Import from server package modules
 from .server import (
     # Client Detection
     MCP_CLIENT,
-    detect_mcp_client,
     # Logging
-    DualStreamHandler,
     logger,
-    # Environment
-    setup_python_paths,
-    check_uv_environment,
-    check_version_consistency,
-    configure_environment,
-    configure_performance_environment,
     # Cache
     _STORAGE_CACHE,
     _MEMORY_SERVICE_CACHE,
-    _CACHE_LOCK,
     _CACHE_STATS,
     _get_cache_lock,
     _get_or_create_memory_service,
@@ -55,11 +46,9 @@ from .server import (
 )
 
 # MCP protocol imports
-from mcp.server.models import InitializationOptions
 import mcp.types as types
 from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
-from mcp.types import Resource, Prompt
+from mcp.types import Resource
 
 # Version import with fallback for testing scenarios
 try:
@@ -72,20 +61,17 @@ except (ImportError, AttributeError):
         __version__ = "0.0.0-dev"
 
 # Package imports
-from .lm_studio_compat import patch_mcp_for_lm_studio, add_windows_timeout_handling
-from .dependency_check import run_dependency_check, get_recommended_timeout
+from .dependency_check import get_recommended_timeout
 from .compat import is_deprecated, transform_deprecated_call
 from .config import (
     BACKUPS_PATH,
     SERVER_NAME,
-    SERVER_VERSION,
     STORAGE_BACKEND,
     EMBEDDING_MODEL_NAME,
     SQLITE_VEC_PATH,
     CONSOLIDATION_ENABLED,
     CONSOLIDATION_CONFIG,
     CONSOLIDATION_SCHEDULE,
-    INCLUDE_HOSTNAME,
     # Cloudflare configuration
     CLOUDFLARE_API_TOKEN,
     CLOUDFLARE_ACCOUNT_ID,
@@ -99,21 +85,15 @@ from .config import (
     # Hybrid backend configuration
     HYBRID_SYNC_INTERVAL,
     HYBRID_BATCH_SIZE,
-    HYBRID_SYNC_ON_STARTUP,
     # Integrity monitoring
     INTEGRITY_CHECK_ENABLED,
 )
 # Storage imports will be done conditionally in the server class
 from .models.memory import Memory
-from .utils.hashing import generate_content_hash
-from .utils.document_processing import _process_and_store_chunk
 from .utils.system_detection import (
     get_system_info,
-    print_system_diagnostics,
-    AcceleratorType
 )
 from .services.memory_service import MemoryService
-from .utils.time_parser import extract_time_expression, parse_time_expression
 
 # Consolidation system imports (conditional)
 if CONSOLIDATION_ENABLED:
@@ -854,7 +834,6 @@ class MemoryServer:
             """Read a specific memory resource."""
             await self._ensure_storage_initialized()
 
-            import json
             from urllib.parse import unquote
 
             # Convert AnyUrl to string if necessary (fix for issue #254)
@@ -1156,7 +1135,6 @@ class MemoryServer:
                 for mem in memories:
                     export_text += f"[{mem.created_at_iso}] {mem.content}\n"
             else:  # json
-                import json
                 export_data = [m.to_dict() for m in memories]
                 export_text += json.dumps(export_data, indent=2, default=str)
             
@@ -2514,7 +2492,6 @@ Examples:
         # Fallback: Create backup directly if no scheduler
         from pathlib import Path
         import sqlite3
-        import asyncio
         from datetime import datetime, timezone
         import tempfile
 
@@ -2609,7 +2586,6 @@ Examples:
 
             from pathlib import Path
             import sqlite3
-            import asyncio
 
             if not Path(db_path).exists():
                 return {

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -24,7 +24,6 @@ else:
 from datetime import datetime
 
 from ..config import (
-    INCLUDE_HOSTNAME,
     CONTENT_PRESERVE_BOUNDARIES,
     CONTENT_SPLIT_OVERLAP,
     ENABLE_AUTO_SPLIT,

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -579,7 +579,6 @@ class CloudflareStorage(MemoryStorage):
         }
         
         # Convert to NDJSON format as required by the HTTP API
-        import json
         ndjson_content = json.dumps(vector_data) + "\n"
         
         try:

--- a/src/mcp_memory_service/storage/graph.py
+++ b/src/mcp_memory_service/storage/graph.py
@@ -28,9 +28,8 @@ import sqlite3
 import json
 import logging
 import asyncio
-from typing import List, Dict, Any, Tuple, Optional, Set
+from typing import List, Dict, Any, Tuple, Optional
 from datetime import datetime, timezone
-import os
 
 from mcp_memory_service.models.ontology import is_symmetric_relationship, validate_relationship
 

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -61,12 +61,9 @@ except ImportError:
 from .base import MemoryStorage
 from .migration_runner import MigrationRunner
 from ..models.memory import Memory, MemoryQueryResult
-from ..utils.hashing import generate_content_hash
 from ..utils.system_detection import (
     get_system_info,
-    get_optimal_embedding_settings,
     get_torch_device,
-    AcceleratorType
 )
 from ..config import SQLITEVEC_MAX_CONTENT_LENGTH
 

--- a/src/mcp_memory_service/sync/importer.py
+++ b/src/mcp_memory_service/sync/importer.py
@@ -20,7 +20,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Any, Set, Optional
+from typing import List, Dict, Any, Set
 
 from ..models.memory import Memory
 from ..storage.base import MemoryStorage

--- a/src/mcp_memory_service/utils/content_splitter.py
+++ b/src/mcp_memory_service/utils/content_splitter.py
@@ -21,7 +21,7 @@ like sentences, paragraphs, and code blocks to maintain readability.
 
 import re
 import math
-from typing import List, Optional
+from typing import List
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/utils/db_utils.py
+++ b/src/mcp_memory_service/utils/db_utils.py
@@ -16,8 +16,6 @@
 from typing import Dict, Any, Tuple
 import logging
 import os
-import json
-from datetime import datetime
 import importlib
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/utils/debug.py
+++ b/src/mcp_memory_service/utils/debug.py
@@ -15,7 +15,6 @@
 """Debug utilities for memory service."""
 from typing import Dict, Any, List
 import logging
-import numpy as np
 from ..models.memory import Memory, MemoryQueryResult
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/utils/gpu_detection.py
+++ b/src/mcp_memory_service/utils/gpu_detection.py
@@ -8,7 +8,7 @@ installation and verification scripts. Supports CUDA, ROCm, MPS, and DirectML.
 
 import os
 import subprocess
-from typing import Dict, Any, Tuple, Optional, Callable, List, Union
+from typing import Dict, Any, Tuple, Optional
 
 
 # Single source of truth for GPU platform detection configuration

--- a/src/mcp_memory_service/utils/http_server_manager.py
+++ b/src/mcp_memory_service/utils/http_server_manager.py
@@ -6,7 +6,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -27,10 +27,7 @@ import sys
 import asyncio
 import logging
 import traceback
-from typing import Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from ..server_impl import MemoryServer
+from typing import Any
 
 # Import necessary functions and constants
 from ..server.client_detection import MCP_CLIENT

--- a/src/mcp_memory_service/utils/system_detection.py
+++ b/src/mcp_memory_service/utils/system_detection.py
@@ -22,7 +22,7 @@ import sys
 import platform
 import logging
 import subprocess
-from typing import Dict, Any, Tuple, Optional, List
+from typing import Dict, Any
 import json
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/utils/time_parser.py
+++ b/src/mcp_memory_service/utils/time_parser.py
@@ -21,7 +21,7 @@ for retrieving memories based on when they were stored.
 import re
 import logging
 from datetime import datetime, timedelta, date, time
-from typing import Tuple, Optional, Dict, Any, List
+from typing import Tuple, Optional, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/web/api/configuration.py
+++ b/src/mcp_memory_service/web/api/configuration.py
@@ -21,8 +21,7 @@ Provides read-only access to environment configuration with sensitive value mask
 import os
 import logging
 from pathlib import Path
-from typing import List, Dict, Any, Optional
-from datetime import datetime
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel

--- a/src/mcp_memory_service/web/api/consolidation.py
+++ b/src/mcp_memory_service/web/api/consolidation.py
@@ -21,7 +21,6 @@ including manual triggers and scheduler status queries.
 
 import logging
 from typing import Dict, Any, Optional
-from datetime import datetime
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field
 

--- a/src/mcp_memory_service/web/api/documents.py
+++ b/src/mcp_memory_service/web/api/documents.py
@@ -31,12 +31,11 @@ from pathlib import Path
 from urllib.parse import urlparse, unquote
 
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException, BackgroundTasks
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from ...ingestion import get_loader_for_file, SUPPORTED_FORMATS
 from ...models.memory import Memory
-from ...utils import create_memory_from_chunk, _process_and_store_chunk, generate_content_hash
+from ...utils import _process_and_store_chunk, generate_content_hash
 from ..dependencies import get_storage
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/api/events.py
+++ b/src/mcp_memory_service/web/api/events.py
@@ -4,11 +4,10 @@ Server-Sent Events endpoints for real-time updates.
 
 from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
-from typing import Dict, Any, List, TYPE_CHECKING
+from typing import List
 
 # OAuth config no longer needed - auth is always enabled
 from ..sse import create_event_stream, sse_manager
-from ..dependencies import get_storage
 
 # OAuth authentication imports
 from ..oauth.middleware import require_read_access, AuthenticationResult

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -20,7 +20,7 @@ import time
 import platform
 import psutil
 from datetime import datetime, timezone
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Dict, Any
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel

--- a/src/mcp_memory_service/web/api/manage.py
+++ b/src/mcp_memory_service/web/api/manage.py
@@ -19,7 +19,7 @@ Provides memory maintenance, bulk operations, and system management tools.
 """
 
 import logging
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from typing import List, Optional
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Depends, Query
@@ -28,7 +28,6 @@ from pydantic import BaseModel, Field
 from ...storage.base import MemoryStorage
 # OAuth config no longer needed - auth is always enabled
 from ..dependencies import get_storage
-from .memories import MemoryResponse, memory_to_response
 
 # OAuth authentication imports
 from ..oauth.middleware import require_write_access, AuthenticationResult

--- a/src/mcp_memory_service/web/api/mcp.py
+++ b/src/mcp_memory_service/web/api/mcp.py
@@ -5,11 +5,10 @@ This module provides MCP protocol endpoints that allow Claude Code clients
 to directly access memory operations using the MCP standard.
 """
 
-import asyncio
 import json
 import logging
-from typing import Dict, List, Any, Optional, Union, TYPE_CHECKING
-from fastapi import APIRouter, HTTPException, Request, Depends
+from typing import Dict, Any, Optional, Union
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
@@ -18,7 +17,7 @@ from ...utils.hashing import generate_content_hash
 # OAuth config no longer needed - auth is always enabled
 
 # Import OAuth dependencies only when needed
-from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult
+from ..oauth.middleware import require_read_access, AuthenticationResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -18,8 +18,7 @@ Memory CRUD endpoints for the HTTP interface.
 
 import logging
 import socket
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
-from datetime import datetime
+from typing import List, Optional, Dict, Any
 
 from fastapi import APIRouter, HTTPException, Depends, Query, Request
 from pydantic import BaseModel, Field
@@ -27,7 +26,6 @@ from pydantic import BaseModel, Field
 from ...storage.base import MemoryStorage
 from ...models.memory import Memory
 from ...services.memory_service import MemoryService
-from ...utils.hashing import generate_content_hash
 from ...config import INCLUDE_HOSTNAME
 # OAuth config no longer needed - auth is always enabled
 from ..dependencies import get_storage, get_memory_service

--- a/src/mcp_memory_service/web/api/quality.py
+++ b/src/mcp_memory_service/web/api/quality.py
@@ -16,7 +16,6 @@
 import logging
 import time
 from typing import Optional, Dict, Any, List
-from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field

--- a/src/mcp_memory_service/web/api/search.py
+++ b/src/mcp_memory_service/web/api/search.py
@@ -19,8 +19,7 @@ Provides semantic search, tag-based search, and time-based recall functionality.
 """
 
 import logging
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
-from datetime import datetime, timedelta, timezone
+from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field

--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -25,7 +25,7 @@ import asyncio
 import logging
 import platform
 import subprocess
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, List, Tuple
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks

--- a/src/mcp_memory_service/web/api/sync.py
+++ b/src/mcp_memory_service/web/api/sync.py
@@ -18,7 +18,6 @@ Sync management endpoints for hybrid backend.
 Provides status monitoring and manual sync triggering for hybrid storage mode.
 """
 
-from typing import Dict, Any, TYPE_CHECKING
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Depends

--- a/src/mcp_memory_service/web/oauth/models.py
+++ b/src/mcp_memory_service/web/oauth/models.py
@@ -16,7 +16,7 @@
 OAuth 2.1 data models and schemas for MCP Memory Service.
 """
 
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from pydantic import BaseModel, Field, HttpUrl
 
 

--- a/src/mcp_memory_service/web/oauth/storage/factory.py
+++ b/src/mcp_memory_service/web/oauth/storage/factory.py
@@ -22,7 +22,6 @@ without changing application code.
 
 import logging
 import os
-from typing import Optional
 from .base import OAuthStorage
 from .memory import MemoryOAuthStorage
 from .sqlite import SQLiteOAuthStorage

--- a/src/mcp_memory_service/web/sse.py
+++ b/src/mcp_memory_service/web/sse.py
@@ -23,10 +23,9 @@ import asyncio
 import json
 import time
 import uuid
-from typing import Dict, List, Any, Optional, Set
+from typing import Dict, Any, Optional, Set
 from datetime import datetime, timezone
-from dataclasses import dataclass, asdict
-from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
 from fastapi import Request
 from sse_starlette import EventSourceResponse


### PR DESCRIPTION
## Summary

Fixes all 100 remaining open CodeQL code scanning alerts across 51 files.

### Alert Types Fixed

| Alert Type | Count | Description |
|---|---|---|
| `py/unused-import` | 92 | Imports declared but never referenced in the file body |
| `py/repeated-import` | 6 | Module imported both at module level AND inside a function |
| `py/cyclic-import` | 2 | Circular import cycle between `server_impl.py` and `startup_orchestrator.py` |

### Key Changes

- **`startup_orchestrator.py`**: Removed `TYPE_CHECKING` guard block that imported `MemoryServer` from `server_impl`, breaking the cyclic import. String annotations (`'MemoryServer'`) continue to work without the runtime import.
- **`lm_studio_compat.py`**: Moved `Field` import into the local `create_cancelled_notification_class()` function where `BaseModel` is also imported locally, after removing the top-level pydantic import.
- **`server/handlers/quality.py`**: Removed local `import json` inside a function (repeated import); the module-level import at line 24 is the active one.
- **`web/api/consolidation.py`, `web/api/quality.py`**: Removed top-level `from datetime import datetime` (the local imports inside functions are the active ones).
- **`server_impl.py`**: Removed 15+ unused imports including `mcp.server.stdio`, `InitializationOptions`, `run_dependency_check`, `SERVER_VERSION`, `print_system_diagnostics`, `generate_content_hash`, local `import json` and `import asyncio` inside functions, etc.
- **48 other files**: Removed unused `typing` generics (`Optional`, `Dict`, `Any`, `List`, `Tuple`, `Set`, `Union`, `TYPE_CHECKING`), unused stdlib imports (`asyncio`, `os`, `json`, `subprocess`, `traceback`), and unused internal imports.

### Verification

- All 51 modified files pass `python3 -m py_compile` syntax checks
- `config.py` was intentionally NOT modified — `SERVER_VERSION` is a legitimate module-level export used by other modules (CodeQL flag is a false positive for module-level constants)
- `Resource` import in `server_impl.py` was kept — it IS used directly in `-> List[Resource]` type annotation at line 789

### Files Changed

51 files, 44 insertions(+), 118 deletions(-)

## Test plan

- [ ] Run `pytest -m unit` to verify no regressions in unit tests
- [ ] Run `python3 -m py_compile` on all 51 modified files (already verified: ALL OK)
- [ ] Monitor CodeQL scan after merge to confirm 0 remaining alerts
- [ ] Verify server starts cleanly: `python -m mcp_memory_service.server`