### PR TITLE
fix: O(n^2) memory in association sampling + broken duplicate detection

### DIFF
--- a/src/mcp_memory_service/consolidation/associations.py
+++ b/src/mcp_memory_service/consolidation/associations.py
@@ -111,7 +111,10 @@ class CreativeAssociationEngine(ConsolidationBase):
             sampled = random.sample(all_index_pairs, max_pairs)
             return [(memories[i], memories[j]) for i, j in sampled]
 
-        # Sparse sampling: generate random index pairs directly
+        # Sparse sampling: generate random index pairs directly.
+        # Invariant: max_pairs <= total_possible * 0.7 (enforced by branch above),
+        # so expected iterations are bounded at ~3.3 * max_pairs.
+        assert max_pairs <= total_possible * 0.7
         pairs: Set[Tuple[int, int]] = set()
         while len(pairs) < max_pairs:
             i, j = random.sample(range(n), 2)

--- a/src/mcp_memory_service/consolidation/associations.py
+++ b/src/mcp_memory_service/consolidation/associations.py
@@ -97,17 +97,26 @@ class CreativeAssociationEngine(ConsolidationBase):
     
     def _sample_memory_pairs(self, memories: List[Memory]) -> List[Tuple[Memory, Memory]]:
         """Sample random pairs of memories for association discovery."""
-        # Calculate maximum possible pairs
-        total_possible = len(memories) * (len(memories) - 1) // 2
+        n = len(memories)
+        total_possible = n * (n - 1) // 2
         max_pairs = min(self.max_pairs_per_run, total_possible)
-        
+
         if total_possible <= max_pairs:
-            # Return all possible pairs if total is manageable
             return list(combinations(memories, 2))
-        else:
-            # Randomly sample pairs to prevent combinatorial explosion
-            all_pairs = list(combinations(memories, 2))
-            return random.sample(all_pairs, max_pairs)
+
+        # When sampling most of the space, enumerate indices and sample
+        # to avoid rejection-sampling tail (coupon-collector degradation)
+        if max_pairs > total_possible * 0.7:
+            all_index_pairs = list(combinations(range(n), 2))
+            sampled = random.sample(all_index_pairs, max_pairs)
+            return [(memories[i], memories[j]) for i, j in sampled]
+
+        # Sparse sampling: generate random index pairs directly
+        pairs: Set[Tuple[int, int]] = set()
+        while len(pairs) < max_pairs:
+            i, j = random.sample(range(n), 2)
+            pairs.add((min(i, j), max(i, j)))
+        return [(memories[i], memories[j]) for i, j in pairs]
     
     async def _calculate_semantic_similarity(self, mem1: Memory, mem2: Memory) -> float:
         """Calculate semantic similarity between two memories using embeddings."""

--- a/src/mcp_memory_service/consolidation/consolidator.py
+++ b/src/mcp_memory_service/consolidation/consolidator.py
@@ -14,7 +14,7 @@
 
 """Main dream-inspired consolidation orchestrator."""
 
-from typing import List, Dict, Any, Protocol, Tuple
+from typing import List, Dict, Any, Optional, Protocol, Tuple
 from datetime import datetime, timedelta, timezone
 import logging
 import time
@@ -39,12 +39,28 @@ class StorageProtocol(Protocol):
     async def get_all_memories(self) -> List[Memory]: pass
     async def get_memories_by_time_range(
         self, start_time: float, end_time: float
-    ) -> List[Memory]: pass
-    async def store(self, memory: Memory) -> Tuple[bool, str]: pass
-    async def update_memory(self, memory: Memory) -> bool: pass
-    async def delete_memory(self, content_hash: str) -> bool: pass
-    async def get_memory_connections(self) -> Dict[str, int]: pass
-    async def get_access_patterns(self) -> Dict[str, datetime]: pass
+    ) -> List[Memory]:
+        pass
+
+    async def search_by_tag(
+        self, tags: List[str], time_start: Optional[float] = None
+    ) -> List[Memory]:
+        pass
+
+    async def store(self, memory: Memory) -> Tuple[bool, str]:
+        pass
+
+    async def update_memory(self, memory: Memory) -> bool:
+        pass
+
+    async def delete_memory(self, content_hash: str) -> bool:
+        pass
+
+    async def get_memory_connections(self) -> Dict[str, int]:
+        pass
+
+    async def get_access_patterns(self) -> Dict[str, datetime]:
+        pass
 
 
 class SyncPauseContext:
@@ -488,18 +504,14 @@ class DreamInspiredConsolidator:
     async def _get_existing_associations(self) -> set:
         """Get existing memory associations to avoid duplicates."""
         try:
-            # Look for existing association memories
-            all_memories = await self.storage.get_all_memories()
+            # Look for existing association memories by tag instead of scanning all
+            all_memories = await self.storage.search_by_tag(["association"])
             associations = set()
 
             for memory in all_memories:
-                if (
-                    memory.memory_type == "association"
-                    and "source_memory_hashes" in memory.metadata
-                ):
+                if "source_memory_hashes" in memory.metadata:
                     source_hashes = memory.metadata["source_memory_hashes"]
                     if isinstance(source_hashes, list) and len(source_hashes) >= 2:
-                        # Create canonical pair representation
                         pair_key = tuple(sorted(source_hashes[:2]))
                         associations.add(pair_key)
 


### PR DESCRIPTION
## Summary

Two fixes in the consolidation subsystem:

**1. O(n^2) memory in `_sample_memory_pairs()`** (`associations.py`)

The method materialized ALL `combinations(memories, 2)` into a list even when only sampling `max_pairs_per_run` (default 100). For 10k memories this creates ~50M pair objects just to pick 100.

Now uses random index pair generation which is O(max_pairs) regardless of memory count, with a fill-factor guard (>70% of space) that falls back to index enumeration + sampling to avoid rejection-sampling degradation.

**2. Broken duplicate detection in `_get_existing_associations()`** (`consolidator.py`)

The method loaded ALL memories via `get_all_memories()` then filtered for `memory_type=="association"`. But new associations are stored with `memory_type="observation"` and tag `"association"` (line 554). The type filter never matched, so the consolidator could never detect existing associations — duplicate associations were never prevented.

Now uses `search_by_tag(["association"])` which correctly matches the actual tag and uses indexed tag search instead of a full table scan. Added `search_by_tag` to `StorageProtocol` for type safety.

## Test plan

- [x] 251 consolidation-related tests pass
- [x] Code-reviewer agent approved with both findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)