### PR TITLE
fix: close remaining soft-delete gaps in query and update methods (PR #560 rebased)

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -2055,7 +2055,7 @@ SOLUTIONS:
             # is not left dangling if the soft-delete UPDATE failed.
             try:
                 self.conn.rollback()
-            except Exception:
+            except sqlite3.OperationalError:
                 pass
             error_msg = f"Failed to delete memory: {str(e)}"
             logger.error(error_msg)
@@ -2514,17 +2514,26 @@ SOLUTIONS:
                 updated_at_iso = now_iso
 
             # Update the memory
-            self.conn.execute('''
+            self.conn.execute(
+                """
                 UPDATE memories SET
                     tags = ?, memory_type = ?, metadata = ?,
                     updated_at = ?, updated_at_iso = ?,
                     created_at = ?, created_at_iso = ?
-                WHERE content_hash = ?
-            ''', (
-                new_tags, new_type, json.dumps(new_metadata),
-                updated_at, updated_at_iso, created_at, created_at_iso, content_hash
-            ))
-            
+                WHERE content_hash = ? AND deleted_at IS NULL
+            """,
+                (
+                    new_tags,
+                    new_type,
+                    json.dumps(new_metadata),
+                    updated_at,
+                    updated_at_iso,
+                    created_at,
+                    created_at_iso,
+                    content_hash,
+                ),
+            )
+
             self.conn.commit()
             
             # Create summary of updated fields
@@ -2613,15 +2622,22 @@ SOLUTIONS:
                     new_type = memory.memory_type if memory.memory_type else current_type
 
                     # Execute update
-                    cursor.execute('''
+                    cursor.execute(
+                        """
                         UPDATE memories SET
                             tags = ?, memory_type = ?, metadata = ?,
                             updated_at = ?, updated_at_iso = ?
-                        WHERE content_hash = ?
-                    ''', (
-                        new_tags, new_type, json.dumps(merged_metadata),
-                        now, now_iso, memory.content_hash
-                    ))
+                        WHERE content_hash = ? AND deleted_at IS NULL
+                    """,
+                        (
+                            new_tags,
+                            new_type,
+                            json.dumps(merged_metadata),
+                            now,
+                            now_iso,
+                            memory.content_hash,
+                        ),
+                    )
 
                     results[idx] = True
 

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -2051,6 +2051,12 @@ SOLUTIONS:
                 return False, f"Memory with hash {content_hash} not found"
 
         except Exception as e:
+            # Rollback the implicit transaction so the embedding DELETE
+            # is not left dangling if the soft-delete UPDATE failed.
+            try:
+                self.conn.rollback()
+            except Exception:
+                pass
             error_msg = f"Failed to delete memory: {str(e)}"
             logger.error(error_msg)
             return False, error_msg
@@ -2438,11 +2444,14 @@ SOLUTIONS:
                 return False, "Database not initialized"
             
             # Get current memory
-            cursor = self.conn.execute('''
+            cursor = self.conn.execute(
+                """
                 SELECT content, tags, memory_type, metadata, created_at, created_at_iso
-                FROM memories WHERE content_hash = ?
-            ''', (content_hash,))
-            
+                FROM memories WHERE content_hash = ? AND deleted_at IS NULL
+            """,
+                (content_hash,),
+            )
+
             row = cursor.fetchone()
             if not row:
                 return False, f"Memory with hash {content_hash} not found"
@@ -2574,10 +2583,13 @@ SOLUTIONS:
             for idx, memory in enumerate(memories):
                 try:
                     # Get current memory data
-                    cursor.execute('''
+                    cursor.execute(
+                        """
                         SELECT content, tags, memory_type, metadata, created_at, created_at_iso
-                        FROM memories WHERE content_hash = ?
-                    ''', (memory.content_hash,))
+                        FROM memories WHERE content_hash = ? AND deleted_at IS NULL
+                    """,
+                        (memory.content_hash,),
+                    )
 
                     row = cursor.fetchone()
                     if not row:
@@ -2922,13 +2934,13 @@ SOLUTIONS:
         try:
             await self.initialize()
             # For now, return basic statistics based on tags and content similarity
-            cursor = self.conn.execute('''
+            cursor = self.conn.execute("""
                 SELECT tags, COUNT(*) as count
                 FROM memories
-                WHERE tags IS NOT NULL AND tags != ''
+                WHERE tags IS NOT NULL AND tags != '' AND deleted_at IS NULL
                 GROUP BY tags
-            ''')
-            
+            """)
+
             connections = {}
             for row in cursor.fetchall():
                 tags_str, count = row
@@ -2948,14 +2960,14 @@ SOLUTIONS:
         try:
             await self.initialize()
             # Return recent access patterns based on updated_at timestamps
-            cursor = self.conn.execute('''
+            cursor = self.conn.execute("""
                 SELECT content_hash, updated_at_iso
                 FROM memories
-                WHERE updated_at_iso IS NOT NULL
+                WHERE updated_at_iso IS NOT NULL AND deleted_at IS NULL
                 ORDER BY updated_at DESC
                 LIMIT 100
-            ''')
-            
+            """)
+
             patterns = {}
             for row in cursor.fetchall():
                 content_hash, updated_at_iso = row

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -1278,10 +1278,96 @@ class TestSqliteVecTimeBasedDeletion:
         assert len(results) == 0
 
 
+    @pytest.mark.asyncio
+    async def test_get_memory_connections_excludes_deleted(self, storage):
+        """get_memory_connections should not count soft-deleted memories in tag groups."""
+        mem1 = Memory(
+            content="Connection test memory 1",
+            content_hash=generate_content_hash("Connection test memory 1"),
+            tags=["conn-tag"],
+        )
+        mem2 = Memory(
+            content="Connection test memory 2",
+            content_hash=generate_content_hash("Connection test memory 2"),
+            tags=["conn-tag"],
+        )
+        await storage.store(mem1)
+        await storage.store(mem2)
+
+        connections_before = await storage.get_memory_connections()
+        assert any(count >= 2 for count in connections_before.values())
+
+        # Soft-delete one
+        await storage.delete(mem1.content_hash)
+
+        connections_after = await storage.get_memory_connections()
+        # The deleted memory's tag group should have one fewer count
+        total_before = sum(connections_before.values())
+        total_after = sum(connections_after.values())
+        assert total_after < total_before
+
+    @pytest.mark.asyncio
+    async def test_get_access_patterns_excludes_deleted(self, storage):
+        """get_access_patterns should not return soft-deleted memories."""
+        mem = Memory(
+            content="Access pattern test memory",
+            content_hash=generate_content_hash("Access pattern test memory"),
+            tags=["access-test"],
+        )
+        await storage.store(mem)
+
+        patterns_before = await storage.get_access_patterns()
+        assert mem.content_hash in patterns_before
+
+        await storage.delete(mem.content_hash)
+
+        patterns_after = await storage.get_access_patterns()
+        assert mem.content_hash not in patterns_after
+
+    @pytest.mark.asyncio
+    async def test_update_memory_metadata_skips_deleted(self, storage):
+        """update_memory_metadata should not modify a soft-deleted memory."""
+        mem = Memory(
+            content="Metadata update test",
+            content_hash=generate_content_hash("Metadata update test"),
+            tags=["meta-test"],
+        )
+        await storage.store(mem)
+        await storage.delete(mem.content_hash)
+
+        success, msg = await storage.update_memory_metadata(
+            mem.content_hash, {"tags": ["should-not-apply"]}
+        )
+        assert not success
+        assert "not found" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_update_memories_batch_skips_deleted(self, storage):
+        """update_memories_batch should skip soft-deleted memories gracefully."""
+        mem = Memory(
+            content="Batch update test",
+            content_hash=generate_content_hash("Batch update test"),
+            tags=["batch-test"],
+            metadata={"new_key": "new_value"},
+        )
+        await storage.store(mem)
+        await storage.delete(mem.content_hash)
+
+        # Batch update should skip the deleted memory without error
+        updated_mem = Memory(
+            content="Batch update test",
+            content_hash=mem.content_hash,
+            tags=["batch-test"],
+            metadata={"updated": True},
+        )
+        results = await storage.update_memories_batch([updated_mem])
+        # Returns List[bool] — the deleted memory should not be updated
+        assert results == [False]
+
 
 class TestSqliteVecStorageWithoutEmbeddings:
     """Test SQLite-vec storage when sentence transformers is not available."""
-    
+
     @pytest.mark.asyncio
     async def test_initialization_without_embeddings(self):
         """Test that storage can initialize without sentence transformers."""


### PR DESCRIPTION
This is a rebased version of #560 (by @chriscoey) which conflicted after #557 and #558 were merged.

## Changes from #560

- Add `deleted_at IS NULL` to 4 methods that could return or modify tombstoned memories:
  - `get_memory_connections()` — tag group counts included deleted memories
  - `get_access_patterns()` — returned content hashes of deleted memories
  - `update_memory_metadata()` — could modify a soft-deleted memory
  - `update_memories_batch()` — same issue for the batch update path
- Add explicit `rollback()` in `delete()` error handler to ensure the embedding DELETE is reversed if the soft-delete UPDATE fails (catches `sqlite3.OperationalError` specifically)

## Tests

- `test_get_memory_connections_excludes_deleted`
- `test_get_access_patterns_excludes_deleted`
- `test_update_memory_metadata_skips_deleted`
- `test_update_memories_batch_skips_deleted`

Co-authored-by: Chris Coey <coey.chris@gmail.com>