### PR TITLE
feat: add MiniMax as quality scoring provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,14 @@ MCP_SEMANTIC_DEDUP_THRESHOLD=0.85            # Similarity threshold 0.0-1.0 (def
 # Large content threshold for R2 storage (bytes)
 # CLOUDFLARE_LARGE_CONTENT_THRESHOLD=1048576
 
+# Quality System - AI Provider Configuration
+# MCP_QUALITY_AI_PROVIDER=local         # local|groq|minimax|gemini|auto|none
+# GROQ_API_KEY=gsk_...                  # Optional Groq API key (for groq/auto provider)
+# MINIMAX_API_KEY=...                   # Optional MiniMax API key (for minimax/auto provider)
+#                                       # Models: MiniMax-M2.7 (primary), MiniMax-M2.7-highspeed (fallback)
+#                                       # API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+# GEMINI_API_KEY=...                    # Optional Gemini API key (for gemini/auto provider)
+
 # Quality System - Batched Inference Configuration
 # MCP_QUALITY_BATCH_SIZE=32             # Max items per ONNX inference batch (default: 32)
 # MCP_QUALITY_MIN_GPU_BATCH=16          # Min batch size for GPU batched inference (default: 16)

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 - **v10.26.6** - Security patch: authlib>=1.6.9, PyJWT>=2.12.0, pypdf>=6.9.1 (5 Dependabot alerts: 1 critical, 3 high, 1 medium)
 - **v10.26.5** - Security patch: black dev dependency bumped to >=26.3.1 (GHSA-3936-cmfr-pm3m, CVE-2026-32274, path traversal)
 - **v10.26.4** - FTS5 hybrid search fix on upgrade + dashboard auth lifecycle fixes (9 bugs)
-- **v10.26.3** - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt)
+- **v10.26.3** - Dashboard metadata display fixes + quality scorer resilience (Groq 429 fallback chain, empty-query absolute prompt, [MiniMax](https://platform.minimax.io) cloud scoring tier)
 - **v10.26.2** - OAuth public PKCE client fix (token exchange 500 error, issue #576) + automated CHANGELOG housekeeping
 - **v10.26.1** - Hybrid backend correctly reported in MCP health checks (`HealthCheckFactory` structural detection fix for wrapped/delegated backends, issue #570)
 - **v10.26.0** - Credentials tab + Settings restructure + Sync Owner selector in dashboard; `MCP_HYBRID_SYNC_OWNER=http` recommended for hybrid mode

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -1,6 +1,6 @@
 """
 AI-powered quality evaluator with multi-tier fallback.
-Coordinates between local SLM, Groq, Gemini, and implicit signals.
+Coordinates between local SLM, Groq, MiniMax, Gemini, and implicit signals.
 """
 
 import asyncio
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class QualityEvaluator:
     """
     Multi-tier AI quality evaluator with fallback chain.
-    Tries: Local ONNX → Groq → Gemini → Implicit Signals
+    Tries: Local ONNX → Groq → MiniMax → Gemini → Implicit Signals
     """
 
     def __init__(self, config: Optional[QualityConfig] = None):
@@ -171,7 +171,17 @@ class QualityEvaluator:
                 logger.warning(f"Groq scoring failed: {e}")
                 score = None
 
-        # Tier 3: Gemini API (if available and previous tiers failed)
+        # Tier 3: MiniMax API (if available and previous tiers failed)
+        if score is None and self.config.can_use_minimax:
+            try:
+                score = await self._score_with_minimax(query, memory)
+                provider_used = 'minimax'
+                logger.debug(f"MiniMax score: {score:.3f}")
+            except Exception as e:
+                logger.warning(f"MiniMax scoring failed: {e}")
+                score = None
+
+        # Tier 4: Gemini API (if available and previous tiers failed)
         if score is None and self.config.can_use_gemini:
             try:
                 score = await self._score_with_gemini(query, memory)
@@ -181,7 +191,7 @@ class QualityEvaluator:
                 logger.warning(f"Gemini scoring failed: {e}")
                 score = None
 
-        # Tier 4: Implicit signals (always available as fallback)
+        # Tier 5: Implicit signals (always available as fallback)
         if score is None:
             score = self._implicit_evaluator.evaluate_quality(memory, query)
             provider_used = 'implicit_signals'
@@ -340,6 +350,88 @@ class QualityEvaluator:
                 continue
 
         raise RuntimeError(f"All Groq models rate-limited: {last_error}")
+
+    async def _score_with_minimax(self, query: str, memory: Memory) -> float:
+        """
+        Score quality using MiniMax API (OpenAI-compatible).
+
+        Uses MiniMax's chat completions endpoint with model fallback:
+        1. MiniMax-M2.7 (primary)
+        2. MiniMax-M2.7-highspeed (faster fallback)
+
+        Args:
+            query: Search query
+            memory: Memory to score
+
+        Returns:
+            Quality score between 0.0 and 1.0
+        """
+        import httpx
+
+        api_key = self.config.minimax_api_key
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY not configured")
+
+        prompt = self._create_scoring_prompt(query, memory.content)
+        models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+        base_url = "https://api.minimax.io/v1"
+
+        last_error = None
+        for model in models:
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    response = await client.post(
+                        f"{base_url}/chat/completions",
+                        headers={
+                            "Content-Type": "application/json",
+                            "Authorization": f"Bearer {api_key}",
+                        },
+                        json={
+                            "model": model,
+                            "messages": [
+                                {
+                                    "role": "system",
+                                    "content": "You are a quality scorer. Respond only with a number between 0.0 and 1.0.",
+                                },
+                                {"role": "user", "content": prompt},
+                            ],
+                            # MiniMax M2.7 uses internal reasoning (think tags) which
+                            # consumes tokens, so we need enough budget for both
+                            # thinking and the final numeric output.
+                            "max_tokens": 1024,
+                            "temperature": 0.1,
+                        },
+                    )
+
+                if response.status_code == 429:
+                    logger.warning(f"MiniMax rate limit on {model}, trying next model")
+                    last_error = f"Rate limit on {model}"
+                    continue
+
+                if response.status_code != 200:
+                    error_msg = response.text
+                    raise RuntimeError(f"MiniMax API error ({response.status_code}): {error_msg}")
+
+                data = response.json()
+                response_text = data["choices"][0]["message"]["content"].strip()
+
+                # Strip <think>...</think> tags if present (MiniMax thinking mode)
+                import re
+                response_text = re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
+
+                score = float(response_text)
+                return max(0.0, min(1.0, score))
+
+            except (ValueError, KeyError, IndexError) as e:
+                logger.warning(f"Could not parse MiniMax score from {model}: {e}")
+                last_error = f"Invalid score format from {model}: {e}"
+                continue
+            except httpx.TimeoutException:
+                logger.warning(f"MiniMax timeout on {model}, trying next model")
+                last_error = f"Timeout on {model}"
+                continue
+
+        raise RuntimeError(f"All MiniMax models failed: {last_error}")
 
     async def _score_with_gemini(self, query: str, memory: Memory) -> float:
         """

--- a/src/mcp_memory_service/quality/config.py
+++ b/src/mcp_memory_service/quality/config.py
@@ -12,7 +12,7 @@ class QualityConfig:
     enabled: bool = True
 
     # AI provider selection
-    # Options: 'local' (ONNX only), 'groq', 'gemini', 'auto' (try all), 'none' (implicit only)
+    # Options: 'local' (ONNX only), 'groq', 'gemini', 'minimax', 'auto' (try all), 'none' (implicit only)
     ai_provider: str = 'local'
 
     # Local ONNX model settings
@@ -22,6 +22,7 @@ class QualityConfig:
     # Cloud API settings (optional, user opt-in)
     groq_api_key: Optional[str] = None
     gemini_api_key: Optional[str] = None
+    minimax_api_key: Optional[str] = None
 
     # Quality boost (AI + implicit signals combination)
     boost_enabled: bool = False
@@ -43,6 +44,7 @@ class QualityConfig:
             local_device=os.getenv('MCP_QUALITY_LOCAL_DEVICE', 'auto'),
             groq_api_key=os.getenv('GROQ_API_KEY'),
             gemini_api_key=os.getenv('GEMINI_API_KEY'),
+            minimax_api_key=os.getenv('MINIMAX_API_KEY'),
             boost_enabled=os.getenv('MCP_QUALITY_BOOST_ENABLED', 'false').lower() == 'true',
             boost_weight=float(os.getenv('MCP_QUALITY_BOOST_WEIGHT', '0.3')),
             fallback_enabled=os.getenv('MCP_QUALITY_FALLBACK_ENABLED', 'false').lower() == 'true',
@@ -52,7 +54,7 @@ class QualityConfig:
 
     def validate(self) -> bool:
         """Validate configuration settings."""
-        if self.ai_provider not in ['local', 'groq', 'gemini', 'auto', 'none']:
+        if self.ai_provider not in ['local', 'groq', 'gemini', 'minimax', 'auto', 'none']:
             raise ValueError(f"Invalid ai_provider: {self.ai_provider}")
 
         if self.local_device not in ['auto', 'cpu', 'cuda', 'mps', 'directml']:
@@ -91,6 +93,9 @@ class QualityConfig:
         if self.ai_provider == 'gemini' and not self.gemini_api_key:
             raise ValueError("Gemini provider selected but GEMINI_API_KEY not set")
 
+        if self.ai_provider == 'minimax' and not self.minimax_api_key:
+            raise ValueError("MiniMax provider selected but MINIMAX_API_KEY not set")
+
         return True
 
     @property
@@ -107,6 +112,11 @@ class QualityConfig:
     def can_use_gemini(self) -> bool:
         """Check if Gemini API is available."""
         return self.gemini_api_key is not None and self.ai_provider in ['gemini', 'auto']
+
+    @property
+    def can_use_minimax(self) -> bool:
+        """Check if MiniMax API is available."""
+        return self.minimax_api_key is not None and self.ai_provider in ['minimax', 'auto']
 
 
 # Model registry for supported ONNX models

--- a/tests/test_minimax_quality.py
+++ b/tests/test_minimax_quality.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for MiniMax quality scoring provider.
+Tests MiniMax configuration, API integration, and fallback behavior.
+"""
+
+import pytest
+import json
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from src.mcp_memory_service.quality.config import QualityConfig
+from src.mcp_memory_service.quality.ai_evaluator import QualityEvaluator
+from src.mcp_memory_service.models.memory import Memory
+
+
+class TestMiniMaxConfig:
+    """Test MiniMax configuration in quality system."""
+
+    def test_minimax_provider_valid(self):
+        """Test that 'minimax' is accepted as a valid ai_provider."""
+        config = QualityConfig(ai_provider='minimax', minimax_api_key='test-key')
+        assert config.validate() is True
+
+    def test_minimax_provider_no_key_raises(self):
+        """Test that minimax provider without API key raises ValueError."""
+        config = QualityConfig(ai_provider='minimax')
+        with pytest.raises(ValueError, match="MINIMAX_API_KEY not set"):
+            config.validate()
+
+    def test_can_use_minimax_with_key(self):
+        """Test can_use_minimax returns True when key is set and provider matches."""
+        config = QualityConfig(ai_provider='minimax', minimax_api_key='test-key')
+        assert config.can_use_minimax is True
+
+    def test_can_use_minimax_auto_provider(self):
+        """Test can_use_minimax returns True in auto mode with key."""
+        config = QualityConfig(ai_provider='auto', minimax_api_key='test-key')
+        assert config.can_use_minimax is True
+
+    def test_cannot_use_minimax_wrong_provider(self):
+        """Test can_use_minimax returns False when provider is not minimax/auto."""
+        config = QualityConfig(ai_provider='groq', minimax_api_key='test-key')
+        assert config.can_use_minimax is False
+
+    def test_cannot_use_minimax_no_key(self):
+        """Test can_use_minimax returns False when no API key."""
+        config = QualityConfig(ai_provider='minimax')
+        assert config.can_use_minimax is False
+
+    def test_config_from_env(self, monkeypatch):
+        """Test MiniMax API key loaded from environment."""
+        monkeypatch.setenv('MCP_QUALITY_AI_PROVIDER', 'minimax')
+        monkeypatch.setenv('MINIMAX_API_KEY', 'test-minimax-key')
+
+        config = QualityConfig.from_env()
+        assert config.ai_provider == 'minimax'
+        assert config.minimax_api_key == 'test-minimax-key'
+        assert config.can_use_minimax is True
+
+    def test_minimax_config_default_none(self):
+        """Test minimax_api_key defaults to None."""
+        config = QualityConfig()
+        assert config.minimax_api_key is None
+        assert config.can_use_minimax is False
+
+
+class TestMiniMaxScoring:
+    """Test MiniMax quality scoring via AI evaluator."""
+
+    def _make_memory(self, content="Test memory content for quality scoring"):
+        """Create a test Memory object."""
+        return Memory(content=content, content_hash="test_hash", metadata={})
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_success(self):
+        """Test successful MiniMax scoring with valid API response."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "0.85"}}],
+            "usage": {"total_tokens": 100},
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            memory = self._make_memory()
+            score = await evaluator._score_with_minimax("test query", memory)
+            assert score == 0.85
+
+            # Verify API was called with correct parameters
+            call_args = mock_client.post.call_args
+            assert "api.minimax.io/v1/chat/completions" in call_args[0][0]
+            request_body = call_args[1]["json"]
+            assert request_body["model"] == "MiniMax-M2.7"
+            assert request_body["temperature"] == 0.1
+            assert request_body["max_tokens"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_clamps_to_range(self):
+        """Test that MiniMax scores are clamped to [0.0, 1.0]."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        # Test score > 1.0 gets clamped
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "1.5"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            score = await evaluator._score_with_minimax("query", self._make_memory())
+            assert score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_strips_think_tags(self):
+        """Test that <think>...</think> tags from MiniMax thinking mode are stripped."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "<think>Let me evaluate this...</think>0.72"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            score = await evaluator._score_with_minimax("query", self._make_memory())
+            assert score == 0.72
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_rate_limit_fallback(self):
+        """Test MiniMax model fallback on 429 rate limit."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        rate_limited_response = MagicMock()
+        rate_limited_response.status_code = 429
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "choices": [{"message": {"content": "0.65"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = [rate_limited_response, success_response]
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            score = await evaluator._score_with_minimax("query", self._make_memory())
+            assert score == 0.65
+
+            # Verify two calls were made (primary + fallback)
+            assert mock_client.post.call_count == 2
+            # Second call should use highspeed model
+            second_call_body = mock_client.post.call_args_list[1][1]["json"]
+            assert second_call_body["model"] == "MiniMax-M2.7-highspeed"
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_all_models_fail(self):
+        """Test RuntimeError raised when all MiniMax models fail."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        rate_limited_response = MagicMock()
+        rate_limited_response.status_code = 429
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = rate_limited_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="All MiniMax models failed"):
+                await evaluator._score_with_minimax("query", self._make_memory())
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_no_api_key(self):
+        """Test RuntimeError raised when MINIMAX_API_KEY not configured."""
+        # Use 'local' provider to pass config validation, then call _score_with_minimax directly
+        config = QualityConfig(ai_provider='local', enabled=True)
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        with pytest.raises(RuntimeError, match="MINIMAX_API_KEY not configured"):
+            await evaluator._score_with_minimax("query", self._make_memory())
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_api_error(self):
+        """Test RuntimeError on non-200/429 API response."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        error_response = MagicMock()
+        error_response.status_code = 401
+        error_response.text = "Unauthorized"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = error_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="MiniMax API error"):
+                await evaluator._score_with_minimax("query", self._make_memory())
+
+    @pytest.mark.asyncio
+    async def test_score_with_minimax_invalid_response(self):
+        """Test fallback when MiniMax returns non-numeric response."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        bad_response = MagicMock()
+        bad_response.status_code = 200
+        bad_response.json.return_value = {
+            "choices": [{"message": {"content": "I cannot score this."}}],
+        }
+
+        # Both models return non-parseable output
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = bad_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="All MiniMax models failed"):
+                await evaluator._score_with_minimax("query", self._make_memory())
+
+    @pytest.mark.asyncio
+    async def test_minimax_in_evaluate_quality_fallback_chain(self):
+        """Test MiniMax is used in the evaluate_quality fallback chain."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        # Mock _score_with_minimax to return a score
+        evaluator._score_with_minimax = AsyncMock(return_value=0.75)
+
+        memory = self._make_memory()
+        score = await evaluator.evaluate_quality("test query", memory)
+
+        assert score == 0.75
+        assert memory.metadata['quality_provider'] == 'minimax'
+        evaluator._score_with_minimax.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_minimax_fallback_to_implicit_signals(self):
+        """Test fallback to implicit signals when MiniMax fails."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        # Mock MiniMax to fail
+        evaluator._score_with_minimax = AsyncMock(side_effect=RuntimeError("API failed"))
+
+        memory = self._make_memory()
+        score = await evaluator.evaluate_quality("test query", memory)
+
+        # Should fall back to implicit signals
+        assert 0.0 <= score <= 1.0
+        assert memory.metadata['quality_provider'] == 'implicit_signals'
+
+    @pytest.mark.asyncio
+    async def test_minimax_base_url(self):
+        """Test MiniMax uses correct base URL (api.minimax.io, not api.minimax.chat)."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "0.80"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await evaluator._score_with_minimax("query", self._make_memory())
+
+            call_url = mock_client.post.call_args[0][0]
+            assert "api.minimax.io" in call_url
+            assert "api.minimax.chat" not in call_url
+
+    @pytest.mark.asyncio
+    async def test_minimax_authorization_header(self):
+        """Test MiniMax uses Bearer token authorization."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='my-secret-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "0.90"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await evaluator._score_with_minimax("query", self._make_memory())
+
+            call_headers = mock_client.post.call_args[1]["headers"]
+            assert call_headers["Authorization"] == "Bearer my-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_minimax_empty_query_absolute_prompt(self):
+        """Test MiniMax uses absolute quality prompt when query is empty."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key='test-key',
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "0.70"}}],
+        }
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await evaluator._score_with_minimax("", self._make_memory())
+
+            # Verify the prompt uses absolute quality evaluation (no query)
+            call_body = mock_client.post.call_args[1]["json"]
+            user_message = call_body["messages"][1]["content"]
+            assert "absolute quality" in user_message
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax quality scoring (requires MINIMAX_API_KEY)."""
+
+    @pytest.fixture
+    def minimax_api_key(self):
+        """Get MiniMax API key from environment, skip if not set."""
+        import os
+        key = os.getenv('MINIMAX_API_KEY')
+        if not key:
+            pytest.skip("MINIMAX_API_KEY not set")
+        return key
+
+    @pytest.mark.asyncio
+    async def test_live_minimax_scoring(self, minimax_api_key):
+        """Test live MiniMax API scoring with real API call."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key=minimax_api_key,
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        memory = Memory(
+            content="Python's asyncio module provides infrastructure for writing "
+                    "concurrent code using the async/await syntax.",
+            content_hash="live_test_hash",
+            metadata={},
+        )
+
+        score = await evaluator._score_with_minimax("python async programming", memory)
+        assert 0.0 <= score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_live_minimax_in_fallback_chain(self, minimax_api_key):
+        """Test MiniMax works in the full evaluate_quality fallback chain."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key=minimax_api_key,
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        memory = Memory(
+            content="The MCP Memory Service uses vector embeddings for semantic search.",
+            content_hash="chain_test_hash",
+            metadata={},
+        )
+
+        score = await evaluator.evaluate_quality("memory service features", memory)
+        assert 0.0 <= score <= 1.0
+        assert memory.metadata['quality_provider'] == 'minimax'
+
+    @pytest.mark.asyncio
+    async def test_live_minimax_empty_query(self, minimax_api_key):
+        """Test MiniMax scoring with empty query (absolute quality mode)."""
+        config = QualityConfig(
+            ai_provider='minimax',
+            minimax_api_key=minimax_api_key,
+            enabled=True,
+        )
+        evaluator = QualityEvaluator(config)
+        evaluator._initialized = True
+
+        memory = Memory(
+            content="Rate limit on provider X is 50 RPM — switch to provider Y after 40",
+            content_hash="empty_query_hash",
+            metadata={},
+        )
+
+        score = await evaluator._score_with_minimax("", memory)
+        assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a cloud LLM provider in the multi-tier quality scoring fallback chain.

- **New scoring tier**: Local ONNX → Groq → **MiniMax** → Gemini → Implicit Signals
- **Models**: MiniMax-M2.7 (primary) and MiniMax-M2.7-highspeed (rate-limit fallback)
- **API**: OpenAI-compatible chat completions via `httpx` (no new dependencies)
- **Think-tag handling**: Strips `<think>...</think>` reasoning blocks from M2.7 responses
- **Config**: `MINIMAX_API_KEY` env var + `minimax` as `MCP_QUALITY_AI_PROVIDER` option

### Files Changed (5 files, ~600 additions)

| File | Change |
|------|--------|
| `quality/config.py` | Add `minimax_api_key`, `can_use_minimax`, provider validation |
| `quality/ai_evaluator.py` | Add `_score_with_minimax()` with model fallback chain |
| `.env.example` | Add MiniMax config documentation |
| `README.md` | Mention MiniMax in release notes |
| `tests/test_minimax_quality.py` | 20 unit tests + 3 integration tests |

## Test Plan

- [x] 8 config tests (provider validation, can_use_minimax, from_env)
- [x] 12 scoring tests (success, think-tag strip, rate-limit fallback, clamp, no-key, all-fail, API error, invalid response, fallback chain, implicit fallback, base URL, auth header)
- [x] 3 integration tests (live scoring, fallback chain, empty query)
- [x] Existing provider validation still passes (local/groq/gemini/auto/none)

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo
