### PR TITLE
fix: correct query bugs and optimize hot paths in sqlite_vec storage (PR #557 rebased)

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -352,6 +352,20 @@ class SqliteVecMemoryStorage(MemoryStorage):
 
         await self._execute_with_retry(update_metadata)
 
+    async def _persist_access_metadata_batch(self, memories: List[Memory]):
+        """Batch-persist access metadata for multiple memories in one transaction."""
+        if not memories:
+            return
+
+        def batch_update():
+            self.conn.executemany(
+                "UPDATE memories SET metadata = ? WHERE content_hash = ?",
+                [(json.dumps(m.metadata), m.content_hash) for m in memories],
+            )
+            self.conn.commit()
+
+        await self._execute_with_retry(batch_update)
+
     def _run_graph_migrations(self):
         """Execute Knowledge Graph table migrations.
 
@@ -1563,12 +1577,11 @@ SOLUTIONS:
                     logger.warning(f"Failed to parse memory result: {parse_error}")
                     continue
 
-            # Persist updated metadata for accessed memories
-            for result in results:
-                try:
-                    await self._persist_access_metadata(result.memory)
-                except Exception as e:
-                    logger.warning(f"Failed to persist access metadata: {e}")
+            # Persist updated metadata for accessed memories (batched)
+            try:
+                await self._persist_access_metadata_batch([r.memory for r in results])
+            except Exception as e:
+                logger.warning(f"Failed to persist access metadata: {e}")
 
             logger.info(f"Retrieved {len(results)} memories for query: {_sanitize_log_value(query)}")
             return results
@@ -1713,11 +1726,42 @@ SOLUTIONS:
                 bm25_scores[content_hash] = self._normalize_bm25_score(bm25_rank)
 
             semantic_scores = {}
+            vector_memories = {}
             for result in vector_results:
                 semantic_scores[result.memory.content_hash] = result.relevance_score
+                vector_memories[result.memory.content_hash] = result.memory
 
             # Merge results by content_hash
             all_hashes = set(bm25_scores.keys()) | set(semantic_scores.keys())
+
+            # Batch-fetch BM25-only memories (not in vector results) in one query
+            bm25_only_hashes = [h for h in all_hashes if h not in vector_memories]
+            fetched_memories = {}
+            if bm25_only_hashes:
+                try:
+                    # Cap at SQLite parameter limit to avoid SQLITE_MAX_VARIABLE_NUMBER
+                    for batch_start in range(0, len(bm25_only_hashes), 999):
+                        batch = bm25_only_hashes[batch_start : batch_start + 999]
+                        placeholders = ",".join("?" for _ in batch)
+
+                        def fetch_batch(ph=placeholders, b=batch):
+                            cursor = self.conn.execute(
+                                f"SELECT content_hash, content, tags, memory_type, metadata, "
+                                f"created_at, updated_at, created_at_iso, updated_at_iso "
+                                f"FROM memories WHERE content_hash IN ({ph}) AND deleted_at IS NULL",
+                                b,
+                            )
+                            return cursor.fetchall()
+
+                        rows = await self._execute_with_retry(fetch_batch)
+                        for row in rows:
+                            memory = self._row_to_memory(row)
+                            if memory:
+                                fetched_memories[memory.content_hash] = memory
+                except Exception as e:
+                    logger.warning(
+                        f"Batch fetch for BM25-only hashes failed, some results may be missing: {e}"
+                    )
 
             merged_results = []
             for content_hash in all_hashes:
@@ -1733,16 +1777,9 @@ SOLUTIONS:
                     semantic_weight
                 )
 
-                # Find corresponding memory (from vector_results if available)
-                memory = None
-                for result in vector_results:
-                    if result.memory.content_hash == content_hash:
-                        memory = result.memory
-                        break
-
-                # If not in vector results, fetch from database
-                if memory is None:
-                    memory = await self.get_by_hash(content_hash)
+                memory = vector_memories.get(content_hash) or fetched_memories.get(
+                    content_hash
+                )
 
                 if memory:
                     merged_results.append(MemoryQueryResult(
@@ -2786,10 +2823,12 @@ SOLUTIONS:
                     '''
                     
                     if time_where:
-                        base_query += f" WHERE {time_where}"
-                    
+                        base_query += f" WHERE m.deleted_at IS NULL AND {time_where}"
+                    else:
+                        base_query += " WHERE m.deleted_at IS NULL"
+
                     base_query += " ORDER BY e.distance"
-                    
+
                     # Prepare parameters: embedding, limit, then time filter params
                     query_params = [serialize_float32(query_embedding), n_results] + params
                     
@@ -2820,12 +2859,21 @@ SOLUTIONS:
                             )
                             
                             # Calculate relevance score (lower distance = higher relevance)
-                            relevance_score = max(0.0, 1.0 - distance)
-                            
+                            # Cosine distance ranges from 0 (identical) to 2 (opposite)
+                            relevance_score = (
+                                max(0.0, 1.0 - (float(distance) / 2.0))
+                                if distance is not None
+                                else 0.0
+                            )
+
                             results.append(MemoryQueryResult(
                                 memory=memory,
                                 relevance_score=relevance_score,
-                                debug_info={"distance": distance, "backend": "sqlite-vec", "time_filtered": bool(time_where)}
+                                debug_info={
+                                    "distance": distance,
+                                    "backend": "sqlite-vec",
+                                    "time_filtered": bool(time_where),
+                                }
                             ))
                             
                         except Exception as parse_error:
@@ -2846,10 +2894,12 @@ SOLUTIONS:
                        created_at, updated_at, created_at_iso, updated_at_iso
                 FROM memories
             '''
-            
+
             if time_where:
-                base_query += f" WHERE {time_where}"
-            
+                base_query += f" WHERE deleted_at IS NULL AND {time_where}"
+            else:
+                base_query += " WHERE deleted_at IS NULL"
+
             base_query += " ORDER BY created_at DESC LIMIT ?"
             
             # Add limit parameter
@@ -2906,7 +2956,7 @@ SOLUTIONS:
                 SELECT content_hash, content, tags, memory_type, metadata,
                        created_at, updated_at, created_at_iso, updated_at_iso
                 FROM memories
-                WHERE created_at BETWEEN ? AND ?
+                WHERE created_at BETWEEN ? AND ? AND deleted_at IS NULL
                 ORDER BY created_at DESC
             ''', (start_time, end_time))
             
@@ -3138,6 +3188,7 @@ SOLUTIONS:
             query = """
                 SELECT content_hash, content, tags, memory_type, metadata, created_at, updated_at
                 FROM memories
+                WHERE deleted_at IS NULL
                 ORDER BY LENGTH(content) DESC
                 LIMIT ?
             """
@@ -3151,7 +3202,7 @@ SOLUTIONS:
                     memory = Memory(
                         content_hash=row[0],
                         content=row[1],
-                        tags=json.loads(row[2]) if row[2] else [],
+                        tags=[t.strip() for t in row[2].split(",") if t.strip()] if row[2] else [],
                         memory_type=row[3],
                         metadata=json.loads(row[4]) if row[4] else {},
                         created_at=row[5],
@@ -3191,7 +3242,7 @@ SOLUTIONS:
                 query = """
                     SELECT created_at
                     FROM memories
-                    WHERE created_at >= ?
+                    WHERE created_at >= ? AND deleted_at IS NULL
                     ORDER BY created_at DESC
                 """
                 cursor = self.conn.execute(query, (cutoff_timestamp,))
@@ -3199,6 +3250,7 @@ SOLUTIONS:
                 query = """
                     SELECT created_at
                     FROM memories
+                    WHERE deleted_at IS NULL
                     ORDER BY created_at DESC
                 """
                 cursor = self.conn.execute(query)

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -1364,6 +1364,198 @@ class TestSqliteVecTimeBasedDeletion:
         # Returns List[bool] — the deleted memory should not be updated
         assert results == [False]
 
+    @pytest.mark.asyncio
+    async def test_recall_time_based_excludes_deleted(self, storage):
+        """Regression: recall() time-based path must exclude soft-deleted memories."""
+        content = "Recall time-based delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["recall-delete"],
+            memory_type="note",
+        )
+        await storage.store(memory)
+
+        # Recall without query triggers time-based path
+        results = await storage.recall(n_results=100)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.recall(n_results=100)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_recall_semantic_excludes_deleted(self, storage):
+        """Regression: recall() semantic search path must exclude soft-deleted memories."""
+        content = "Recall semantic delete test unique phrase"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["recall-semantic-delete"],
+            memory_type="note",
+        )
+        await storage.store(memory)
+
+        # Recall with query triggers semantic search path
+        results = await storage.recall(query=content, n_results=10)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.recall(query=content, n_results=10)
+        hashes = [r.memory.content_hash for r in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_memories_by_time_range_excludes_deleted(self, storage):
+        """Regression: get_memories_by_time_range() must exclude soft-deleted memories."""
+        content = "Time range delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timerange-delete"],
+        )
+        await storage.store(memory)
+
+        now = time.time()
+        results = await storage.get_memories_by_time_range(now - 60, now + 60)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.get_memories_by_time_range(now - 60, now + 60)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_search_by_tag_chronological_excludes_deleted(self, storage):
+        """Regression: search_by_tag_chronological() must exclude soft-deleted memories."""
+        content = "Tag chrono delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["chrono-delete-tag"],
+        )
+        await storage.store(memory)
+
+        results = await storage.search_by_tag_chronological(["chrono-delete-tag"])
+        assert len(results) >= 1
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.search_by_tag_chronological(["chrono-delete-tag"])
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_memory_timestamps_excludes_deleted(self, storage):
+        """Regression: get_memory_timestamps() must exclude soft-deleted memories."""
+        content = "Timestamps delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timestamps-delete"],
+        )
+        await storage.store(memory)
+
+        timestamps_before = await storage.get_memory_timestamps()
+        count_before = len(timestamps_before)
+        assert count_before >= 1
+
+        await storage.delete(memory.content_hash)
+
+        timestamps_after = await storage.get_memory_timestamps()
+        assert len(timestamps_after) == count_before - 1
+
+    @pytest.mark.asyncio
+    async def test_get_memory_timestamps_with_days_excludes_deleted(self, storage):
+        """Regression: get_memory_timestamps(days=N) must exclude soft-deleted memories."""
+        content = "Timestamps days delete test"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["timestamps-days-delete"],
+        )
+        await storage.store(memory)
+
+        timestamps_before = await storage.get_memory_timestamps(days=1)
+        count_before = len(timestamps_before)
+        assert count_before >= 1
+
+        await storage.delete(memory.content_hash)
+
+        timestamps_after = await storage.get_memory_timestamps(days=1)
+        assert len(timestamps_after) == count_before - 1
+
+    @pytest.mark.asyncio
+    async def test_get_largest_memories_excludes_deleted(self, storage):
+        """Regression: get_largest_memories() must exclude soft-deleted memories."""
+        content = "A" * 500  # Large memory to ensure it ranks high
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["largest-delete"],
+        )
+        await storage.store(memory)
+
+        results = await storage.get_largest_memories(n=100)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash in hashes
+
+        await storage.delete(memory.content_hash)
+
+        results = await storage.get_largest_memories(n=100)
+        hashes = [m.content_hash for m in results]
+        assert memory.content_hash not in hashes
+
+    @pytest.mark.asyncio
+    async def test_get_largest_memories_parses_csv_tags(self, storage):
+        """Regression: get_largest_memories() must parse comma-separated tags, not JSON."""
+        content = "Tag parsing test for largest memories"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["alpha", "beta", "gamma"],
+        )
+        await storage.store(memory)
+
+        results = await storage.get_largest_memories(n=100)
+        matched = [m for m in results if m.content_hash == memory.content_hash]
+        assert len(matched) == 1
+        assert matched[0].tags == ["alpha", "beta", "gamma"]
+
+    @pytest.mark.asyncio
+    async def test_recall_score_formula_cosine_distance(self, storage):
+        """Regression: recall() relevance score must map cosine distance [0,2] to [1,0]."""
+        content = "The quick brown fox jumps over the lazy dog"
+        memory = Memory(
+            content=content,
+            content_hash=generate_content_hash(content),
+            tags=["score-test"],
+        )
+        await storage.store(memory)
+
+        results = await storage.recall(query=content, n_results=5)
+        assert len(results) >= 1
+
+        for r in results:
+            # Score must be in [0, 1] (not negative, which the old formula produced for distance > 1)
+            assert 0.0 <= r.relevance_score <= 1.0, (
+                f"Score {r.relevance_score} out of [0,1] range"
+            )
+
+        best = results[0]
+        assert best.relevance_score > 0.8, (
+            f"Exact content match scored only {best.relevance_score}"
+        )
+
 
 class TestSqliteVecStorageWithoutEmbeddings:
     """Test SQLite-vec storage when sentence transformers is not available."""


### PR DESCRIPTION
This is a rebased version of #557 (by @chriscoey) which conflicted with #558 and #562 (all touching `sqlite_vec.py`).

## Changes from #557

**Bug fixes (P0):**
- **Soft-delete leaks**: `recall()` (both semantic and time-based paths), `get_memories_by_time_range()`, `get_largest_memories()`, `get_memory_timestamps()` (both branches) were missing `deleted_at IS NULL` filters
- **Score formula**: `recall()` used `1.0 - distance` for cosine distance, but cosine distance ranges [0, 2] — changed to `max(0.0, 1.0 - (distance / 2.0))` to correctly map to [0, 1]
- **Tag parsing**: `get_largest_memories()` used `json.loads()` to parse tags, but tags are stored as comma-separated strings — changed to `split(",")`

**Performance optimizations (P1):**
- **Batch access metadata**: `retrieve()` now persists access metadata in one `executemany` call instead of N individual UPDATE+COMMIT round-trips (new `_persist_access_metadata_batch()` method)
- **Hybrid search dedup**: `retrieve_hybrid()` replaced O(n×m) nested-loop deduplication with O(n+m) dict-based merging, and replaced N+1 individual embedding fetches with a single batch query (capped at 999 to avoid `SQLITE_MAX_VARIABLE_NUMBER`)

## Tests

9 new regression tests covering all fixed methods.

Co-authored-by: Chris Coey <coey.chris@gmail.com>

Closes #557