### PR TITLE
fix: hybrid sync early-exit and dashboard version badge (clean)

### DIFF
--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1187,8 +1187,8 @@ class HybridMemoryStorage(MemoryStorage):
                     if consecutive_empty_batches >= HYBRID_MAX_EMPTY_BATCHES and synced_count > 0:
                         logger.info(f"Completed after {consecutive_empty_batches} empty batches - {synced_count}/{missing_count} synced")
                         break
-                    elif processed_count >= HYBRID_MIN_CHECK_COUNT and synced_count == 0:
-                        logger.info(f"No missing memories after checking {processed_count} memories")
+                    elif processed_count >= secondary_count and synced_count == 0:
+                        logger.info(f"No missing memories after checking all {processed_count} memories")
                         break
 
                     await asyncio.sleep(0.01)

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -784,7 +784,7 @@ class MemoryDashboard {
      */
     async loadVersion() {
         try {
-            const healthResponse = await this.apiCall('/health');
+            const healthResponse = await this.apiCall('/health/detailed');
             const versionBadge = document.getElementById('versionBadge');
             if (versionBadge && healthResponse.version) {
                 versionBadge.textContent = `v${healthResponse.version}`;


### PR DESCRIPTION
## Summary
Supersedes #565 — clean PR with only the two actual fixes, no unrelated MCP Apps code.

- **Hybrid sync premature termination**: Cloud-to-local sync aborted after checking `HYBRID_MIN_CHECK_COUNT` (1000) memories when `synced_count == 0`, even with thousands still unchecked. Changed early-exit to only break after checking all `secondary_count` memories.
- **Dashboard version badge**: `loadVersion()` called `/health` (returns only `{"status":"healthy"}` since v10.21.0 GHSA-73hc), now calls `/health/detailed` which includes the version field.

## Changes
- `src/mcp_memory_service/storage/hybrid.py`: Early-exit threshold changed from `HYBRID_MIN_CHECK_COUNT` to `secondary_count`
- `src/mcp_memory_service/web/static/app.js`: `/health` → `/health/detailed` in `loadVersion()`

## Test plan
- [ ] Start fresh local DB with fewer memories than Cloudflare — verify sync completes fully
- [ ] Verify dashboard shows version badge (e.g. `v10.25.2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)