### PR TITLE
fix(deps): security patch -- authlib>=1.6.9, PyJWT>=2.12.0, pypdf>=6.9.1 (v10.26.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.26.6] - 2026-03-20
+
+### Security
+
+- **[#597] bump authlib>=1.6.9 — JWS JWK header injection, JWE Bleichenbacher padding oracle, fail-open OIDC hash binding (Critical + 2 High)**: `authlib` minimum version raised from `>=1.6.5` to `>=1.6.9`. Three vulnerabilities addressed: (1) JWS JWK header injection allowed an attacker to inject their own public key into the header and bypass signature verification (Critical); (2) JWE RSA1_5 algorithm was susceptible to a Bleichenbacher padding oracle attack allowing ciphertext decryption (High); (3) OIDC hash binding (`c_hash`/`at_hash`) validation was fail-open — invalid hash values were silently accepted rather than rejected (High). These affect deployments using the OAuth 2.1 endpoints.
+- **[#597] bump PyJWT[crypto]>=2.12.0 — unknown `crit` header extension acceptance (High)**: `PyJWT` minimum version raised from `>=2.8.0` to `>=2.12.0`. Prior versions accepted JWTs with unknown `crit` header extensions instead of rejecting them, which could allow crafted tokens to bypass validation checks relying on extension semantics.
+- **[#597] bump pypdf>=6.9.1 — inefficient array-stream decoding (DoS) (Medium)**: `pypdf` minimum version raised from `>=3.0.0` to `>=6.9.1`. Processing attacker-controlled PDF files with large array-based content streams could cause excessive CPU/memory usage. Fix limits stream length and improves decoding performance.
+- **[#598] uv.lock updated**: `pypdf` 6.8.0 -> 6.9.1, `authlib` 1.6.8 -> 1.6.9 (Dependabot lock-file sync).
+
 ## [10.26.5] - 2026-03-13
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.26.5 - Security patch: black dev dependency bumped to >=26.3.1 (GHSA-3936-cmfr-pm3m, CVE-2026-32274) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.26.6 - Security patch: authlib>=1.6.9, PyJWT>=2.12.0, pypdf>=6.9.1 (5 Dependabot alerts: 1 critical, 3 high, 1 medium) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -347,16 +347,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.26.5** (March 13, 2026)
+## Latest Release: **v10.26.6** (March 20, 2026)
 
-**Security patch: bump black dev dependency to >=26.3.1 (GHSA-3936-cmfr-pm3m, CVE-2026-32274)**
+**Security patch: authlib>=1.6.9, PyJWT>=2.12.0, pypdf>=6.9.1 — 5 Dependabot alerts resolved (1 critical, 3 high, 1 medium)**
 
 **What's New:**
-- **Security fix: black path traversal vulnerability** (GHSA-3936-cmfr-pm3m, CVE-2026-32274, High): `black` code formatter updated from `>=24.0.0` to `>=26.3.1` to address a path traversal vulnerability via the `--python-cell-magics` option. Dev/CI environments only — `black` is not a runtime dependency.
+- **Security fix: authlib JWS/JWE vulnerabilities** (Critical + 2 High): `authlib` bumped from `>=1.6.5` to `>=1.6.9` to address JWS JWK header injection (signature verification bypass), JWE RSA1_5 Bleichenbacher padding oracle, and fail-open OIDC hash binding vulnerabilities.
+- **Security fix: PyJWT unknown `crit` header extensions** (High): `PyJWT[crypto]` bumped from `>=2.8.0` to `>=2.12.0` to prevent acceptance of unknown `crit` header extensions in JWT verification.
+- **Security fix: pypdf inefficient array-stream decoding** (Medium): `pypdf` bumped from `>=3.0.0` to `>=6.9.1` to address a DoS vector via inefficient array-based content stream processing.
+- `uv.lock` updated: pypdf 6.8.0 -> 6.9.1, authlib 1.6.8 -> 1.6.9.
 
 ---
 
 **Previous Releases**:
+- **v10.26.5** - Security patch: black dev dependency bumped to >=26.3.1 (GHSA-3936-cmfr-pm3m, CVE-2026-32274, path traversal)
 - **v10.26.4** - FTS5 hybrid search fix on upgrade + dashboard auth lifecycle fixes (9 bugs)
 - **v10.26.3** - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt)
 - **v10.26.2** - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.26.5"
+version = "10.26.6"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.26.5"
+__version__ = "10.26.6"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.26.5"
+version = "10.26.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

Security patch release bumping three runtime dependencies to resolve 5 open Dependabot alerts.

| Alert | Package | Severity | Vulnerability | Fix |
|-------|---------|----------|--------------|-----|
| #51 | authlib | **Critical** | JWS JWK header injection — signature verification bypass | >=1.6.9 |
| #52 | authlib | **High** | JWE RSA1_5 Bleichenbacher padding oracle | >=1.6.9 |
| #53 | authlib | **High** | Fail-open OIDC hash binding (c_hash/at_hash) | >=1.6.9 |
| #50 | PyJWT | **High** | Accepts unknown `crit` header extensions | >=2.12.0 |
| #54 | pypdf | **Medium** | Inefficient array-stream decoding (DoS) | >=6.9.1 |

### pyproject.toml changes
- `authlib>=1.6.5` → `>=1.6.9`
- `PyJWT[crypto]>=2.8.0` → `>=2.12.0`
- `pypdf>=3.0.0` → `>=6.9.1`

### uv.lock changes (PR #598, already merged)
- pypdf 6.8.0 → 6.9.1
- authlib 1.6.8 → 1.6.9

## Motivation

Three of the five vulnerabilities affect the OAuth 2.1 endpoints introduced in v7.0.0. The authlib Critical (signature bypass) is especially important for deployments that expose the Remote MCP endpoint to the internet.

## Testing

- `pip install -e .` — all three packages resolve to patched versions
- CI green on main (PRs #597 and #598 already merged)
- No new tests needed (dependency version constraint change only)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated with detailed security entries
- [x] `README.md` "Latest Release" section updated; v10.26.5 moved to Previous Releases
- [x] `CLAUDE.md` version callout updated
- [x] `docs/index.html` NOT updated (PATCH release)
- [x] No breaking changes

Closes #50, #51, #52, #53, #54