### PR TITLE
feat: read-only OAuth status display in dashboard (v10.19.0, closes #259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.19.0] - 2026-02-27
+
+### Added
+- **Read-only OAuth status display in dashboard** (#515, closes #259): New `GET /api/oauth/status` endpoint and Settings > System Info tab section expose OAuth configuration visibility to authenticated dashboard users without revealing any credentials or secrets.
+  - New `GET /api/oauth/status` endpoint returns: `enabled` (bool), `storage_backend` (str), `client_count` (int), `active_token_count` (int). Requires authentication; returns 401 when unauthenticated.
+  - Dashboard Settings tab gains an "OAuth Status" card inside the System Info accordion. Shows enabled/disabled badge, storage backend, registered client count, and active token count when OAuth is enabled. Detail rows are hidden when OAuth is disabled, preventing visual noise.
+  - Full i18n support across all 7 supported locales: English, German, Spanish, French, Japanese, Korean, and Simplified Chinese.
+  - No credentials, secrets, client IDs, or token values are exposed — the endpoint is intentionally read-only and informational.
+
 ## [10.18.3] - 2026-02-27
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.18.3 - Security patch: fix 5 Dependabot vulnerabilities (minimatch ReDoS CVE-2026-27903/27904, pypdf RAM exhaustion CVE-2026-27888, #513) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.19.0 - New feature: read-only OAuth status display in dashboard (`GET /api/oauth/status`, Settings > System Info, i18n for 7 locales, #515, closes #259) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.18.3** (February 27, 2026)
+## 🆕 Latest Release: **v10.19.0** (February 27, 2026)
 
-**Security Patch: 5 Dependabot Vulnerabilities Fixed**
+**New Feature: Read-Only OAuth Status in Dashboard**
 
 **What's New:**
-- **minimatch ReDoS patched** (#513): Updated `minimatch` override to `^10.2.3` in npm test packages, fixing 4 high-severity ReDoS alerts (CVE-2026-27903, CVE-2026-27904, Dependabot #39-#42).
-- **pypdf RAM exhaustion fixed** (#513): Updated `pypdf` to 6.7.4, fixing a medium-severity RAM exhaustion vulnerability (CVE-2026-27888, Dependabot #43).
-- **uv.lock updated** to reflect the new pypdf transitive closure.
+- **OAuth status visibility** (#515, closes #259): New `GET /api/oauth/status` endpoint lets authenticated dashboard users see OAuth configuration at a glance — enabled status, storage backend, client count, and active token count. No credentials or secrets exposed.
+- **Dashboard Settings integration**: OAuth Status card added to Settings > System Info tab; detail rows hidden automatically when OAuth is disabled.
+- **Full i18n support**: All new UI strings translated across all 7 supported locales (en, de, es, fr, ja, ko, zh).
+- **Auth-gated**: Endpoint requires authentication and returns 401 when unauthenticated.
 
 ---
 
 **Previous Releases**:
+- **v10.18.3** - Security patch: 5 Dependabot vulnerabilities fixed (minimatch ReDoS CVE-2026-27903/27904 #39-#42, pypdf RAM exhaustion CVE-2026-27888 #43)
 - **v10.18.2** - Dev dependency fix: add missing pytest-timeout/pytest-subtests, fix update_and_restart.sh to install .[dev] (#509, closes #508)
 - **v10.18.1** - Security patch: sanitize consolidation recommendations response (CWE-209, CodeQL alert #356 py/stack-trace-exposure)
 - **v10.18.0** - SSE transport mode (`--sse` flag), hook installer improvements (merge, raised timeouts, uvx support), setup docs for pyenv+uvx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.18.3"
+version = "10.19.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.18.3"
+__version__ = "10.19.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.18.3"
+version = "10.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **New `GET /api/oauth/status` endpoint** (auth-gated, read-only): returns `enabled`, `storage_backend`, `client_count`, `active_token_count`. Returns 401 when unauthenticated. No credentials or secrets are exposed.
- **Dashboard Settings > System Info tab**: new OAuth Status card shows enabled/disabled badge, storage backend, registered client count, and active token count. Detail rows are hidden when OAuth is disabled to avoid visual noise.
- **i18n**: all new UI strings translated across all 7 supported locales — English, German, Spanish, French, Japanese, Korean, Simplified Chinese.

## Motivation

Issue #259 requested a way for dashboard users to inspect OAuth configuration at a glance without needing to access server logs or config files. The endpoint and dashboard card are intentionally read-only and auth-gated, following the principle of least privilege.

## Testing

- Endpoint tested with OAuth enabled and disabled
- Auth requirement verified (401 returned without valid session)
- i18n strings verified for all 7 locales
- Dashboard card verified to hide detail rows when OAuth is disabled

## Related Issues

Closes #259 via PR #515

## Checklist

- [x] Version bumped in `_version.py` and `pyproject.toml` (10.18.3 → 10.19.0, MINOR bump)
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with `## [10.19.0] - 2026-02-27` under `### Added`
- [x] `README.md` Latest Release section updated; v10.18.3 moved to Previous Releases
- [x] `CLAUDE.md` version reference updated