### PR TITLE
fix: FTS5 table not created for existing databases (hybrid search broken on upgrade)

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -399,6 +399,69 @@ class SqliteVecMemoryStorage(MemoryStorage):
         except Exception as e:
             logger.warning(f"Failed to run graph migrations (non-fatal): {e}")
 
+    def _ensure_fts5_initialized(self):
+        """Ensure FTS5 virtual table exists for BM25 keyword search (v10.8.0+).
+
+        Called during initialization for both new and existing databases.
+        Creates the FTS5 table, sync triggers, and rebuilds the index.
+        Failures are non-fatal.
+        """
+        try:
+            cursor = self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE name='memory_content_fts'"
+            )
+            if cursor.fetchone() is not None:
+                return  # Already exists
+
+            logger.info("Creating FTS5 table for hybrid BM25 search...")
+            self.conn.execute('''
+                CREATE VIRTUAL TABLE IF NOT EXISTS memory_content_fts USING fts5(
+                    content,
+                    content='memories',
+                    content_rowid='id',
+                    tokenize='trigram'
+                )
+            ''')
+
+            self.conn.execute('''
+                CREATE TRIGGER IF NOT EXISTS memories_fts_ai AFTER INSERT ON memories
+                BEGIN
+                    INSERT INTO memory_content_fts(rowid, content)
+                    VALUES (new.id, new.content);
+                END;
+            ''')
+            self.conn.execute('''
+                CREATE TRIGGER IF NOT EXISTS memories_fts_au AFTER UPDATE ON memories
+                BEGIN
+                    DELETE FROM memory_content_fts WHERE rowid = old.id;
+                    INSERT INTO memory_content_fts(rowid, content)
+                    VALUES (new.id, new.content);
+                END;
+            ''')
+            self.conn.execute('''
+                CREATE TRIGGER IF NOT EXISTS memories_fts_ad AFTER DELETE ON memories
+                BEGIN
+                    DELETE FROM memory_content_fts WHERE rowid = old.id;
+                END;
+            ''')
+
+            # External content FTS5 tables require 'rebuild' to populate the
+            # trigram index from the source table. Plain INSERT populates the
+            # content mapping but not the actual search index.
+            logger.info("Rebuilding FTS5 trigram index from memories table...")
+            self.conn.execute(
+                "INSERT INTO memory_content_fts(memory_content_fts) VALUES('rebuild')"
+            )
+
+            self.conn.execute("""
+                INSERT OR REPLACE INTO metadata (key, value)
+                VALUES ('fts5_enabled', 'true')
+            """)
+            self.conn.commit()
+            logger.info("FTS5 initialization complete")
+        except Exception as e:
+            logger.warning(f"FTS5 initialization failed (non-fatal): {e}")
+
     def _check_extension_support(self):
         """Check if Python's sqlite3 supports loading extensions."""
         test_conn = None
@@ -626,6 +689,9 @@ SOLUTIONS:
                     # Execute graph table migrations (Knowledge Graph feature v9.0.0+)
                     self._run_graph_migrations()
 
+                    # Ensure FTS5 table exists (v10.8.0+ migration for existing databases)
+                    self._ensure_fts5_initialized()
+
                     await self._initialize_embedding_model()
                     self._initialized = True
                     logger.info(f"SQLite-vec storage initialized successfully (existing database) with embedding dimension: {self.embedding_dimension}")
@@ -770,65 +836,8 @@ SOLUTIONS:
                 INSERT OR REPLACE INTO metadata (key, value) VALUES ('distance_metric', 'cosine')
             """)
 
-            # Create FTS5 virtual table for BM25 keyword search (v10.8.0+)
-            # Uses external content table pattern for minimal storage overhead
-            # Trigram tokenizer provides optimal multilingual support and exact matching
-            self.conn.execute('''
-                CREATE VIRTUAL TABLE IF NOT EXISTS memory_content_fts USING fts5(
-                    content,
-                    content='memories',
-                    content_rowid='id',
-                    tokenize='trigram'
-                )
-            ''')
-
-            # Add triggers for automatic FTS5 synchronization
-            # INSERT trigger
-            self.conn.execute('''
-                CREATE TRIGGER IF NOT EXISTS memories_fts_ai AFTER INSERT ON memories
-                BEGIN
-                    INSERT INTO memory_content_fts(rowid, content)
-                    VALUES (new.id, new.content);
-                END;
-            ''')
-
-            # UPDATE trigger
-            self.conn.execute('''
-                CREATE TRIGGER IF NOT EXISTS memories_fts_au AFTER UPDATE ON memories
-                BEGIN
-                    DELETE FROM memory_content_fts WHERE rowid = old.id;
-                    INSERT INTO memory_content_fts(rowid, content)
-                    VALUES (new.id, new.content);
-                END;
-            ''')
-
-            # DELETE trigger (including soft deletes)
-            self.conn.execute('''
-                CREATE TRIGGER IF NOT EXISTS memories_fts_ad AFTER DELETE ON memories
-                BEGIN
-                    DELETE FROM memory_content_fts WHERE rowid = old.id;
-                END;
-            ''')
-
-            # Backfill FTS5 index with existing memories (one-time operation)
-            cursor = self.conn.execute('SELECT COUNT(*) FROM memory_content_fts')
-            fts_count = cursor.fetchone()[0]
-            cursor = self.conn.execute('SELECT COUNT(*) FROM memories WHERE deleted_at IS NULL')
-            mem_count = cursor.fetchone()[0]
-
-            if fts_count == 0 and mem_count > 0:
-                logger.info(f"Backfilling FTS5 index with {mem_count} existing memories...")
-                self.conn.execute('''
-                    INSERT INTO memory_content_fts(rowid, content)
-                    SELECT id, content FROM memories WHERE deleted_at IS NULL
-                ''')
-                logger.info("FTS5 backfill complete")
-
-            # Mark FTS5 as enabled in metadata
-            self.conn.execute("""
-                INSERT OR REPLACE INTO metadata (key, value)
-                VALUES ('fts5_enabled', 'true')
-            """)
+            # Ensure FTS5 table exists (v10.8.0+)
+            self._ensure_fts5_initialized()
 
             # Create indexes for better performance
             self.conn.execute('CREATE INDEX IF NOT EXISTS idx_content_hash ON memories(content_hash)')


### PR DESCRIPTION
Two bugs in `initialize()` prevent hybrid BM25 search from working on databases that existed before v10.8.0:

**Bug 1: Early return skips FTS5 creation**

When `initialize()` detects an existing database (both `memories` and `memory_embeddings` tables present), it runs schema migrations for `deleted_at` and knowledge graph, then returns early at line 632 **without creating the FTS5 virtual table**. The FTS5 creation code (line 773+) is only reached for fresh installs.

This means any user upgrading from pre-v10.8.0 never gets the `memory_content_fts` table, and hybrid BM25+vector search silently falls back to vector-only.

**Bug 2: Wrong backfill method for external content FTS5 tables**

The original backfill uses `INSERT INTO memory_content_fts(rowid, content) SELECT ...` to populate the index. However, with `content='memories'` external content mode, this creates row mappings but does NOT build the trigram search index. The FTS5 `rebuild` command is required instead:

```sql
INSERT INTO memory_content_fts(memory_content_fts) VALUES('rebuild')
```

Without this, `SELECT ... FROM memory_content_fts WHERE memory_content_fts MATCH 'query'` returns zero results even though `SELECT count(*) FROM memory_content_fts` shows rows.

**Fix**

- Extract FTS5 setup into `_ensure_fts5_initialized()` (matching the pattern of `_run_graph_migrations()`)
- Call it from both the existing-DB early return path and the full init path (DRY)
- Use the `rebuild` command instead of INSERT for index population
- Failures are non-fatal (logged as warnings), consistent with other migrations

**Testing**

Verified on a real database with 850+ memories upgraded from v8.71.0 to v10.26.3:
- Before fix: `memory_content_fts` table missing, BM25 search returns 0 results
- After fix: FTS5 table created, trigram index populated, BM25 search works correctly
