### PR TITLE
fix: render object metadata values as JSON instead of [object Object]

### DIFF
--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -2591,10 +2591,10 @@ class MemoryDashboard {
                 displayValue = `<span class="metadata-boolean">${value}</span>`;
             } else if (Array.isArray(value)) {
                 displayValue = `<span class="metadata-array">[${value.map(v =>
-                    typeof v === 'string' ? `"${this.escapeHtml(v)}"` : (typeof v === "object" ? JSON.stringify(v) : v)
+                    typeof v === 'string' ? `"${this.escapeHtml(v)}"` : (v !== null && typeof v === "object" ? this.escapeHtml(JSON.stringify(v)) : v)
                 ).join(', ')}]</span>`;
             } else {
-                displayValue = `<span class="metadata-object">${JSON.stringify(value)}</span>`;
+                displayValue = `<span class="metadata-object">${this.escapeHtml(JSON.stringify(value))}</span>`;
             }
 
             html += `

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -2591,7 +2591,7 @@ class MemoryDashboard {
                 displayValue = `<span class="metadata-boolean">${value}</span>`;
             } else if (Array.isArray(value)) {
                 displayValue = `<span class="metadata-array">[${value.map(v =>
-                    typeof v === 'string' ? `"${this.escapeHtml(v)}"` : v
+                    typeof v === 'string' ? `"${this.escapeHtml(v)}"` : (typeof v === "object" ? JSON.stringify(v) : v)
                 ).join(', ')}]</span>`;
             } else {
                 displayValue = `<span class="metadata-object">${JSON.stringify(value)}</span>`;


### PR DESCRIPTION
## Summary

  Metadata values that are objects inside arrays are now serialized with `JSON.stringify()` instead of being rendered as `[object Object]`.

  ## Problem

  The `renderMetadata()` method in the dashboard handles string, number, boolean, and array values. For arrays, each element is rendered — strings get quoted, but non-string values are inserted directly via
  template literal interpolation. When an array contains objects (e.g. `ai_scores` or `access_queries` metadata fields), JavaScript coerces them to `[object Object]` instead of showing the actual data.

  ## Changes

  **app.js** — `renderMetadata()`:
  - Array element rendering: added `typeof v === "object" ? JSON.stringify(v) : v` check for non-string array elements

  One-line fix.

  ## Test plan

  - [ ] Open detail modal for a memory that has `ai_scores` in metadata → should show JSON objects, not `[object Object]`
  - [ ] Open detail modal for a memory with `access_queries` → should show array of query objects with timestamps
  - [ ] Simple metadata (strings, numbers) still renders correctly