### PR TITLE
chore: release v10.25.3 — stdio timeout cap, hybrid sync fix, dashboard badge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.25.3] - 2026-03-07
+
+### Fixed
+
+- **[#561] Strict stdio MCP clients (e.g. Codex CLI) timing out during startup handshake**: Non-LM-Studio stdio clients performing eager initialization could exceed the client's fixed handshake budget (Codex uses ~10 s). The eager-init timeout is now capped at 5.0 s for these clients, ensuring the MCP handshake completes within budget. Co-authored-by SergioChan.
+- **Syntax errors in eager-init timeout cap (follow-up to PR #569)**: Resolved a duplicate function call, an orphaned closing parenthesis, and a duplicate `return` statement introduced in the initial fix. Named constants replace magic numbers, a dead-code guard was corrected, and warning messages were clarified.
+- **Hybrid sync premature termination**: The cloud-to-local sync aborted early when `synced_count` was 0 at the `HYBRID_MIN_CHECK_COUNT` (1,000) threshold, even though thousands of memories remained unchecked. The early-exit condition now only triggers after all `secondary_count` memories have been inspected, ensuring a complete Cloudflare-to-local sync.
+- **Dashboard version badge always blank**: `loadVersion()` called `/health` which returns only `{"status":"healthy"}` since the v10.21.0 GHSA-73hc security hardening. Changed to `/health/detailed` which includes the `version` field.
+
+### Chores
+
+- `.gitignore` updated to exclude TLS certificate files (`*.pem`, `certs/` directory) to prevent accidental credential commits.
+
 ## [10.25.2] - 2026-03-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.25.2 - Health check in `update_and_restart.sh` fixed to read `status` field instead of removed `version` field (GHSA-73hc-m4hx-79pj follow-up) — scripts-only patch, 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.25.3 - Strict stdio handshake timeout capped at 5 s for Codex CLI (#561), syntax fixes for PR #569, hybrid sync early-exit fix, dashboard version badge fix — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,17 +265,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.25.2** (March 7, 2026)
+## Latest Release: **v10.25.3** (March 7, 2026)
 
-**Patch fix: `update_and_restart.sh` health check now reads `status` field instead of removed `version` field**
+**Patch release: stdio handshake timeout cap, syntax fixes, hybrid sync fix, dashboard version badge fix**
 
 **What's New:**
-- **Fix `update_and_restart.sh` always reporting "unknown" version**: The `/api/health` endpoint had its `version` field removed in v10.25.1 (security patch GHSA-73hc-m4hx-79pj), but the update script still tried to read `data.get('version')`. This caused the script to always report "unknown" and wait the full 15-second timeout. The check now reads the `status` field (`"healthy"`) to confirm the server is up and reports the pip-installed version instead.
-- **No Python changes**: Scripts-only fix; all 1,420 tests continue to pass unchanged.
+- **Fix Codex CLI / strict stdio MCP startup timeout (#561)**: Non-LM-Studio stdio clients now have their eager-init timeout capped at 5.0 s, preventing handshake failures in clients with tight startup budgets (e.g. Codex CLI ~10 s). Co-authored-by SergioChan.
+- **Follow-up syntax fixes for PR #569**: Resolved duplicate function call, orphaned parenthesis, duplicate return, magic numbers, and dead-code guard introduced in the initial fix.
+- **Fix hybrid sync premature early-exit**: Cloud-to-local sync no longer aborts at the 1,000-memory threshold when `synced_count` is 0 — all memories are now checked before the sync exits.
+- **Fix dashboard version badge**: `loadVersion()` now calls `/health/detailed` (includes `version` field) instead of `/health` (status-only since GHSA-73hc hardening in v10.21.0).
 
 ---
 
 **Previous Releases**:
+- **v10.25.2** - Patch fix: `update_and_restart.sh` health check reads `status` field instead of removed `version` field
 - **v10.25.1** - Security: CORS wildcard default changed to localhost-only, soft-delete leak in `search_by_tag_chronological()` fixed (GHSA-g9rg-8vq5-mpwm)
 - **v10.25.0** - Embedding migration script, 5 soft-delete leak fixes, cosine distance formula fix, substring tag matching fix, O(n²) association sampling fix — 23 new tests, 1,420 total
 - **v10.24.0** - External embedding API silent fallback fixed: raises RuntimeError on API failure instead of mixing embedding spaces (#551) — 10 new tests, 1,397 total

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.25.2"
+version = "10.25.3"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.25.2"
+__version__ = "10.25.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.25.2"
+version = "10.25.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

This patch release bundles four fixes that landed on \`main\` after the v10.25.2 tag.

### Fixed

- **[#561] Strict stdio MCP clients (Codex CLI) timeout during startup handshake** (PR #569, co-author: @SergioChan)
  Non-LM-Studio stdio clients performing eager initialization could exceed the client's fixed handshake budget (~10 s for Codex). The eager-init timeout is now capped at **5.0 s** for these clients so the MCP handshake always completes within budget. Closes #561.

- **Syntax errors in initial eager-init timeout cap (follow-up to PR #569)**
  Duplicate function call, orphaned closing parenthesis, and duplicate `return` statement. Named constants replace magic numbers, dead-code guard corrected, warning messages clarified.

- **Hybrid sync premature early-exit** (PR #568)
  Cloud-to-local sync aborted when `synced_count == 0` at the `HYBRID_MIN_CHECK_COUNT` (1,000) threshold even though thousands of memories remained unchecked. Early-exit now only fires after all `secondary_count` memories have been inspected.

- **Dashboard version badge always blank** (PR #568)
  `loadVersion()` called `/health` which returns only `{"status":"healthy"}` since the GHSA-73hc security hardening in v10.21.0. Changed to `/health/detailed` which includes the `version` field.

### Chores

- `.gitignore` updated to exclude TLS certificate files (`*.pem`, `certs/`) to prevent accidental credential commits.

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new entry at top, no duplicates)
- [x] `README.md` "Latest Release" and "Previous Releases" updated
- [x] `CLAUDE.md` version callout updated
- [x] No Python test-count change (all 1,420 tests unchanged)

Closes #561