### PR TITLE
fix: report hybrid backend correctly in MCP health checks

### DIFF
--- a/src/mcp_memory_service/utils/health_check.py
+++ b/src/mcp_memory_service/utils/health_check.py
@@ -226,6 +226,21 @@ class HealthCheckFactory:
     """Factory for creating appropriate health check strategies."""
 
     @staticmethod
+    def _is_hybrid_like_storage(storage: Any) -> bool:
+        """Detect hybrid storage instances, including delegated/wrapped variants."""
+        if storage.__class__.__name__ == "HybridMemoryStorage":
+            return True
+
+        # Hybrid storage exposes a primary backend and either secondary backend
+        # or sync service metadata. Use structural detection to avoid relying
+        # solely on class names when storage objects are wrapped/delegated.
+        has_primary = hasattr(storage, 'primary')
+        has_secondary = hasattr(storage, 'secondary')
+        has_sync_service = hasattr(storage, 'sync_service')
+
+        return has_primary and (has_secondary or has_sync_service)
+
+    @staticmethod
     def create(storage: Any) -> HealthCheckStrategy:
         """
         Create a health check strategy based on storage type.
@@ -238,12 +253,12 @@ class HealthCheckFactory:
         """
         storage_type = storage.__class__.__name__
 
-        if storage_type == "SqliteVecMemoryStorage":
+        if HealthCheckFactory._is_hybrid_like_storage(storage):
+            return HybridHealthChecker()
+        elif storage_type == "SqliteVecMemoryStorage":
             return SqliteHealthChecker()
         elif storage_type == "CloudflareStorage":
             return CloudflareHealthChecker()
-        elif storage_type == "HybridMemoryStorage":
-            return HybridHealthChecker()
         else:
             # Default to a simple unknown strategy
             return UnknownStorageChecker()

--- a/tests/test_health_check_factory.py
+++ b/tests/test_health_check_factory.py
@@ -1,0 +1,37 @@
+"""Tests for health check strategy selection."""
+
+from mcp_memory_service.utils.health_check import (
+    HealthCheckFactory,
+    HybridHealthChecker,
+    SqliteHealthChecker,
+    UnknownStorageChecker,
+)
+
+
+class SqliteVecMemoryStorage:
+    pass
+
+
+class DelegatedHybridStorage:
+    def __init__(self):
+        self.primary = object()
+        self.secondary = object()
+
+
+class UnknownStorage:
+    pass
+
+
+def test_factory_selects_sqlite_checker_by_class_name():
+    checker = HealthCheckFactory.create(SqliteVecMemoryStorage())
+    assert isinstance(checker, SqliteHealthChecker)
+
+
+def test_factory_selects_hybrid_checker_for_structural_hybrid_storage():
+    checker = HealthCheckFactory.create(DelegatedHybridStorage())
+    assert isinstance(checker, HybridHealthChecker)
+
+
+def test_factory_selects_unknown_checker_for_unrecognized_storage():
+    checker = HealthCheckFactory.create(UnknownStorage())
+    assert isinstance(checker, UnknownStorageChecker)


### PR DESCRIPTION
# Pull Request

## Description

Fixes MCP `memory_health` backend detection so hybrid deployments are reported as `hybrid` instead of `sqlite-vec` when storage objects are delegated/wrapped.

## Motivation

Issue #570 reports that MCP health output can misidentify hybrid backend state, which hides Cloudflare sync status from users.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test improvement

## Changes

- Added structural hybrid detection in `HealthCheckFactory` (`primary` + `secondary`/`sync_service`) instead of relying only on class name.
- Kept existing SQLite/Cloudflare strategy selection behavior unchanged.
- Added focused unit tests for strategy selection:
  - sqlite class-name detection
  - delegated/wrapped hybrid structural detection
  - unknown fallback behavior

**Breaking Changes** (if any):

- None

## Testing

### How Has This Been Tested?

- [x] Unit tests

**Test Configuration**:
- Python version: 3.12
- OS: Linux (WSL2)
- Storage backend: sqlite_vec (test harness default)
- Installation method: repo local dev checkout

### Test Coverage

- [x] Added new tests

Command run:

```bash
pytest -q tests/test_health_check_factory.py
```

## Related Issues

Fixes #570

## Documentation

- [x] Updated code comments/docstrings
- [x] No documentation needed

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)

## Additional Notes

This PR intentionally keeps the change scoped to backend checker selection and test coverage only.
