### PR TITLE
chore: release v10.18.3 - security patch (5 Dependabot vulnerabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.18.3] - 2026-02-27
+
+### Security
+- **Fix 5 Dependabot vulnerabilities** (#513): Address 4 high-severity ReDoS alerts in npm dependencies and 1 medium-severity RAM exhaustion alert in Python dependency.
+  - **minimatch ReDoS (4 alerts, High severity)**: Updated `minimatch` override from `^10.2.1` to `^10.2.3` in `tests/bridge/package.json` and `tests/integration/package.json`, with regenerated lockfiles. Fixes CVE-2026-27903, CVE-2026-27904 (Dependabot alerts #39, #40, #41, #42).
+  - **pypdf RAM exhaustion (1 alert, Medium severity)**: Updated `pypdf` from 6.7.2 to 6.7.4 via `uv lock`. Fixes CVE-2026-27888 (Dependabot alert #43).
+
 ## [10.18.2] - 2026-02-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.18.2 - Dev dependency fix: add missing pytest-timeout/pytest-subtests, fix update_and_restart.sh to install .[dev] (#509, closes #508) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.18.3 - Security patch: fix 5 Dependabot vulnerabilities (minimatch ReDoS CVE-2026-27903/27904, pypdf RAM exhaustion CVE-2026-27888, #513) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.18.2** (February 27, 2026)
+## 🆕 Latest Release: **v10.18.3** (February 27, 2026)
 
-**Dev Dependency Fix: Missing Test Packages and Install Script**
+**Security Patch: 5 Dependabot Vulnerabilities Fixed**
 
 **What's New:**
-- **Missing test dependencies added** (#509, closes #508): `pytest-timeout` and `pytest-subtests` added to `[dev]` extras in `pyproject.toml`.
-- **Install script fixed**: `scripts/update_and_restart.sh` now installs `.[dev]` (was bare `.`), ensuring all dev dependencies are available after running the script.
-- **uv.lock updated** to reflect the new transitive closure of dev dependencies.
+- **minimatch ReDoS patched** (#513): Updated `minimatch` override to `^10.2.3` in npm test packages, fixing 4 high-severity ReDoS alerts (CVE-2026-27903, CVE-2026-27904, Dependabot #39-#42).
+- **pypdf RAM exhaustion fixed** (#513): Updated `pypdf` to 6.7.4, fixing a medium-severity RAM exhaustion vulnerability (CVE-2026-27888, Dependabot #43).
+- **uv.lock updated** to reflect the new pypdf transitive closure.
 
 ---
 
 **Previous Releases**:
+- **v10.18.2** - Dev dependency fix: add missing pytest-timeout/pytest-subtests, fix update_and_restart.sh to install .[dev] (#509, closes #508)
 - **v10.18.1** - Security patch: sanitize consolidation recommendations response (CWE-209, CodeQL alert #356 py/stack-trace-exposure)
 - **v10.18.0** - SSE transport mode (`--sse` flag), hook installer improvements (merge, raised timeouts, uvx support), setup docs for pyenv+uvx
 - **v10.17.16** - Security patch: fix minimatch ReDoS (Dependabot #3/#6, High), replace abandoned PyPDF2 with pypdf (Dependabot moderate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.18.2"
+version = "10.18.3"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.18.2"
+__version__ = "10.18.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.18.2"
+version = "10.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Security patch release addressing 5 Dependabot vulnerabilities merged in #513.

### Changes

- **Version bump**: `10.18.2` -> `10.18.3` across `_version.py`, `pyproject.toml`, `README.md`, `CHANGELOG.md`, `CLAUDE.md`, and `uv.lock`

### Security Fixes

| Alert | Severity | Package | CVE | Fix |
|-------|----------|---------|-----|-----|
| Dependabot #39, #40, #41, #42 | High | minimatch (npm) | CVE-2026-27903, CVE-2026-27904 | Bumped override from `^10.2.1` to `^10.2.3` |
| Dependabot #43 | Medium | pypdf (Python) | CVE-2026-27888 | Bumped from 6.7.2 to 6.7.4 via `uv lock` |

**minimatch ReDoS (4 alerts, High)**: Updated `minimatch` npm override in `tests/bridge/package.json` and `tests/integration/package.json` + regenerated lockfiles. Fixes a Regular Expression Denial of Service vector.

**pypdf RAM exhaustion (1 alert, Medium)**: Updated `pypdf` Python package from 6.7.2 to 6.7.4. Fixes a crafted-PDF-triggered RAM exhaustion vulnerability.

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated (`uv lock` run locally)
- [x] `CHANGELOG.md` updated with `[10.18.3]` Security section
- [x] `CLAUDE.md` version reference updated
- [x] All CVEs and Dependabot alert numbers referenced

Ref: #513