### PR TITLE
fix(deps): bump serialize-javascript to 7.0.5 in tests/bridge

### DIFF
--- a/tests/bridge/package-lock.json
+++ b/tests/bridge/package-lock.json
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

- Bump `serialize-javascript` from 7.0.3 to 7.0.5 in `tests/bridge/package-lock.json`
- Fixes Dependabot alert #66 (CVE-2026-34043: CPU exhaustion DoS via crafted array-like objects)
- Companion to PR #623 which fixed the same vulnerability in `tests/integration/`

## Test plan

- [ ] CI passes (no code changes, only lock file update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)