### PR TITLE
fix(deps): security patch v10.28.4 — cryptography>=46.0.6, serialize-javascript>=7.0.5, CodeQL cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.28.4] - 2026-03-29
+
+### Security
+
+- **[#622] bump cryptography from 46.0.5 to 46.0.6**: Fixes CVE-2026-34073 (incomplete DNS name constraint enforcement). Dependabot alert #68 (low severity). Automated Dependabot bump.
+- **[#623] bump serialize-javascript to >=7.0.5**: Fixes CVE-2026-34043 (CPU exhaustion DoS via crafted array-like objects in serialized output). Dependabot alerts #66 and #67 (medium severity). Applied to `tests/integration/` and `tests/web/` npm packages.
+
+### Fixed
+
+- **[#623] Remove unused `Optional` import in `harvester.py`**: CodeQL alert #379 (note). Import was a leftover from an earlier implementation; removal has no functional impact.
+
+### Maintenance
+
+- **[#623] Sort dependencies alphabetically in `pyproject.toml`**: Improves readability and prevents merge conflicts on future dependency updates.
+
 ## [10.28.3] - 2026-03-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.26.9 - Refactor: eliminate N+1 query in update_memories_batch, simplify age calc, extract hash-embedding helper (#610) — 1,340 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.28.4 - Security patch: cryptography>=46.0.6 (CVE-2026-34073), serialize-javascript>=7.0.5 (CVE-2026-34043), CodeQL cleanup (#622, #623) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -368,18 +368,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.28.3** (March 26, 2026)
+## Latest Release: **v10.28.4** (March 29, 2026)
 
-**HTTP MCP endpoint fix: accept 'content' as alias for 'query' so Claude Code HTTP transport returns results**
+**Security patch: cryptography>=46.0.6 (CVE-2026-34073), serialize-javascript>=7.0.5 (CVE-2026-34043), CodeQL unused import cleanup**
 
 **What's New:**
-- **Parameter alias fix**: `retrieve_memory` and `recall_memory` now accept `content` in addition to `query` as the search parameter name.
-- **Claude Code HTTP transport**: Resolves always-empty results when Claude Code invokes memory tools via HTTP (it sends `content`, not `query`).
-- **Backward compatible**: Existing callers using `query` are unaffected; `query` takes precedence when both are present.
+- **cryptography>=46.0.6**: Fixes CVE-2026-34073 (incomplete DNS name constraint enforcement, Dependabot #68).
+- **serialize-javascript>=7.0.5**: Fixes CVE-2026-34043 (CPU exhaustion DoS via crafted array-like objects, Dependabot #66, #67).
+- **CodeQL cleanup**: Removed unused `Optional` import in `harvester.py` (CodeQL #379).
+- **Dependency hygiene**: Alphabetical sorting of dependencies in `pyproject.toml`.
 
 ---
 
 **Previous Releases**:
+- **v10.28.3** - HTTP MCP endpoint fix: accept 'content' as alias for 'query' so Claude Code HTTP transport returns results
 - **v10.28.2** - Relationship inference tuning: 93.5% typed labels vs 0.5% before + German language support
 - **v10.28.1** - Harvest false-positive fix: skip system prompts, skill outputs, and long injected content (3 new tests)
 - **v10.28.0** - Session harvest tool (`memory_harvest`): extract learnings from Claude Code transcripts + security dependency updates (#614-#616)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.28.3"
+version = "10.28.4"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.28.3"
+__version__ = "10.28.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.28.3"
+version = "10.28.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **cryptography >=46.0.6** (CVE-2026-34073): Incomplete DNS name constraint enforcement — Dependabot #68 (low)
- **serialize-javascript >=7.0.5** (CVE-2026-34043): CPU exhaustion DoS via crafted array-like objects — Dependabot #66, #67 (medium)
- **CodeQL #379**: Remove unused `Optional` import in `harvester.py`
- **Alphabetical dep sorting** in `pyproject.toml` for readability

This is a PATCH release (v10.28.3 → v10.28.4). No functional changes.

## Changes
- `_version.py`, `pyproject.toml`, `uv.lock` — version bump to 10.28.4
- `CHANGELOG.md` — v10.28.4 entry added
- `README.md` — Latest Release section updated; v10.28.3 moved to Previous Releases
- `CLAUDE.md` — version string updated

## Checklist
- [x] Version bumped in `_version.py`, `pyproject.toml`, `uv.lock`
- [x] `CHANGELOG.md` updated
- [x] `README.md` updated
- [x] `CLAUDE.md` updated
- [x] Landing page NOT updated (patch release — skip `docs/index.html`)

Closes Dependabot alerts #66, #67, #68. Resolves CodeQL #379.

Merges #622 and #623 into a versioned release.