### PR TITLE
feat(dashboard): Credentials tab + Settings restructure + Sync Owner (v10.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.26.0] - 2026-03-07
+
+### Added
+
+- **Credentials tab in Settings modal** (`GET /api/config/credentials`, `POST /api/config/credentials/test`, `POST /api/config/credentials`): Manage Cloudflare API token, Account ID, D1 Database ID, and Vectorize Index directly from the dashboard. Credentials shown with partial-reveal (masked) display and an eye-toggle for full reveal.
+- **Connection test gate (test-gate pattern)**: Credentials must pass a live connection test before they can be saved, preventing accidental misconfiguration.
+- **Sync Owner selector** (`MCP_HYBRID_SYNC_OWNER`: `http` / `both` / `mcp`): New setting to control which server handles Cloudflare sync in hybrid mode. Default is `http` (recommended) — HTTP server owns all sync; MCP server (Claude Desktop) uses SQLite-Vec only, removing the need for a Cloudflare token in the MCP config.
+- **Settings tabs restructured**: The Backup tab is split into three focused tabs — Quality, Backup, and Server — bringing the total to 7 tabs for clearer organisation.
+
+### Security
+
+- **SSRF protection on credentials endpoint**: `account_id` validated against `[a-f0-9]{32}` regex before use in Cloudflare API calls, blocking Server-Side Request Forgery via crafted account IDs.
+- **Newline injection prevention**: Credential values sanitised to reject embedded newlines, preventing HTTP header injection.
+- **`sync_owner` allowlist**: Only `http`, `both`, and `mcp` are accepted; unknown values are rejected with a 422 error.
+
+### Documentation
+
+- `CLAUDE.md` and `README.md` updated: `MCP_HYBRID_SYNC_OWNER=http` documented as the recommended configuration for hybrid mode, along with the rationale (HTTP server as sole sync owner, MCP server token-free).
+
+### CI
+
+- Claude Code Review GitHub Actions workflow disabled due to OAuth token expiry issues (will be migrated to API key auth).
+
+### Tests
+
+- No new tests added in this release (1,420 total).
+
 ## [10.25.3] - 2026-03-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.25.3 - Strict stdio handshake timeout capped at 5 s for Codex CLI (#561), syntax fixes for PR #569, hybrid sync early-exit fix, dashboard version badge fix — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.26.0 - Credentials tab + Settings restructure + Sync Owner selector in dashboard; `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -265,19 +265,21 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.25.3** (March 7, 2026)
+## Latest Release: **v10.26.0** (March 7, 2026)
 
-**Patch release: stdio handshake timeout cap, syntax fixes, hybrid sync fix, dashboard version badge fix**
+**Minor release: Credentials tab + Settings restructure + Sync Owner selector in dashboard**
 
 **What's New:**
-- **Fix Codex CLI / strict stdio MCP startup timeout (#561)**: Non-LM-Studio stdio clients now have their eager-init timeout capped at 5.0 s, preventing handshake failures in clients with tight startup budgets (e.g. Codex CLI ~10 s). Co-authored-by SergioChan.
-- **Follow-up syntax fixes for PR #569**: Resolved duplicate function call, orphaned parenthesis, duplicate return, magic numbers, and dead-code guard introduced in the initial fix.
-- **Fix hybrid sync premature early-exit**: Cloud-to-local sync no longer aborts at the 1,000-memory threshold when `synced_count` is 0 — all memories are now checked before the sync exits.
-- **Fix dashboard version badge**: `loadVersion()` now calls `/health/detailed` (includes `version` field) instead of `/health` (status-only since GHSA-73hc hardening in v10.21.0).
+- **Credentials tab in Settings modal**: Manage Cloudflare API token, Account ID, D1 Database ID, and Vectorize Index directly from the dashboard. Credentials shown with partial-reveal (masked) display and eye-toggle.
+- **Connection test gate**: Credentials must pass a live connection test before they can be saved — prevents accidental misconfiguration.
+- **Sync Owner selector**: New `MCP_HYBRID_SYNC_OWNER` setting (`http` / `both` / `mcp`) with "http only (recommended)" as default. HTTP server handles all Cloudflare sync; MCP server uses SQLite-Vec only.
+- **Settings tabs restructured**: Backup tab split into Quality / Backup / Server tabs — 7 tabs total for clearer organisation.
+- **Security hardening**: SSRF protection (account_id validated to `[a-f0-9]{32}`), newline injection prevention, sync_owner allowlist.
 
 ---
 
 **Previous Releases**:
+- **v10.25.3** - Patch release: stdio handshake timeout cap, syntax fixes, hybrid sync fix, dashboard version badge fix
 - **v10.25.2** - Patch fix: `update_and_restart.sh` health check reads `status` field instead of removed `version` field
 - **v10.25.1** - Security: CORS wildcard default changed to localhost-only, soft-delete leak in `search_by_tag_chronological()` fixed (GHSA-g9rg-8vq5-mpwm)
 - **v10.25.0** - Embedding migration script, 5 soft-delete leak fixes, cosine distance formula fix, substring tag matching fix, O(n²) association sampling fix — 23 new tests, 1,420 total

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.25 — Persistent Memory for AI Agents</title>
+<title>MCP Memory Service v10.26 — Persistent Memory for AI Agents</title>
 <meta name="description" content="Self-hosted persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation. Now with Streamable HTTP + OAuth 2.1 for Claude.ai.">
-<meta property="og:title" content="MCP Memory Service v10.25">
+<meta property="og:title" content="MCP Memory Service v10.26">
 <meta property="og:description" content="Your self-hosted memory server now connects to Claude.ai. Streamable HTTP + OAuth 2.1 + PKCE.">
 <meta property="og:type" content="website">
 <style>
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.25 &mdash; Now Available</span>
+  <span class="hero-badge">v10.26 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,7 +136,7 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.25</h2>
+    <h2 class="section-title">What's New in v10.26</h2>
     <p class="section-subtitle">Claude.ai can now connect to your self-hosted memory server. Your knowledge, your data, your server.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
@@ -239,7 +239,7 @@ footer a{color:var(--cyan)}
       <a href="https://github.com/doobidoo/mcp-memory-service/wiki" class="btn btn-secondary" target="_blank">
         Documentation
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.25.1" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.26.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.25.3"
+version = "10.26.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.25.3"
+__version__ = "10.26.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.25.3"
+version = "10.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- New Credentials tab in Settings modal — manage Cloudflare API token, Account ID, D1 Database ID, Vectorize Index with partial-reveal (masked) display and eye-toggle
- Connection test requirement before saving credentials (test-gate pattern)
- Sync Owner selector (`MCP_HYBRID_SYNC_OWNER`: `http`/`both`/`mcp`) with \"http only (recommended)\" as default
- Settings tabs restructured: Backup tab split into Quality / Backup / Server tabs (7 tabs total)
- New backend endpoints: `GET /api/config/credentials`, `POST /api/config/credentials/test`, `POST /api/config/credentials`
- Security: SSRF protection (`account_id` validated to `[a-f0-9]{32}`), newline injection prevention, `sync_owner` allowlist
- Documentation: `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode in CLAUDE.md and README.md
- CI: Claude Code Review workflow disabled (OAuth token expiry issues)

## Version Bump

`10.25.3` → `10.26.0` (MINOR — new features, backward compatible)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`, `uv.lock`
- [x] CHANGELOG.md updated (v10.26.0 entry at top, after [Unreleased])
- [x] README.md Latest Release section updated
- [x] README.md Previous Releases list updated (v10.25.3 added)
- [x] CLAUDE.md current version reference updated
- [x] docs/index.html version badge updated to v10.26, release notes link updated

## Related

PR #572 (feat(dashboard): Credentials tab + Settings restructure + Sync Owner) was merged to main.