### PR TITLE
fix: address issue #505 setup problems (entry point, hook installer, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ These warnings disappear after the first successful run. The service is working 
 - **System Python** on macOS lacks SQLite extension support by default
 - **Solution**: Use Homebrew Python: `brew install python && rehash`
 - **Alternative**: Use pyenv: `PYTHON_CONFIGURE_OPTS='--enable-loadable-sqlite-extensions' pyenv install 3.12.0`
+- **If using uvx/uv**: Add `UV_PYTHON_PREFERENCE=only-managed` to your MCP server `env` block — this forces uv to use its own managed Python (which has SQLite extension support) instead of your pyenv Python
 - **Fallback**: Use Cloudflare or Hybrid backend: `--storage-backend cloudflare` or `--storage-backend hybrid`
 - See [Troubleshooting Guide](docs/troubleshooting/general.md#macos-sqlite-extension-issues) for details
 
@@ -933,6 +934,34 @@ uv run memory health
   }
 }
 ```
+
+### Claude Code (uvx) Configuration
+
+For users installing via `uvx` (no local clone required), add to `~/.claude/claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "mcp-memory-service", "memory", "server"],
+      "env": {
+        "MCP_MEMORY_STORAGE_BACKEND": "sqlite_vec",
+        "UV_PYTHON_PREFERENCE": "only-managed"
+      }
+    }
+  }
+}
+```
+
+> **Note:** `UV_PYTHON_PREFERENCE=only-managed` is required when using `uvx`. pyenv-managed
+> Python builds typically lack `--enable-loadable-sqlite-extensions`, which breaks `sqlite_vec`.
+> Setting this variable forces `uv` to use its own managed Python (which supports SQLite
+> extensions) instead of picking up the pyenv Python from your `PATH`.
+
+> **Note:** The `mcp-memory-server` entry point is **not** for stdio use. Always use
+> `memory server` (or `python -m mcp_memory_service.server`) in stdio MCP configurations.
 
 ### Environment Variables
 

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -740,14 +740,38 @@ async def get_cache_stats(ctx: Context) -> Dict[str, Any]:
 # =============================================================================
 
 def main():
-    """Main entry point for the FastAPI MCP server."""
+    """Main entry point for the FastAPI MCP server (StreamableHTTP transport).
+
+    WARNING: This entry point (`mcp-memory-server`) uses StreamableHTTP transport,
+    NOT stdio transport. It is NOT suitable for use with `"type": "stdio"` in Claude
+    Code or Claude Desktop MCP configuration.
+
+    If you are configuring Claude Code or Claude Desktop with stdio transport, use:
+        memory server
+    or:
+        python -m mcp_memory_service.server
+
+    This `mcp-memory-server` entry point starts an HTTP server on a port and is
+    intended for remote/HTTP-based MCP clients only.
+    """
     # Configure for Claude Code integration
     port = int(os.getenv("MCP_SERVER_PORT", "8000"))
     host = os.getenv("MCP_SERVER_HOST", "0.0.0.0")
-    
+
+    # Emit a prominent warning so users who accidentally invoke this via stdio
+    # see a clear message rather than a silent misconfiguration.
+    print(
+        "\n"
+        "WARNING: mcp-memory-server uses StreamableHTTP transport, NOT stdio.\n"
+        "  If you are configuring a stdio MCP client (Claude Code, Claude Desktop),\n"
+        "  use 'memory server' or 'python -m mcp_memory_service.server' instead.\n"
+        "  Starting HTTP server now...\n",
+        file=sys.stderr
+    )
+
     logger.info(f"Starting MCP Memory Service FastAPI server on {host}:{port}")
     logger.info(f"Storage backend: {STORAGE_BACKEND}")
-    
+
     # Run server with streamable HTTP transport
     mcp.run("streamable-http")
 


### PR DESCRIPTION
## Summary

Fixes three distinct setup problems reported in issue #505.

### Fix 1: `mcp-memory-server` entry point misleads stdio users

The `mcp-memory-server` script entry point calls `mcp_server.py:main()` which starts a **StreamableHTTP** server, not a stdio server. Users who copy-paste this command into a `"type": "stdio"` Claude Code config get a silently broken setup.

- Added a clear `stderr` warning in `mcp_server.py main()` explaining that this command uses HTTP transport and directing users to `memory server` for stdio.

### Fix 2: Document `UV_PYTHON_PREFERENCE=only-managed` for uvx users

pyenv Python builds lack `--enable-loadable-sqlite-extensions`, which breaks `sqlite_vec` when `uvx` picks up the pyenv Python from `PATH`.

- Added a new **"Claude Code (uvx) Configuration"** section in README with a correct example including `UV_PYTHON_PREFERENCE=only-managed`.
- Added a note to the existing macOS SQLite Extension Support section.

### Fix 3: Hook installer issues

**3a. Temp-dir serverWorkingDir**: When the installer runs from a temp directory (e.g. via `uvx`), the temp dir is cleaned up after the process exits, making a hardcoded `serverWorkingDir` invalid. Now uses `uvx --from mcp-memory-service memory server` (no `serverWorkingDir`) in that case; falls back to `uv run` with working dir for local installs.

**3b. Timeout too short for uvx cold-start**: `connectionTimeout` was 5s and `toolCallTimeout` was 10s. The server needs 4–15 seconds to start on a cold uvx cache (package resolution + embedding model load). Increased to 30s / 60s in all three places.

**3c. Hooks section replaced instead of merged**: `configure_claude_settings()` called `dict.update()` on the "no conflicts" path, which silently **replaced** the entire hooks section. Any pre-existing hooks for `SessionEnd`, `PostToolUse`, etc. were lost. The fix always merges by event type (append-if-not-present), making reinstalls idempotent while preserving all user-defined hooks.

## Test plan

- [ ] Verify `mcp-memory-server` now prints a warning to stderr on startup
- [ ] Verify README uvx config example includes `UV_PYTHON_PREFERENCE=only-managed`
- [ ] Run hook installer from a temp dir and verify generated config uses `uvx --from mcp-memory-service memory server` (no `serverWorkingDir`)
- [ ] Run hook installer normally and verify generated config uses `uv run` with `serverWorkingDir`
- [ ] Verify `connectionTimeout` is 30000 and `toolCallTimeout` is 60000 in generated config
- [ ] Configure Claude Code with existing hooks, run the installer, verify existing hooks are preserved

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)