### PR TITLE
chore: release v10.17.15 — permission-request hook opt-in (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.17.15] - 2026-02-23
+
+### Changed
+- **Permission hook now opt-in** (#503): `permission-request.js` is no longer silently installed with all other hooks. Users are now prompted during `install_hooks.py` with a clear explanation of its global effect (applies to ALL MCP servers, not just memory). Can also be controlled via `--permission-hook` / `--no-permission-hook` CLI flags for non-interactive installs.
+
+### Fixed
+- `config.template.json`: `permissionRequest.enabled` now defaults to `false`
+
+### Documentation
+- `README-PERMISSION-REQUEST.md`: Added "Why is this in mcp-memory-service?" rationale section and "Opt-in Installation" instructions
+- `claude-hooks/README.md`: Marked permission-request hook as opt-in with global-effect note
+
 ## [10.17.14] - 2026-02-22
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.17.14 - Security + Performance: CVE-2024-23342 (ecdsa Minerva attack) eliminated via PyJWT migration, CWE-209 stack-trace exposure fixed in consolidation API, MCP_ASSOCIATION_MAX_PAIRS default raised 100->1000 for large memory sets - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.17.15 - Permission-request hook made opt-in (#503): no longer silently installed, users prompted with global-effect warning, CLI flags added for non-interactive control - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,19 +259,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.17.14** (February 22, 2026)
+## 🆕 Latest Release: **v10.17.15** (February 23, 2026)
 
-**Security + Performance: CVE-2024-23342 Eliminated, CWE-209 Fixed, Consolidation Association Discovery Restored**
+**Permission-Request Hook Made Opt-In — No More Silent Global Hook Installation**
 
 **What's New:**
-- **CVE-2024-23342 eliminated**: Replaced python-jose with PyJWT[crypto] — removes ecdsa transitive dependency (Minerva timing attack, CVSS 7.4).
-- **CWE-209 fixed (CodeQL #356)**: Consolidation API no longer leaks exception messages in HTTP error responses.
-- **Consolidation association discovery restored**: Default `MCP_ASSOCIATION_MAX_PAIRS` raised from 100 to 1000 — fixes 0 associations found on large memory sets (8000+ memories).
-- **5 transitive packages removed**: ecdsa, python-jose, pyasn1, rsa, six no longer in dependency tree.
+- **Permission hook is now opt-in** (#503): `permission-request.js` is no longer silently installed alongside other hooks — users are prompted with a clear explanation of its global scope.
+- **Global-effect warning**: Hook applies to ALL MCP servers on the system, not just mcp-memory-service — now clearly documented.
+- **CLI flags added**: `--permission-hook` / `--no-permission-hook` for non-interactive scripted installs.
+- **Config default fixed**: `permissionRequest.enabled` now defaults to `false` in `config.template.json`.
 
 ---
 
 **Previous Releases**:
+- **v10.17.14** - Security + Performance: CVE-2024-23342 (ecdsa Minerva attack) eliminated via PyJWT migration, CWE-209 fixed, MCP_ASSOCIATION_MAX_PAIRS raised 100→1000
 - **v10.17.13** - Security: Final 4 CodeQL Alerts Resolved (log-injection, stack-trace-exposure) — Zero Open Alerts
 - **v10.17.12** - Security: File Restoration + 43 CodeQL Alerts (repeated-import, multiple-definition, log-injection, stack-trace-exposure)
 - **v10.17.11** - Security: 6 CodeQL Alerts Resolved (log injection, stack-trace-exposure, unused variable)

--- a/claude-hooks/README-PERMISSION-REQUEST.md
+++ b/claude-hooks/README-PERMISSION-REQUEST.md
@@ -11,6 +11,30 @@ This hook intercepts Claude Code permission requests and makes intelligent decis
 - **Works universally** across all MCP servers (memory, browser, context7, etc.)
 - **Safe-by-default** - unknown patterns require user confirmation
 
+## Why is this in mcp-memory-service?
+
+This hook was developed alongside the memory service because memory operations
+are frequent and repetitive — retrieving, searching, and listing memories would
+otherwise generate constant permission prompts.
+
+The hook is tested against the memory service's tool naming conventions and ships
+here for convenience. However, it works universally across **all MCP servers**,
+which is also why installation is **opt-in** (see below).
+
+A standalone version is available as a GitHub Gist:
+https://gist.github.com/doobidoo/fa84d31c0819a9faace345ca227b268f
+
+## Opt-in Installation
+
+This hook is **not installed automatically**. During `install_hooks.py` you will
+be prompted with an explanation of its global effect and asked to confirm.
+
+To install non-interactively:
+```bash
+python install_hooks.py --permission-hook      # install it
+python install_hooks.py --no-permission-hook   # skip it explicitly
+```
+
 ## Features
 
 ✅ **Smart Pattern Matching** - Analyzes tool names to determine safety

--- a/claude-hooks/README.md
+++ b/claude-hooks/README.md
@@ -24,7 +24,7 @@ This installs hooks that automatically:
 
 ## Components
 
-- **Core Hooks**: `session-start.js` (Hook v2.2), `session-end.js`, `memory-retrieval.js`, `permission-request.js` (v1.0) - Smart memory management and permission automation
+- **Core Hooks**: `session-start.js` (Hook v2.2), `session-end.js`, `memory-retrieval.js`, `permission-request.js` (v1.0, opt-in, global effect on ALL MCP servers) - Smart memory management and permission automation
 - **Utilities**: Project detection, quality-aware scoring, intelligent formatting, context shift detection
 - **Tests**: Comprehensive integration test suite (14 tests)
 
@@ -65,7 +65,7 @@ Three complementary ways to view session memory context:
 - **Project Awareness**: Detect current project context and frameworks
 - **Memory Consolidation**: Store session outcomes and insights
 - **Intelligent Selection**: Quality-aware scoring that prioritizes meaningful content over just recency
-- **🆕 Permission Automation** (v1.0): Auto-approve safe MCP tool operations, block destructive actions - See [README-PERMISSION-REQUEST.md](README-PERMISSION-REQUEST.md)
+- **🆕 Permission Automation** (v1.0, opt-in, global effect on ALL MCP servers): Auto-approve safe MCP tool operations, block destructive actions - See [README-PERMISSION-REQUEST.md](README-PERMISSION-REQUEST.md)
 
 ### 🎮 **User Overrides** (`#skip` / `#remember`)
 

--- a/claude-hooks/config.template.json
+++ b/claude-hooks/config.template.json
@@ -70,7 +70,7 @@
     "logFilePath": "./claude-hooks.log"
   },
   "permissionRequest": {
-    "enabled": true,
+    "enabled": false,
     "autoApprove": true,
     "customSafePatterns": [],
     "customDestructivePatterns": [],

--- a/claude-hooks/core/permission-request.js
+++ b/claude-hooks/core/permission-request.js
@@ -75,7 +75,7 @@ const DEFAULT_SAFE_PATTERNS = [
 
 // Configuration state (loaded at startup)
 let config = {
-    enabled: true,
+    enabled: false,
     autoApprove: true,
     logDecisions: false,
     destructivePatterns: DEFAULT_DESTRUCTIVE_PATTERNS,
@@ -106,7 +106,7 @@ function loadConfiguration() {
         const hookConfig = fullConfig.permissionRequest;
 
         // Load flags (with defaults)
-        config.enabled = hookConfig.enabled !== undefined ? hookConfig.enabled : true;
+        config.enabled = hookConfig.enabled !== undefined ? hookConfig.enabled : false;
         config.autoApprove = hookConfig.autoApprove !== undefined ? hookConfig.autoApprove : true;
         config.logDecisions = hookConfig.logDecisions !== undefined ? hookConfig.logDecisions : false;
 

--- a/claude-hooks/install_hooks.py
+++ b/claude-hooks/install_hooks.py
@@ -790,6 +790,24 @@ class HookInstaller:
             self.error(f"Failed to install basic hooks: {e}")
             return False
 
+    def install_permission_hook(self) -> bool:
+        """Copy permission-request.js to the hooks directory (opt-in, issue #503)."""
+        self.info("Installing permission-request hook...")
+        try:
+            (self.claude_hooks_dir / "core").mkdir(parents=True, exist_ok=True)
+            src = self.script_dir / "core" / "permission-request.js"
+            dst = self.claude_hooks_dir / "core" / "permission-request.js"
+            if src.exists():
+                shutil.copy2(src, dst)
+                self.success("permission-request.js installed")
+                return True
+            else:
+                self.error("permission-request.js not found in source directory")
+                return False
+        except Exception as e:
+            self.error(f"Failed to install permission hook: {e}")
+            return False
+
     def install_auto_capture(self) -> bool:
         """Install Smart Auto-Capture hooks for automatic memory capture."""
         self.info("Installing Smart Auto-Capture hooks...")

--- a/claude-hooks/install_hooks.py
+++ b/claude-hooks/install_hooks.py
@@ -1384,6 +1384,8 @@ Examples:
   python install_hooks.py --auto-capture     # Smart Auto-Capture only
   python install_hooks.py --test             # Run tests only
   python install_hooks.py --uninstall        # Remove hooks
+  python install_hooks.py --permission-hook      # Include permission hook (opt-in)
+  python install_hooks.py --no-permission-hook   # Skip permission hook
 
 Features:
   Basic: Session-start and session-end hooks for memory awareness
@@ -1408,6 +1410,12 @@ Features:
                         help='Remove installed hooks')
     parser.add_argument('--force', action='store_true',
                         help='Force installation even if prerequisites fail')
+    parser.add_argument('--permission-hook', action='store_true', default=None,
+                        dest='permission_hook',
+                        help='Install the permission-request hook (opt-in, global effect on ALL MCP servers)')
+    parser.add_argument('--no-permission-hook', action='store_false',
+                        dest='permission_hook',
+                        help='Skip the permission-request hook installation')
     parser.add_argument('--dry-run', action='store_true',
                         help='Show what would be installed without making changes')
 

--- a/claude-hooks/install_hooks.py
+++ b/claude-hooks/install_hooks.py
@@ -722,8 +722,7 @@ class HookInstaller:
                 "session-start.js",
                 "session-end.js",
                 "memory-retrieval.js",
-                "topic-change.js",
-                "permission-request.js"
+                "topic-change.js"
             ]
 
             for file in core_files:

--- a/claude-hooks/install_hooks.py
+++ b/claude-hooks/install_hooks.py
@@ -1488,6 +1488,41 @@ Features:
     install_natural_triggers = args.natural_triggers or install_all
     install_auto_capture = args.auto_capture or install_all
 
+    # Permission hook: explicit opt-in required (issue #503)
+    if args.permission_hook is True:
+        install_permission_hook = True
+        installer.info("Permission hook: enabled via --permission-hook flag")
+    elif args.permission_hook is False:
+        install_permission_hook = False
+        installer.info("Permission hook: skipped via --no-permission-hook flag")
+    else:
+        # Interactive prompt - default is NO
+        installer.header("Optional: Permission Request Hook")
+        installer.info("")
+        installer.info("This hook auto-approves safe MCP tool calls (read-only operations like")
+        installer.info("get, list, retrieve, search) and prompts for destructive ones")
+        installer.info("(delete, write, update, etc.), reducing repetitive confirmation dialogs.")
+        installer.info("")
+        installer.warn("GLOBAL EFFECT: This hook applies to ALL MCP servers on your system,")
+        installer.warn("not just the memory service. It will affect every MCP server you use")
+        installer.warn("(browser automation, code-context, Context7, and any future servers).")
+        installer.info("")
+        installer.info("Why it ships with mcp-memory-service:")
+        installer.info("  Memory operations are frequent and repetitive by design. This hook")
+        installer.info("  was developed alongside the memory service and is tested against its")
+        installer.info("  tool naming conventions. A standalone Gist version is also available:")
+        installer.info("  https://gist.github.com/doobidoo/fa84d31c0819a9faace345ca227b268f")
+        installer.info("")
+        try:
+            answer = input("  Install permission-request hook? [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        install_permission_hook = answer in ("y", "yes")
+        if install_permission_hook:
+            installer.success("Permission hook will be installed")
+        else:
+            installer.info("Permission hook skipped (install later with --permission-hook)")
+
     installer.info(f"Installation plan:")
     installer.info(f"  Basic hooks: {'Yes' if install_basic else 'No'}")
     installer.info(f"  Natural Memory Triggers: {'Yes' if install_natural_triggers else 'No'}")

--- a/claude-hooks/install_hooks.py
+++ b/claude-hooks/install_hooks.py
@@ -1546,6 +1546,10 @@ Features:
             installer.info("  - Smart Auto-Capture hooks")
             installer.info("  - Pattern detection for Decision/Error/Learning/Implementation")
             installer.info("  - PostToolUse hook (Edit, Write, Bash)")
+        if install_permission_hook:
+            installer.info("  - Permission Request Hook (global: affects ALL MCP servers)")
+        else:
+            installer.info("  - Permission Request Hook: SKIPPED (opt-in, use --permission-hook)")
         return
 
     # Create backup
@@ -1597,6 +1601,10 @@ Features:
                 installer.info("  ✅ Mid-conversation memory injection")
                 installer.info("  ✅ Smart Auto-Capture (PostToolUse for Edit/Write/Bash)")
                 installer.info("  ✅ Performance optimization and CLI management")
+                if install_permission_hook:
+                    installer.info("  ✅ Permission Request Hook (auto-approves safe MCP operations)")
+                else:
+                    installer.info("  ℹ  Permission Request Hook not installed (run with --permission-hook to add)")
                 installer.info("")
                 installer.info("CLI Management:")
                 installer.info(f"  node {installer.claude_hooks_dir}/memory-mode-controller.js status")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.17.14"
+version = "10.17.15"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.17.14"
+__version__ = "10.17.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.17.14"
+version = "10.17.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **Permission hook now opt-in** (#503): `permission-request.js` is no longer silently installed alongside other hooks. Users are now prompted during `install_hooks.py` with a clear explanation that this hook applies to ALL MCP servers on the system (not just mcp-memory-service).
- **CLI flags**: `--permission-hook` / `--no-permission-hook` added for non-interactive / scripted installs.
- **Config default fixed**: `permissionRequest.enabled` now defaults to `false` in `config.template.json`.
- **Documentation**: `README-PERMISSION-REQUEST.md` gets a rationale section; `claude-hooks/README.md` marks the hook as opt-in with a global-effect note.

## Version Bump

`10.17.14` → `10.17.15` (patch)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`, `CLAUDE.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new section at top, no duplicates)
- [x] `README.md` "Latest Release" section updated; v10.17.14 moved to Previous Releases
- [x] `CLAUDE.md` version callout updated

## Related Issues

Closes #503