### PR TITLE
fix: add Groq model fallback chain to handle 429 rate limits

### DIFF
--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -293,9 +293,10 @@ class QualityEvaluator:
         """
         Score quality using Groq API with model fallback chain.
 
-        Tries models in order, falling back on 429 rate limit errors:
-        1. moonshotai/kimi-k2-instruct (faster, higher quota)
-        2. llama-3.1-8b-instant (fallback)
+        Tries models in order, falling back on 429 rate limit errors
+        or unparseable responses:
+        1. moonshotai/kimi-k2-instruct (richer comprehension, 1T MoE)
+        2. llama-3.1-8b-instant (faster, independent quota)
 
         Args:
             query: Search query
@@ -335,7 +336,8 @@ class QualityEvaluator:
                 return max(0.0, min(1.0, score))
             except ValueError:
                 logger.warning(f"Could not parse Groq score from {model}: {response_text}")
-                raise ValueError(f"Invalid score format: {response_text}")
+                last_error = f"Invalid score format from {model}: {response_text}"
+                continue
 
         raise RuntimeError(f"All Groq models rate-limited: {last_error}")
 

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -291,7 +291,11 @@ class QualityEvaluator:
 
     async def _score_with_groq(self, query: str, memory: Memory) -> float:
         """
-        Score quality using Groq API.
+        Score quality using Groq API with model fallback chain.
+
+        Tries models in order, falling back on 429 rate limit errors:
+        1. moonshotai/kimi-k2-instruct (faster, higher quota)
+        2. llama-3.1-8b-instant (fallback)
 
         Args:
             query: Search query
@@ -304,27 +308,36 @@ class QualityEvaluator:
             raise RuntimeError("Groq bridge not initialized")
 
         prompt = self._create_scoring_prompt(query, memory.content)
+        models = ["moonshotai/kimi-k2-instruct", "llama-3.1-8b-instant"]
 
-        # Use fast model for quality scoring
-        result = self._groq_bridge.call_model(
-            prompt=prompt,
-            model="llama-3.3-70b-versatile",
-            max_tokens=50,
-            temperature=0.1,
-            system_message="You are a quality scorer. Respond only with a number between 0.0 and 1.0."
-        )
+        last_error = None
+        for model in models:
+            result = self._groq_bridge.call_model(
+                prompt=prompt,
+                model=model,
+                max_tokens=50,
+                temperature=0.1,
+                system_message="You are a quality scorer. Respond only with a number between 0.0 and 1.0."
+            )
 
-        if result["status"] != "success":
-            raise RuntimeError(f"Groq API error: {result.get('error', 'Unknown error')}")
+            if result["status"] != "success":
+                error_msg = result.get("error", "Unknown error")
+                if "429" in str(error_msg):
+                    logger.warning(f"Groq rate limit on {model}, trying next model")
+                    last_error = error_msg
+                    continue
+                raise RuntimeError(f"Groq API error: {error_msg}")
 
-        # Parse score from response
-        response_text = result["response"].strip()
-        try:
-            score = float(response_text)
-            return max(0.0, min(1.0, score))
-        except ValueError:
-            logger.warning(f"Could not parse Groq score: {response_text}")
-            raise ValueError(f"Invalid score format: {response_text}")
+            # Parse score from response
+            response_text = result["response"].strip()
+            try:
+                score = float(response_text)
+                return max(0.0, min(1.0, score))
+            except ValueError:
+                logger.warning(f"Could not parse Groq score from {model}: {response_text}")
+                raise ValueError(f"Invalid score format: {response_text}")
+
+        raise RuntimeError(f"All Groq models rate-limited: {last_error}")
 
     async def _score_with_gemini(self, query: str, memory: Memory) -> float:
         """


### PR DESCRIPTION
## Summary

  The Groq quality scorer now tries multiple models in sequence, falling back to the next model when a 429 rate limit is hit.

  ## Problem

  The quality scorer uses a single hardcoded model (`llama-3.3-70b-versatile`) which has a relatively low free-tier daily token limit. Once exhausted, all quality scoring fails until the quota resets. This
  makes bulk operations like rescoring unreliable and blocks quality evaluation for newly stored memories.

  ## Solution

  Replace the single model with an ordered fallback chain:

  1. **`moonshotai/kimi-k2-instruct`** (primary) — large MoE model with strong text comprehension, produces more nuanced quality scores for complex content
  2. **`llama-3.1-8b-instant`** (fallback) — smaller dense model, significantly faster, adequate for simple 0.0–1.0 scoring

  Groq free tier has independent token budgets per model, so falling back to a different model avoids the exhausted quota entirely.

  ## Changes

  **ai_evaluator.py** — `_score_with_groq()`:
  - Replace single hardcoded model with an ordered fallback chain
  - On 429 rate limit error, log a warning and try the next model
  - On other errors, raise immediately (no fallback)
  - If all models are rate-limited, raise `RuntimeError` with the last error

  ## Test plan

  - [ ] Store a new memory → quality score is assigned via first available model
  - [ ] Simulate 429 on primary model → scorer falls back to `llama-3.1-8b-instant`
  - [ ] Non-429 errors still raise immediately without trying fallback models