### PR TITLE
chore: release v10.17.14 (security + performance patch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.17.13 - Security: resolve 17 remaining CodeQL alerts (clear-text logging x5, log-injection x4, stack-trace-exposure x3, tarslip x1, polynomial-ReDoS x1, url-redirection x3) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.14 - Security + Performance: CVE-2024-23342 (ecdsa Minerva attack) eliminated via PyJWT migration, CWE-209 stack-trace exposure fixed in consolidation API, MCP_ASSOCIATION_MAX_PAIRS default raised 100->1000 for large memory sets - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.17.13** (February 22, 2026)
+## 🆕 Latest Release: **v10.17.14** (February 22, 2026)
 
-**Security: Final 4 CodeQL Alerts Resolved — Zero Open Alerts**
+**Security + Performance: CVE-2024-23342 Eliminated, CWE-209 Fixed, Consolidation Association Discovery Restored**
 
 **What's New:**
-- **Zero open CodeQL alerts**: Complete remediation of all GitHub code scanning findings.
-- **py/log-injection (1 alert)**: Removed integer arg from `logger.info` in `web/api/documents.py`.
-- **py/stack-trace-exposure (3 alerts)**: Explicit type casting (`str`/`int`/`float`) in API response dicts in `web/api/documents.py` and `web/api/consolidation.py` to break taint flow from user input to responses.
+- **CVE-2024-23342 eliminated**: Replaced python-jose with PyJWT[crypto] — removes ecdsa transitive dependency (Minerva timing attack, CVSS 7.4).
+- **CWE-209 fixed (CodeQL #356)**: Consolidation API no longer leaks exception messages in HTTP error responses.
+- **Consolidation association discovery restored**: Default `MCP_ASSOCIATION_MAX_PAIRS` raised from 100 to 1000 — fixes 0 associations found on large memory sets (8000+ memories).
+- **5 transitive packages removed**: ecdsa, python-jose, pyasn1, rsa, six no longer in dependency tree.
 
 ---
 
 **Previous Releases**:
+- **v10.17.13** - Security: Final 4 CodeQL Alerts Resolved (log-injection, stack-trace-exposure) — Zero Open Alerts
 - **v10.17.12** - Security: File Restoration + 43 CodeQL Alerts (repeated-import, multiple-definition, log-injection, stack-trace-exposure)
 - **v10.17.11** - Security: 6 CodeQL Alerts Resolved (log injection, stack-trace-exposure, unused variable)
 - **v10.17.10** - Security: All 30 Remaining CodeQL Alerts Resolved (log injection, clear-text logging, URL redirection, stack-trace-exposure)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.17.13"
+version = "10.17.14"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.17.13"
+__version__ = "10.17.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.17.13"
+version = "10.17.14"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Security and performance patch release.

- CVE-2024-23342 (CVSS 7.4) eliminated: Replaced python-jose with PyJWT[crypto] to remove the ecdsa transitive dependency vulnerable to a Minerva timing attack. The ecdsa project explicitly considers side-channel attacks out of scope with no fix planned. Five packages removed from dependency tree: ecdsa, python-jose, pyasn1, rsa, six.
- CWE-209 fixed (CodeQL alert 356): Consolidation API was passing str(e) directly to HTTPException(detail=...), potentially leaking internal exception messages to API clients. Replaced with generic fixed error strings; full exceptions still logged via logger.error().
- Consolidation association discovery restored: Default MCP_ASSOCIATION_MAX_PAIRS increased from 100 to 1000 in config.py. With 8000+ memories the old default resulted in 0 associations found (~6% sampling coverage). New default yields 13 associations from same dataset. Still overridable via env var; ConsolidationConfig dataclass default preserved at 100 for backward compatibility.

## Commits included

- 412d4d3 security: fix stack-trace exposure in consolidation API (CWE-209)
- fb0a9e9 security: replace python-jose with PyJWT to eliminate ecdsa CVE-2024-23342
- c180201 perf(consolidation): increase default MCP_ASSOCIATION_MAX_PAIRS from 100 to 1000

## Files changed

- pyproject.toml - version bump 10.17.13 to 10.17.14; python-jose replaced with PyJWT[crypto]
- src/mcp_memory_service/_version.py - version bump
- src/mcp_memory_service/web/api/consolidation.py - generic error messages (CWE-209 fix)
- src/mcp_memory_service/web/oauth/authorization.py - jose replaced with jwt import
- src/mcp_memory_service/web/oauth/middleware.py - exception type mapping updated
- src/mcp_memory_service/config.py - MCP_ASSOCIATION_MAX_PAIRS default 100 to 1000
- CHANGELOG.md - v10.17.14 entry added
- README.md - Latest Release section updated; v10.17.13 added to Previous Releases
- CLAUDE.md - Current Version line updated
- uv.lock - regenerated (ecdsa and 4 related packages removed)

## Checklist

- [x] Version bumped in _version.py, pyproject.toml, README.md
- [x] uv.lock updated (uv lock run locally)
- [x] CHANGELOG.md updated with v10.17.14 entry
- [x] README.md Latest Release section updated
- [x] CLAUDE.md Current Version line updated
- [x] No breaking changes - all changes are backward compatible
