### PR TITLE
fix: dashboard auth detection and credential persistence

### DIFF
--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -90,6 +90,11 @@ class MemoryDashboard {
             initComplete: false  // Guard against credential clearing during startup
         };
 
+        // Internal state for reconnect/polling management
+        this._sseReconnectAttempts = 0;
+        this._syncMonitorInterval = null;
+        this._lastAuthFailureToast = null;
+
         // Settings with defaults
         this.settings = {
             theme: 'light',
@@ -170,10 +175,7 @@ class MemoryDashboard {
                 this.authState.requiresAuth = true;
                 // Stored credentials are invalid — clear them
                 if (this.authState.apiKey || this.authState.oauthToken) {
-                    this.authState.apiKey = null;
-                    this.authState.oauthToken = null;
-                    localStorage.removeItem('mcp_api_key');
-                    localStorage.removeItem('mcp_oauth_token');
+                    this._clearCredentials();
                 }
                 return true;
             } else if (response.ok) {
@@ -3526,11 +3528,18 @@ class MemoryDashboard {
         }
 
         // Genuinely unauthenticated after init — clear and re-prompt.
+        this._clearCredentials();
+        this.showAuthModal();
+    }
+
+    /**
+     * Clear stored credentials from both in-memory state and localStorage.
+     */
+    _clearCredentials() {
         this.authState.apiKey = null;
         this.authState.oauthToken = null;
         localStorage.removeItem('mcp_api_key');
         localStorage.removeItem('mcp_oauth_token');
-        this.showAuthModal();
     }
 
     /**
@@ -3582,8 +3591,7 @@ class MemoryDashboard {
         } catch (error) {
             // Key is invalid — clean up
             this.showToast('Authentication failed. Please check your API key.', 'error');
-            this.authState.apiKey = null;
-            localStorage.removeItem('mcp_api_key');
+            this._clearCredentials();
             return false;
         }
     }

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -86,7 +86,8 @@ class MemoryDashboard {
             authMethod: null, // 'api_key', 'oauth', 'anonymous', or null
             apiKey: localStorage.getItem('mcp_api_key') || null,
             oauthToken: localStorage.getItem('mcp_oauth_token') || null,
-            requiresAuth: false
+            requiresAuth: false,
+            initComplete: false  // Guard against credential clearing during startup
         };
 
         // Settings with defaults
@@ -120,8 +121,6 @@ class MemoryDashboard {
         this.applyTheme();
         this.setupEventListeners();
         this.setupAuthListeners();
-        this.setupServerManagement();
-        this.setupSSE();
 
         // Check for secure context
         if (location.protocol !== 'https:' && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
@@ -129,12 +128,19 @@ class MemoryDashboard {
             this.showToast('Warning: Connection not secure. Please use HTTPS in production.', 'warning');
         }
 
-        // Detect authentication requirement before loading data
+        // Detect authentication requirement before loading data or starting
+        // background services. setupServerManagement and setupSSE are deferred
+        // until after auth to prevent early 401s from clearing stored credentials.
         const needsAuth = await this.detectAuthRequirement();
         if (needsAuth && !this.authState.apiKey && !this.authState.oauthToken) {
             this.showAuthModal();
             return; // Don't load data until authenticated
         }
+
+        // Auth established — safe to start background services and load data
+        this.authState.initComplete = true;
+        this.setupServerManagement();
+        this.setupSSE();
 
         await this.loadVersion();
         await this.loadDashboardData();
@@ -150,14 +156,31 @@ class MemoryDashboard {
      */
     async detectAuthRequirement() {
         try {
-            const response = await fetch(`${this.apiBase}/health`);
-            if (response.status === 401) {
+            // Probe an authenticated endpoint — /health never requires auth
+            // (GHSA-73hc-m4hx-79pj) so it cannot detect whether API key is needed.
+            // Send stored credentials if available to verify they still work.
+            const headers = {};
+            if (this.authState.apiKey) {
+                headers['X-API-Key'] = this.authState.apiKey;
+            } else if (this.authState.oauthToken) {
+                headers['Authorization'] = `Bearer ${this.authState.oauthToken}`;
+            }
+            const response = await fetch(`${this.apiBase}/health/detailed`, { headers });
+            if (response.status === 401 || response.status === 403) {
                 this.authState.requiresAuth = true;
+                // Stored credentials are invalid — clear them
+                if (this.authState.apiKey || this.authState.oauthToken) {
+                    this.authState.apiKey = null;
+                    this.authState.oauthToken = null;
+                    localStorage.removeItem('mcp_api_key');
+                    localStorage.removeItem('mcp_oauth_token');
+                }
                 return true;
             } else if (response.ok) {
                 this.authState.requiresAuth = false;
                 this.authState.isAuthenticated = true;
-                this.authState.authMethod = 'anonymous';
+                this.authState.authMethod = this.authState.apiKey ? 'api_key'
+                    : this.authState.oauthToken ? 'oauth' : 'anonymous';
                 return false;
             }
         } catch (error) {
@@ -3447,12 +3470,27 @@ class MemoryDashboard {
      * Handle authentication failure (401 response)
      */
     handleAuthFailure() {
-        // Clear invalid credentials
-        this.authState.isAuthenticated = false;
+        // During startup, various components (setupServerManagement, SSE) may
+        // fire API calls before auth is established. Don't clear stored
+        // credentials for those early 401s — they'll be validated properly
+        // by detectAuthRequirement.
+        if (!this.authState.initComplete) {
+            console.debug('Ignoring 401 during init — auth not yet established');
+            return;
+        }
+
+        // After init, a 401 on an already-authenticated session likely means
+        // a scope mismatch rather than invalid credentials — don't nuke them.
+        if (this.authState.isAuthenticated) {
+            console.warn('Got 401 despite being authenticated — endpoint may require higher scope');
+            return;
+        }
+
+        // Genuinely unauthenticated after init — clear and re-prompt.
+        this.authState.apiKey = null;
+        this.authState.oauthToken = null;
         localStorage.removeItem('mcp_api_key');
         localStorage.removeItem('mcp_oauth_token');
-
-        // Show authentication modal
         this.showAuthModal();
     }
 
@@ -3470,29 +3508,39 @@ class MemoryDashboard {
      * Authenticate with API key
      */
     async authenticateWithApiKey(apiKey) {
-        // Store API key
+        // Set API key in state temporarily for the validation call
         this.authState.apiKey = apiKey;
-        localStorage.setItem('mcp_api_key', apiKey);
 
-        // Test authentication
+        // Validate against an authenticated endpoint — /health never requires
+        // auth so it would accept any key (see issue #591)
         try {
-            await this.apiCall('/health');
+            await this.apiCall('/health/detailed');
+
+            // Key is valid — persist it and complete initialization
+            localStorage.setItem('mcp_api_key', apiKey);
             this.authState.isAuthenticated = true;
             this.authState.authMethod = 'api_key';
+            this.authState.initComplete = true;
 
-            // Close modal and refresh data
+            // Close modal
             const modal = document.getElementById('authModal');
             if (modal) {
                 this.closeModal(modal);
             }
 
-            // Reload dashboard data
+            // Start deferred background services now that auth is ready
+            this.setupServerManagement();
+            this.setupSSE();
+
+            // Load dashboard data
+            await this.loadVersion();
             this.loadDashboardData();
+            this.checkSyncStatus();
             this.showToast('Authentication successful', 'success');
 
             return true;
         } catch (error) {
-            // Authentication failed
+            // Key is invalid — clean up
             this.showToast('Authentication failed. Please check your API key.', 'error');
             this.authState.apiKey = null;
             localStorage.removeItem('mcp_api_key');

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -3524,6 +3524,10 @@ class MemoryDashboard {
                 console.warn('Got 401 despite being authenticated — credentials may have been invalidated');
                 this.showToast('Session expired or credentials changed. Please refresh the page.', 'warning');
             }
+            // Mark as unauthenticated so the next 401 triggers the full
+            // re-auth flow (clear credentials + show modal) instead of
+            // toasting indefinitely with invalid credentials.
+            this.authState.isAuthenticated = false;
             return;
         }
 
@@ -3582,7 +3586,7 @@ class MemoryDashboard {
 
             // Load dashboard data
             await this.loadVersion();
-            this.loadDashboardData();
+            await this.loadDashboardData();
             this.checkSyncStatus();
             this.startSyncStatusMonitoring();
             this.showToast('Authentication successful', 'success');

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -671,6 +671,20 @@ class MemoryDashboard {
      * Set up Server-Sent Events for real-time updates
      */
     setupSSE() {
+        // Close any existing connection to prevent connection multiplication.
+        // Without this, each failed reconnect spawns a new EventSource while
+        // the old one may still be retrying, leading to exponential 401 spam.
+        if (this.eventSource) {
+            this.eventSource.close();
+            this.eventSource = null;
+        }
+
+        // Don't attempt SSE if we know auth is required but we're not authenticated.
+        // The auth flow (modal → authenticateWithApiKey) will call setupSSE after success.
+        if (this.authState.requiresAuth && !this.authState.isAuthenticated) {
+            return;
+        }
+
         try {
             // Build SSE URL with query parameter auth (EventSource API doesn't support custom headers)
             const sseUrl = new URL(`${this.apiBase}/events`, window.location.origin);
@@ -682,6 +696,8 @@ class MemoryDashboard {
             this.eventSource = new EventSource(sseUrl.toString());
 
             this.eventSource.onopen = () => {
+                // Reset backoff on successful connection
+                this._sseReconnectAttempts = 0;
                 this.updateConnectionStatus('connected');
             };
 
@@ -717,12 +733,23 @@ class MemoryDashboard {
                 console.error('SSE connection error:', error);
                 this.updateConnectionStatus('disconnected');
 
-                // Attempt to reconnect after 5 seconds
+                // Don't reconnect if we're not authenticated — avoids infinite
+                // 401 loop when EventSource can't send auth headers and the
+                // query-param fallback isn't accepted.
+                if (!this.authState.isAuthenticated) {
+                    return;
+                }
+
+                // Exponential backoff: 5s → 10s → 20s → 40s → 60s max
+                const attempts = this._sseReconnectAttempts || 0;
+                const delay = Math.min(5000 * Math.pow(2, attempts), 60000);
+                this._sseReconnectAttempts = attempts + 1;
+
                 setTimeout(() => {
-                    if (this.eventSource.readyState === EventSource.CLOSED) {
+                    if (this.eventSource && this.eventSource.readyState === EventSource.CLOSED) {
                         this.setupSSE();
                     }
-                }, 5000);
+                }, delay);
             };
 
         } catch (error) {
@@ -1832,8 +1859,12 @@ class MemoryDashboard {
      * Start periodic sync status monitoring
      */
     startSyncStatusMonitoring() {
+        // Clear any existing interval to prevent duplicate polling loops
+        if (this._syncMonitorInterval) {
+            clearInterval(this._syncMonitorInterval);
+        }
         // Check sync status every 10 seconds
-        setInterval(() => {
+        this._syncMonitorInterval = setInterval(() => {
             this.checkSyncStatus();
         }, 10000);
     }
@@ -3479,10 +3510,18 @@ class MemoryDashboard {
             return;
         }
 
-        // After init, a 401 on an already-authenticated session likely means
-        // a scope mismatch rather than invalid credentials — don't nuke them.
+        // After init, a 401 on an already-authenticated session means
+        // credentials are no longer valid (e.g., server restarted with a new
+        // key, token expired). Notify the user so they can re-authenticate.
+        // Debounce: only show the toast once per 30 seconds to avoid spam from
+        // polling loops (sync status, SSE reconnect) all hitting 401 at once.
         if (this.authState.isAuthenticated) {
-            console.warn('Got 401 despite being authenticated — endpoint may require higher scope');
+            const now = Date.now();
+            if (!this._lastAuthFailureToast || (now - this._lastAuthFailureToast) > 30000) {
+                this._lastAuthFailureToast = now;
+                console.warn('Got 401 despite being authenticated — credentials may have been invalidated');
+                this.showToast('Session expired or credentials changed. Please refresh the page.', 'warning');
+            }
             return;
         }
 
@@ -3536,6 +3575,7 @@ class MemoryDashboard {
             await this.loadVersion();
             this.loadDashboardData();
             this.checkSyncStatus();
+            this.startSyncStatusMonitoring();
             this.showToast('Authentication successful', 'success');
 
             return true;
@@ -6187,6 +6227,11 @@ This action cannot be undone. Are you sure?`);
     destroy() {
         if (this.eventSource) {
             this.eventSource.close();
+            this.eventSource = null;
+        }
+        if (this._syncMonitorInterval) {
+            clearInterval(this._syncMonitorInterval);
+            this._syncMonitorInterval = null;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #591 — Dashboard authentication flow is broken when `MCP_API_KEY` is configured.

The dashboard's auth lifecycle has several interrelated bugs that cause API keys to not persist across page refreshes and generate excessive 401 errors in logs. This PR addresses all of them:

### Auth Detection & Credential Persistence (commit 1)
1. **`detectAuthRequirement()` probes wrong endpoint**: Probed `/health` which never requires auth (GHSA-73hc-m4hx-79pj hardening), so it could never detect that a key was needed. Now probes `/health/detailed`.
2. **`setupServerManagement()` and `setupSSE()` race with auth**: Both fired before authentication was established, triggering early 401s that called `handleAuthFailure()` and nuked stored credentials. Now deferred until after auth succeeds.
3. **`handleAuthFailure()` unconditionally clears credentials**: Added `initComplete` guard to ignore 401s during startup, and post-auth 401s now show a user-visible toast instead of silently failing.
4. **`authenticateWithApiKey()` validates against wrong endpoint**: Validated against `/health` (always 200), accepting any key. Now validates against `/health/detailed`.
5. **`startSyncStatusMonitoring()` missing from modal auth path**: Users authenticating via the modal never got the 10-second sync polling loop started (Greptile review feedback).

### SSE & Polling Robustness (commit 2, review feedback)
6. **SSE reconnect loop on 401**: `setupSSE()` never closed the old EventSource before creating a new one. Each failed reconnect spawned another connection, causing exponential 401 spam in logs. Now closes existing connections, skips reconnect when not authenticated, and uses exponential backoff (5s → 60s max).
7. **Sync polling duplication**: `startSyncStatusMonitoring()` created `setInterval` without storing the ID — no way to prevent duplicates or clean up. Now stores the interval ID and clears any existing one first.
8. **Toast spam from polling**: Post-auth 401s from sync polling (every 10s) each showed a toast. Now debounced to once per 30 seconds.
9. **Resource cleanup**: `destroy()` now properly cleans up both EventSource and sync polling interval.

## Test plan

- [x] Fresh load with `MCP_API_KEY` set and no cached credentials → auth modal appears
- [x] Enter valid key → dashboard loads, key persists in localStorage
- [x] Page refresh → key is read from localStorage, no modal, dashboard loads
- [x] Enter invalid key → "Authentication failed" toast, modal stays open
- [x] Server logs show clean 200s, no 401 spam from SSE or sync polling
- [x] SSE reconnects with backoff on network error (not on auth failure)
- [x] Anonymous mode (`MCP_ALLOW_ANONYMOUS_ACCESS=true`) still works without modal

## Addresses review feedback from

- @gemini-code-assist — post-auth 401 suppression too aggressive
- @greptile-apps — missing `startSyncStatusMonitoring()`, silent 401 swallow

🤖 Generated with [Claude Code](https://claude.com/claude-code)