### PR TITLE
fix: tolerate missing index in external embedding responses

### DIFF
--- a/src/mcp_memory_service/embeddings/external_api.py
+++ b/src/mcp_memory_service/embeddings/external_api.py
@@ -200,11 +200,11 @@ class ExternalEmbeddingModel:
                 # Extract embeddings in order (API may return out of order)
                 batch_embeddings = [None] * len(batch)
                 seen_indices = set()
-                for item in data['data']:
-                    if 'index' not in item:
-                        raise RuntimeError(f"API response from {self.api_url} is missing the 'index' field.")
+                for pos, item in enumerate(data['data']):
+                    # Some OpenAI-compatible providers may omit `index` while
+                    # still returning embeddings in input order.
+                    idx = item.get('index', pos)
 
-                    idx = item['index']
                     if not (0 <= idx < len(batch)):
                         logger.warning(f"API returned out-of-bounds index {idx} for batch size {len(batch)}")
                         continue
@@ -212,6 +212,9 @@ class ExternalEmbeddingModel:
                     if idx in seen_indices:
                         raise RuntimeError(f"API returned duplicate index {idx} in the same batch.")
                     seen_indices.add(idx)
+
+                    if 'embedding' not in item:
+                        raise RuntimeError(f"API response from {self.api_url} is missing the 'embedding' field.")
 
                     batch_embeddings[idx] = item['embedding']
 

--- a/tests/test_external_embeddings.py
+++ b/tests/test_external_embeddings.py
@@ -110,6 +110,43 @@ class TestExternalEmbeddingModel:
         assert result.shape == (3, 768)
 
     @patch('mcp_memory_service.embeddings.external_api.requests.post')
+    def test_encode_multiple_sentences_without_index_uses_positional_order(self, mock_post):
+        """Providers that omit `index` should still work if order is preserved."""
+        # First call for connection verification
+        mock_response_init = MagicMock()
+        mock_response_init.status_code = 200
+        mock_response_init.json.return_value = {
+            'data': [{'embedding': [0.1] * 4, 'index': 0}]
+        }
+
+        # Second call omits `index` but preserves order
+        mock_response_encode = MagicMock()
+        mock_response_encode.status_code = 200
+        mock_response_encode.json.return_value = {
+            'data': [
+                {'embedding': [1.0, 0.0, 0.0, 0.0]},
+                {'embedding': [0.0, 1.0, 0.0, 0.0]},
+                {'embedding': [0.0, 0.0, 1.0, 0.0]},
+            ]
+        }
+        mock_response_encode.raise_for_status = MagicMock()
+
+        mock_post.side_effect = [mock_response_init, mock_response_encode]
+
+        model = ExternalEmbeddingModel(
+            api_url='http://test:8890/v1/embeddings',
+            model_name='test-model'
+        )
+
+        result = model.encode(["sentence 1", "sentence 2", "sentence 3"])
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3, 4)
+        assert result[0].tolist() == [1.0, 0.0, 0.0, 0.0]
+        assert result[1].tolist() == [0.0, 1.0, 0.0, 0.0]
+        assert result[2].tolist() == [0.0, 0.0, 1.0, 0.0]
+
+    @patch('mcp_memory_service.embeddings.external_api.requests.post')
     def test_get_sentence_embedding_dimension(self, mock_post):
         """Test getting embedding dimension."""
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary\nSome OpenAI-compatible embedding providers return embeddings in input order but omit the `index` field in each `data` item.\n\nThe current external embedding adapter raises an error when `index` is missing, which breaks otherwise compatible providers.\n\nThis change keeps the existing behavior when `index` is present, and falls back to positional order when it is absent.\n\n## Why\nThis improves compatibility with OpenAI-compatible embedding APIs that preserve ordering but do not include an explicit `index` field.\n\n## Change\n- Use `item.get("index", pos)` when iterating through embedding results\n- Keep duplicate / bounds checks intact\n- Add a clearer error if `embedding` itself is missing\n\n## Compatibility\n- No behavior change for providers that already return `index`\n- More tolerant for providers that omit `index` while keeping result order stable\n