### PR TITLE
fix: add expand/collapse for long content in detail modal + fetch full details on quality tab click

### DIFF
--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -434,6 +434,20 @@ class MemoryDashboard {
      */
     setupEventListeners() {
         console.log('⚡ setupEventListeners() called');
+
+        // Content expand/collapse delegation
+        document.addEventListener('click', (e) => {
+            if (e.target.matches('[data-action="toggle-content"]')) {
+                const textDiv = e.target.previousElementSibling;
+                if (textDiv && textDiv.classList.contains('detail-content-text')) {
+                    textDiv.classList.toggle('detail-content-collapsed');
+                    e.target.textContent = textDiv.classList.contains('detail-content-collapsed')
+                        ? '▼ Show full content'
+                        : '▲ Collapse';
+                }
+            }
+        });
+
         // Navigation
         document.querySelectorAll('.nav-item').forEach(item => {
             item.addEventListener('click', this.handleNavigation);
@@ -2542,9 +2556,10 @@ class MemoryDashboard {
                     <p><strong>ID:</strong> ${memory.content_hash}</p>
                 </div>
 
-                <div class="memory-content">
+                <div class="memory-detail-section">
                     <h4>Content</h4>
-                    <div class="content-text">${this.escapeHtml(memory.content)}</div>
+                    <div class="content-text detail-content-text detail-content-collapsed">${this.escapeHtml(memory.content)}</div>
+                    ${memory.content && memory.content.length > 200 ? '<button class="content-toggle-btn" data-action="toggle-content">▼ Show full content</button>' : ''}
                 </div>
 
                 ${memory.tags && memory.tags.length > 0 ? `

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -6002,7 +6002,15 @@ class MemoryDashboard {
      */
     _attachMemoryClickHandlers(container, memories) {
         container.querySelectorAll('.memory-preview').forEach((el, index) => {
-            el.addEventListener('click', () => this.handleMemoryClick(memories[index]));
+            el.addEventListener('click', async () => {
+                const mem = memories[index];
+                try {
+                    const full = await this.apiCall('/memories/' + mem.content_hash);
+                    this.showMemoryDetails(full);
+                } catch (e) {
+                    this.showMemoryDetails(mem);
+                }
+            });
         });
     }
 

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -2558,7 +2558,7 @@ class MemoryDashboard {
 
                 <div class="memory-detail-section">
                     <h4>Content</h4>
-                    <div class="content-text detail-content-text detail-content-collapsed">${this.escapeHtml(memory.content)}</div>
+                    <div class="content-text detail-content-text${memory.content && memory.content.length > 200 ? ' detail-content-collapsed' : ''}">${this.escapeHtml(memory.content)}</div>
                     ${memory.content && memory.content.length > 200 ? '<button class="content-toggle-btn" data-action="toggle-content">▼ Show full content</button>' : ''}
                 </div>
 
@@ -6003,12 +6003,16 @@ class MemoryDashboard {
     _attachMemoryClickHandlers(container, memories) {
         container.querySelectorAll('.memory-preview').forEach((el, index) => {
             el.addEventListener('click', async () => {
+                if (el.dataset.loading === 'true') return;
+                el.dataset.loading = 'true';
                 const mem = memories[index];
                 try {
                     const full = await this.apiCall('/memories/' + mem.content_hash);
                     this.showMemoryDetails(full);
                 } catch (e) {
                     this.showMemoryDetails(mem);
+                } finally {
+                    el.dataset.loading = 'false';
                 }
             });
         });

--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -5990,3 +5990,46 @@ body.dark-mode .env-param-description {
     color: var(--text-muted);
     margin-top: var(--space-3);
 }
+
+/* Memory detail expand/collapse */
+.memory-detail-section {
+    margin-bottom: var(--space-4);
+}
+.memory-detail-section .detail-content-text {
+    color: var(--neutral-700);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.memory-detail-section .detail-content-text.detail-content-collapsed {
+    display: -webkit-box;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.content-toggle-btn {
+    display: inline-block;
+    background: none;
+    border: 1px solid var(--neutral-300);
+    color: var(--primary-500);
+    cursor: pointer;
+    padding: 4px 12px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    margin-top: 8px;
+    transition: all 0.2s;
+}
+.content-toggle-btn:hover {
+    background: var(--primary-50);
+    border-color: var(--primary-300);
+}
+body.dark-mode .memory-detail-section .detail-content-text {
+    color: var(--neutral-800);
+}
+body.dark-mode .content-toggle-btn {
+    border-color: var(--neutral-600);
+    color: var(--primary-300);
+}
+body.dark-mode .content-toggle-btn:hover {
+    background: var(--neutral-800);
+}

--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -6011,7 +6011,7 @@ body.dark-mode .env-param-description {
     display: inline-block;
     background: none;
     border: 1px solid var(--neutral-300);
-    color: var(--primary-500);
+    color: var(--primary);
     cursor: pointer;
     padding: 4px 12px;
     border-radius: 4px;
@@ -6020,16 +6020,16 @@ body.dark-mode .env-param-description {
     transition: all 0.2s;
 }
 .content-toggle-btn:hover {
-    background: var(--primary-50);
-    border-color: var(--primary-300);
+    background: var(--neutral-100);
+    border-color: var(--primary);
 }
 body.dark-mode .memory-detail-section .detail-content-text {
     color: var(--neutral-800);
 }
 body.dark-mode .content-toggle-btn {
     border-color: var(--neutral-600);
-    color: var(--primary-300);
+    color: var(--primary);
 }
 body.dark-mode .content-toggle-btn:hover {
-    background: var(--neutral-800);
+    background: var(--neutral-200);
 }


### PR DESCRIPTION
## Summary

  - Long memory content in the detail modal is now collapsed by default (6 lines via `-webkit-line-clamp`) with a toggle button to expand/collapse
  - Quality tab memory cards now fetch the full memory object from `/api/memories/:hash` before opening the detail modal, so metadata, updated_at and content toggle are all available

  ## Problem

  1. Memory detail modal shows the full content inline without any truncation — for long memories this makes the modal extremely tall and hard to navigate
  2. Quality tab uses `/api/quality/distribution` which returns partial memory objects (no `metadata`, no `updated_at`). Clicking a quality card opens a detail modal with missing metadata section and no
  expand/collapse button

  ## Changes

  **app.js:**
  - Wrap content in `.memory-detail-section` with `.detail-content-collapsed` class and a toggle button for content > 200 chars
  - Add event delegation on `[data-action="toggle-content"]` to handle expand/collapse clicks
  - `_attachMemoryClickHandlers`: fetch full memory from `/api/memories/:hash` before calling `showMemoryDetails()`, with fallback to partial object on error

  **style.css:**
  - `.detail-content-collapsed`: `-webkit-line-clamp: 6` truncation
  - `.content-toggle-btn`: styled toggle button with dark mode support

  ## Test plan

  - [ ] Open any memory from Dashboard → detail modal shows collapsed content with "Show full content" button
  - [ ] Click toggle → content expands; click again → collapses
  - [ ] Open memory from Quality tab → detail modal shows full metadata section (tags, type, access_count, quality_score, etc.)
  - [ ] Verify dark mode styling for toggle button and collapsed content