### PR TITLE
chore: release v10.26.3 — dashboard fixes + quality scorer resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.26.3] - 2026-03-10
+
+### Fixed
+
+- **Dashboard: metadata object values now rendered as JSON** (`app.js`, #582): Metadata values that are objects (or arrays of objects) were previously rendered as `[object Object]`. They are now serialised with `JSON.stringify` and HTML-escaped via `escapeHtml`, fixing both the display issue and a potential XSS vector introduced by the naive object-to-string coercion.
+- **Dashboard: long memory content collapsed by default in detail modal; quality tab fetches full object** (`app.js`, `style.css`, #583): Memory content longer than 500 characters is now collapsed with a "Show more / Show less" toggle in the detail modal. When opening a memory from the quality tab, the full memory object is fetched via `GET /api/memories/{hash}` before the modal opens, preventing incomplete data display.
+- **Quality scorer: empty query during `store_memory` no longer yields 0.0 score** (`ai_evaluator.py`, #584): The Groq scorer previously used a relevance-based prompt even when the query was empty (as is the case for `store_memory` calls). An empty query produced a semantically meaningless prompt and a near-zero score. The scorer now detects an empty query and switches to an absolute quality prompt that evaluates content quality independently of any query.
+- **Quality scorer: Groq 429 rate limit triggers model fallback chain** (`ai_evaluator.py`, #585): The Groq quality scorer now attempts a sequence of models (`llama-3.1-8b-instant`, `llama3-8b-8192`, `gemma2-9b-it`) in order when a `429 Too Many Requests` response is received, instead of failing hard. This prevents quality scoring from failing silently under rate pressure and improves resilience for high-throughput deployments.
+
 ## [10.26.2] - 2026-03-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.26.2 - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping workflow — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.26.3 - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -324,27 +324,26 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.26.2** (March 8, 2026)
+## Latest Release: **v10.26.3** (March 10, 2026)
 
-**Patch release: OAuth public PKCE client fix + automated CHANGELOG housekeeping**
+**Patch release: Dashboard metadata display fixes + quality scorer resilience improvements**
 
 **What's New:**
-- **[#576] OAuth 500 fixed for public PKCE clients**: claude.ai and other MCP clients using PKCE without `client_secret` now complete token exchange correctly. The endpoint detects public clients and uses the PKCE `code_verifier` as identity proof per OAuth 2.1 §2.1.
-- **`/.well-known/oauth-protected-resource` endpoint added** (RFC 9728): Previously returning 404, breaking OAuth discovery for compliant MCP clients.
-- **Improved OAuth error logging**: `exc_info=True` added to token/authorization exception handlers for full tracebacks in logs.
-- **Automated CHANGELOG housekeeping**: Monthly GitHub Actions workflow keeps `CHANGELOG.md` lean by archiving entries older than the 8 most recent versions. Supports `--dry-run` preview.
+- **Dashboard: metadata objects now shown as JSON** (#582): Object-typed metadata values rendered as `[object Object]` are now serialised with `JSON.stringify` + HTML-escaped. XSS vector closed.
+- **Dashboard: long content collapsed in detail modal; quality tab fetches full object** (#583): Content >500 chars collapses with a Show more/less toggle. Quality-tab clicks now fetch the full memory object before opening the modal.
+- **Quality scorer: empty-query path uses absolute quality prompt** (#584): `store_memory` calls (query = "") no longer produce a 0.0 score — a dedicated absolute quality prompt is used instead of the relevance-based one.
+- **Quality scorer: Groq 429 triggers model fallback chain** (#585): Rate-limit responses now try `llama-3.1-8b-instant` → `llama3-8b-8192` → `gemma2-9b-it` in sequence instead of failing hard.
 
 ---
 
 **Previous Releases**:
+- **v10.26.2** - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping
 - **v10.26.1** - Hybrid backend correctly reported in MCP health checks (`HealthCheckFactory` structural detection fix for wrapped/delegated backends, issue #570)
 - **v10.26.0** - Credentials tab + Settings restructure + Sync Owner selector in dashboard; `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode
 - **v10.25.3** - Patch release: stdio handshake timeout cap, syntax fixes, hybrid sync fix, dashboard version badge fix
 - **v10.25.2** - Patch fix: `update_and_restart.sh` health check reads `status` field instead of removed `version` field
 - **v10.25.1** - Security: CORS wildcard default changed to localhost-only, soft-delete leak in `search_by_tag_chronological()` fixed (GHSA-g9rg-8vq5-mpwm)
 - **v10.25.0** - Embedding migration script, 5 soft-delete leak fixes, cosine distance formula fix, substring tag matching fix, O(n²) association sampling fix — 23 new tests, 1,420 total
-- **v10.24.0** - External embedding API silent fallback fixed: raises RuntimeError on API failure instead of mixing embedding spaces (#551) — 10 new tests, 1,397 total
-- **v10.23.0** - Quality scorer fix, consolidator improvements, two new opt-out flags: fix asyncio NameError in ai_evaluator.py (#544), fix consolidator invalid memory_type and dedup bug (#545), MCP_TYPED_EDGES_ENABLED opt-out (#546), MCP_CONSOLIDATION_STORE_ASSOCIATIONS opt-out (#547) — 14 new tests
 
 **Full version history**: [CHANGELOG.md](CHANGELOG.md) | [Older versions (v10.22.0 and earlier)](docs/archive/CHANGELOG-HISTORIC.md) | [All Releases](https://github.com/doobidoo/mcp-memory-service/releases)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.26.2"
+version = "10.26.3"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.26.2"
+__version__ = "10.26.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.26.2"
+version = "10.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

Patch release v10.26.3 incorporating 4 fixes from contributor @lukyrys:

- **#582** — Dashboard: metadata object values rendered as `[object Object]` now shown as formatted JSON (+ XSS fix via `escapeHtml`)
- **#583** — Dashboard: long memory content in detail modal now collapsed by default with expand/collapse toggle; quality tab fetches full memory object before opening modal
- **#584** — Quality scorer: empty query during `store_memory` no longer causes 0.0 score — uses absolute quality prompt instead of relevance-based prompt
- **#585** — Quality scorer: Groq rate limit (429) now triggers model fallback chain (`llama-3.1-8b-instant` → `llama3-8b-8192` → `gemma2-9b-it`) instead of hard failure

## Files Changed

- `src/mcp_memory_service/_version.py` — bumped to 10.26.3
- `pyproject.toml` — bumped to 10.26.3
- `uv.lock` — updated
- `CHANGELOG.md` — new [10.26.3] section added
- `README.md` — Latest Release updated; v10.26.2 moved to Previous Releases
- `CLAUDE.md` — Current Version updated

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new section at top, no duplicates, correct order)
- [x] `README.md` Latest Release updated; Previous Releases list maintained
- [x] `CLAUDE.md` version reference updated
- [x] `docs/index.html` NOT updated (patch release — landing page update skipped per policy)
- [x] All 4 contributor PRs (#582, #583, #584, #585) merged to main before this branch

## Test Count

1,420 tests (unchanged — no new tests in these PRs).