### PR TITLE
chore: release v10.26.2 — OAuth PKCE fix + changelog housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.26.2] - 2026-03-08
+
+### Fixed
+
+- **[#576] OAuth token exchange fails with 500 for public PKCE clients** (`authorization.py`): claude.ai and other MCP clients that use OAuth 2.1 public-client flow (PKCE without `client_secret`) received a `500 Internal Server Error` during token exchange because the endpoint unconditionally called `authenticate_client()`, which requires a secret. The endpoint now detects public PKCE clients — requests that supply a `code_verifier` but no `client_secret` — and skips secret authentication, using the PKCE verifier as the sole identity proof instead, in accordance with OAuth 2.1 §2.1. Confidential clients (with `client_secret`) are unaffected. Closes #576.
+- **Missing `/.well-known/oauth-protected-resource` endpoint** (`discovery.py`): The endpoint required by RFC 9728 and the MCP OAuth spec was returning 404, breaking OAuth discovery for compliant clients. Added `OAuthProtectedResourceMetadata` Pydantic model and the corresponding route, which advertises the resource identifier and authorization server URLs with `token_endpoint_auth_methods_supported: ["none"]`.
+- **Opaque OAuth error logging**: Added `exc_info=True` to exception handlers in the token and authorization endpoints so that full tracebacks are recorded in logs instead of generic error messages, making future debugging significantly easier.
+
+### Added
+
+- **Automated CHANGELOG housekeeping workflow** (`.github/workflows/changelog-housekeeping.yml`): Monthly GitHub Actions workflow (runs on the 1st of each month, also triggerable via `workflow_dispatch`) that automatically archives CHANGELOG entries older than the 8 most recent versions into `docs/archive/CHANGELOG-HISTORIC.md`. Keeps the main CHANGELOG lean for faster reads while preserving full history. Validates that no version entries are lost during archival.
+- **Changelog housekeeping script** (`scripts/maintenance/changelog_housekeeping.py`): Python script backing the workflow. Keeps the 8 most recent versions in `CHANGELOG.md`, moves older entries to the historic archive, and trims the README "Previous Releases" section to a maximum of 7 entries. Supports `--dry-run` for safe preview before applying changes.
+
 ## [10.26.1] - 2026-03-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.26.1 - Hybrid backend correctly reported in MCP health checks (`HealthCheckFactory` structural detection fix for wrapped/delegated backends, issue #570) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.26.2 - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping workflow — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -324,17 +324,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.26.1** (March 8, 2026)
+## Latest Release: **v10.26.2** (March 8, 2026)
 
-**Patch release: Hybrid backend correctly reported in MCP health checks**
+**Patch release: OAuth public PKCE client fix + automated CHANGELOG housekeeping**
 
 **What's New:**
-- **[#570] Hybrid backend misidentified as sqlite-vec in `memory_health`**: `HealthCheckFactory` now uses structural detection (checks for `primary` + `secondary`/`sync_service` attributes) instead of class-name matching to identify hybrid storage. Wrapped or delegated hybrid backends are now reported correctly as `"hybrid"`, ensuring Cloudflare sync status is visible in health output.
-- Three focused unit tests added for strategy selection (sqlite class-name path, wrapped hybrid structural path, unknown fallback).
+- **[#576] OAuth 500 fixed for public PKCE clients**: claude.ai and other MCP clients using PKCE without `client_secret` now complete token exchange correctly. The endpoint detects public clients and uses the PKCE `code_verifier` as identity proof per OAuth 2.1 §2.1.
+- **`/.well-known/oauth-protected-resource` endpoint added** (RFC 9728): Previously returning 404, breaking OAuth discovery for compliant MCP clients.
+- **Improved OAuth error logging**: `exc_info=True` added to token/authorization exception handlers for full tracebacks in logs.
+- **Automated CHANGELOG housekeeping**: Monthly GitHub Actions workflow keeps `CHANGELOG.md` lean by archiving entries older than the 8 most recent versions. Supports `--dry-run` preview.
 
 ---
 
 **Previous Releases**:
+- **v10.26.1** - Hybrid backend correctly reported in MCP health checks (`HealthCheckFactory` structural detection fix for wrapped/delegated backends, issue #570)
 - **v10.26.0** - Credentials tab + Settings restructure + Sync Owner selector in dashboard; `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode
 - **v10.25.3** - Patch release: stdio handshake timeout cap, syntax fixes, hybrid sync fix, dashboard version badge fix
 - **v10.25.2** - Patch fix: `update_and_restart.sh` health check reads `status` field instead of removed `version` field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.26.1"
+version = "10.26.2"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.26.1"
+__version__ = "10.26.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.26.1"
+version = "10.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

### Fixed
- **[#576] OAuth token exchange 500 for public PKCE clients** (`authorization.py`): claude.ai and other MCP clients using OAuth 2.1 public-client PKCE flow received a `500 Internal Server Error` because the token endpoint unconditionally called `authenticate_client()`. The endpoint now detects public clients (PKCE `code_verifier` present, no `client_secret`) and skips secret authentication, using the verifier as identity proof per OAuth 2.1 §2.1. Confidential clients are unaffected.
- **Missing `/.well-known/oauth-protected-resource` endpoint** (`discovery.py`): Required by RFC 9728 and the MCP OAuth spec; was returning 404. Added `OAuthProtectedResourceMetadata` Pydantic model and corresponding route.
- **Opaque OAuth error logging**: Added `exc_info=True` to exception handlers in token/authorization endpoints for full tracebacks in logs.

### Added
- **Automated CHANGELOG housekeeping** (`.github/workflows/changelog-housekeeping.yml`): Monthly workflow that archives entries older than the 8 most recent versions into `docs/archive/CHANGELOG-HISTORIC.md`. Manually triggerable via `workflow_dispatch`.
- **`scripts/maintenance/changelog_housekeeping.py`**: Backing script with `--dry-run` support and README "Previous Releases" trimming (max 7 entries).

## Version Bump

`v10.26.1` → `v10.26.2` (PATCH — bug fix + maintenance tooling)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new `[10.26.2]` section at top, no duplicates)
- [x] `README.md` "Latest Release" section updated; v10.26.1 moved to "Previous Releases"
- [x] `CLAUDE.md` version callout updated
- [x] CHANGELOG structure validated (versions in reverse-chronological order, no duplicates)

## Related Issues

Closes #576

🤖 Orchestrated by [github-release-manager](https://claude.ai/claude-code)