### PR TITLE
fix: use absolute quality prompt when query is empty in Groq scorer

### DIFF
--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -465,15 +465,19 @@ class QualityEvaluator:
 Respond only with a number between 0.0 (very low quality) and 1.0 (very high quality).
 Consider: specificity, structure, actionability, completeness.
 
-Memory: {content_preview}
+<memory>
+{content_preview}
+</memory>
 
 Score:"""
 
         return f"""Rate the relevance and quality of this memory for the given query.
 Respond only with a number between 0.0 (completely irrelevant/low quality) and 1.0 (highly relevant/high quality).
 
-Query: {query}
+<query>{query}</query>
 
-Memory: {content_preview}
+<memory>
+{content_preview}
+</memory>
 
 Score:"""

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -339,6 +339,7 @@ class QualityEvaluator:
         """
         # Placeholder for Gemini integration
         # This would use Gemini CLI or API similar to Groq
+        # TODO: use _create_scoring_prompt(query, memory.content) to handle empty queries
         logger.warning("Gemini scoring not yet implemented")
         raise NotImplementedError("Gemini scoring tier not yet implemented")
 

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -446,18 +446,33 @@ class QualityEvaluator:
         """
         Create a prompt for AI-based quality scoring.
 
+        When query is empty (e.g. during store_memory), uses an absolute
+        quality prompt instead of a relevance-based one to avoid the model
+        returning 0.0 for missing query context.
+
         Args:
-            query: Search query
+            query: Search query (may be empty for store operations)
             memory_content: Memory content to score
 
         Returns:
             Formatted prompt for AI model
         """
+        content_preview = memory_content[:500]
+
+        if not query or not query.strip():
+            return f"""Rate the absolute quality of this memory content.
+Respond only with a number between 0.0 (very low quality) and 1.0 (very high quality).
+Consider: specificity, structure, actionability, completeness.
+
+Memory: {content_preview}
+
+Score:"""
+
         return f"""Rate the relevance and quality of this memory for the given query.
 Respond only with a number between 0.0 (completely irrelevant/low quality) and 1.0 (highly relevant/high quality).
 
 Query: {query}
 
-Memory: {memory_content[:500]}
+Memory: {content_preview}
 
 Score:"""


### PR DESCRIPTION
## Summary

  When `_create_scoring_prompt()` receives an empty query (which happens during `store_memory` operations), it now uses an absolute quality evaluation prompt instead of a relevance-based one.

  ## Problem

  During `store_memory`, the quality evaluation is triggered without a search query. The current prompt template always includes `Query: {query}` — when query is empty, the AI model sees "Query: " with nothing
   after it and tends to return 0.0, because it interprets the missing query as "no relevance context".

  This causes newly stored memories to get artificially low quality scores (often 0.0) regardless of their actual content quality.

  ## Changes

  **ai_evaluator.py** — `_create_scoring_prompt()`:
  - When `query` is empty/blank, use an absolute quality prompt: "Rate the absolute quality of this memory content" with criteria: specificity, structure, actionability, completeness
  - When `query` is present, use the existing relevance-based prompt (unchanged)
  - Extract `content_preview = memory_content[:500]` for both paths

  ## Test plan

  - [ ] Store a new high-quality memory → quality score should be > 0.5 (not 0.0)
  - [ ] Store a vague/low-quality memory → quality score should be low
  - [ ] Search-triggered scoring (with query) still works as before