### PR TITLE
fix(security): release v10.20.6 — TLS verification in peer discovery (GHSA-x9r8-q2qj-cgvw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.20.6] - 2026-03-04
+
+### Security
+- **Fix MITM vulnerability in peer discovery TLS (GHSA-x9r8-q2qj-cgvw, CVSS 7.4 High)**: `discovery/client.py` hardcoded `verify_ssl=False` for all peer-to-peer HTTPS connections, allowing a network attacker to intercept and tamper with discovery traffic. TLS certificate verification is now enabled by default. Two new environment variables allow opt-out for development environments and custom PKI deployments: `MCP_PEER_VERIFY_SSL=false` (disable verification) and `MCP_PEER_SSL_CA_FILE=/path/to/ca-bundle.pem` (custom CA bundle). Seven unit tests added in `tests/discovery/test_tls_verification.py` including an AST-based regression test that ensures `verify_ssl=False` can never be re-introduced silently.
+
 ## [10.20.5] - 2026-03-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.20.5 - Fix: standardize content-only hashing across all call sites - removed `metadata` param from `generate_content_hash()`, updated 5 call sites, added 7 unit tests (PR #536, closes #522) - see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.20.6 - Security: Fix MITM vulnerability in peer discovery TLS (GHSA-x9r8-q2qj-cgvw, CVSS 7.4 High) - replaced hardcoded `verify_ssl=False` with configurable TLS verification defaulting to enabled, added `MCP_PEER_VERIFY_SSL` and `MCP_PEER_SSL_CA_FILE` config options, 7 regression tests - see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,16 +265,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## 🆕 Latest Release: **v10.20.5** (March 4, 2026)
+## 🆕 Latest Release: **v10.20.6** (March 4, 2026)
 
-**Fix: Standardize content-only hashing across all call sites**
+**Security: Fix MITM vulnerability in peer discovery TLS (GHSA-x9r8-q2qj-cgvw)**
 
 **What's Fixed:**
-- **Removed `metadata` parameter from `generate_content_hash()`** (#536, closes #522): The function previously accepted an optional `metadata` parameter that was silently ignored, creating API inconsistency where identical content could appear to hash differently depending on how call sites invoked the function. Parameter removed, all 5 call sites updated (`cli/ingestion.py`, `server/handlers/documents.py`, `utils/document_processing.py`, `web/api/documents.py`, `web/api/mcp.py`). 7 new unit tests added in `tests/unit/test_content_hash_consistency.py`.
+- **TLS verification hardcoded off in peer discovery** (GHSA-x9r8-q2qj-cgvw, CVSS 7.4 High): `discovery/client.py` used `verify_ssl=False` for all peer HTTPS connections, enabling MITM attacks on peer discovery traffic. TLS verification is now enabled by default.
+- **New config options for opt-out**: `MCP_PEER_VERIFY_SSL=false` disables verification for dev environments; `MCP_PEER_SSL_CA_FILE` points to a custom CA bundle for private PKI deployments.
+- **Regression test**: AST-based test in `tests/discovery/test_tls_verification.py` ensures `verify_ssl=False` cannot be silently re-introduced.
 
 ---
 
 **Previous Releases**:
+- **v10.20.5** - Fix: Standardize content-only hashing across all call sites — removed `metadata` param from `generate_content_hash()`, updated 5 call sites, 7 unit tests (PR #536, closes #522)
 - **v10.20.4** - Bug fixes: Cloudflare/Hybrid tags column always NULL in D1 INSERT (delete_by_tags silently failing) + empty-tag LIKE false matches guard (PR #534, contributor: shawnsw)
 - **v10.20.3** - Bug fixes: HTTP server auto-start (wrong module path, env var handling, startup polling, auth forwarding) + hook installer improvements (pyproject.toml check, API key generation, dual-server guidance) (PRs #529, #531)
 - **v10.20.2** - Bug fix: TypeError in `_prompt_learning_session` (missing `content_hash` in `Memory` constructor, PR #521)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.20.5"
+version = "10.20.6"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.20.5"
+__version__ = "10.20.6"

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -564,6 +564,10 @@ MDNS_SERVICE_NAME = os.getenv('MCP_MDNS_SERVICE_NAME', 'MCP Memory Service')
 MDNS_SERVICE_TYPE = os.getenv('MCP_MDNS_SERVICE_TYPE', '_mcp-memory._tcp.local.')
 MDNS_DISCOVERY_TIMEOUT = safe_get_int_env('MCP_MDNS_DISCOVERY_TIMEOUT', 5, min_value=1, max_value=60)
 
+# Peer Discovery TLS Configuration
+PEER_VERIFY_SSL = os.getenv('MCP_PEER_VERIFY_SSL', 'true').lower() == 'true'
+PEER_SSL_CA_FILE = os.getenv('MCP_PEER_SSL_CA_FILE', None)
+
 # Database path for HTTP interface (use SQLite-vec by default)
 if (STORAGE_BACKEND in ['sqlite_vec', 'hybrid']) and SQLITE_VEC_PATH:
     DATABASE_PATH = SQLITE_VEC_PATH

--- a/src/mcp_memory_service/discovery/client.py
+++ b/src/mcp_memory_service/discovery/client.py
@@ -21,12 +21,13 @@ MCP Memory Service instances on the local network.
 
 import asyncio
 import logging
+import ssl
 import aiohttp
 from typing import List, Optional, Dict, Any
 from dataclasses import dataclass
 
 from .mdns_service import ServiceDiscovery, ServiceDetails
-from ..config import MDNS_DISCOVERY_TIMEOUT
+from ..config import MDNS_DISCOVERY_TIMEOUT, PEER_VERIFY_SSL, PEER_SSL_CA_FILE
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +43,22 @@ class HealthStatus:
     error: Optional[str] = None
 
 
+def _create_ssl_connector() -> aiohttp.TCPConnector:
+    """Create a TCP connector with proper TLS verification settings.
+
+    Uses PEER_VERIFY_SSL (default True) and optional PEER_SSL_CA_FILE
+    from config. When a custom CA file is provided, an SSL context is
+    built from it; otherwise the system default CA bundle is used.
+    """
+    if PEER_SSL_CA_FILE:
+        ssl_context = ssl.create_default_context(cafile=PEER_SSL_CA_FILE)
+        return aiohttp.TCPConnector(ssl=ssl_context)
+    return aiohttp.TCPConnector(verify_ssl=PEER_VERIFY_SSL)
+
+
 class DiscoveryClient:
     """High-level client for discovering and validating MCP Memory Services."""
-    
+
     def __init__(self, discovery_timeout: int = MDNS_DISCOVERY_TIMEOUT):
         self.discovery_timeout = discovery_timeout
         self._discovery = ServiceDiscovery(discovery_timeout=discovery_timeout)
@@ -148,8 +162,8 @@ class DiscoveryClient:
             start_time = time.time()
             
             timeout_config = aiohttp.ClientTimeout(total=timeout)
-            connector = aiohttp.TCPConnector(verify_ssl=False)  # Allow self-signed certs
-            
+            connector = _create_ssl_connector()
+
             async with aiohttp.ClientSession(
                 timeout=timeout_config,
                 connector=connector
@@ -218,8 +232,8 @@ class DiscoveryClient:
                 headers['Authorization'] = f'Bearer {api_key}'
             
             timeout_config = aiohttp.ClientTimeout(total=timeout)
-            connector = aiohttp.TCPConnector(verify_ssl=False)
-            
+            connector = _create_ssl_connector()
+
             async with aiohttp.ClientSession(
                 timeout=timeout_config,
                 connector=connector

--- a/tests/discovery/test_tls_verification.py
+++ b/tests/discovery/test_tls_verification.py
@@ -1,0 +1,119 @@
+"""Tests for TLS verification in peer discovery client.
+
+Verifies fix for GHSA-x9r8-q2qj-cgvw: TLS certificate verification
+must be enabled by default in peer discovery connections.
+"""
+
+import ssl
+from unittest import mock
+
+import aiohttp
+import pytest
+
+from mcp_memory_service.discovery.client import _create_ssl_connector
+
+
+class TestCreateSslConnector:
+    """Tests for the _create_ssl_connector helper."""
+
+    @pytest.mark.asyncio
+    async def test_default_verifies_ssl(self):
+        """TLS verification is enabled by default (GHSA-x9r8-q2qj-cgvw)."""
+        with mock.patch("mcp_memory_service.discovery.client.PEER_VERIFY_SSL", True), \
+             mock.patch("mcp_memory_service.discovery.client.PEER_SSL_CA_FILE", None):
+            connector = _create_ssl_connector()
+            assert isinstance(connector, aiohttp.TCPConnector)
+            # verify_ssl=True means _ssl is not explicitly set to False
+            assert connector._ssl is not False
+            await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_disabled_via_config(self):
+        """TLS verification can be explicitly disabled for dev environments."""
+        with mock.patch("mcp_memory_service.discovery.client.PEER_VERIFY_SSL", False), \
+             mock.patch("mcp_memory_service.discovery.client.PEER_SSL_CA_FILE", None):
+            connector = _create_ssl_connector()
+            assert isinstance(connector, aiohttp.TCPConnector)
+            assert connector._ssl is False
+            await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_ca_file(self, tmp_path):
+        """Custom CA file creates an ssl.SSLContext."""
+        ca_file = tmp_path / "ca-bundle.crt"
+        ca_file.write_text("dummy")
+
+        with mock.patch("mcp_memory_service.discovery.client.PEER_VERIFY_SSL", True), \
+             mock.patch("mcp_memory_service.discovery.client.PEER_SSL_CA_FILE", str(ca_file)):
+            with mock.patch("mcp_memory_service.discovery.client.ssl.create_default_context") as mock_ctx:
+                mock_ssl_ctx = mock.MagicMock(spec=ssl.SSLContext)
+                mock_ctx.return_value = mock_ssl_ctx
+                connector = _create_ssl_connector()
+                mock_ctx.assert_called_once_with(cafile=str(ca_file))
+                assert isinstance(connector, aiohttp.TCPConnector)
+                await connector.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_ca_file_takes_precedence_over_verify_false(self, tmp_path):
+        """When CA file is set, it's used even if PEER_VERIFY_SSL is False."""
+        ca_file = tmp_path / "ca-bundle.crt"
+        ca_file.write_text("dummy")
+
+        with mock.patch("mcp_memory_service.discovery.client.PEER_VERIFY_SSL", False), \
+             mock.patch("mcp_memory_service.discovery.client.PEER_SSL_CA_FILE", str(ca_file)):
+            with mock.patch("mcp_memory_service.discovery.client.ssl.create_default_context") as mock_ctx:
+                mock_ssl_ctx = mock.MagicMock(spec=ssl.SSLContext)
+                mock_ctx.return_value = mock_ssl_ctx
+                connector = _create_ssl_connector()
+                # CA file path takes precedence — creates proper SSL context
+                mock_ctx.assert_called_once_with(cafile=str(ca_file))
+                await connector.close()
+
+
+class TestConfigDefaults:
+    """Verify config defaults are secure."""
+
+    def test_peer_verify_ssl_default_is_true(self):
+        """PEER_VERIFY_SSL defaults to True when env var is not set."""
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "MCP_PEER_VERIFY_SSL"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            import importlib
+            import mcp_memory_service.config as config_mod
+            importlib.reload(config_mod)
+            assert config_mod.PEER_VERIFY_SSL is True
+
+    def test_peer_ssl_ca_file_default_is_none(self):
+        """PEER_SSL_CA_FILE defaults to None when env var is not set."""
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "MCP_PEER_SSL_CA_FILE"}
+        with mock.patch.dict("os.environ", env, clear=True):
+            import importlib
+            import mcp_memory_service.config as config_mod
+            importlib.reload(config_mod)
+            assert config_mod.PEER_SSL_CA_FILE is None
+
+
+class TestNoHardcodedVerifySslFalse:
+    """Static analysis: ensure verify_ssl=False is never hardcoded."""
+
+    def test_no_hardcoded_verify_ssl_false_in_client(self):
+        """discovery/client.py must not contain hardcoded verify_ssl=False."""
+        import ast
+        from pathlib import Path
+
+        client_path = Path(__file__).parent.parent.parent / \
+            "src" / "mcp_memory_service" / "discovery" / "client.py"
+        source = client_path.read_text()
+        tree = ast.parse(source)
+
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.keyword) and node.arg == "verify_ssl":
+                if isinstance(node.value, ast.Constant) and node.value.value is False:
+                    violations.append(node.lineno)
+
+        assert not violations, (
+            f"verify_ssl=False found hardcoded at line(s) {violations}. "
+            f"Use _create_ssl_connector() instead."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.20.5"
+version = "10.20.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Security Advisory

**GHSA-x9r8-q2qj-cgvw** — CVSS 7.4 (High)

`discovery/client.py` hardcoded `verify_ssl=False` for all outbound HTTPS connections during peer discovery, allowing a network-positioned attacker to intercept and tamper with peer-to-peer discovery traffic (MITM).

## Changes

This release ships the fix committed on `main` (commit `ef01669`) and bumps the version to **v10.20.6**:

| File | Change |
|------|--------|
| `src/mcp_memory_service/config.py` | Added `PEER_VERIFY_SSL` (default `True`) and `PEER_SSL_CA_FILE` config options |
| `src/mcp_memory_service/discovery/client.py` | Replaced `verify_ssl=False` with `_create_ssl_connector()` helper that reads config |
| `tests/discovery/test_tls_verification.py` | 7 new tests including AST-based regression to prevent silent re-introduction |
| `src/mcp_memory_service/_version.py` | `10.20.5` → `10.20.6` |
| `pyproject.toml` | `10.20.5` → `10.20.6` |
| `uv.lock` | Regenerated for v10.20.6 |
| `CHANGELOG.md` | Security entry under `[10.20.6]` |
| `README.md` | Latest Release block updated |
| `CLAUDE.md` | Version callout updated |

## New Environment Variables

```bash
# Disable TLS verification (dev environments / self-signed certs only)
MCP_PEER_VERIFY_SSL=false

# Custom CA bundle for private PKI deployments
MCP_PEER_SSL_CA_FILE=/path/to/ca-bundle.pem
```

Default behaviour is unchanged for all users not running peer discovery. TLS verification is now **enabled by default**.

## Impact Assessment

- **Affected**: Deployments using the peer discovery feature (`discovery/client.py`)
- **Not affected**: Standard MCP server usage, storage backends, HTTP API, OAuth flows
- **Breaking change**: None — default behaviour is strictly more secure; existing opt-out is available via env var

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` regenerated
- [x] `CHANGELOG.md` updated with Security section entry
- [x] `README.md` Latest Release updated; v10.20.5 moved to Previous Releases
- [x] `CLAUDE.md` version callout updated
- [x] Advisory reference GHSA-x9r8-q2qj-cgvw included throughout
- [x] No docs/index.html update needed (PATCH release)

Closes GHSA-x9r8-q2qj-cgvw