### PR TITLE
fix: update_and_restart.sh health check reads status field (v10.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.25.2] - 2026-03-07
+
+### Fixed
+
+- **Health check in `update_and_restart.sh` always reported "unknown" version**: The `/api/health` endpoint was stripped of its `version` field in v10.25.1 (security patch GHSA-73hc-m4hx-79pj). The update script still tried to read `data.get('version')`, causing it to always fall back to "unknown" and wait the full 15-second timeout before giving up. The check now reads the `status` field (`"healthy"`) to confirm the server is up, and reports the already-known pip-installed version instead.
+
 ## [10.25.1] - 2026-03-06
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.24.0 - External embedding API silent fallback fixed: raises RuntimeError on API failure instead of mixing embedding spaces (#551), DRY error messages with DB dimension detection, stale health endpoint integration test corrected — 10 new tests, 1,397 total — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.25.2 - Health check in `update_and_restart.sh` fixed to read `status` field instead of removed `version` field (GHSA-73hc-m4hx-79pj follow-up) — scripts-only patch, 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,19 +265,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.25.1** (March 5, 2026)
+## Latest Release: **v10.25.2** (March 7, 2026)
 
-**Bug fix: external embedding API failure now raises an error instead of silently corrupting the vector space**
+**Patch fix: `update_and_restart.sh` health check now reads `status` field instead of removed `version` field**
 
 **What's New:**
-- **Fix silent fallback on external embedding API failure** (closes #551): When an external embedding provider (vLLM, Ollama, TEI, OpenAI-compatible) returned an error, the service silently fell back to the local ONNX model, mixing embedding spaces and causing all semantic searches to return incorrect results. Now raises a hard `RuntimeError` with the API failure reason and, when detectable, the existing DB dimension.
-- **DRY, informative error messages**: Error includes the detected DB embedding dimension from `sqlite_master` (via `_get_existing_db_embedding_dimension()`) to help diagnose mismatches.
-- **Stale integration test corrected**: `/api/health` integration test updated to match the security-hardened endpoint (GHSA-73hc-m4hx-79pj stripped the `version` field).
-- **1,397 tests** now passing (10 new regression tests for issue #551)
+- **Fix `update_and_restart.sh` always reporting "unknown" version**: The `/api/health` endpoint had its `version` field removed in v10.25.1 (security patch GHSA-73hc-m4hx-79pj), but the update script still tried to read `data.get('version')`. This caused the script to always report "unknown" and wait the full 15-second timeout. The check now reads the `status` field (`"healthy"`) to confirm the server is up and reports the pip-installed version instead.
+- **No Python changes**: Scripts-only fix; all 1,420 tests continue to pass unchanged.
 
 ---
 
 **Previous Releases**:
+- **v10.25.1** - Security: CORS wildcard default changed to localhost-only, soft-delete leak in `search_by_tag_chronological()` fixed (GHSA-g9rg-8vq5-mpwm)
+- **v10.25.0** - Embedding migration script, 5 soft-delete leak fixes, cosine distance formula fix, substring tag matching fix, O(n²) association sampling fix — 23 new tests, 1,420 total
+- **v10.24.0** - External embedding API silent fallback fixed: raises RuntimeError on API failure instead of mixing embedding spaces (#551) — 10 new tests, 1,397 total
 - **v10.23.0** - Quality scorer fix, consolidator improvements, two new opt-out flags: fix asyncio NameError in ai_evaluator.py (#544), fix consolidator invalid memory_type and dedup bug (#545), MCP_TYPED_EDGES_ENABLED opt-out (#546), MCP_CONSOLIDATION_STORE_ASSOCIATIONS opt-out (#547) — 14 new tests
 - **v10.22.0** - Consolidation engine stability: fix memory_consolidate status KeyError (#542), prevent exponential metadata prefix nesting (#543), reduce RelationshipInferenceEngine false positive rate (#541) — 40 new tests
 - **v10.21.1** - Security: Resolve 5 CodeQL code scanning alerts — removed unused imports, fixed empty except clause with explanatory comment, mitigated stack-trace exposure via `repr()` in consolidation API responses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.25.1"
+version = "10.25.2"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update_and_restart.sh
+++ b/scripts/update_and_restart.sh
@@ -468,12 +468,12 @@ else
 
     while [ $WAIT_COUNT -lt $MAX_WAIT ]; do
         # Try HTTPS first (most common), then HTTP
+        # Note: /api/health returns only {"status":"healthy"} (no version)
+        # since v10.25.1 security patch (GHSA-73hc-m4hx-79pj)
         if curl -sk --max-time 2 "$HEALTH_URL_HTTPS" > /dev/null 2>&1; then
-            # Get health data
             HEALTH_DATA=$(curl -sk --max-time 2 "$HEALTH_URL_HTTPS")
             HEALTH_URL="$HEALTH_URL_HTTPS"
         elif curl -s --max-time 2 "$HEALTH_URL_HTTP" > /dev/null 2>&1; then
-            # Get health data
             HEALTH_DATA=$(curl -s --max-time 2 "$HEALTH_URL_HTTP")
             HEALTH_URL="$HEALTH_URL_HTTP"
         else
@@ -481,14 +481,14 @@ else
         fi
 
         if [ -n "$HEALTH_DATA" ]; then
-            SERVER_VERSION=$(echo "$HEALTH_DATA" | "$VENV_PYTHON" -c "import sys, json; data=json.load(sys.stdin); print(data.get('version', 'unknown'))" 2>/dev/null || echo "unknown")
+            HEALTH_STATUS=$(echo "$HEALTH_DATA" | "$VENV_PYTHON" -c "import sys, json; data=json.load(sys.stdin); print(data.get('status', 'unknown'))" 2>/dev/null || echo "unknown")
 
-            if [ "$SERVER_VERSION" = "$NEW_VERSION" ]; then
-                log_success "Server healthy and running version ${SERVER_VERSION}"
+            if [ "$HEALTH_STATUS" = "healthy" ]; then
+                log_success "Server healthy (installed version: ${INSTALLED_VERSION})"
                 break
             else
-                log_warning "Server running old version: ${SERVER_VERSION} (expected: ${NEW_VERSION})"
-                log_info "Waiting for server to reload... (${WAIT_COUNT}s)"
+                log_warning "Server returned status: ${HEALTH_STATUS}"
+                log_info "Waiting for server to become healthy... (${WAIT_COUNT}s)"
             fi
         fi
 

--- a/scripts/update_and_restart.sh
+++ b/scripts/update_and_restart.sh
@@ -470,11 +470,9 @@ else
         # Try HTTPS first (most common), then HTTP
         # Note: /api/health returns only {"status":"healthy"} (no version)
         # since v10.25.1 security patch (GHSA-73hc-m4hx-79pj)
-        if curl -sk --max-time 2 "$HEALTH_URL_HTTPS" > /dev/null 2>&1; then
-            HEALTH_DATA=$(curl -sk --max-time 2 "$HEALTH_URL_HTTPS")
+        if HEALTH_DATA=$(curl -sk --max-time 2 "$HEALTH_URL_HTTPS" 2>/dev/null); then
             HEALTH_URL="$HEALTH_URL_HTTPS"
-        elif curl -s --max-time 2 "$HEALTH_URL_HTTP" > /dev/null 2>&1; then
-            HEALTH_DATA=$(curl -s --max-time 2 "$HEALTH_URL_HTTP")
+        elif HEALTH_DATA=$(curl -s --max-time 2 "$HEALTH_URL_HTTP" 2>/dev/null); then
             HEALTH_URL="$HEALTH_URL_HTTP"
         else
             HEALTH_DATA=""

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.25.1"
+__version__ = "10.25.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.25.1"
+version = "10.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- Fix `update_and_restart.sh` health check: reads `status` field (`"healthy"`) instead of the removed `version` field, preventing the script from always reporting "unknown" version and waiting the full 15-second timeout
- Version bump to v10.25.2 across `_version.py`, `pyproject.toml`, `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `uv.lock`

## Motivation

The `/api/health` endpoint had its `version` field stripped in v10.25.1 as part of security patch GHSA-73hc-m4hx-79pj. The `update_and_restart.sh` script was not updated to match, so it always fell back to "unknown" for the version display and then waited the full 15-second timeout before concluding the server was running. This was a user-visible regression for anyone using the update script after upgrading to v10.25.1.

## Testing

- No Python changes; shell script only
- All 1,420 existing tests continue to pass unchanged
- Verified version consistency across all four version files

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with `[10.25.2]` entry
- [x] `README.md` Latest Release section updated (also corrects stale v10.25.1 content description)
- [x] `CLAUDE.md` Current Version callout updated
- [x] No `docs/index.html` change (PATCH release — landing page only updated for MINOR/MAJOR)