### PR TITLE
fix(cloudflare): handle D1 returning success with empty PRAGMA results on fresh database

### DIFF
--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -320,6 +320,16 @@ class CloudflareStorage(MemoryStorage):
                     if "name" in row:
                         columns.add(row["name"])
 
+            # On a fresh D1 database, PRAGMA table_info returns success with
+            # empty results when the table doesn't exist. In this case, skip
+            # migration — the table will be created by _initialize_d1_schema.
+            if not columns:
+                logger.debug(
+                    "Schema migration check: No columns found (table does not exist yet), "
+                    "skipping migration"
+                )
+                return
+
             migrations_needed = []
 
             # Check if 'tags' column exists

--- a/tests/unit/test_cloudflare_migration.py
+++ b/tests/unit/test_cloudflare_migration.py
@@ -57,6 +57,35 @@ class TestCloudflareD1Migration:
             assert "PRAGMA table_info(memories)" in str(call_args)
 
     @pytest.mark.asyncio
+    async def test_migrate_d1_schema_fresh_database_d1_success_empty(self, cloudflare_storage):
+        """Test migration when D1 returns success with empty results for a fresh database.
+
+        Cloudflare D1 returns {"success": true, "result": [{"results": []}]}
+        when PRAGMA table_info is run on a non-existent table, rather than
+        returning success=false. The migration should detect the empty results
+        and skip gracefully, allowing _initialize_d1_schema to create the table.
+
+        Regression test for https://github.com/doobidoo/mcp-memory-service/issues/600
+        """
+        # Mock PRAGMA response matching actual D1 behavior on fresh database
+        mock_pragma_response = Mock()
+        mock_pragma_response.json.return_value = {
+            "success": True,
+            "result": [{"results": []}]
+        }
+
+        with patch.object(cloudflare_storage, '_retry_request') as mock_request:
+            mock_request.return_value = mock_pragma_response
+
+            # Should not raise, just return early
+            await cloudflare_storage._migrate_d1_schema()
+
+            # Verify only the PRAGMA call was made (no ALTER TABLE attempts)
+            assert mock_request.call_count == 1
+            call_args = mock_request.call_args
+            assert "PRAGMA table_info(memories)" in str(call_args)
+
+    @pytest.mark.asyncio
     async def test_migrate_d1_schema_from_v8_69_0(self, cloudflare_storage):
         """Test migration from v8.69.0 schema (no tags, no deleted_at).
 


### PR DESCRIPTION
## Summary

Fixes #600 — D1 schema initialization fails on fresh database due to PRAGMA returning success with empty results.

## Problem

On a fresh Cloudflare D1 database, `PRAGMA table_info(memories)` returns:
```json
{"success": true, "result": [{"results": []}]}
```

The migration code in `_migrate_d1_schema()` only checked for `success=false` to detect a missing table. Since D1 returns `success=true`, the code fell through to ALTER TABLE operations on a non-existent table, resulting in `400 Bad Request` errors and a 5-second initialization timeout.

## Fix

After parsing the PRAGMA response, check if `columns` is empty. If no columns are found, the table doesn't exist yet — return early and let `_initialize_d1_schema()` create it via `CREATE TABLE IF NOT EXISTS`.

```python
if not columns:
    logger.debug(
        "Schema migration check: No columns found (table does not exist yet), "
        "skipping migration"
    )
    return
```

## Testing

- Added regression test `test_migrate_d1_schema_fresh_database_d1_success_empty` that mocks actual D1 behavior (success=true, empty results)
- All 10 existing migration tests continue to pass
- The fix is minimal and only affects the fresh-database code path