### PR TITLE
fix: cap strict stdio eager-init timeout to avoid handshake timeouts

### DIFF
--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -260,14 +260,16 @@ def get_recommended_timeout() -> float:
     # Keep eager init conservative and rely on lazy-load fallback.
     client = detect_mcp_client_simple()
     ADAPTIVE_TIMEOUT_CLIENT = 'lm_studio'
-    STRICT_CLIENT_TIMEOUT_CAP_S = 5.0
-    if client != ADAPTIVE_TIMEOUT_CLIENT:
-        strict_timeout = min(timeout, STRICT_CLIENT_TIMEOUT_CAP_S)
-        if strict_timeout != timeout:
-            logger.info(
-                "Strict MCP client detected (%s); capping eager init timeout to %.1fs",
-                client,
-                strict_timeout,
+    client = detect_mcp_client_simple()
+    if client != 'lm_studio':
+        strict_timeout = min(timeout, 5.0)
+        logger.info(
+            "Strict MCP client detected (%s); capping eager init timeout from %.1fs to %.1fs",
+            client,
+            timeout,
+            strict_timeout,
+        )
+        timeout = strict_timeout
             )
         timeout = strict_timeout
 

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -259,8 +259,10 @@ def get_recommended_timeout() -> float:
     # Strict stdio clients often have small handshake budgets.
     # Keep eager init conservative and rely on lazy-load fallback.
     client = detect_mcp_client_simple()
-    if client != 'lm_studio':
-        strict_timeout = min(timeout, 5.0)
+    ADAPTIVE_TIMEOUT_CLIENT = 'lm_studio'
+    STRICT_CLIENT_TIMEOUT_CAP_S = 5.0
+    if client != ADAPTIVE_TIMEOUT_CLIENT:
+        strict_timeout = min(timeout, STRICT_CLIENT_TIMEOUT_CAP_S)
         if strict_timeout != timeout:
             logger.info(
                 "Strict MCP client detected (%s); capping eager init timeout to %.1fs",

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -221,6 +221,9 @@ def get_recommended_timeout() -> float:
 
     Can be overridden via MCP_INIT_TIMEOUT environment variable.
     Useful for Windows systems where ONNX model initialization takes longer.
+
+    For strict stdio clients (default: Claude Desktop/Codex-like), keep eager
+    initialization timeout short so MCP handshake is not blocked by heavy startup.
     """
     # Allow explicit override via environment variable
     env_timeout = os.getenv('MCP_INIT_TIMEOUT')
@@ -252,5 +255,18 @@ def get_recommended_timeout() -> float:
     if first_run:
         timeout *= 2  # Double the timeout
         logger.warning(f"First run detected, extending timeout to {timeout}s")
+
+    # Strict stdio clients often have small handshake budgets.
+    # Keep eager init conservative and rely on lazy-load fallback.
+    client = detect_mcp_client_simple()
+    if client != 'lm_studio':
+        strict_timeout = min(timeout, 5.0)
+        if strict_timeout != timeout:
+            logger.info(
+                "Strict MCP client detected (%s); capping eager init timeout to %.1fs",
+                client,
+                strict_timeout,
+            )
+        timeout = strict_timeout
 
     return timeout

--- a/src/mcp_memory_service/dependency_check.py
+++ b/src/mcp_memory_service/dependency_check.py
@@ -271,6 +271,6 @@ def get_recommended_timeout() -> float:
         )
         timeout = strict_timeout
             )
-        timeout = strict_timeout
+    return timeout
 
     return timeout

--- a/tests/unit/test_dependency_check.py
+++ b/tests/unit/test_dependency_check.py
@@ -57,3 +57,23 @@ class TestGetRecommendedTimeout:
         from mcp_memory_service.dependency_check import get_recommended_timeout
         result = get_recommended_timeout()
         assert result > 0
+
+    def test_strict_clients_are_capped_to_5s(self, monkeypatch):
+        """Strict stdio clients should not block handshake with long eager init."""
+        monkeypatch.delenv('MCP_INIT_TIMEOUT', raising=False)
+        from mcp_memory_service import dependency_check
+        monkeypatch.setattr(dependency_check, 'detect_mcp_client_simple', lambda: 'claude_desktop')
+        monkeypatch.setattr(dependency_check, 'check_critical_dependencies', lambda: (False, ['torch']))
+        monkeypatch.setattr(dependency_check, 'is_first_run', lambda: True)
+        result = dependency_check.get_recommended_timeout()
+        assert result == 5.0
+
+    def test_lm_studio_keeps_adaptive_timeout(self, monkeypatch):
+        """LM Studio keeps longer adaptive timeout for heavyweight local startup."""
+        monkeypatch.delenv('MCP_INIT_TIMEOUT', raising=False)
+        from mcp_memory_service import dependency_check
+        monkeypatch.setattr(dependency_check, 'detect_mcp_client_simple', lambda: 'lm_studio')
+        monkeypatch.setattr(dependency_check, 'check_critical_dependencies', lambda: (False, ['torch']))
+        monkeypatch.setattr(dependency_check, 'is_first_run', lambda: True)
+        result = dependency_check.get_recommended_timeout()
+        assert result >= 30.0

--- a/tests/unit/test_dependency_check.py
+++ b/tests/unit/test_dependency_check.py
@@ -70,10 +70,14 @@ class TestGetRecommendedTimeout:
 
     def test_lm_studio_keeps_adaptive_timeout(self, monkeypatch):
         """LM Studio keeps longer adaptive timeout for heavyweight local startup."""
+        import platform
         monkeypatch.delenv('MCP_INIT_TIMEOUT', raising=False)
         from mcp_memory_service import dependency_check
         monkeypatch.setattr(dependency_check, 'detect_mcp_client_simple', lambda: 'lm_studio')
         monkeypatch.setattr(dependency_check, 'check_critical_dependencies', lambda: (False, ['torch']))
         monkeypatch.setattr(dependency_check, 'is_first_run', lambda: True)
+
+        base_timeout = 30.0 if platform.system() == "Windows" else 15.0
+        expected_timeout = base_timeout * 2 * 2  # For missing deps and first run
         result = dependency_check.get_recommended_timeout()
-        assert result >= 30.0
+        assert result == expected_timeout


### PR DESCRIPTION
# Pull Request

## Description

Cap eager storage initialization timeout for strict stdio MCP clients to avoid blocking the MCP handshake long enough to trigger client startup timeouts.

## Motivation

Issue #561 reports Codex timing out during stdio MCP startup because eager initialization can consume the full adaptive timeout budget (15-60s). For strict clients this can exceed handshake limits before the server is usable.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## Changes

- In `get_recommended_timeout()`, cap eager init timeout to `5.0s` for strict stdio clients (`client != lm_studio`).
- Keep existing adaptive timeout behavior for LM Studio.
- Add unit tests validating strict-client cap and LM Studio adaptive behavior.

**Breaking Changes** (if any):

- None.

## Testing

### How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version: 3.12 (pytest runtime in this environment)
- OS: Linux (WSL2)
- Storage backend: sqlite_vec (test harness default)
- Installation method: source checkout

Command run:

```bash
pytest tests/unit/test_dependency_check.py -q
```

Result: 9 passed.

### Test Coverage

- [x] Added new tests
- [ ] Updated existing tests
- [x] Test coverage maintained/improved

## Related Issues

Fixes #561
Closes #561
Relates to #561

## Screenshots

N/A

## Documentation

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [ ] Updated CHANGELOG.md
- [x] Updated code comments/docstrings
- [ ] Added API documentation
- [x] No documentation needed

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [ ] ✅ Any dependent changes have been merged and published
- [ ] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [ ] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

This intentionally keeps the fix minimal-scope: strict clients still get eager init attempts, but they quickly fall back to existing lazy initialization rather than waiting through long adaptive timeouts.
