### PR TITLE
feat: add SSE transport mode for long-lived server deployments

### DIFF
--- a/src/mcp_memory_service/cli/main.py
+++ b/src/mcp_memory_service/cli/main.py
@@ -56,9 +56,12 @@ def cli(ctx):
 @cli.command()
 @click.option('--debug', is_flag=True, help='Enable debug logging')
 @click.option('--http', is_flag=True, help='Start HTTP REST API server instead of MCP server (dashboard at http://localhost:8000)')
+@click.option('--sse', is_flag=True, help='Start MCP server with SSE transport (HTTP-based, for systemd services)')
+@click.option('--sse-host', default=None, help='SSE transport host (default: 127.0.0.1)')
+@click.option('--sse-port', default=None, type=int, help='SSE transport port (default: 8765)')
 @click.option('--storage-backend', '-s', default=None,
               type=click.Choice(['sqlite_vec', 'sqlite-vec', 'cloudflare', 'hybrid']), help='Storage backend to use (defaults to environment or sqlite_vec)')
-def server(debug, http, storage_backend):
+def server(debug, http, sse, sse_host, sse_port, storage_backend):
     """
     Start the MCP Memory Service server.
 
@@ -75,6 +78,14 @@ def server(debug, http, storage_backend):
     if debug:
         import logging
         logging.basicConfig(level=logging.DEBUG)
+
+    # Set SSE mode environment variables
+    if sse:
+        os.environ['MCP_SSE_MODE'] = '1'
+        if sse_host is not None:
+            os.environ['MCP_SSE_HOST'] = sse_host
+        if sse_port is not None:
+            os.environ['MCP_SSE_PORT'] = str(sse_port)
 
     # Start HTTP server if --http flag is provided
     if http:

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -542,8 +542,6 @@ else:
 MCP_SSE_HOST = os.getenv('MCP_SSE_HOST', '127.0.0.1')
 MCP_SSE_PORT = safe_get_int_env('MCP_SSE_PORT', 8765, min_value=1024, max_value=65535)
 
-logger.info(f"SSE transport config: host={MCP_SSE_HOST}, port={MCP_SSE_PORT}")
-
 # HTTP Server Configuration
 HTTP_ENABLED = os.getenv('MCP_HTTP_ENABLED', 'false').lower() == 'true'
 HTTP_PORT = safe_get_int_env('MCP_HTTP_PORT', 8000, min_value=1024, max_value=65535)  # Non-privileged ports only

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -536,6 +536,14 @@ else:
     CLOUDFLARE_WARNING_THRESHOLD_PERCENT = None
     CLOUDFLARE_CRITICAL_THRESHOLD_PERCENT = None
 
+# =============================================================================
+# MCP SSE Transport Configuration
+# =============================================================================
+MCP_SSE_HOST = os.getenv('MCP_SSE_HOST', '127.0.0.1')
+MCP_SSE_PORT = safe_get_int_env('MCP_SSE_PORT', 8765, min_value=1024, max_value=65535)
+
+logger.info(f"SSE transport config: host={MCP_SSE_HOST}, port={MCP_SSE_PORT}")
+
 # HTTP Server Configuration
 HTTP_ENABLED = os.getenv('MCP_HTTP_ENABLED', 'false').lower() == 'true'
 HTTP_PORT = safe_get_int_env('MCP_HTTP_PORT', 8000, min_value=1024, max_value=65535)  # Non-privileged ports only

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2797,7 +2797,9 @@ async def async_main():
         # Run server based on mode
         run_manager = ServerRunManager(memory_server, system_info)
 
-        if ServerRunManager.is_standalone_mode():
+        if ServerRunManager.is_sse_mode():
+            await run_manager.run_sse()
+        elif ServerRunManager.is_standalone_mode():
             await run_manager.run_standalone()
         else:
             await run_manager.run_stdio()

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -247,7 +247,6 @@ class ServerRunManager:
                     elif message["type"] == "lifespan.shutdown":
                         await send({"type": "lifespan.shutdown.complete"})
                         return
-                return
 
             path = scope.get("path", "")
             if path == "/sse":


### PR DESCRIPTION
## Summary

- Add `--sse` CLI flag to run the MCP server with SSE transport over HTTP instead of stdio
- Enables running the memory server as a persistent system service (e.g., systemd, launchd) where multiple MCP client sessions share a single server instance
- Uses existing dependencies (`starlette`, `uvicorn`, `sse-starlette`, `mcp.server.sse`) — no new packages required

## Motivation

When running with stdio transport, MCP clients spawn a new server process per session. This causes:

1. **Cold-start latency** — the embedding model reloads on every new session
2. **Redundant memory usage** — multiple instances of the same server consuming RAM
3. **Race conditions** — clients like Claude Code have `SessionStart` hooks that fire before the stdio server finishes initializing, causing tool calls to fail

SSE transport solves all three by running the server as a long-lived HTTP service that's already warm when clients connect.

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `MCP_SSE_HOST` (default `127.0.0.1`) and `MCP_SSE_PORT` (default `8765`) config constants |
| `utils/startup_orchestrator.py` | Add `is_sse_mode()` and `run_sse()` to `ServerRunManager` using `SseServerTransport` |
| `cli/main.py` | Add `--sse`, `--sse-host`, `--sse-port` options to the `server` command |
| `server_impl.py` | Add SSE mode check to `async_main()` mode selection |

## Usage

```bash
# Start with defaults (127.0.0.1:8765)
memory server --sse

# Custom host/port
memory server --sse --sse-host 0.0.0.0 --sse-port 9000

# With storage backend
memory server --sse --storage-backend hybrid
```

Example systemd user service:
```ini
[Service]
ExecStart=uv --directory /path/to/mcp-memory-service run memory server --sse
Restart=on-failure
```

MCP client config (e.g., Claude Code `.claude.json`):
```json
{
  "memory": {
    "type": "sse",
    "url": "http://127.0.0.1:8765/sse"
  }
}
```

## Technical Notes

- Uses a raw ASGI app for routing (`/sse` for SSE connections, `/messages/` for message POSTs) rather than Starlette `Route`/`Mount` — this avoids `request_response()` wrapping issues with SSE streaming and `root_path` prefix problems that cause incorrect message endpoint URLs
- Lifespan events are handled for clean uvicorn startup/shutdown
- The existing stdio and standalone modes are unchanged — SSE is additive

## Test plan

- [x] `memory server --sse` starts and listens on default port 8765
- [x] `GET /sse` returns `200 OK` with SSE `endpoint` event containing correct `/messages/` URL
- [x] `POST /messages/?session_id=...` returns `202 Accepted`
- [x] Claude Code connects via `{"type": "sse", "url": "http://127.0.0.1:8765/sse"}` and memory tools work
- [x] Multiple concurrent client sessions share one server instance
- [x] `--sse-port` and `--sse-host` override defaults correctly
- [ ] Existing stdio mode still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)