### PR TITLE
fix(cloudflare): tags column NULL in D1 INSERT breaks delete_by_tags (v10.20.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.20.4] - 2026-03-04
+
+### Fixed
+- **Cloudflare/Hybrid: tags column always NULL in D1 INSERT** (#534, contributor: shawnsw): The denormalized `tags` TEXT column in the D1 INSERT statement was never populated — only `tag_relations` rows were written. This caused `delete_by_tags()` and `delete_by_timeframe()` to silently return success without deleting any memories on Cloudflare and Hybrid storage backends. Fix: the `tags` parameter is now joined as a comma-separated string and written to the `tags` column in every INSERT.
+- **Cloudflare/Hybrid: empty-tag LIKE false matches** (#534, contributor: shawnsw): When the `tags` list contained empty strings, the JOIN query produced a trailing comma in the LIKE pattern (e.g. `%,`) causing spurious matches. Empty strings are now filtered out before the `tags` column value is assembled.
+
 ## [10.20.3] - 2026-03-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.20.3 - Bug fixes: HTTP server auto-start (wrong module path, env var handling, startup polling, auth forwarding) + hook installer improvements (pyproject.toml check, API key generation, dual-server guidance) (PRs #529, #531) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.20.4 - Bug fix: Cloudflare/Hybrid backends tags column always NULL in D1 INSERT (delete_by_tags/delete_by_timeframe silently failing) + empty-tag LIKE false matches guard (PR #534, contributor: shawnsw) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,22 +265,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.20.3** (March 3, 2026)
+## 🆕 Latest Release: **v10.20.4** (March 4, 2026)
 
-**Bug Fix: HTTP server auto-start and hook installer reliability**
+**Bug Fix: Cloudflare/Hybrid tags column NULL in D1 INSERT**
 
 **What's Fixed:**
-- **HTTP server auto-start: wrong module path** (#529): Corrected subprocess command from `src.mcp_memory_service.app` to `mcp_memory_service.web.app` — fixes installs via `pip`/`uvx`.
-- **HTTP server auto-start: `MCP_HTTP_ENABLED` env var ignored** (#529): Both `MCP_HTTP_ENABLED` and `MCP_MEMORY_HTTP_AUTO_START` are now accepted as equivalent triggers.
-- **HTTP server auto-start: startup wait too short** (#529): Fixed 3-second sleep replaced with 30-second polling loop (2 s intervals) to handle `sentence-transformers` model loading time.
-- **HTTP server auto-start: auth env vars not forwarded** (#529): `MCP_API_KEY`, `MCP_HTTP_PORT`, `MCP_HTTP_HOST`, and storage-path variables are now propagated to the HTTP server subprocess.
-- **Hook installer: `uv run` without `pyproject.toml` check** (#531): Falls back to `uvx --from mcp-memory-service memory server` when not in a source-tree context.
-- **Hook installer: no API key generated** (#531): Auto-generates a cryptographically strong API key via `secrets.token_urlsafe(32)` and writes it to `~/.claude/hooks/config.json`.
-- **Hook installer: no guidance on dual-server requirement** (#531): Post-installation output now clearly explains both servers must run with a ready-to-use bash wrapper snippet.
+- **Cloudflare/Hybrid: tags column always NULL in D1 INSERT** (#534, contributor: shawnsw): The denormalized `tags` TEXT column was never populated, causing `delete_by_tags()` and `delete_by_timeframe()` to silently return success without deleting any memories on Cloudflare and Hybrid backends. Tags are now joined as a comma-separated string and written on every INSERT.
+- **Cloudflare/Hybrid: empty-tag LIKE false matches** (#534, contributor: shawnsw): Empty strings in the tags list produced trailing commas in LIKE patterns (e.g. `%,`) causing spurious matches. Empty tags are now filtered out before assembly.
 
 ---
 
 **Previous Releases**:
+- **v10.20.3** - Bug fixes: HTTP server auto-start (wrong module path, env var handling, startup polling, auth forwarding) + hook installer improvements (pyproject.toml check, API key generation, dual-server guidance) (PRs #529, #531)
 - **v10.20.2** - Bug fix: TypeError in `_prompt_learning_session` (missing `content_hash` in `Memory` constructor, PR #521)
 - **v10.20.1** - Security patch: serialize-javascript RCE (alerts #44 #45) + pypdf RAM exhaustion (CVE-2026-28351 / CVE-2026-27888, alerts #43 #46)
 - **v10.20.0** - Streamable HTTP transport with OAuth 2.1 + PKCE for Claude.ai remote MCP connectivity (`--streamable-http`, PKCE S256, RFC 9728, #518)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.20.3"
+version = "10.20.4"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.20.3"
+__version__ = "10.20.4"

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -630,7 +630,7 @@ class CloudflareStorage(MemoryStorage):
         # The `tags` TEXT column is a denormalized cache required by `delete_by_tags`
         # and `delete_by_timeframe`, both of which query it with LIKE patterns.
         # Tags are also stored relationally via `_store_d1_tags` (join table) for reads.
-        tags_str = ",".join(filter(None, memory.tags)) or None
+        tags_str = ",".join(filter(None, memory.tags)) if memory.tags else None
 
         insert_sql = """
         INSERT INTO memories (


### PR DESCRIPTION
## Summary

Patch release v10.20.4 fixing a data-loss bug in Cloudflare and Hybrid storage backends where tag-based and timeframe-based deletions silently did nothing.

## Changes

- **fix(cloudflare): populate tags column in D1 INSERT** (#534, contributor: shawnsw): The denormalized `tags` TEXT column in the D1 INSERT statement was never populated — only `tag_relations` rows were written. This caused `delete_by_tags()` and `delete_by_timeframe()` to silently return success without deleting any memories on Cloudflare and Hybrid backends.
- **fix(cloudflare): guard against None/empty tags list** (#534, contributor: shawnsw): Empty strings in the tags list produced a trailing comma in LIKE patterns (e.g. `%,`) causing spurious matches. Empty strings are now filtered out before the `tags` column value is assembled, and a None guard prevents TypeError.
- **docs: update CHANGELOG, README, and CLAUDE.md** for v10.20.4 version references.

## Affected Backends

- `cloudflare` storage backend
- `hybrid` storage backend (uses Cloudflare D1 for sync)

## Root Cause

In `storage/cloudflare.py`, the D1 INSERT built the `tags_str` value but never passed it into the SQL parameters tuple, so the column received NULL on every write. Subsequent `DELETE WHERE tags LIKE` queries matched nothing.

## Checklist

- [x] Version bumped in `_version.py` and `pyproject.toml` (10.20.4)
- [x] CHANGELOG.md updated
- [x] README.md "Latest Release" section updated
- [x] CLAUDE.md "Current Version" updated
- [x] docs/index.html NOT updated (patch release — skip per release policy)

## Related

Fixes contributor PR #534 by shawnsw.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>