### PR TITLE
fix(cloudflare): populate tags column in D1 INSERT to fix delete_by_tags

### DIFF
--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -630,7 +630,7 @@ class CloudflareStorage(MemoryStorage):
         # The `tags` TEXT column is a denormalized cache required by `delete_by_tags`
         # and `delete_by_timeframe`, both of which query it with LIKE patterns.
         # Tags are also stored relationally via `_store_d1_tags` (join table) for reads.
-        tags_str = ",".join(memory.tags) if memory.tags else None
+        tags_str = ",".join(filter(None, memory.tags)) or None
 
         insert_sql = """
         INSERT INTO memories (

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -626,17 +626,22 @@ class CloudflareStorage(MemoryStorage):
     
     async def _store_d1_memory(self, memory: Memory, vector_id: str, content_size: int, r2_key: Optional[str], stored_content: str) -> None:
         """Store memory metadata in D1."""
-        # Insert memory record
+        # Insert memory record.
+        # The `tags` TEXT column is a denormalized cache required by `delete_by_tags`
+        # and `delete_by_timeframe`, both of which query it with LIKE patterns.
+        # Tags are also stored relationally via `_store_d1_tags` (join table) for reads.
+        tags_str = ",".join(memory.tags) if memory.tags else None
+
         insert_sql = """
         INSERT INTO memories (
             content_hash, content, memory_type, created_at, created_at_iso,
-            updated_at, updated_at_iso, metadata_json, vector_id, content_size, r2_key
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            updated_at, updated_at_iso, metadata_json, vector_id, content_size, r2_key, tags
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
-        
+
         now = time.time()
         now_iso = datetime.now().isoformat()
-        
+
         params = [
             memory.content_hash,
             stored_content,
@@ -648,7 +653,8 @@ class CloudflareStorage(MemoryStorage):
             json.dumps(memory.metadata) if memory.metadata else None,
             vector_id,
             content_size,
-            r2_key
+            r2_key,
+            tags_str,
         ]
         
         payload = {"sql": insert_sql, "params": params}


### PR DESCRIPTION
## Problem

`delete_by_tags()` and `delete_by_timeframe()` both query the denormalized `memories.tags TEXT` column using LIKE patterns:

```python
# delete_by_tags (line ~1133)
conditions.append("(tags LIKE ? OR tags LIKE ? OR tags LIKE ? OR tags = ?)")

# delete_by_timeframe (line ~1182)
AND (tags LIKE ? OR tags LIKE ? OR tags LIKE ? OR tags = ?)
```

However, `_store_d1_memory()` never populated this column. The INSERT statement only included 11 columns (`r2_key` was last) — `tags` was omitted despite the column existing in the schema since v8.72.0.

**Result:** Tag-based deletion silently matched zero rows. Memories could not be deleted by tag via the D1 backend.

## Root cause

The schema has two tag storage mechanisms:
1. **`memory_tags` join table** — populated by `_store_d1_tags()` after INSERT, used for read operations (listing, filtering)
2. **`memories.tags TEXT` column** — denormalized cache, used exclusively by `delete_by_tags` / `delete_by_timeframe` LIKE queries

`_store_d1_tags()` was wired up correctly, but the denormalized `tags TEXT` column was never written to.

## Fix

Add `tags` as the 12th column in the D1 INSERT with a comma-joined string (`"tag1,tag2,tag3"`), consistent with how the LIKE patterns match it:
- `"tag1,%"` — tag at start  
- `"%,tag2,%"` — tag in middle
- `"%,tag3"` — tag at end
- `"tag4"` — exact match (single tag)

Both storage paths are now populated on every write.

## Testing

Verified against a live Cloudflare D1 instance:
- Stored memories with tags
- Confirmed `memories.tags` column is populated in D1
- Confirmed `delete_by_tags` now correctly identifies and soft-deletes matching rows
- Confirmed `memory_tags` join table still populated (reads unaffected)

Fixes the silent failure reported when using tag-based deletion on the Cloudflare backend.