### PR TITLE
chore: release v10.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.17.6] - 2026-02-22
+
+### Fixed
+
+- **Resolve 100 CodeQL import alerts across 51 files**: Eliminated all open `py/unused-import`, `py/repeated-import`, and `py/cyclic-import` CodeQL code scanning alerts with no functional changes.
+  - **py/unused-import (92 alerts)**: Removed unused imports from `typing`, stdlib (`os`, `sys`, `re`, `time`, `json`, `datetime`, etc.), and internal modules across 51 files in `storage/`, `server/`, `web/`, `consolidation/`, `quality/`, `ingestion/`, `utils/`, and `models/` packages.
+  - **py/repeated-import (6 alerts)**: Removed local duplicate imports (same module imported twice within a file) in `server_impl.py`, `consolidation/scheduler.py`, and related modules.
+  - **py/cyclic-import (2 alerts)**: Resolved circular import dependency in `utils/startup_orchestrator.py` by guarding type-only imports under `TYPE_CHECKING` block.
+
 ## [10.17.5] - 2026-02-22
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.17.5 - Security patch: upgrade 15 vulnerable dependencies to address 38 Dependabot alerts (h11, aiohttp, starlette, cryptography, pillow, protobuf, and more) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.6 - Code quality: resolve 100 CodeQL import alerts (py/unused-import, py/repeated-import, py/cyclic-import) across 51 files with no functional changes - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,17 +259,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.17.3** (February 21, 2026)
+## 🆕 Latest Release: **v10.17.6** (February 22, 2026)
 
-**Security + Code Quality: 21 CodeQL Scanning Alerts Resolved**
+**Code Quality: 100 CodeQL Import Alerts Resolved Across 51 Files**
 
 **What's New:**
-- **Log injection prevention (CWE-117)**: Tag sanitization in `memory_service.py` now strips CRLF characters before logging, closing 2 ERROR-severity CodeQL alerts (#258, #259).
-- **HTTPClientStorage signature fix**: `retrieve()` now accepts the required `tags` parameter to match the `BaseStorage` interface, resolving 1 WARNING-severity alert (#261).
-- **Import-time print replaced with `warnings.warn`**: Three modules no longer execute `print()` at import time; use `warnings.warn()` instead, resolving 3 NOTE-severity alerts (#254, #255, #257).
-- **16 additional code quality alerts resolved**: Unnecessary `pass` statements, unused global cache variables, unused imports in consolidation modules, and `Ellipsis` literals in `StorageProtocol` all cleaned up (alerts #248-#253, #263-#270).
+- **100 CodeQL alerts eliminated**: All open `py/unused-import`, `py/repeated-import`, and `py/cyclic-import` alerts resolved across 51 files with no functional changes.
+- **92 unused imports removed**: Cleaned up unused `typing`, stdlib, and internal module imports across `storage/`, `server/`, `web/`, `consolidation/`, `quality/`, `ingestion/`, `utils/`, and `models/` packages.
+- **6 repeated imports fixed**: Removed local duplicate imports within files in `server_impl.py`, `consolidation/scheduler.py`, and related modules.
+- **2 cyclic imports resolved**: Fixed circular import dependency in `utils/startup_orchestrator.py` using `TYPE_CHECKING` guard.
 
 **Previous Releases**:
+- **v10.17.5** - Security Patch: upgrade 15 vulnerable dependencies (38 Dependabot alerts - h11, aiohttp, starlette, cryptography, pillow, protobuf, and more)
+- **v10.17.3** - Security + Code Quality: 21 CodeQL Scanning Alerts Resolved (log injection CWE-117, HTTPClientStorage signature, import-time prints)
 - **v10.17.2** - CI Stability Fixes: uv CLI test timeout 60s→120s, CI job timeout 10→20min, root install.py test skip guard
 - **v10.17.1** - Hook System Bug Fixes + Root Installer + Session-Start Reliability (session-end SyntaxError on Node.js v24, MCP_HTTP_PORT detection, exponential backoff retry)
 - **v10.17.0** - Default "untagged" Tag for All Tagless Memories + Cleanup Script (306 production memories retroactively fixed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.17.5"
+version = "10.17.6"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.17.5"
+__version__ = "10.17.6"

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.17.5"
+version = "10.17.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- Version bump to v10.17.6 in `_version.py`, `pyproject.toml`, `uv.lock`
- CHANGELOG.md entry for v10.17.6 added
- README.md Latest Release section updated to v10.17.6
- CLAUDE.md current version reference updated to v10.17.6

## Summary

Patch release capturing the 100 CodeQL alert fixes from PR #494:
- 92x `py/unused-import` - removed unused imports from typing, stdlib, and internal modules across 51 files
- 6x `py/repeated-import` - removed duplicate imports within files
- 2x `py/cyclic-import` - resolved circular import in `startup_orchestrator.py` via `TYPE_CHECKING` guard

No functional changes. Pure code quality improvement.

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with new version entry
- [x] `README.md` Latest Release section updated
- [x] `CLAUDE.md` current version line updated
- [x] No duplicate CHANGELOG sections (validated with grep)
- [x] Versions in reverse chronological order

Closes #494 (already merged)