### PR TITLE
chore: release v10.20.5 - standardize content-only hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.20.5] - 2026-03-04
+
+### Fixed
+- **Standardize content-only hashing across all call sites** (#522, closes #522): `generate_content_hash()` previously accepted an optional `metadata` parameter that was silently ignored, creating an inconsistent API where the same content could appear to produce different hashes depending on how call sites invoked the function. The `metadata` parameter has been removed — the function now only accepts `content` — and all 5 affected call sites updated (`cli/ingestion.py`, `server/handlers/documents.py`, `utils/document_processing.py`, `web/api/documents.py`, `web/api/mcp.py`). Hash output is identical for all previously correct call sites; call sites that incorrectly passed `metadata` now produce the same hash as content-only call sites (resolving the inconsistency). 7 new `@pytest.mark.unit` tests added in `tests/unit/test_content_hash_consistency.py` covering: no-metadata-parameter enforcement, deterministic output, content sensitivity, whitespace handling, Unicode, empty string, and long content.
+
 ## [10.20.4] - 2026-03-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.20.4 - Bug fix: Cloudflare/Hybrid backends tags column always NULL in D1 INSERT (delete_by_tags/delete_by_timeframe silently failing) + empty-tag LIKE false matches guard (PR #534, contributor: shawnsw) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.20.5 - Fix: standardize content-only hashing across all call sites - removed `metadata` param from `generate_content_hash()`, updated 5 call sites, added 7 unit tests (PR #536, closes #522) - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,17 +265,17 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.20.4** (March 4, 2026)
+## 🆕 Latest Release: **v10.20.5** (March 4, 2026)
 
-**Bug Fix: Cloudflare/Hybrid tags column NULL in D1 INSERT**
+**Fix: Standardize content-only hashing across all call sites**
 
 **What's Fixed:**
-- **Cloudflare/Hybrid: tags column always NULL in D1 INSERT** (#534, contributor: shawnsw): The denormalized `tags` TEXT column was never populated, causing `delete_by_tags()` and `delete_by_timeframe()` to silently return success without deleting any memories on Cloudflare and Hybrid backends. Tags are now joined as a comma-separated string and written on every INSERT.
-- **Cloudflare/Hybrid: empty-tag LIKE false matches** (#534, contributor: shawnsw): Empty strings in the tags list produced trailing commas in LIKE patterns (e.g. `%,`) causing spurious matches. Empty tags are now filtered out before assembly.
+- **Removed `metadata` parameter from `generate_content_hash()`** (#536, closes #522): The function previously accepted an optional `metadata` parameter that was silently ignored, creating API inconsistency where identical content could appear to hash differently depending on how call sites invoked the function. Parameter removed, all 5 call sites updated (`cli/ingestion.py`, `server/handlers/documents.py`, `utils/document_processing.py`, `web/api/documents.py`, `web/api/mcp.py`). 7 new unit tests added in `tests/unit/test_content_hash_consistency.py`.
 
 ---
 
 **Previous Releases**:
+- **v10.20.4** - Bug fixes: Cloudflare/Hybrid tags column always NULL in D1 INSERT (delete_by_tags silently failing) + empty-tag LIKE false matches guard (PR #534, contributor: shawnsw)
 - **v10.20.3** - Bug fixes: HTTP server auto-start (wrong module path, env var handling, startup polling, auth forwarding) + hook installer improvements (pyproject.toml check, API key generation, dual-server guidance) (PRs #529, #531)
 - **v10.20.2** - Bug fix: TypeError in `_prompt_learning_session` (missing `content_hash` in `Memory` constructor, PR #521)
 - **v10.20.1** - Security patch: serialize-javascript RCE (alerts #44 #45) + pypdf RAM exhaustion (CVE-2026-28351 / CVE-2026-27888, alerts #43 #46)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.20.4"
+version = "10.20.5"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.20.4"
+__version__ = "10.20.5"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.20.3"
+version = "10.20.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **Version bump**: 10.20.4 -> 10.20.5 (patch)

## Summary

Patch release for the content-only hashing standardization merged in PR #536.

### What Changed (PR #536, closes #522)

`generate_content_hash()` previously accepted an optional `metadata` parameter that was silently ignored. This created an inconsistent API: the same content could appear to produce different hashes depending on how call sites invoked the function, making the hashing behavior opaque and fragile.

**Fix**: The `metadata` parameter has been removed entirely. The function now only accepts `content`. All 5 affected call sites were updated:

- `src/mcp_memory_service/cli/ingestion.py`
- `src/mcp_memory_service/server/handlers/documents.py`
- `src/mcp_memory_service/utils/document_processing.py`
- `src/mcp_memory_service/web/api/documents.py`
- `src/mcp_memory_service/web/api/mcp.py`

7 new `@pytest.mark.unit` tests added in `tests/unit/test_content_hash_consistency.py` covering: no-metadata-parameter enforcement, deterministic output, content sensitivity, whitespace handling, Unicode, empty string, and long content.

## Files Updated

- `pyproject.toml` - version 10.20.4 -> 10.20.5
- `src/mcp_memory_service/_version.py` - version 10.20.4 -> 10.20.5
- `CHANGELOG.md` - new [10.20.5] entry at top
- `README.md` - Latest Release section updated, v10.20.4 moved to Previous Releases
- `CLAUDE.md` - current version line updated
- `uv.lock` - updated for new package version

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with new entry at top (after [Unreleased])
- [x] `README.md` Latest Release section updated
- [x] `CLAUDE.md` current version line updated
- [x] No `docs/index.html` update (patch release)

Fixes #522