### PR TITLE
feat(harvest): Phase 2 — LLM-based classification via Groq (v10.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.29.0] - 2026-03-29
+
+### Added
+
+- **[#628] LLM-based classification layer for session harvest (Phase 2)**: `memory_harvest` now accepts an optional `use_llm` boolean parameter. When `true`, extracted memories are routed through a new `_GroqClassifierBridge` (in `harvest/classifier.py`) that calls the Groq API to produce higher-precision category labels. Falls back transparently to the existing rule-based classifier when `use_llm=false` (the default) or when the Groq API is unavailable. Closes #618.
+- **[#628] `harvest/classifier.py`**: New module implementing `_GroqClassifierBridge` — a lightweight, async-compatible adapter that wraps Groq's chat-completion API for memory classification. Includes rate-limit handling, structured output parsing, and a `classify_batch()` method for efficient bulk classification.
+- **[#628] 14 new tests**: Full unit and integration coverage for `_GroqClassifierBridge` (mock API responses, fallback on 429/503, batch classification), the `use_llm` path in the harvest MCP handler, and end-to-end harvest flows with and without LLM classification enabled.
+
 ## [10.28.5] - 2026-03-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.28.5 - Bug fix: MCP_ALLOW_ANONYMOUS_ACCESS=true now respected in the dashboard (#621) — 1,420 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.29.0 - feat(harvest): LLM-based classification via Groq (Phase 2, #628) — 1,483 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -368,18 +368,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.28.5** (March 29, 2026)
+## Latest Release: **v10.29.0** (March 29, 2026)
 
-**Bug fix: MCP_ALLOW_ANONYMOUS_ACCESS=true now respected in the dashboard (#621)**
+**feat(harvest): LLM-based classification via Groq (Phase 2) (#628)**
 
 **What's New:**
-- **Anonymous access fix**: `MCP_ALLOW_ANONYMOUS_ACCESS=true` now correctly grants full access in the dashboard — no more login prompt when the flag is set.
-- **Scope clarified**: Anonymous users receive `read write` scope (not read-only) when the flag is enabled, matching the server's intended behavior.
-- **Documentation updated**: `.env.example` and dashboard auth modal now explicitly warn that this flag grants full read+write access.
+- **LLM-powered harvest classification**: `memory_harvest` now supports an optional `use_llm=true` parameter that routes extracted memories through a Groq-backed classifier for higher-precision category labels.
+- **_GroqClassifierBridge**: New `harvest/classifier.py` module provides a lightweight bridge to Groq's LLM API, with graceful fallback to the existing rule-based classifier when the API is unavailable.
+- **14 new tests**: Full coverage for the classifier bridge, fallback behaviour, and end-to-end `use_llm` harvest flow.
+- **Closes #618**: Completes the two-phase harvest roadmap (Phase 1: rule-based extraction; Phase 2: LLM re-classification).
 
 ---
 
 **Previous Releases**:
+- **v10.28.5** - Bug fix: MCP_ALLOW_ANONYMOUS_ACCESS=true now respected in the dashboard (anonymous users granted read+write scope)
 - **v10.28.4** - Security patch: cryptography>=46.0.6 (CVE-2026-34073), serialize-javascript>=7.0.5 (CVE-2026-34043), CodeQL cleanup
 - **v10.28.3** - HTTP MCP endpoint fix: accept 'content' as alias for 'query' so Claude Code HTTP transport returns results
 - **v10.28.2** - Relationship inference tuning: 93.5% typed labels vs 0.5% before + German language support

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.26 — Persistent Memory for AI Agents</title>
+<title>MCP Memory Service v10.29 — Persistent Memory for AI Agents</title>
 <meta name="description" content="Self-hosted persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation. Now with Streamable HTTP + OAuth 2.1 for Claude.ai.">
-<meta property="og:title" content="MCP Memory Service v10.26">
+<meta property="og:title" content="MCP Memory Service v10.29">
 <meta property="og:description" content="Your self-hosted memory server now connects to Claude.ai. Streamable HTTP + OAuth 2.1 + PKCE.">
 <meta property="og:type" content="website">
 <style>
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.26 &mdash; Now Available</span>
+  <span class="hero-badge">v10.29 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,7 +136,7 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.26</h2>
+    <h2 class="section-title">What's New in v10.29</h2>
     <p class="section-subtitle">Claude.ai can now connect to your self-hosted memory server. Your knowledge, your data, your server.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1420">0</div>
+        <div class="stat-number" data-target="1483">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.28.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.29.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.28.5"
+version = "10.29.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.28.5"
+__version__ = "10.29.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.28.5"
+version = "10.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- LLM-backed classification layer for `memory_harvest` via new `use_llm` parameter
- New `harvest/classifier.py` with `_GroqClassifierBridge` (Groq API adapter, batch classification, graceful fallback)
- 14 new tests covering classifier bridge, fallback paths, and end-to-end harvest flows
- Version bump to v10.29.0 (MINOR — new feature, backward compatible)

## Motivation

Completes the two-phase harvest roadmap. Phase 1 (PR #614) established rule-based extraction from Claude Code transcripts. Phase 2 adds an optional LLM re-classification pass to produce higher-precision memory category labels, especially for nuanced or multi-topic memories where regex patterns are insufficient.

The `_GroqClassifierBridge` is opt-in (`use_llm=false` by default), so existing integrations are unaffected.

## Testing

- 14 new unit and integration tests added in PR #628
- All existing tests continue to pass
- Fallback behaviour verified: when Groq returns 429/503 the classifier silently falls back to rule-based labels

## Related Issues

- Closes #618 (LLM-based harvest classification)
- Builds on #614 (Phase 1 — rule-based harvest)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (v10.29.0 entry at top after [Unreleased])
- [x] `README.md` Latest Release section updated
- [x] `CLAUDE.md` version string updated
- [x] `docs/index.html` updated (version badge v10.29, test count 1483, release notes link)