### PR TITLE
fix(auth): MCP_ALLOW_ANONYMOUS_ACCESS=true ignored in dashboard (#621)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,8 +109,9 @@ MCP_HTTP_PORT=8000
 MCP_OAUTH_STORAGE_BACKEND=memory
 MCP_OAUTH_SQLITE_PATH=./data/oauth.db
 
-# Anonymous Access (allow unauthenticated read-only access)
-# Only enable this if you're behind a firewall or using external auth (e.g., Nginx Basic Auth)
+# Anonymous Access (allow unauthenticated access with read+write permissions)
+# When enabled, all users can read, store, and delete memories without credentials.
+# Only enable for local development or if you're behind a firewall/external auth.
 # MCP_ALLOW_ANONYMOUS_ACCESS=false
 
 # Hybrid Backend Configuration (if using hybrid)

--- a/src/mcp_memory_service/web/api/health.py
+++ b/src/mcp_memory_service/web/api/health.py
@@ -75,15 +75,13 @@ async def health_check():
 @router.get("/health/detailed", response_model=DetailedHealthResponse)
 async def detailed_health_check(
     storage: MemoryStorage = Depends(get_storage),
-    user: AuthenticationResult = Depends(require_write_access)
+    user: AuthenticationResult = Depends(require_read_access)
 ):
     """Detailed health check with storage information.
 
-    Requires write (admin) access to prevent information disclosure
-    to anonymous or read-only users (GHSA-73hc-m4hx-79pj).
-
-    System details are limited to memory/disk usage percentages —
-    no OS version, Python version, absolute paths, or hardware specs.
+    Requires read access. System details are limited to memory/disk
+    usage percentages — no OS version, Python version, absolute paths,
+    or hardware specs (GHSA-73hc-m4hx-79pj).
     """
 
     # Only expose resource utilization percentages — no fingerprinting data

--- a/src/mcp_memory_service/web/oauth/middleware.py
+++ b/src/mcp_memory_service/web/oauth/middleware.py
@@ -370,11 +370,11 @@ async def get_current_user(
 
     # Allow anonymous access only if explicitly enabled
     if ALLOW_ANONYMOUS_ACCESS:
-        logger.debug("Anonymous access explicitly enabled, granting read-only access")
+        logger.debug("Anonymous access explicitly enabled, granting full local access")
         return AuthenticationResult(
             authenticated=True,
             client_id="anonymous",
-            scope="read",  # Anonymous users get read-only access for security
+            scope="read write",  # User explicitly opted in via MCP_ALLOW_ANONYMOUS_ACCESS=true
             auth_method="none"
         )
 

--- a/src/mcp_memory_service/web/static/index.html
+++ b/src/mcp_memory_service/web/static/index.html
@@ -1633,7 +1633,7 @@
                 </div>
 
                 <div class="auth-footer">
-                    <p><strong>For local development:</strong> Set <code>MCP_ALLOW_ANONYMOUS_ACCESS=true</code> in your environment.</p>
+                    <p><strong>For local development:</strong> Set <code>MCP_ALLOW_ANONYMOUS_ACCESS=true</code> in your environment. This grants full read+write access without credentials.</p>
                 </div>
             </div>
         </div>

--- a/tests/web/api/test_health_info_disclosure.py
+++ b/tests/web/api/test_health_info_disclosure.py
@@ -39,8 +39,8 @@ class TestHealthEndpointSecurity:
         GHSA-73hc-m4hx-79pj protection: sensitive data was removed from the
         response (no OS version, paths, hardware specs — only memory/disk
         percentages). Read access is sufficient since the endpoint is read-only.
-        Anonymous users with MCP_ALLOW_ANONYMOUS_ACCESS=true get read scope
-        and can access this endpoint for dashboard auth detection (#621).
+        Anonymous users with MCP_ALLOW_ANONYMOUS_ACCESS=true get read write
+        scope and can access this endpoint for dashboard auth detection (#621).
         """
         from pathlib import Path
 

--- a/tests/web/api/test_health_info_disclosure.py
+++ b/tests/web/api/test_health_info_disclosure.py
@@ -33,8 +33,15 @@ class TestHealthEndpointSecurity:
         fields = set(HealthResponse.model_fields.keys())
         assert fields == {"status"}, f"HealthResponse has extra fields: {fields - {'status'}}"
 
-    def test_detailed_health_requires_write_access(self):
-        """GET /health/detailed must use require_write_access, not require_read_access."""
+    def test_detailed_health_requires_authentication(self):
+        """GET /health/detailed must require authentication (at least read access).
+
+        GHSA-73hc-m4hx-79pj protection: sensitive data was removed from the
+        response (no OS version, paths, hardware specs — only memory/disk
+        percentages). Read access is sufficient since the endpoint is read-only.
+        Anonymous users with MCP_ALLOW_ANONYMOUS_ACCESS=true get read scope
+        and can access this endpoint for dashboard auth detection (#621).
+        """
         from pathlib import Path
 
         health_path = Path(__file__).parent.parent.parent.parent / \
@@ -44,16 +51,12 @@ class TestHealthEndpointSecurity:
 
         for node in ast.walk(tree):
             if isinstance(node, ast.AsyncFunctionDef) and node.name == "detailed_health_check":
-                # Check decorator/default arguments for require_write_access
                 source_lines = source.split("\n")
-                # Get the function's full source range
                 func_start = node.lineno - 1
                 func_source = "\n".join(source_lines[func_start:func_start + 10])
-                assert "require_write_access" in func_source, (
-                    "detailed_health_check must use require_write_access"
-                )
-                assert "require_read_access" not in func_source, (
-                    "detailed_health_check must NOT use require_read_access"
+                # Must require at least read access (not unauthenticated)
+                assert "require_read_access" in func_source or "require_write_access" in func_source, (
+                    "detailed_health_check must require authentication"
                 )
                 break
         else:


### PR DESCRIPTION
## Summary

Fixes #621 — `MCP_ALLOW_ANONYMOUS_ACCESS=true` had no effect on the dashboard. Users were still prompted to authenticate.

**Root cause:** Two compounding issues:
- Anonymous users received only `read` scope, but the dashboard's auth probe endpoint (`/health/detailed`) required `write` scope → 403 → auth modal shown
- Even if the modal were bypassed, all management endpoints (store, delete, update) require `write` scope → anonymous users couldn't manage memories

**Fix:**
- Grant anonymous users `read write` scope (they explicitly opted in via env var)
- Downgrade `/health/detailed` to `require_read_access` (read-only endpoint; sensitive data already stripped per GHSA-73hc-m4hx-79pj)
- Update guard test to reflect new scope requirement

## Test plan

- [x] `tests/web/` — 42 passed, 1 xpassed
- [x] `tests/integration/test_api_with_memory_service.py` — 31 passed
- [x] Pre-existing clustering test failure confirmed unrelated
- [ ] Manual: `MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http` → dashboard loads without auth modal
- [ ] Manual: Store/delete/search memories works without credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)