### PR TITLE
chore: release v10.20.2 -- fix TypeError in _prompt_learning_session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.20.2] - 2026-03-01
+
+### Fixed
+- **Fix TypeError in `_prompt_learning_session` prompt handler** (#521): The `Memory` dataclass requires `content_hash` as a mandatory positional argument, but `_prompt_learning_session` was constructing a `Memory` object without providing it. This caused a `TypeError` at MCP server startup (`Memory.__init__() missing 1 required positional argument: 'content_hash'`), preventing the `learning_session` prompt from loading and resulting in `ERROR: failed to get prompt from MCP server (promptName=learning_session)` for any client that requested it. Fix: import `generate_content_hash` utility and compute the hash from the memory content before constructing the `Memory` object, passing it as the required field.
+
 ## [10.20.1] - 2026-02-28
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.20.1 - Security patch: serialize-javascript RCE fix, pypdf RAM exhaustion fixes (CVE-2026-28351, CVE-2026-27888, alerts #43-#46) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.20.2 - Bug fix: TypeError in `_prompt_learning_session` (missing `content_hash` in `Memory` constructor, PR #521) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -259,18 +259,17 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.20.1** (February 28, 2026)
+## 🆕 Latest Release: **v10.20.2** (March 1, 2026)
 
-**Security Patch: serialize-javascript RCE + pypdf RAM Exhaustion**
+**Bug Fix: TypeError in `_prompt_learning_session` prompt handler**
 
 **What's Fixed:**
-- **serialize-javascript RCE** (High, alerts #44 #45): Updated 6.0.2 to 7.0.3 via npm override — RCE via `RegExp.flags` and `Date.prototype.toISOString()`
-- **pypdf RunLengthDecode RAM exhaustion** (Medium, CVE-2026-28351, alert #46): Updated 6.7.2 to 6.7.4
-- **pypdf FlateDecode XFA RAM exhaustion** (Medium, CVE-2026-27888, alert #43): Same pypdf 6.7.4 update
+- **`learning_session` prompt crash at startup** (#521): `Memory.__init__()` was called without the required `content_hash` argument, raising a `TypeError` that prevented the `learning_session` MCP prompt from loading. Fix: compute `generate_content_hash()` before constructing the `Memory` object and pass it as the required field.
 
 ---
 
 **Previous Releases**:
+- **v10.20.1** - Security patch: serialize-javascript RCE (alerts #44 #45) + pypdf RAM exhaustion (CVE-2026-28351 / CVE-2026-27888, alerts #43 #46)
 - **v10.20.0** - Streamable HTTP transport with OAuth 2.1 + PKCE for Claude.ai remote MCP connectivity (`--streamable-http`, PKCE S256, RFC 9728, #518)
 - **v10.19.0** - Read-only OAuth status display in dashboard (`GET /api/oauth/status`, Settings > System Info, i18n for 7 locales, #515, closes #259)
 - **v10.18.3** - Security patch: 5 Dependabot vulnerabilities fixed (minimatch ReDoS CVE-2026-27903/27904 #39-#42, pypdf RAM exhaustion CVE-2026-27888 #43)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.20.1"
+version = "10.20.2"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.20.1"
+__version__ = "10.20.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.20.1"
+version = "10.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Patch release v10.20.2 — bundles the bug fix from PR #521 with version bump and documentation updates.

## Changes

- **Bug fix**: `_prompt_learning_session` now correctly passes `content_hash` to the `Memory` constructor via `generate_content_hash()`, eliminating a `TypeError` that caused the `learning_session` MCP prompt to fail at server startup.

## Motivation

PR #521 fixed a `TypeError` crash (`Memory.__init__() missing 1 required positional argument: 'content_hash'`) in the `_prompt_learning_session` handler. The crash prevented any MCP client from retrieving the `learning_session` prompt, resulting in:

```
ERROR: failed to get prompt from MCP server (promptName=learning_session)
```

This release packages that fix with the standard version bump, lock file update, and documentation updates.

## Files Changed

| File | Change |
|------|--------|
| `pyproject.toml` | Version 10.20.1 -> 10.20.2 |
| `src/mcp_memory_service/_version.py` | Version 10.20.1 -> 10.20.2 |
| `uv.lock` | Regenerated for v10.20.2 |
| `CHANGELOG.md` | Added v10.20.2 entry |
| `README.md` | Latest Release updated to v10.20.2 |
| `CLAUDE.md` | Current Version updated to v10.20.2 |

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (v10.20.2 entry added, positioned after [Unreleased])
- [x] `README.md` Latest Release section updated
- [x] `README.md` Previous Releases list updated (v10.20.1 added at top)
- [x] `CLAUDE.md` version reference updated
- [x] `docs/index.html` NOT updated (patch release — skip per project policy)
- [x] No wiki roadmap update needed (patch release)

## Related

- Fixes PR #521 (fix: add missing content_hash in `_prompt_learning_session`)
