### PR TITLE
fix: correct query bugs and optimize hot paths in sqlite_vec storage

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1694,17 +1694,30 @@ SOLUTIONS:
             bm25_only_hashes = [h for h in all_hashes if h not in vector_memories]
             fetched_memories = {}
             if bm25_only_hashes:
-                placeholders = ",".join("?" for _ in bm25_only_hashes)
-                cursor = self.conn.execute(
-                    f"SELECT content_hash, content, tags, memory_type, metadata, "
-                    f"created_at, updated_at, created_at_iso, updated_at_iso "
-                    f"FROM memories WHERE content_hash IN ({placeholders}) AND deleted_at IS NULL",
-                    bm25_only_hashes,
-                )
-                for row in cursor.fetchall():
-                    memory = self._row_to_memory(row)
-                    if memory:
-                        fetched_memories[memory.content_hash] = memory
+                try:
+                    # Cap at SQLite parameter limit to avoid SQLITE_MAX_VARIABLE_NUMBER
+                    for batch_start in range(0, len(bm25_only_hashes), 999):
+                        batch = bm25_only_hashes[batch_start : batch_start + 999]
+                        placeholders = ",".join("?" for _ in batch)
+
+                        def fetch_batch(ph=placeholders, b=batch):
+                            cursor = self.conn.execute(
+                                f"SELECT content_hash, content, tags, memory_type, metadata, "
+                                f"created_at, updated_at, created_at_iso, updated_at_iso "
+                                f"FROM memories WHERE content_hash IN ({ph}) AND deleted_at IS NULL",
+                                b,
+                            )
+                            return cursor.fetchall()
+
+                        rows = await self._execute_with_retry(fetch_batch)
+                        for row in rows:
+                            memory = self._row_to_memory(row)
+                            if memory:
+                                fetched_memories[memory.content_hash] = memory
+                except Exception as e:
+                    logger.warning(
+                        f"Batch fetch for BM25-only hashes failed, some results may be missing: {e}"
+                    )
 
             merged_results = []
             for content_hash in all_hashes:

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1920,14 +1920,14 @@ SOLUTIONS:
             limit_clause = f"LIMIT {limit}" if limit is not None else ""
             offset_clause = f"OFFSET {offset}" if offset > 0 else ""
 
-            query = f'''
+            query = f"""
                 SELECT content_hash, content, tags, memory_type, metadata,
                        created_at, updated_at, created_at_iso, updated_at_iso
                 FROM memories
-                WHERE {tag_conditions}
+                WHERE ({tag_conditions}) AND deleted_at IS NULL
                 ORDER BY created_at DESC
                 {limit_clause} {offset_clause}
-            '''
+            """
 
             cursor = self.conn.execute(query, tag_params)
             results = []
@@ -2703,8 +2703,10 @@ SOLUTIONS:
                     '''
                     
                     if time_where:
-                        base_query += f" WHERE {time_where}"
-                    
+                        base_query += f" WHERE m.deleted_at IS NULL AND {time_where}"
+                    else:
+                        base_query += " WHERE m.deleted_at IS NULL"
+
                     base_query += " ORDER BY e.distance"
                     
                     # Prepare parameters: embedding, limit, then time filter params
@@ -2737,14 +2739,25 @@ SOLUTIONS:
                             )
                             
                             # Calculate relevance score (lower distance = higher relevance)
-                            relevance_score = max(0.0, 1.0 - distance)
-                            
-                            results.append(MemoryQueryResult(
-                                memory=memory,
-                                relevance_score=relevance_score,
-                                debug_info={"distance": distance, "backend": "sqlite-vec", "time_filtered": bool(time_where)}
-                            ))
-                            
+                            # Cosine distance ranges from 0 (identical) to 2 (opposite)
+                            relevance_score = (
+                                max(0.0, 1.0 - (float(distance) / 2.0))
+                                if distance is not None
+                                else 0.0
+                            )
+
+                            results.append(
+                                MemoryQueryResult(
+                                    memory=memory,
+                                    relevance_score=relevance_score,
+                                    debug_info={
+                                        "distance": distance,
+                                        "backend": "sqlite-vec",
+                                        "time_filtered": bool(time_where),
+                                    },
+                                )
+                            )
+
                         except Exception as parse_error:
                             logger.warning(f"Failed to parse memory result: {parse_error}")
                             continue
@@ -2765,8 +2778,10 @@ SOLUTIONS:
             '''
             
             if time_where:
-                base_query += f" WHERE {time_where}"
-            
+                base_query += f" WHERE deleted_at IS NULL AND {time_where}"
+            else:
+                base_query += " WHERE deleted_at IS NULL"
+
             base_query += " ORDER BY created_at DESC LIMIT ?"
             
             # Add limit parameter
@@ -2819,14 +2834,17 @@ SOLUTIONS:
         """Get memories within a specific time range."""
         try:
             await self.initialize()
-            cursor = self.conn.execute('''
+            cursor = self.conn.execute(
+                """
                 SELECT content_hash, content, tags, memory_type, metadata,
                        created_at, updated_at, created_at_iso, updated_at_iso
                 FROM memories
-                WHERE created_at BETWEEN ? AND ?
+                WHERE created_at BETWEEN ? AND ? AND deleted_at IS NULL
                 ORDER BY created_at DESC
-            ''', (start_time, end_time))
-            
+            """,
+                (start_time, end_time),
+            )
+
             results = []
             for row in cursor.fetchall():
                 try:
@@ -3049,6 +3067,7 @@ SOLUTIONS:
             query = """
                 SELECT content_hash, content, tags, memory_type, metadata, created_at, updated_at
                 FROM memories
+                WHERE deleted_at IS NULL
                 ORDER BY LENGTH(content) DESC
                 LIMIT ?
             """
@@ -3062,7 +3081,9 @@ SOLUTIONS:
                     memory = Memory(
                         content_hash=row[0],
                         content=row[1],
-                        tags=json.loads(row[2]) if row[2] else [],
+                        tags=[t.strip() for t in row[2].split(",") if t.strip()]
+                        if row[2]
+                        else [],
                         memory_type=row[3],
                         metadata=json.loads(row[4]) if row[4] else {},
                         created_at=row[5],
@@ -3102,7 +3123,7 @@ SOLUTIONS:
                 query = """
                     SELECT created_at
                     FROM memories
-                    WHERE created_at >= ?
+                    WHERE created_at >= ? AND deleted_at IS NULL
                     ORDER BY created_at DESC
                 """
                 cursor = self.conn.execute(query, (cutoff_timestamp,))
@@ -3110,6 +3131,7 @@ SOLUTIONS:
                 query = """
                     SELECT created_at
                     FROM memories
+                    WHERE deleted_at IS NULL
                     ORDER BY created_at DESC
                 """
                 cursor = self.conn.execute(query)

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -343,6 +343,20 @@ class SqliteVecMemoryStorage(MemoryStorage):
 
         await self._execute_with_retry(update_metadata)
 
+    async def _persist_access_metadata_batch(self, memories: List[Memory]):
+        """Batch-persist access metadata for multiple memories in one transaction."""
+        if not memories:
+            return
+
+        def batch_update():
+            self.conn.executemany(
+                "UPDATE memories SET metadata = ? WHERE content_hash = ?",
+                [(json.dumps(m.metadata), m.content_hash) for m in memories],
+            )
+            self.conn.commit()
+
+        await self._execute_with_retry(batch_update)
+
     def _run_graph_migrations(self):
         """Execute Knowledge Graph table migrations.
 
@@ -1519,12 +1533,11 @@ SOLUTIONS:
                     logger.warning(f"Failed to parse memory result: {parse_error}")
                     continue
 
-            # Persist updated metadata for accessed memories
-            for result in results:
-                try:
-                    await self._persist_access_metadata(result.memory)
-                except Exception as e:
-                    logger.warning(f"Failed to persist access metadata: {e}")
+            # Persist updated metadata for accessed memories (batched)
+            try:
+                await self._persist_access_metadata_batch([r.memory for r in results])
+            except Exception as e:
+                logger.warning(f"Failed to persist access metadata: {e}")
 
             logger.info(f"Retrieved {len(results)} memories for query: {_sanitize_log_value(query)}")
             return results
@@ -1669,11 +1682,29 @@ SOLUTIONS:
                 bm25_scores[content_hash] = self._normalize_bm25_score(bm25_rank)
 
             semantic_scores = {}
+            vector_memories = {}
             for result in vector_results:
                 semantic_scores[result.memory.content_hash] = result.relevance_score
+                vector_memories[result.memory.content_hash] = result.memory
 
             # Merge results by content_hash
             all_hashes = set(bm25_scores.keys()) | set(semantic_scores.keys())
+
+            # Batch-fetch BM25-only memories (not in vector results) in one query
+            bm25_only_hashes = [h for h in all_hashes if h not in vector_memories]
+            fetched_memories = {}
+            if bm25_only_hashes:
+                placeholders = ",".join("?" for _ in bm25_only_hashes)
+                cursor = self.conn.execute(
+                    f"SELECT content_hash, content, tags, memory_type, metadata, "
+                    f"created_at, updated_at, created_at_iso, updated_at_iso "
+                    f"FROM memories WHERE content_hash IN ({placeholders}) AND deleted_at IS NULL",
+                    bm25_only_hashes,
+                )
+                for row in cursor.fetchall():
+                    memory = self._row_to_memory(row)
+                    if memory:
+                        fetched_memories[memory.content_hash] = memory
 
             merged_results = []
             for content_hash in all_hashes:
@@ -1689,16 +1720,9 @@ SOLUTIONS:
                     semantic_weight
                 )
 
-                # Find corresponding memory (from vector_results if available)
-                memory = None
-                for result in vector_results:
-                    if result.memory.content_hash == content_hash:
-                        memory = result.memory
-                        break
-
-                # If not in vector results, fetch from database
-                if memory is None:
-                    memory = await self.get_by_hash(content_hash)
+                memory = vector_memories.get(content_hash) or fetched_memories.get(
+                    content_hash
+                )
 
                 if memory:
                     merged_results.append(MemoryQueryResult(

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -1211,6 +1211,201 @@ class TestSqliteVecTimeBasedDeletion:
         results = await storage.get_by_exact_content(content)
         assert len(results) == 0
 
+    @pytest.mark.asyncio
+    async def test_recall_time_based_excludes_deleted(self, storage):
+        """Regression: recall() time-based path must exclude soft-deleted memories."""
+        content = "Recall time-based delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["recall-delete"],
+            memory_type="note",
+        )
+        await storage.store(memory)
+
+        # Recall without query triggers time-based path
+        results = await storage.recall(n_results=100)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.recall(n_results=100)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_recall_semantic_excludes_deleted(self, storage):
+        """Regression: recall() semantic search path must exclude soft-deleted memories."""
+        content = "Recall semantic delete test unique phrase"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["recall-semantic-delete"],
+            memory_type="note",
+        )
+        await storage.store(memory)
+
+        # Recall with query triggers semantic search path
+        results = await storage.recall(query=content, n_results=10)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.recall(query=content, n_results=10)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_memories_by_time_range_excludes_deleted(self, storage):
+        """Regression: get_memories_by_time_range() must exclude soft-deleted memories."""
+        content = "Time range delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timerange-delete"],
+        )
+        await storage.store(memory)
+
+        now = time.time()
+        results = await storage.get_memories_by_time_range(now - 60, now + 60)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.get_memories_by_time_range(now - 60, now + 60)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_search_by_tag_chronological_excludes_deleted(self, storage):
+        """Regression: search_by_tag_chronological() must exclude soft-deleted memories."""
+        content = "Tag chrono delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["chrono-delete-tag"],
+        )
+        await storage.store(memory)
+
+        results = await storage.search_by_tag_chronological(["chrono-delete-tag"])
+        assert len(results) >= 1
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.search_by_tag_chronological(["chrono-delete-tag"])
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_memory_timestamps_excludes_deleted(self, storage):
+        """Regression: get_memory_timestamps() must exclude soft-deleted memories."""
+        content = "Timestamps delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timestamps-delete"],
+        )
+        await storage.store(memory)
+
+        timestamps_before = await storage.get_memory_timestamps()
+        count_before = len(timestamps_before)
+        assert count_before >= 1
+
+        await storage.delete(memory.content_hash)
+
+        timestamps_after = await storage.get_memory_timestamps()
+        assert len(timestamps_after) == count_before - 1
+
+    @pytest.mark.asyncio
+    async def test_get_memory_timestamps_with_days_excludes_deleted(self, storage):
+        """Regression: get_memory_timestamps(days=N) must exclude soft-deleted memories."""
+        content = "Timestamps days delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timestamps-days-delete"],
+        )
+        await storage.store(memory)
+
+        timestamps_before = await storage.get_memory_timestamps(days=1)
+        count_before = len(timestamps_before)
+        assert count_before >= 1
+
+        await storage.delete(memory.content_hash)
+
+        timestamps_after = await storage.get_memory_timestamps(days=1)
+        assert len(timestamps_after) == count_before - 1
+
+    @pytest.mark.asyncio
+    async def test_get_largest_memories_excludes_deleted(self, storage):
+        """Regression: get_largest_memories() must exclude soft-deleted memories."""
+        content = "A" * 500  # Large memory to ensure it ranks high
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["largest-delete"],
+        )
+        await storage.store(memory)
+
+        results = await storage.get_largest_memories(n=100)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.get_largest_memories(n=100)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_largest_memories_parses_csv_tags(self, storage):
+        """Regression: get_largest_memories() must parse comma-separated tags, not JSON."""
+        content = "Tag parsing test for largest memories"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["alpha", "beta", "gamma"],
+        )
+        await storage.store(memory)
+
+        results = await storage.get_largest_memories(n=100)
+        matched = [m for m in results if m.content_hash == memory.content_hash]
+        assert len(matched) == 1
+        assert matched[0].tags == ["alpha", "beta", "gamma"]
+
+    @pytest.mark.asyncio
+    async def test_recall_score_formula_cosine_distance(self, storage):
+        """Regression: recall() relevance score must map cosine distance [0,2] to [1,0]."""
+        # Store a memory so we can do a semantic recall
+        content = "The quick brown fox jumps over the lazy dog"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["score-test"],
+        )
+        await storage.store(memory)
+
+        # Query with the exact content — should get high relevance (close to 1.0)
+        results = await storage.recall(query=content, n_results=5)
+        assert len(results) >= 1
+
+        for r in results:
+            # Score must be in [0, 1] (not negative, which the old formula produced for distance > 1)
+            assert 0.0 <= r.relevance_score <= 1.0, (
+                f"Score {r.relevance_score} out of [0,1] range"
+            )
+
+        # The best match (exact content) should score very high
+        best = results[0]
+        assert best.relevance_score > 0.8, (
+            f"Exact content match scored only {best.relevance_score}"
+        )
+
 
 class TestSqliteVecStorageWithoutEmbeddings:
     """Test SQLite-vec storage when sentence transformers is not available."""


### PR DESCRIPTION
## Summary

Fixes 3 categories of bugs in `sqlite_vec.py` and optimizes 2 performance-critical query paths:

**Bug fixes (P0):**
- **Soft-delete leaks**: 6 query methods were missing `deleted_at IS NULL` filters, causing soft-deleted memories to appear in results: `recall()` (both semantic and time-based paths), `get_memories_by_time_range()`, `search_by_tag_chronological()`, `get_memory_timestamps()` (both branches), `get_largest_memories()`
- **Score formula**: `recall()` used `1.0 - distance` for cosine distance, but cosine distance ranges [0, 2] — changed to `max(0.0, 1.0 - (distance / 2.0))` to correctly map to [0, 1] (matching `retrieve()`)
- **Tag parsing**: `get_largest_memories()` used `json.loads()` to parse tags, but tags are stored as comma-separated strings — changed to `split(",")` (matching all other methods)

**Performance optimizations (P1):**
- **Batch access metadata**: `retrieve()` now persists access metadata in one `executemany` call instead of N individual UPDATE+COMMIT round-trips
- **Hybrid search dedup**: `retrieve_hybrid()` replaced O(n×m) nested-loop deduplication with O(n+m) dict-based merging, and replaced N+1 individual embedding fetches with a single batch query

## Test plan

- [x] 9 new regression tests added covering every fixed method
- [x] All 65 sqlite_vec tests pass (was 56 before)
- [x] Full test suite: 392/393 pass (1 pre-existing failure in `test_http_server_startup` also fails on `main`)
- [x] Code-reviewer agent approved with no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)