### PR TITLE
feat: add Streamable HTTP transport with OAuth 2.1 + PKCE (v10.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.20.0] - 2026-02-28
+
+### Added
+- **Streamable HTTP transport with OAuth 2.1 + PKCE** (#518): Enable Claude.ai remote MCP server connectivity by adding Streamable HTTP as a new transport mode alongside the existing SSE transport. The new transport is a fully separate code path — SSE users are completely unaffected.
+  - New `--streamable-http` CLI flag and `run_streamable_http()` method on `ServerRunManager`. Configure host/port via `MCP_STREAMABLE_HTTP_HOST` (default `0.0.0.0`) and `MCP_STREAMABLE_HTTP_PORT` (default `9000`).
+  - Bearer token / API key authentication middleware on the `/mcp` endpoint — unauthenticated requests receive HTTP 401 before any MCP protocol handling occurs.
+  - API key-gated HTML authorization page: `/authorize` now requires `MCP_API_KEY` instead of auto-approving, preventing unauthorized OAuth token issuance.
+  - JavaScript `window.location` redirect after authorization (instead of HTTP 302) for compatibility with Claude.ai's OAuth popup flow, which does not reliably follow server-side redirects from form POST.
+  - **PKCE (S256) support** added to OAuth authorization code flow across all storage backends (in-memory and SQLite). Both backends store `code_challenge` / `code_challenge_method` per authorization code and verify the PKCE proof before issuing access tokens. S256 support is advertised in OAuth server metadata discovery.
+  - **Schema migration** for existing SQLite OAuth databases: `code_challenge` and `code_challenge_method` columns are added automatically on startup when absent, enabling zero-downtime upgrades from pre-PKCE installations.
+  - **RFC 9728 OAuth Protected Resource Metadata** endpoint (`/.well-known/oauth-protected-resource`): returns the authorization server URL, enabling OAuth 2.1-compliant clients to discover the authorization server from the resource server.
+  - `refresh_token` grant type accepted in Dynamic Client Registration (DCR) requests: Claude.ai includes `refresh_token` in `grant_types` during DCR; adding it to the accepted list prevents HTTP 400 errors during the OAuth handshake.
+  - `streamable-http` mode added to Docker unified entrypoint (`tools/docker/docker-entrypoint-unified.sh`), enabling containerized Streamable HTTP deployments.
+
 ## [10.18.1] - 2026-02-24
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.18.1"
+version = "10.20.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.18.1"
+__version__ = "10.20.0"

--- a/src/mcp_memory_service/cli/main.py
+++ b/src/mcp_memory_service/cli/main.py
@@ -57,11 +57,12 @@ def cli(ctx):
 @click.option('--debug', is_flag=True, help='Enable debug logging')
 @click.option('--http', is_flag=True, help='Start HTTP REST API server instead of MCP server (dashboard at http://localhost:8000)')
 @click.option('--sse', is_flag=True, help='Start MCP server with SSE transport (HTTP-based, for systemd services)')
-@click.option('--sse-host', default=None, help='SSE transport host (default: 127.0.0.1)')
-@click.option('--sse-port', default=None, type=int, help='SSE transport port (default: 8765)')
+@click.option('--streamable-http', 'streamable_http', is_flag=True, help='Start MCP server with Streamable HTTP transport (for Claude.ai remote MCP)')
+@click.option('--sse-host', default=None, help='SSE/Streamable HTTP transport host (default: 127.0.0.1)')
+@click.option('--sse-port', default=None, type=int, help='SSE/Streamable HTTP transport port (default: 8765)')
 @click.option('--storage-backend', '-s', default=None,
               type=click.Choice(['sqlite_vec', 'sqlite-vec', 'cloudflare', 'hybrid']), help='Storage backend to use (defaults to environment or sqlite_vec)')
-def server(debug, http, sse, sse_host, sse_port, storage_backend):
+def server(debug, http, sse, streamable_http, sse_host, sse_port, storage_backend):
     """
     Start the MCP Memory Service server.
 
@@ -82,6 +83,14 @@ def server(debug, http, sse, sse_host, sse_port, storage_backend):
     # Set SSE mode environment variables
     if sse:
         os.environ['MCP_SSE_MODE'] = '1'
+        if sse_host is not None:
+            os.environ['MCP_SSE_HOST'] = sse_host
+        if sse_port is not None:
+            os.environ['MCP_SSE_PORT'] = str(sse_port)
+
+    # Set Streamable HTTP mode environment variables
+    if streamable_http:
+        os.environ['MCP_STREAMABLE_HTTP_MODE'] = '1'
         if sse_host is not None:
             os.environ['MCP_SSE_HOST'] = sse_host
         if sse_port is not None:

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2786,7 +2786,9 @@ async def async_main():
         # Run server based on mode
         run_manager = ServerRunManager(memory_server, system_info)
 
-        if ServerRunManager.is_sse_mode():
+        if ServerRunManager.is_streamable_http_mode():
+            await run_manager.run_streamable_http()
+        elif ServerRunManager.is_sse_mode():
             await run_manager.run_sse()
         elif ServerRunManager.is_standalone_mode():
             await run_manager.run_standalone()

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -370,8 +370,11 @@ class ServerRunManager:
             api_key_header = headers.get(b"x-api-key", b"").decode("latin-1")
 
             # Try Bearer token (OAuth)
-            if auth_header.lower().startswith("bearer ") and OAUTH_ENABLED:
-                token = auth_header[7:]
+            is_bearer = auth_header.lower().startswith("bearer ")
+            token = auth_header[7:] if is_bearer else ""
+
+            # Try Bearer token (OAuth)
+            if is_bearer and OAUTH_ENABLED:
                 result = await authenticate_bearer_token(token)
                 if result.authenticated:
                     return True
@@ -383,8 +386,7 @@ class ServerRunManager:
                     return True
 
             # Try Bearer token as API key fallback
-            if auth_header.lower().startswith("bearer ") and API_KEY:
-                token = auth_header[7:]
+            if is_bearer and API_KEY:
                 result = authenticate_api_key(token)
                 if result.authenticated:
                     return True

--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -285,10 +285,11 @@ async def authorize_post(
         # Use HTML meta-refresh + JS redirect for maximum popup compatibility.
         # Some OAuth clients (Claude.ai) use popups where HTTP 302 from a
         # form POST can be unreliable across cross-origin boundaries.
+        import json
         return HTMLResponse(f"""<!DOCTYPE html>
 <html><head>
-<meta http-equiv="refresh" content="0;url={redirect_url}">
-<script>window.location.href = {__import__('json').dumps(redirect_url)};</script>
+<meta http-equiv=\"refresh\" content=\"0;url={redirect_url}\">
+<script>window.location.href = {json.dumps(redirect_url)};</script>
 </head><body>Redirecting...</body></html>""")
 
     except HTTPException:

--- a/src/mcp_memory_service/web/oauth/discovery.py
+++ b/src/mcp_memory_service/web/oauth/discovery.py
@@ -51,7 +51,8 @@ async def oauth_authorization_server_metadata() -> OAuthServerMetadata:
         response_types_supported=["code"],
         token_endpoint_auth_methods_supported=["client_secret_basic", "client_secret_post"],
         scopes_supported=["read", "write", "admin"],
-        id_token_signing_alg_values_supported=[algorithm]
+        id_token_signing_alg_values_supported=[algorithm],
+        code_challenge_methods_supported=["S256"]
     )
 
     logger.debug(f"Returning OAuth metadata: issuer={metadata.issuer}")

--- a/src/mcp_memory_service/web/oauth/models.py
+++ b/src/mcp_memory_service/web/oauth/models.py
@@ -17,7 +17,7 @@ OAuth 2.1 data models and schemas for MCP Memory Service.
 """
 
 from typing import List, Optional
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 
 class OAuthServerMetadata(BaseModel):
@@ -48,12 +48,23 @@ class OAuthServerMetadata(BaseModel):
         default=None,
         description="Supported JWT signing algorithms for access tokens"
     )
+    code_challenge_methods_supported: Optional[List[str]] = Field(
+        default=None,
+        description="Supported PKCE code challenge methods"
+    )
 
 
 class ClientRegistrationRequest(BaseModel):
-    """OAuth 2.1 Dynamic Client Registration Request (RFC 7591)."""
+    """OAuth 2.1 Dynamic Client Registration Request (RFC 7591).
 
-    redirect_uris: Optional[List[HttpUrl]] = Field(
+    Uses permissive types (str instead of HttpUrl) to accept varied client
+    implementations (e.g., Claude.ai) that may send URIs in formats that
+    strict Pydantic HttpUrl validation rejects.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    redirect_uris: Optional[List[str]] = Field(
         default=None,
         description="Array of redirection URI strings for use in redirect-based flows"
     )
@@ -73,7 +84,7 @@ class ClientRegistrationRequest(BaseModel):
         default=None,
         description="Human-readable string name of the client"
     )
-    client_uri: Optional[HttpUrl] = Field(
+    client_uri: Optional[str] = Field(
         default=None,
         description="URL string of a web page providing information about the client"
     )

--- a/src/mcp_memory_service/web/oauth/registration.py
+++ b/src/mcp_memory_service/web/oauth/registration.py
@@ -170,7 +170,7 @@ def validate_redirect_uris(redirect_uris: Optional[List[str]]) -> None:
 
 def validate_grant_types(grant_types: List[str]) -> None:
     """Validate that requested grant types are supported."""
-    supported_grant_types = {"authorization_code", "client_credentials"}
+    supported_grant_types = {"authorization_code", "client_credentials", "refresh_token"}
 
     for grant_type in grant_types:
         if grant_type not in supported_grant_types:

--- a/src/mcp_memory_service/web/oauth/storage/base.py
+++ b/src/mcp_memory_service/web/oauth/storage/base.py
@@ -85,7 +85,9 @@ class OAuthStorage(ABC):
         client_id: str,
         redirect_uri: Optional[str] = None,
         scope: Optional[str] = None,
-        expires_in: Optional[int] = None
+        expires_in: Optional[int] = None,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None
     ) -> None:
         """
         Store an authorization code for the authorization code flow.

--- a/src/mcp_memory_service/web/oauth/storage/memory.py
+++ b/src/mcp_memory_service/web/oauth/storage/memory.py
@@ -102,7 +102,9 @@ class MemoryOAuthStorage(OAuthStorage):
         client_id: str,
         redirect_uri: Optional[str] = None,
         scope: Optional[str] = None,
-        expires_in: Optional[int] = None
+        expires_in: Optional[int] = None,
+        code_challenge: Optional[str] = None,
+        code_challenge_method: Optional[str] = None
     ) -> None:
         """
         Store an authorization code for the authorization code flow.
@@ -113,6 +115,8 @@ class MemoryOAuthStorage(OAuthStorage):
             redirect_uri: Redirect URI associated with this authorization
             scope: Space-separated list of granted scopes
             expires_in: Expiration time in seconds (None uses default)
+            code_challenge: PKCE code challenge
+            code_challenge_method: PKCE code challenge method (S256)
         """
         if expires_in is None:
             expires_in = OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES * 60
@@ -121,7 +125,9 @@ class MemoryOAuthStorage(OAuthStorage):
                 "client_id": client_id,
                 "redirect_uri": redirect_uri,
                 "scope": scope,
-                "expires_at": time.time() + expires_in
+                "expires_at": time.time() + expires_in,
+                "code_challenge": code_challenge,
+                "code_challenge_method": code_challenge_method,
             }
 
     async def get_authorization_code(self, code: str) -> Optional[Dict]:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -90,8 +90,8 @@ RUN chmod a+rw /dev/stdin /dev/stdout /dev/stderr && \
 # Add volume mount points for data persistence
 VOLUME ["/app/sqlite_db", "/app/backups"]
 
-# Expose the port (if needed)
-EXPOSE 8000
+# Expose ports: 8000 for HTTP API, 8765 for SSE/Streamable HTTP transport
+EXPOSE 8000 8765
 
 # Use the unified entrypoint script by default
 # Can be overridden with docker-entrypoint.sh for backward compatibility

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.18.1"
+version = "10.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Add `--streamable-http` CLI flag and `run_streamable_http()` transport method alongside existing `--sse`
- Add PKCE (S256) support to OAuth authorization flow across all storage backends (memory + SQLite)
- Add API key-gated HTML authorization page so `/authorize` is not auto-approve
- Add Bearer token / API key auth middleware on `/mcp` endpoint (401 if unauthenticated)
- Add RFC 9728 OAuth Protected Resource Metadata endpoint
- Accept `refresh_token` grant type in DCR for Claude.ai compatibility
- Add `streamable-http` mode to Docker entrypoint

## Motivation

Claude.ai remote MCP servers require Streamable HTTP transport with OAuth 2.1 + PKCE. The existing SSE transport works for Claude Code (stdio/local) but not for Claude.ai's web-based OAuth flow. This PR adds the new transport as a separate code path — SSE is completely untouched.

## Key design decisions

1. **Separate method, not modified `run_sse`** — `run_streamable_http()` is a new method. SSE users aren't affected.
2. **Auth at the transport boundary** — The ASGI app validates Bearer tokens before passing requests to `StreamableHTTPSessionManager`.
3. **API key gate on `/authorize`** — Instead of auto-approving, shows an HTML login page requiring `MCP_API_KEY`. Prevents unauthorized OAuth token issuance.
4. **JS redirect after authorize** — Claude.ai's OAuth popup doesn't reliably follow HTTP 302 from form POST. Uses meta-refresh + `window.location` instead.
5. **`refresh_token` accepted in DCR** — Claude.ai sends it in `grant_types`. Without this, registration returns 400.

## Test plan

- [x] `pytest tests/unit/test_oauth_storage_backends.py` — 35 passed, 1 expected skip
- [x] PKCE round-trip tests (parametrized across memory + SQLite)
- [x] DCR extra fields test (Claude.ai sends contacts, logo_uri, etc.)
- [x] Production test: Claude.ai successfully connects to `https://memory.crunchtools.com/mcp` via full OAuth flow
- [x] Verify `--sse` mode still works (no changes to `run_sse()`)
- [ ] Verify `--http` REST API mode still works (no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)