### PR TITLE
fix: add missing content_hash in _prompt_learning_session

### DIFF
--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -63,6 +63,7 @@ except (ImportError, AttributeError):
 # Package imports
 from .dependency_check import get_recommended_timeout
 from .compat import is_deprecated, transform_deprecated_call
+from .utils.hashing import generate_content_hash
 from .config import (
     BACKUPS_PATH,
     SERVER_NAME,
@@ -1192,8 +1193,10 @@ class MemoryServer:
                     learning_note += f"- {question.strip()}\n"
             
             # Store the learning note
+            content_hash = generate_content_hash(learning_note)
             memory = Memory(
                 content=learning_note,
+                content_hash=content_hash,
                 tags=["learning", topic.lower().replace(" ", "_")],
                 memory_type="learning_note"
             )


### PR DESCRIPTION
## Problem

`_prompt_learning_session` in `server_impl.py` constructs a `Memory` object without providing the required `content_hash` field, causing a `TypeError` at runtime:

```
TypeError: Memory.__init__() missing 1 required positional argument: 'content_hash'
```

The `Memory` dataclass defines `content_hash: str` as a mandatory field (no default value), so any call to `Memory(...)` without it will fail.

## Fix

- Import `generate_content_hash` from `mcp_memory_service.utils.hashing`
- Generate the hash from `learning_note` before constructing the `Memory` object
- Pass `content_hash` to the constructor

## Changes

```diff
+from .utils.hashing import generate_content_hash

 # in _prompt_learning_session():
+content_hash = generate_content_hash(learning_note)
 memory = Memory(
     content=learning_note,
+    content_hash=content_hash,
     tags=["learning", topic.lower().replace(" ", "_")],
     memory_type="learning_note"
 )
```

## Testing

The fix follows the same pattern used elsewhere in the codebase where `Memory` objects are constructed (e.g. `store_memory`, `batch_store_memories`).
