### PR TITLE
chore: release v10.26.4 — FTS5 hybrid search fix + dashboard auth lifecycle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.26.4] - 2026-03-12
+
+### Fixed
+
+- **[#589] FTS5 table not created for existing databases (hybrid search broken on upgrade)** (`sqlite_vec.py`, contributed by @xXGeminiXx): Databases created before v10.8.0 never had the `memory_content_fts` FTS5 virtual table initialised because `initialize()` returned early after running graph migrations for existing DBs, bypassing the FTS5 creation block entirely. This caused hybrid BM25+vector search to silently fall back to vector-only on any pre-v10.8.0 upgrade. Added `_ensure_fts5_initialized()` idempotent method that checks `sqlite_master` for the table's existence before creating it and running the `rebuild` backfill command. The method is now called on both the new-DB and existing-DB paths, eliminating 57 lines of duplicated inline DDL.
+- **[#592] Dashboard auth detection and credential persistence** (`web/static/app.js`, contributed by @jeremykoerber, fixes #591): Fixed 9 bugs in the dashboard authentication lifecycle: API key no longer lost on page refresh; `detectAuthRequirement()` and `authenticateWithApiKey()` now probe `/health/detailed` instead of `/health` (which is always public since v10.21.0); `setupServerManagement()` and `setupSSE()` deferred until after auth resolves (race condition); `handleAuthFailure()` respects `initComplete` guard — credentials no longer wiped during startup 401s; SSE reconnect closes existing connection before opening a new one (leak fix); `startSyncStatusMonitoring()` now called in modal auth path; sync monitor interval ID stored and cleaned up in `destroy()`; auth failure toasts debounced to 30 s.
+
 ## [10.26.3] - 2026-03-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.26.3 - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.26.4 - FTS5 hybrid search fix on upgrade + dashboard auth lifecycle fixes (9 bugs) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -324,19 +324,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.26.3** (March 10, 2026)
+## Latest Release: **v10.26.4** (March 12, 2026)
 
-**Patch release: Dashboard metadata display fixes + quality scorer resilience improvements**
+**Patch release: FTS5 hybrid search fix on upgrade + dashboard auth lifecycle fixes**
 
 **What's New:**
-- **Dashboard: metadata objects now shown as JSON** (#582): Object-typed metadata values rendered as `[object Object]` are now serialised with `JSON.stringify` + HTML-escaped. XSS vector closed.
-- **Dashboard: long content collapsed in detail modal; quality tab fetches full object** (#583): Content >500 chars collapses with a Show more/less toggle. Quality-tab clicks now fetch the full memory object before opening the modal.
-- **Quality scorer: empty-query path uses absolute quality prompt** (#584): `store_memory` calls (query = "") no longer produce a 0.0 score — a dedicated absolute quality prompt is used instead of the relevance-based one.
-- **Quality scorer: Groq 429 triggers model fallback chain** (#585): Rate-limit responses now try `llama-3.1-8b-instant` → `llama3-8b-8192` → `gemma2-9b-it` in sequence instead of failing hard.
+- **FTS5 table now created for existing databases on upgrade** (#589): Hybrid BM25+vector search silently fell back to vector-only on databases created before v10.8.0 because `_ensure_fts5_initialized()` was never called on the early-return path. Now idempotent and called on both new and existing database paths.
+- **Dashboard auth detection and credential persistence fixed** (#592, fixes #591): 9 bugs in the dashboard auth lifecycle resolved — API key not persisted across page reload, 401 spam in logs, SSE connection leak, sync polling not started on modal auth path, auth detection probing wrong endpoint, and more.
 
 ---
 
 **Previous Releases**:
+- **v10.26.3** - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt)
 - **v10.26.2** - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping
 - **v10.26.1** - Hybrid backend correctly reported in MCP health checks (`HealthCheckFactory` structural detection fix for wrapped/delegated backends, issue #570)
 - **v10.26.0** - Credentials tab + Settings restructure + Sync Owner selector in dashboard; `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.26.3"
+version = "10.26.4"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.26.3"
+__version__ = "10.26.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.26.3"
+version = "10.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",


### PR DESCRIPTION
## Changes

- **FTS5 hybrid search fix** (#589 by @xXGeminiXx): `_ensure_fts5_initialized()` idempotent method ensures BM25+vector hybrid search works on pre-v10.8.0 upgraded databases
- **Dashboard auth lifecycle** (#592 by @jeremykoerber, fixes #591): 9 bugs fixed — API key persistence, 401 spam, SSE leak, polling dedup, auth detection endpoint

## Checklist
- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated
- [x] `CLAUDE.md` updated
- [x] `docs/index.html` NOT updated (patch release)

Fixes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)