### PR TITLE
fix: resolve 6 bugs in consolidation, embeddings, and memory types (#603-#608)

### DIFF
--- a/src/mcp_memory_service/consolidation/base.py
+++ b/src/mcp_memory_service/consolidation/base.py
@@ -132,14 +132,28 @@ class ConsolidationBase(ABC):
         return True
     
     def _get_memory_age_days(self, memory: Memory, reference_time: Optional[datetime] = None) -> int:
-        """Get the age of a memory in days."""
+        """Get the age of a memory in days.
+
+        Uses the most recent of created_at and updated_at so that content updates
+        effectively 'renew' a memory's age for consolidation purposes (#606).
+        """
         ref_time = reference_time or datetime.now(timezone.utc)
         if ref_time.tzinfo is None:
             ref_time = ref_time.replace(tzinfo=timezone.utc)
-        
+
+        # Determine the best reference timestamp: max(created_at, updated_at)
+        reference_ts = None
         if memory.created_at:
-            created_dt = datetime.fromtimestamp(memory.created_at, tz=timezone.utc)
-            return (ref_time - created_dt).days
+            reference_ts = memory.created_at
+        if memory.updated_at:
+            if reference_ts is None:
+                reference_ts = memory.updated_at
+            else:
+                reference_ts = max(reference_ts, memory.updated_at)
+
+        if reference_ts:
+            ref_dt = datetime.fromtimestamp(reference_ts, tz=timezone.utc)
+            return (ref_time - ref_dt).days
         elif memory.timestamp:
             ts = memory.timestamp
             if ts.tzinfo is None:

--- a/src/mcp_memory_service/consolidation/consolidator.py
+++ b/src/mcp_memory_service/consolidation/consolidator.py
@@ -477,7 +477,7 @@ class DreamInspiredConsolidator:
 
         # Single batch transaction instead of 500+ sequential calls
         if memories_to_update:
-            await self.storage.update_memories_batch(memories_to_update)
+            await self.storage.update_memories_batch(memories_to_update, preserve_timestamps=True)
 
         return relevance_scores
 
@@ -758,7 +758,7 @@ class DreamInspiredConsolidator:
 
         # Use batch update for optimal performance
         try:
-            results = await self.storage.update_memories_batch(memories)
+            results = await self.storage.update_memories_batch(memories, preserve_timestamps=True)
             success_count = sum(results)
             self.logger.info(
                 f"Consolidation timestamps updated: {success_count}/{len(memories)} memories"

--- a/src/mcp_memory_service/consolidation/decay.py
+++ b/src/mcp_memory_service/consolidation/decay.py
@@ -293,5 +293,6 @@ class ExponentialDecayCalculator(ConsolidationBase):
                     f"{original_quality:.3f} → {boosted_quality:.3f}"
                 )
 
-        memory.touch()  # Update the updated_at timestamp
+        # NOTE: Do NOT call memory.touch() here — relevance scoring is a read path.
+        # Advancing updated_at corrupts age calculations and inflates access boosts. (#604)
         return memory

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1198,7 +1198,7 @@ class MemoryServer:
                 content=learning_note,
                 content_hash=content_hash,
                 tags=["learning", topic.lower().replace(" ", "_")],
-                memory_type="learning_note"
+                memory_type="learning"
             )
             success, message = await self.storage.store(memory)
             

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -729,7 +729,7 @@ class MemoryStorage(ABC):
         )
         return success
 
-    async def update_memories_batch(self, memories: List[Memory]) -> List[bool]:
+    async def update_memories_batch(self, memories: List[Memory], preserve_timestamps: bool = False) -> List[bool]:
         """
         Update multiple memories in a batch operation.
 
@@ -739,6 +739,7 @@ class MemoryStorage(ABC):
 
         Args:
             memories: List of Memory objects with updated fields
+            preserve_timestamps: If True, do not advance updated_at for metadata-only changes (#605)
 
         Returns:
             List of success booleans, one for each memory in the batch

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1476,7 +1476,7 @@ class HybridMemoryStorage(MemoryStorage):
 
         return success, message
 
-    async def update_memories_batch(self, memories: List[Memory]) -> List[bool]:
+    async def update_memories_batch(self, memories: List[Memory], preserve_timestamps: bool = False) -> List[bool]:
         """
         Update multiple memories in a batch operation with optimal performance.
 
@@ -1485,12 +1485,13 @@ class HybridMemoryStorage(MemoryStorage):
 
         Args:
             memories: List of Memory objects with updated fields
+            preserve_timestamps: If True, do not advance updated_at for metadata-only changes (#605)
 
         Returns:
             List of success booleans, one for each memory in the batch
         """
         # Use primary storage's optimized batch update (single transaction)
-        results = await self.primary.update_memories_batch(memories)
+        results = await self.primary.update_memories_batch(memories, preserve_timestamps=preserve_timestamps)
 
         # Queue successful updates for background sync to secondary
         if self.sync_service:

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -935,6 +935,9 @@ SOLUTIONS:
                         self.embedding_model = _MODEL_CACHE[cache_key]
                         if cache_key in _DIMENSION_CACHE:
                             self.embedding_dimension = _DIMENSION_CACHE[cache_key]
+                        elif hasattr(self.embedding_model, 'embedding_dimension'):
+                            self.embedding_dimension = self.embedding_model.embedding_dimension
+                            _DIMENSION_CACHE[cache_key] = self.embedding_dimension  # backfill cache
                         logger.info("Using cached external embedding model")
                         return
 
@@ -987,6 +990,9 @@ SOLUTIONS:
                         self.embedding_model = _MODEL_CACHE[cache_key]
                         if cache_key in _DIMENSION_CACHE:
                             self.embedding_dimension = _DIMENSION_CACHE[cache_key]
+                        elif hasattr(self.embedding_model, 'embedding_dimension'):
+                            self.embedding_dimension = self.embedding_model.embedding_dimension
+                            _DIMENSION_CACHE[cache_key] = self.embedding_dimension  # backfill cache
                         logger.info(f"Using cached ONNX embedding model: {self.embedding_model_name}")
                         return
 
@@ -1011,6 +1017,14 @@ SOLUTIONS:
                 logger.warning(
                     "Neither ONNX nor sentence-transformers available; using pure-Python hash embeddings (quality reduced)."
                 )
+                # Detect existing DB dimension to avoid mismatch (#608)
+                existing_dim = self._get_existing_db_embedding_dimension()
+                if existing_dim and existing_dim != self.embedding_dimension:
+                    logger.warning(
+                        f"Adjusting hash embedding dimension from {self.embedding_dimension} to "
+                        f"{existing_dim} to match existing database schema."
+                    )
+                    self.embedding_dimension = existing_dim
                 self.embedding_model = _HashEmbeddingModel(self.embedding_dimension)
                 return
 
@@ -1020,6 +1034,14 @@ SOLUTIONS:
                 self.embedding_model = _MODEL_CACHE[cache_key]
                 if cache_key in _DIMENSION_CACHE:
                     self.embedding_dimension = _DIMENSION_CACHE[cache_key]
+                elif hasattr(self.embedding_model, 'get_sentence_embedding_dimension'):
+                    dim = self.embedding_model.get_sentence_embedding_dimension()
+                    if dim:
+                        self.embedding_dimension = dim
+                        _DIMENSION_CACHE[cache_key] = dim  # backfill cache
+                elif hasattr(self.embedding_model, 'embedding_dimension'):
+                    self.embedding_dimension = self.embedding_model.embedding_dimension
+                    _DIMENSION_CACHE[cache_key] = self.embedding_dimension  # backfill cache
                 logger.info(f"Using cached embedding model: {self.embedding_model_name}")
                 return
 
@@ -1123,6 +1145,14 @@ SOLUTIONS:
             logger.warning(
                 "Falling back to pure-Python hash embeddings due to embedding init failure (quality reduced)."
             )
+            # Detect existing DB dimension to avoid mismatch (#608)
+            existing_dim = self._get_existing_db_embedding_dimension()
+            if existing_dim and existing_dim != self.embedding_dimension:
+                logger.warning(
+                    f"Adjusting hash embedding dimension from {self.embedding_dimension} to "
+                    f"{existing_dim} to match existing database schema."
+                )
+                self.embedding_dimension = existing_dim
             self.embedding_model = _HashEmbeddingModel(self.embedding_dimension)
 
     def _get_docker_network_help(self) -> str:
@@ -2545,18 +2575,30 @@ SOLUTIONS:
             now = time.time()
             now_iso = datetime.utcfromtimestamp(now).isoformat() + "Z"
 
-            # Handle timestamp updates based on preserve_timestamps flag
-            if not preserve_timestamps:
-                # When preserve_timestamps=False, use timestamps from updates dict if provided
-                # This allows syncing timestamps from source (e.g., Cloudflare → SQLite)
-                # Always preserve created_at (never reset to current time!)
+            # Handle timestamp updates based on preserve_timestamps flag (#605)
+            # preserve_timestamps=True (default): do NOT advance updated_at — used by
+            # consolidation/scoring callers that write computed metadata without changing content.
+            # preserve_timestamps=False: allow caller-supplied timestamps (sync use case)
+            #   or fall back to current time for content/structural changes.
+            structural_change = any(k in updates for k in ("tags", "memory_type", "content"))
+            if preserve_timestamps and not structural_change:
+                # Pure metadata update — keep existing timestamps
+                # We need to read the current updated_at from the DB
+                ts_cursor = self.conn.execute(
+                    "SELECT updated_at, updated_at_iso FROM memories WHERE content_hash = ? AND deleted_at IS NULL",
+                    (content_hash,),
+                )
+                ts_row = ts_cursor.fetchone()
+                updated_at = ts_row[0] if ts_row else now
+                updated_at_iso = ts_row[1] if ts_row else now_iso
+            elif not preserve_timestamps:
+                # Sync use case: use timestamps from updates dict if provided
                 created_at = updates.get('created_at', created_at)
                 created_at_iso = updates.get('created_at_iso', created_at_iso)
-                # Use updated_at from updates or current time
                 updated_at = updates.get('updated_at', now)
                 updated_at_iso = updates.get('updated_at_iso', now_iso)
             else:
-                # preserve_timestamps=True: only update updated_at to current time
+                # preserve_timestamps=True but structural change — advance updated_at
                 updated_at = now
                 updated_at_iso = now_iso
 
@@ -2608,7 +2650,7 @@ SOLUTIONS:
             logger.error(traceback.format_exc())
             return False, error_msg
 
-    async def update_memories_batch(self, memories: List[Memory]) -> List[bool]:
+    async def update_memories_batch(self, memories: List[Memory], preserve_timestamps: bool = False) -> List[bool]:
         """
         Update multiple memories in a single database transaction for optimal performance.
 
@@ -2617,6 +2659,7 @@ SOLUTIONS:
 
         Args:
             memories: List of Memory objects with updated fields
+            preserve_timestamps: If True, do not advance updated_at for metadata-only changes (#605)
 
         Returns:
             List of success booleans, one for each memory in the batch
@@ -2668,6 +2711,24 @@ SOLUTIONS:
                     new_tags = ",".join(memory.tags) if memory.tags else current_tags
                     new_type = memory.memory_type if memory.memory_type else current_type
 
+                    # Determine whether to advance updated_at (#605)
+                    structural_change = (
+                        new_tags != current_tags or
+                        new_type != current_type
+                    )
+                    if preserve_timestamps and not structural_change:
+                        # Pure metadata update — read and keep existing timestamps
+                        cursor.execute(
+                            "SELECT updated_at, updated_at_iso FROM memories WHERE content_hash = ? AND deleted_at IS NULL",
+                            (memory.content_hash,),
+                        )
+                        ts_row = cursor.fetchone()
+                        mem_updated_at = ts_row[0] if ts_row else now
+                        mem_updated_at_iso = ts_row[1] if ts_row else now_iso
+                    else:
+                        mem_updated_at = now
+                        mem_updated_at_iso = now_iso
+
                     # Execute update
                     cursor.execute(
                         """
@@ -2680,8 +2741,8 @@ SOLUTIONS:
                             new_tags,
                             new_type,
                             json.dumps(merged_metadata),
-                            now,
-                            now_iso,
+                            mem_updated_at,
+                            mem_updated_at_iso,
                             memory.content_hash,
                         ),
                     )

--- a/tests/consolidation/conftest.py
+++ b/tests/consolidation/conftest.py
@@ -71,101 +71,99 @@ def sample_memories():
     """Create a sample set of memories for testing."""
     base_time = datetime.now().timestamp()
     
+    def _mem_ts(offset):
+        """Helper: return created_at/updated_at kwargs for a memory `offset` seconds old."""
+        ts = base_time - offset
+        iso = datetime.fromtimestamp(ts).isoformat() + 'Z'
+        return dict(created_at=ts, created_at_iso=iso, updated_at=ts, updated_at_iso=iso)
+
     memories = [
         # Recent critical memory
         Memory(
             content="Critical system configuration backup completed successfully",
             content_hash="hash001",
             tags=["critical", "backup", "system"],
-            memory_type="decision",  # Changed from 'critical' to valid ontology type
-            embedding=[0.1, 0.2, 0.3, 0.4, 0.5] * 64,  # 320-dim embedding
+            memory_type="decision",
+            embedding=[0.1, 0.2, 0.3, 0.4, 0.5] * 64,
             metadata={"importance_score": 2.0},
-            created_at=base_time - 86400,  # 1 day ago
-            created_at_iso=datetime.fromtimestamp(base_time - 86400).isoformat() + 'Z'
+            **_mem_ts(86400),  # 1 day ago
         ),
-        
+
         # Related system memory
         Memory(
             content="System configuration updated with new security settings",
             content_hash="hash002",
             tags=["system", "security", "config"],
-            memory_type="observation",  # Changed from 'standard' to valid ontology type
-            embedding=[0.15, 0.25, 0.35, 0.45, 0.55] * 64,  # Similar embedding
+            memory_type="observation",
+            embedding=[0.15, 0.25, 0.35, 0.45, 0.55] * 64,
             metadata={},
-            created_at=base_time - 172800,  # 2 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 172800).isoformat() + 'Z'
+            **_mem_ts(172800),  # 2 days ago
         ),
-        
+
         # Unrelated old memory
         Memory(
             content="Weather is nice today, went for a walk in the park",
             content_hash="hash003",
             tags=["personal", "weather"],
-            memory_type="observation",  # Changed from 'temporary' to valid ontology type
-            embedding=[0.9, 0.8, 0.7, 0.6, 0.5] * 64,  # Different embedding
+            memory_type="observation",
+            embedding=[0.9, 0.8, 0.7, 0.6, 0.5] * 64,
             metadata={},
-            created_at=base_time - 259200,  # 3 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 259200).isoformat() + 'Z'
+            **_mem_ts(259200),  # 3 days ago
         ),
-        
+
         # Reference memory
         Memory(
             content="Python documentation: List comprehensions provide concise syntax",
             content_hash="hash004",
             tags=["reference", "python", "documentation"],
-            memory_type="learning",  # Changed from 'reference' to valid ontology type
+            memory_type="learning",
             embedding=[0.2, 0.3, 0.4, 0.5, 0.6] * 64,
             metadata={"importance_score": 1.5},
-            created_at=base_time - 604800,  # 1 week ago
-            created_at_iso=datetime.fromtimestamp(base_time - 604800).isoformat() + 'Z'
+            **_mem_ts(604800),  # 1 week ago
         ),
-        
+
         # Related programming memory
         Memory(
             content="Python best practices: Use list comprehensions for simple transformations",
             content_hash="hash005",
             tags=["python", "best-practices", "programming"],
-            memory_type="observation",  # Changed from 'standard' to valid ontology type
-            embedding=[0.25, 0.35, 0.45, 0.55, 0.65] * 64,  # Related to reference
+            memory_type="observation",
+            embedding=[0.25, 0.35, 0.45, 0.55, 0.65] * 64,
             metadata={},
-            created_at=base_time - 691200,  # 8 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 691200).isoformat() + 'Z'
+            **_mem_ts(691200),  # 8 days ago
         ),
-        
+
         # Old low-quality memory
         Memory(
             content="test test test",
             content_hash="hash006",
             tags=["test"],
-            memory_type="observation",  # Changed from 'temporary' to valid ontology type
+            memory_type="observation",
             embedding=[0.1, 0.1, 0.1, 0.1, 0.1] * 64,
             metadata={},
-            created_at=base_time - 2592000,  # 30 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 2592000).isoformat() + 'Z'
+            **_mem_ts(2592000),  # 30 days ago
         ),
-        
+
         # Another programming memory for clustering
         Memory(
             content="JavaScript arrow functions provide cleaner syntax for callbacks",
             content_hash="hash007",
             tags=["javascript", "programming", "syntax"],
-            memory_type="observation",  # Changed from 'standard' to valid ontology type
-            embedding=[0.3, 0.4, 0.5, 0.6, 0.7] * 64,  # Related to other programming
+            memory_type="observation",
+            embedding=[0.3, 0.4, 0.5, 0.6, 0.7] * 64,
             metadata={},
-            created_at=base_time - 777600,  # 9 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 777600).isoformat() + 'Z'
+            **_mem_ts(777600),  # 9 days ago
         ),
-        
+
         # Duplicate-like memory
         Memory(
             content="test test test duplicate",
             content_hash="hash008",
             tags=["test", "duplicate"],
-            memory_type="observation",  # Changed from 'temporary' to valid ontology type
-            embedding=[0.11, 0.11, 0.11, 0.11, 0.11] * 64,  # Very similar to hash006
+            memory_type="observation",
+            embedding=[0.11, 0.11, 0.11, 0.11, 0.11] * 64,
             metadata={},
-            created_at=base_time - 2678400,  # 31 days ago
-            created_at_iso=datetime.fromtimestamp(base_time - 2678400).isoformat() + 'Z'
+            **_mem_ts(2678400),  # 31 days ago
         ),
 
         # Very old memory to ensure low relevance score for testing
@@ -176,8 +174,7 @@ def sample_memories():
             memory_type="observation",
             embedding=[0.05, 0.05, 0.05, 0.05, 0.05] * 64,
             metadata={},
-            created_at=base_time - 7776000,  # 90 days ago - ensures low decay factor
-            created_at_iso=datetime.fromtimestamp(base_time - 7776000).isoformat() + 'Z'
+            **_mem_ts(7776000),  # 90 days ago
         )
     ]
 
@@ -229,7 +226,7 @@ def mock_storage(sample_memories):
                 return True
             return False
 
-        async def update_memories_batch(self, memories: List[Memory]) -> List[bool]:
+        async def update_memories_batch(self, memories: List[Memory], preserve_timestamps: bool = False) -> List[bool]:
             """Batch update memories and return list of success statuses."""
             results = []
             for memory in memories:
@@ -341,7 +338,7 @@ def mock_large_storage(large_memory_set):
                 return True
             return False
 
-        async def update_memories_batch(self, memories: List[Memory]) -> List[bool]:
+        async def update_memories_batch(self, memories: List[Memory], preserve_timestamps: bool = False) -> List[bool]:
             """Batch update memories and return list of success statuses."""
             results = []
             for memory in memories:

--- a/tests/consolidation/test_decay.py
+++ b/tests/consolidation/test_decay.py
@@ -42,16 +42,20 @@ class TestExponentialDecayCalculator:
             tags=["test"],
             embedding=[0.1] * 320,
             created_at=recent_time.timestamp(),
-            created_at_iso=recent_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+            created_at_iso=recent_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            updated_at=recent_time.timestamp(),
+            updated_at_iso=recent_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         )
-        
+
         old_memory = Memory(
             content="Old memory",
             content_hash="old",
             tags=["test"],
             embedding=[0.1] * 320,
             created_at=old_time.timestamp(),
-            created_at_iso=old_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+            created_at_iso=old_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            updated_at=old_time.timestamp(),
+            updated_at_iso=old_time.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         )
         
         scores = await decay_calculator.process([recent_memory, old_memory])
@@ -70,24 +74,29 @@ class TestExponentialDecayCalculator:
         age_days = 60  # 2 months old
         
         # Create memories of different types but same age
+        mem_time = now - timedelta(days=age_days)
         critical_memory = Memory(
             content="Critical memory",
             content_hash="critical",
             tags=["critical"],
             memory_type="decision",  # Changed from 'critical' to valid ontology type
             embedding=[0.1] * 320,
-            created_at=(now - timedelta(days=age_days)).timestamp(),
-            created_at_iso=(now - timedelta(days=age_days)).isoformat() + 'Z'
+            created_at=mem_time.timestamp(),
+            created_at_iso=mem_time.isoformat() + 'Z',
+            updated_at=mem_time.timestamp(),
+            updated_at_iso=mem_time.isoformat() + 'Z'
         )
-        
+
         temporary_memory = Memory(
             content="Temporary memory",
             content_hash="temporary",
             tags=["temp"],
             memory_type="observation",  # Changed from 'temporary' to valid ontology type
             embedding=[0.1] * 320,
-            created_at=(now - timedelta(days=age_days)).timestamp(),
-            created_at_iso=(now - timedelta(days=age_days)).isoformat() + 'Z'
+            created_at=mem_time.timestamp(),
+            created_at_iso=mem_time.isoformat() + 'Z',
+            updated_at=mem_time.timestamp(),
+            updated_at_iso=mem_time.isoformat() + 'Z'
         )
         
         scores = await decay_calculator.process([critical_memory, temporary_memory])
@@ -216,14 +225,17 @@ class TestExponentialDecayCalculator:
     async def test_protected_memory_minimum_relevance(self, decay_calculator):
         """Test that protected memories maintain minimum relevance."""
         # Create a very old memory that would normally have very low relevance
+        old_time = datetime.now() - timedelta(days=500)
         old_critical_memory = Memory(
             content="Old critical memory",
             content_hash="old_critical",
             tags=["critical", "important"],
             memory_type="decision",  # Changed from 'critical' to valid ontology type
             embedding=[0.1] * 320,
-            created_at=(datetime.now() - timedelta(days=500)).timestamp(),
-            created_at_iso=(datetime.now() - timedelta(days=500)).isoformat() + 'Z'
+            created_at=old_time.timestamp(),
+            created_at_iso=old_time.isoformat() + 'Z',
+            updated_at=old_time.timestamp(),
+            updated_at_iso=old_time.isoformat() + 'Z'
         )
         
         scores = await decay_calculator.process([old_critical_memory])

--- a/tests/consolidation/test_forgetting.py
+++ b/tests/consolidation/test_forgetting.py
@@ -201,7 +201,8 @@ class TestControlledForgettingEngine:
             tags=["temporary"],
             memory_type="observation",  # Changed from 'temporary' to valid ontology type
             embedding=[0.1] * 320,
-            created_at=(now - timedelta(days=10)).timestamp()  # Older than 7 days
+            created_at=(now - timedelta(days=10)).timestamp(),  # Older than 7 days
+            updated_at=(now - timedelta(days=10)).timestamp(),
         )
         
         score = RelevanceScore(

--- a/tests/test_issues_603_to_608.py
+++ b/tests/test_issues_603_to_608.py
@@ -1,0 +1,247 @@
+"""Tests for bug fixes #603-#608.
+
+Each test class corresponds to a specific GitHub issue.
+"""
+
+import time
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.consolidation.base import ConsolidationBase, ConsolidationConfig
+from mcp_memory_service.consolidation.decay import ExponentialDecayCalculator, RelevanceScore
+
+
+# ---------------------------------------------------------------------------
+# #603 — invalid memory_type "learning_note" should not exist
+# ---------------------------------------------------------------------------
+
+class TestIssue603LearningNoteType:
+    """memory_type='learning_note' is not in the ontology; it should be 'learning'."""
+
+    def test_learning_note_is_coerced_to_observation(self):
+        """Verify the ontology rejects 'learning_note' (pre-fix behaviour)."""
+        m = Memory(content="test", content_hash="abc", memory_type="learning_note")
+        assert m.memory_type == "observation"
+
+    def test_learning_is_valid_type(self):
+        """'learning' must be accepted as-is by the ontology."""
+        m = Memory(content="test", content_hash="abc", memory_type="learning")
+        assert m.memory_type == "learning"
+
+    def test_server_impl_uses_learning_type(self):
+        """Verify server_impl.py no longer contains 'learning_note' as a memory_type."""
+        import pathlib
+        server_impl_path = pathlib.Path(__file__).parent.parent / "src" / "mcp_memory_service" / "server_impl.py"
+        source = server_impl_path.read_text()
+        assert 'memory_type="learning_note"' not in source
+        assert 'memory_type="learning"' in source
+
+
+# ---------------------------------------------------------------------------
+# #604 — update_memory_relevance_metadata must not call memory.touch()
+# ---------------------------------------------------------------------------
+
+class TestIssue604NoTouchInRelevanceScoring:
+    """Relevance scoring is a read path and must not mutate updated_at."""
+
+    @pytest.mark.asyncio
+    async def test_relevance_metadata_does_not_advance_updated_at(self):
+        """updated_at should remain unchanged after update_memory_relevance_metadata."""
+        original_updated = 1700000000.0
+        memory = Memory(
+            content="test content",
+            content_hash="hash604",
+            tags=["test"],
+            memory_type="observation",
+            created_at=1690000000.0,
+        )
+        # Override updated_at after __post_init__ (which auto-sets it to now)
+        memory.updated_at = original_updated
+
+        score = RelevanceScore(
+            memory_hash="hash604",
+            total_score=0.75,
+            base_importance=0.5,
+            decay_factor=0.9,
+            connection_boost=0.05,
+            access_boost=0.1,
+            metadata={},
+        )
+
+        config = ConsolidationConfig()
+        calculator = ExponentialDecayCalculator(config)
+        result = await calculator.update_memory_relevance_metadata(memory, score)
+
+        # updated_at must not have changed
+        assert result.updated_at == original_updated
+        # But relevance metadata should be written
+        assert result.metadata.get("relevance_score") == 0.75
+        assert result.metadata.get("decay_factor") == 0.9
+
+    def test_touch_not_called_in_source(self):
+        """Verify source code does not call touch() as an active statement."""
+        import inspect
+        source = inspect.getsource(ExponentialDecayCalculator.update_memory_relevance_metadata)
+        # Filter out comments — only check actual code lines
+        code_lines = [
+            line.strip() for line in source.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        assert not any("memory.touch()" in line for line in code_lines)
+
+
+# ---------------------------------------------------------------------------
+# #605 — preserve_timestamps in batch updates
+# ---------------------------------------------------------------------------
+
+class TestIssue605PreserveTimestamps:
+    """update_memories_batch must accept preserve_timestamps parameter."""
+
+    def test_update_memories_batch_signature_has_preserve_timestamps(self):
+        """The method signature must include preserve_timestamps."""
+        import inspect
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        sig = inspect.signature(SqliteVecMemoryStorage.update_memories_batch)
+        assert "preserve_timestamps" in sig.parameters
+
+    def test_base_storage_signature_has_preserve_timestamps(self):
+        """MemoryStorage.update_memories_batch must also have the parameter."""
+        import inspect
+        from mcp_memory_service.storage.base import MemoryStorage
+
+        sig = inspect.signature(MemoryStorage.update_memories_batch)
+        assert "preserve_timestamps" in sig.parameters
+
+    def test_hybrid_storage_signature_has_preserve_timestamps(self):
+        """HybridMemoryStorage.update_memories_batch must also have the parameter."""
+        import inspect
+        from mcp_memory_service.storage.hybrid import HybridMemoryStorage
+
+        sig = inspect.signature(HybridMemoryStorage.update_memories_batch)
+        assert "preserve_timestamps" in sig.parameters
+
+    def test_update_memory_metadata_preserves_on_pure_metadata_change(self):
+        """update_memory_metadata with preserve_timestamps=True should check structural changes."""
+        import inspect
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        source = inspect.getsource(SqliteVecMemoryStorage.update_memory_metadata)
+        assert "structural_change" in source
+
+
+# ---------------------------------------------------------------------------
+# #606 — _get_memory_age_days should use max(created_at, updated_at)
+# ---------------------------------------------------------------------------
+
+class _ConcreteConsolidation(ConsolidationBase):
+    """Minimal concrete subclass for testing _get_memory_age_days."""
+    async def process(self, memories):
+        return memories
+
+
+class TestIssue606AgeUsesUpdatedAt:
+    """Memory age should be calculated from the most recent timestamp."""
+
+    def _make_base(self):
+        config = ConsolidationConfig()
+        base = _ConcreteConsolidation(config)
+        return base
+
+    def test_age_uses_created_at_when_no_updated_at(self):
+        """When updated_at is None, fall back to created_at."""
+        base = self._make_base()
+        now = datetime.now(timezone.utc)
+        created_ts = now.timestamp() - (30 * 86400)
+
+        memory = Memory(content="test", content_hash="h606a", created_at=created_ts)
+        # Override updated_at to None after __post_init__ auto-sets it
+        memory.updated_at = None
+        age = base._get_memory_age_days(memory, reference_time=now)
+        assert age == 30
+
+    def test_age_uses_updated_at_when_more_recent(self):
+        """When updated_at is more recent than created_at, use updated_at."""
+        base = self._make_base()
+        now = datetime.now(timezone.utc)
+        created_ts = now.timestamp() - (90 * 86400)
+        updated_ts = now.timestamp() - (5 * 86400)
+
+        memory = Memory(content="test", content_hash="h606b", created_at=created_ts)
+        memory.updated_at = updated_ts
+        age = base._get_memory_age_days(memory, reference_time=now)
+        assert age == 5
+
+    def test_age_uses_created_at_when_more_recent_than_updated(self):
+        """Edge case: created_at > updated_at (shouldn't happen, but be safe)."""
+        base = self._make_base()
+        now = datetime.now(timezone.utc)
+        created_ts = now.timestamp() - (5 * 86400)
+        updated_ts = now.timestamp() - (30 * 86400)
+
+        memory = Memory(content="test", content_hash="h606c", created_at=created_ts)
+        memory.updated_at = updated_ts
+        age = base._get_memory_age_days(memory, reference_time=now)
+        assert age == 5
+
+
+# ---------------------------------------------------------------------------
+# #607 — _DIMENSION_CACHE miss on _MODEL_CACHE hit
+# ---------------------------------------------------------------------------
+
+class TestIssue607DimensionCacheFallback:
+    """When _MODEL_CACHE hits but _DIMENSION_CACHE misses, fall back to model attribute."""
+
+    def test_source_has_fallback_for_external(self):
+        """External embedding cache-hit block should have hasattr fallback."""
+        import inspect
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        source = inspect.getsource(SqliteVecMemoryStorage._initialize_embedding_model)
+        assert "hasattr(self.embedding_model, 'embedding_dimension')" in source
+
+    def test_source_has_fallback_for_sentence_transformer(self):
+        """SentenceTransformer cache-hit block should have get_sentence_embedding_dimension fallback."""
+        import inspect
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        source = inspect.getsource(SqliteVecMemoryStorage._initialize_embedding_model)
+        assert "get_sentence_embedding_dimension" in source
+
+
+# ---------------------------------------------------------------------------
+# #608 — _HashEmbeddingModel should detect existing DB dimension
+# ---------------------------------------------------------------------------
+
+class TestIssue608HashModelDimensionFromDB:
+    """Hash embedding fallback must check existing DB schema for dimension."""
+
+    def test_source_checks_existing_dimension_before_hash_model(self):
+        """Both hash fallback paths should call _get_existing_db_embedding_dimension."""
+        import inspect
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        source = inspect.getsource(SqliteVecMemoryStorage._initialize_embedding_model)
+        count = source.count("_get_existing_db_embedding_dimension")
+        assert count >= 2, f"Expected >=2 calls to _get_existing_db_embedding_dimension, found {count}"
+
+    def test_hash_model_respects_custom_dimension(self):
+        """_HashEmbeddingModel should work with any dimension."""
+        from mcp_memory_service.storage.sqlite_vec import _HashEmbeddingModel
+
+        model = _HashEmbeddingModel(768)
+        assert model.embedding_dimension == 768
+        result = model.encode(["hello world"])
+        assert len(result[0]) == 768
+
+    def test_hash_model_default_dimension(self):
+        """_HashEmbeddingModel with default 384 should produce 384-dim vectors."""
+        from mcp_memory_service.storage.sqlite_vec import _HashEmbeddingModel
+
+        model = _HashEmbeddingModel(384)
+        assert model.embedding_dimension == 384
+        result = model.encode(["test"])
+        assert len(result[0]) == 384


### PR DESCRIPTION
## Summary

Fixes 6 interrelated bugs discovered in consolidation, embedding initialization, and memory type handling:

- **#603**: `learning_session` prompt used invalid `memory_type="learning_note"` → silently coerced to `"observation"`, causing 6x shorter retention (30d vs 180d). Fixed to `"learning"`.
- **#604**: `update_memory_relevance_metadata()` called `memory.touch()` on a read path, corrupting `updated_at` timestamps on every consolidation run. Removed the call.
- **#605**: `update_memories_batch()` unconditionally set `updated_at=now` even for pure metadata updates. Added `preserve_timestamps` parameter; consolidation callers now pass `True`.
- **#606**: `_get_memory_age_days()` only used `created_at`, ignoring `updated_at`. Updated memories decayed as if never touched. Now uses `max(created_at, updated_at)`.
- **#607**: `_DIMENSION_CACHE` miss on `_MODEL_CACHE` hit left `embedding_dimension` at default 384. Added fallback to `model.embedding_dimension` with cache backfill at all 3 cache-hit paths.
- **#608**: `_HashEmbeddingModel` fallback always used dimension 384, ignoring existing DB schema. Now queries `sqlite_master` for actual dimension at both fallback paths.

**Bug chain**: #604 + #605 corrupted `updated_at` → #606 couldn't use it → consolidation scores were meaningless. All three must be fixed together.

## Files Changed

| File | Changes |
|------|---------|
| `server_impl.py` | #603: `learning_note` → `learning` |
| `consolidation/decay.py` | #604: Remove `memory.touch()` |
| `consolidation/base.py` | #606: `max(created_at, updated_at)` in age calc |
| `consolidation/consolidator.py` | #605: Pass `preserve_timestamps=True` |
| `storage/sqlite_vec.py` | #605, #607, #608: timestamps, dimension fallbacks |
| `storage/base.py` | #605: `preserve_timestamps` param |
| `storage/hybrid.py` | #605: Pass-through `preserve_timestamps` |

## Test plan

- [x] 17 new tests in `tests/test_issues_603_to_608.py` covering all 6 fixes
- [x] Updated 4 existing tests that relied on implicit `updated_at=now` behavior
- [x] Full test suite: **1323 passed**, 0 failed (1 pre-existing benchmark error excluded)

Closes #603, closes #604, closes #605, closes #606, closes #607, closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)