### PR TITLE
chore: release v10.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.27.0] - 2026-03-25
+
+### Fixed
+
+- **[#612] Tolerate missing index in external embedding responses (community contribution by [@qq540491950](https://github.com/qq540491950))**: The external embedding client raised a `KeyError` when the upstream API returned responses without an `index` field (non-standard but valid for single-item batches). The fix falls back to enumerate-based ordering when `index` is absent, making the client compatible with a broader range of self-hosted embedding providers.
+
+### Documentation
+
+- **[e9b5db0] Add real-world self-hosted Docker + Cloudflare deployment example**: Added a complete end-to-end deployment walkthrough covering Docker Compose setup, Cloudflare D1 + Vectorize configuration, and hybrid storage mode for production self-hosted deployments.
+
 ## [10.26.9] - 2026-03-24
 
 ### Refactored

--- a/README.md
+++ b/README.md
@@ -368,21 +368,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.26.8** (March 24, 2026)
+## Latest Release: **v10.27.0** (March 25, 2026)
 
-**6 bug fixes in consolidation, embeddings, and memory types (#603-#608)**
+**External embedding compatibility fix + real-world Docker/Cloudflare deployment docs (#612)**
 
 **What's New:**
-- **Bug fix: invalid memory_type "learning_note"** (#603): learning session prompt now emits `"learning"` instead of the non-existent `"learning_note"` type.
-- **Bug fix: update_memory_relevance_metadata no longer corrupts updated_at** (#604): removed the spurious `memory.touch()` side-effect.
-- **Bug fix: consolidation preserves original timestamps** (#605): `update_memories_batch` gains `preserve_timestamps` flag; consolidation callers opt in.
-- **Bug fix: memory age uses max(created_at, updated_at)** (#606): updated memories are no longer prematurely forgotten.
-- **Bug fix: embedding dimension fallback on partial cache hit** (#607): re-derives dimension from cached model instead of raising `KeyError`.
-- **Bug fix: _HashEmbeddingModel fallback reads DB schema dimension** (#608): prevents vector dimension mismatch when reopening an existing database with the fallback encoder.
+- **Bug fix: tolerate missing index in external embedding responses** (#612, community contribution by @qq540491950): the external embedding client no longer raises `KeyError` when upstream APIs omit the `index` field, improving compatibility with a broader range of self-hosted providers.
+- **Docs: real-world self-hosted Docker + Cloudflare deployment example**: added a complete end-to-end walkthrough covering Docker Compose, Cloudflare D1 + Vectorize, and hybrid storage mode for production deployments.
+- **Refactor: eliminate N+1 query in update_memories_batch, simplify age calc, extract hash-embedding helper** (#610): three targeted refactors reducing DB round-trips and improving code clarity (v10.26.9).
 
 ---
 
 **Previous Releases**:
+- **v10.26.8** - 6 bug fixes in consolidation, embeddings, and memory types (#603-#608)
 - **v10.26.7** - Cloudflare D1 fresh-database schema initialization fix (issue #600), community contribution by @Lyt060814
 - **v10.26.6** - Security patch: authlib>=1.6.9, PyJWT>=2.12.0, pypdf>=6.9.1 (5 Dependabot alerts: 1 critical, 3 high, 1 medium)
 - **v10.26.5** - Security patch: black dev dependency bumped to >=26.3.1 (GHSA-3936-cmfr-pm3m, CVE-2026-32274, path traversal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.26.9"
+version = "10.27.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.26.9"
+__version__ = "10.27.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.26.9"
+version = "10.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- **Version bump**: 10.26.9 → 10.27.0
- **PR #612**: fix: tolerate missing `index` in external embedding responses (community contribution by @qq540491950)
- **Docs**: add real-world self-hosted Docker + Cloudflare deployment example

## Changes
- `pyproject.toml` — version bump
- `_version.py` — version bump
- `uv.lock` — version sync
- `CHANGELOG.md` — new v10.27.0 section
- `README.md` — updated latest release info

## Test plan
- [ ] CI passes on this branch
- [ ] Version strings consistent across all files
- [ ] CHANGELOG entry matches merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)