### PR TITLE
fix: clean up orphaned graph edges on memory deletion (v10.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.29.1] - 2026-03-29
+
+### Fixed
+
+- **[#632] Clean up orphaned graph edges on memory deletion**: When memories were deleted, their associated edges in the `memory_graph` table were not removed, causing dead references to accumulate over time and pollute graph queries. The fix adds explicit edge removal to `delete()`, `delete_by_tag()`, and `delete_by_tags()` in `sqlite_vec.py`. The consolidation forgetting phase now also performs a periodic orphan-pruning pass after archival, ensuring edges referencing non-existent memories are swept up even for memories removed by other means.
+
 ## [10.29.0] - 2026-03-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **[#632] Clean up orphaned graph edges on memory deletion**: When memories were deleted, their associated edges in the `memory_graph` table were not removed, causing dead references to accumulate over time and pollute graph queries. The fix adds explicit edge removal to `delete()`, `delete_by_tag()`, and `delete_by_tags()` in `sqlite_vec.py`. The consolidation forgetting phase now also performs a periodic orphan-pruning pass after archival, ensuring edges referencing non-existent memories are swept up even for memories removed by other means.
 
+### Documentation
+
+- **Troubleshooting additions**: Pre-commit hook PATH workaround (`.venv/bin`), editable install vs PyPI version switching, Cloudflare 401 memory-first diagnosis, dashboard testing guidelines, uv.lock revision downgrade
+- **Instincts bootstrap**: Added `instincts/learned.instincts.yaml` with 4 session-derived instincts (PR workflow, memory-first debugging, env/dashboard token sync, release agent usage)
+
 ## [10.29.0] - 2026-03-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,6 +508,9 @@ memory.memory_type or ''
 | Cloudflare 403 / sync not running (IPv6) | Python prefers IPv6 but token IP allowlist may only have IPv4. Add your IPv6 /64 network to token's Client IP Address Filtering, or remove IP filtering entirely |
 | Strict stdio client times out during handshake (e.g. Codex, 10s budget) | Set `MCP_INIT_TIMEOUT=5` to force lazy loading — storage initializes on first tool call instead (issue #561) |
 | uv.lock revision downgraded (revision=2 vs revision=3) | Local uv 0.7.16 silently downgrades lockfile. Restore with `git checkout uv.lock` or upgrade uv. Don't include revision-only changes in PRs |
+| Pre-commit hook fails "Package not installed" | Hook uses system Python, not venv. Use `PATH=".venv/bin:$PATH" git commit -m "..."` for all commits |
+| Editable install replaced PyPI version | `uv pip install -e .` replaces PyPI package with local source. After commit, restore with `uv pip install mcp-memory-service==<version>` |
+| Cloudflare 401 after upgrade/restart | First search Memory (`cloudflare 401`), then verify `.env` token matches Cloudflare Dashboard. Token rotation in dashboard does NOT update local `.env` |
 
 **Comprehensive troubleshooting:** [docs/troubleshooting/hooks-quick-reference.md](docs/troubleshooting/hooks-quick-reference.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.29.0 - feat(harvest): LLM-based classification via Groq (Phase 2, #628) — 1,483 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.29.1 - fix: orphaned graph edges cleaned up on memory deletion (#632) — 1,483 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -368,19 +368,20 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.29.0** (March 29, 2026)
+## Latest Release: **v10.29.1** (March 29, 2026)
 
-**feat(harvest): LLM-based classification via Groq (Phase 2) (#628)**
+**fix: clean up orphaned graph edges on memory deletion (#632)**
 
 **What's New:**
-- **LLM-powered harvest classification**: `memory_harvest` now supports an optional `use_llm=true` parameter that routes extracted memories through a Groq-backed classifier for higher-precision category labels.
-- **_GroqClassifierBridge**: New `harvest/classifier.py` module provides a lightweight bridge to Groq's LLM API, with graceful fallback to the existing rule-based classifier when the API is unavailable.
-- **14 new tests**: Full coverage for the classifier bridge, fallback behaviour, and end-to-end `use_llm` harvest flow.
-- **Closes #618**: Completes the two-phase harvest roadmap (Phase 1: rule-based extraction; Phase 2: LLM re-classification).
+- **Orphaned edge cleanup**: Deleting a memory now removes its associated edges from the `memory_graph` table immediately, preventing dead references from accumulating.
+- **Cascade deletion**: `delete()`, `delete_by_tag()`, and `delete_by_tags()` in the SQLite-Vec backend all perform graph edge removal as part of the same operation.
+- **Periodic orphan pruning**: The consolidation forgetting phase sweeps up any remaining orphaned edges after archival, providing a safety net for edges left by other deletion paths.
+- **Fixes #632**: Graph queries no longer return or traverse stale edges referencing deleted memories.
 
 ---
 
 **Previous Releases**:
+- **v10.29.0** - feat(harvest): LLM-based classification via Groq (Phase 2, #628) — `memory_harvest` supports `use_llm=true` for higher-precision category labels via _GroqClassifierBridge
 - **v10.28.5** - Bug fix: MCP_ALLOW_ANONYMOUS_ACCESS=true now respected in the dashboard (anonymous users granted read+write scope)
 - **v10.28.4** - Security patch: cryptography>=46.0.6 (CVE-2026-34073), serialize-javascript>=7.0.5 (CVE-2026-34043), CodeQL cleanup
 - **v10.28.3** - HTTP MCP endpoint fix: accept 'content' as alias for 'query' so Claude Code HTTP transport returns results

--- a/instincts/learned.instincts.yaml
+++ b/instincts/learned.instincts.yaml
@@ -1,0 +1,68 @@
+version: "1.0"
+instincts:
+  never-push-main-directly:
+    id: never-push-main-directly
+    rule: "Never push commits directly to main. Always create a feature branch and open a PR, even for single-line fixes. PRs are quality gates for code review, not bureaucracy."
+    domain: git
+    tags: [git, workflow, pr, code-review, branch-protection]
+    trigger_patterns:
+      - "git push.*main"
+      - "push to main"
+      - "commit.*main"
+    confidence: 0.8
+    min_confidence: 0.5
+    approved_by: human
+    active: true
+    created_at: "2026-03-29T16:25:00Z"
+    outcome_log: []
+
+  check-memory-before-diagnosing:
+    id: check-memory-before-diagnosing
+    rule: "When hitting a recurring error (especially Cloudflare 401, auth failures), search MCP Memory for prior incidents before investigating from scratch. The fix is often already documented."
+    domain: troubleshooting
+    tags: [troubleshooting, memory, cloudflare, auth, debugging]
+    trigger_patterns:
+      - "401"
+      - "unauthorized"
+      - "authentication error"
+      - "cloudflare.*fail"
+    confidence: 0.75
+    min_confidence: 0.5
+    approved_by: human
+    active: true
+    created_at: "2026-03-29T16:25:00Z"
+    outcome_log: []
+
+  verify-env-matches-dashboard:
+    id: verify-env-matches-dashboard
+    rule: "When Cloudflare API returns 401/auth errors, first verify the token in .env matches the active token in the Cloudflare Dashboard. Token rotation in the dashboard does not auto-update local config files."
+    domain: cloudflare
+    tags: [cloudflare, env, token, auth, configuration]
+    trigger_patterns:
+      - "cloudflare.*401"
+      - "invalid.*api.*token"
+      - "authentication error.*cloudflare"
+    confidence: 0.7
+    min_confidence: 0.5
+    approved_by: human
+    active: true
+    created_at: "2026-03-29T16:25:00Z"
+    outcome_log: []
+
+  use-release-agent-for-versions:
+    id: use-release-agent-for-versions
+    rule: "Never manually bump versions or create release commits. Always use the github-release-manager agent which handles version sync across pyproject.toml, _version.py, CHANGELOG, README, and CLAUDE.md consistently."
+    domain: workflow
+    tags: [workflow, release, versioning, automation]
+    trigger_patterns:
+      - "version bump"
+      - "release"
+      - "changelog"
+      - "patch release"
+      - "new version"
+    confidence: 0.75
+    min_confidence: 0.5
+    approved_by: human
+    active: true
+    created_at: "2026-03-29T16:25:00Z"
+    outcome_log: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.29.0"
+version = "10.29.1"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.29.0"
+__version__ = "10.29.1"

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -2058,3 +2058,157 @@ class TestSemanticDeduplication:
 
         # Should return empty results, not unfiltered results
         assert len(results) == 0
+
+
+class TestGraphEdgeCleanupOnDelete:
+    """Regression tests for #632: orphaned graph edges on memory deletion."""
+
+    @pytest_asyncio.fixture
+    async def storage(self):
+        """Create a test storage instance."""
+        temp_dir = tempfile.mkdtemp()
+        db_path = os.path.join(temp_dir, "test_memory.db")
+
+        storage = SqliteVecMemoryStorage(db_path)
+        await storage.initialize()
+
+        yield storage
+
+        if storage.conn:
+            storage.conn.close()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _insert_edge(self, storage, source, target, similarity=0.8):
+        """Helper to insert a graph edge."""
+        storage.conn.execute(
+            'INSERT INTO memory_graph (source_hash, target_hash, similarity, connection_types, relationship_type, created_at) '
+            'VALUES (?, ?, ?, ?, ?, ?)',
+            (source, target, similarity, 'semantic', 'related', time.time())
+        )
+        storage.conn.commit()
+
+    def _count_edges(self, storage, content_hash=None):
+        """Count graph edges, optionally filtered by hash."""
+        if content_hash:
+            return storage.conn.execute(
+                'SELECT COUNT(*) FROM memory_graph WHERE source_hash = ? OR target_hash = ?',
+                (content_hash, content_hash)
+            ).fetchone()[0]
+        return storage.conn.execute('SELECT COUNT(*) FROM memory_graph').fetchone()[0]
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_graph_edges(self, storage):
+        """Deleting a memory must remove all its graph edges (#632)."""
+        m1 = Memory(content="Memory A", content_hash=generate_content_hash("Memory A"), tags=["test"])
+        m2 = Memory(content="Memory B", content_hash=generate_content_hash("Memory B"), tags=["test"])
+        m3 = Memory(content="Memory C", content_hash=generate_content_hash("Memory C"), tags=["test"])
+        await storage.store(m1)
+        await storage.store(m2)
+        await storage.store(m3)
+
+        # Create edges: m1<->m2, m1<->m3, m2<->m3
+        self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+
+        assert self._count_edges(storage) == 6
+
+        # Delete m1 — should remove 4 edges (m1<->m2 and m1<->m3, both directions)
+        success, _ = await storage.delete(m1.content_hash)
+        assert success
+
+        assert self._count_edges(storage, m1.content_hash) == 0, "Deleted memory should have no graph edges"
+        assert self._count_edges(storage) == 2, "Only m2<->m3 edges should remain"
+
+    @pytest.mark.asyncio
+    async def test_delete_by_tag_removes_graph_edges(self, storage):
+        """Deleting memories by tag must remove their graph edges (#632)."""
+        m1 = Memory(content="Tagged mem 1", content_hash=generate_content_hash("Tagged mem 1"), tags=["cleanup"])
+        m2 = Memory(content="Tagged mem 2", content_hash=generate_content_hash("Tagged mem 2"), tags=["cleanup"])
+        m3 = Memory(content="Keep this one", content_hash=generate_content_hash("Keep this one"), tags=["keep"])
+        await storage.store(m1)
+        await storage.store(m2)
+        await storage.store(m3)
+
+        # Edges between all three
+        self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+
+        assert self._count_edges(storage) == 6
+
+        # Delete by "cleanup" tag — m1 and m2 go, m3 stays
+        count, _ = await storage.delete_by_tag("cleanup")
+        assert count == 2
+
+        # All edges involving m1 or m2 should be gone
+        assert self._count_edges(storage, m1.content_hash) == 0
+        assert self._count_edges(storage, m2.content_hash) == 0
+        assert self._count_edges(storage) == 0, "No edges should remain (m3 had edges only to deleted memories)"
+
+    @pytest.mark.asyncio
+    async def test_delete_by_tags_removes_graph_edges(self, storage):
+        """Deleting memories by multiple tags must remove their graph edges (#632)."""
+        m1 = Memory(content="Alpha mem", content_hash=generate_content_hash("Alpha mem"), tags=["alpha"])
+        m2 = Memory(content="Beta mem", content_hash=generate_content_hash("Beta mem"), tags=["beta"])
+        m3 = Memory(content="Gamma mem", content_hash=generate_content_hash("Gamma mem"), tags=["gamma"])
+        await storage.store(m1)
+        await storage.store(m2)
+        await storage.store(m3)
+
+        self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+
+        assert self._count_edges(storage) == 4
+
+        # Delete by both alpha and beta tags
+        count, _, _ = await storage.delete_by_tags(["alpha", "beta"])
+        assert count == 2
+
+        assert self._count_edges(storage, m1.content_hash) == 0
+        assert self._count_edges(storage, m2.content_hash) == 0
+        assert self._count_edges(storage) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_without_edges_succeeds(self, storage):
+        """Deleting a memory with no graph edges should not error (#632)."""
+        m1 = Memory(content="Lone memory", content_hash=generate_content_hash("Lone memory"), tags=["test"])
+        await storage.store(m1)
+
+        assert self._count_edges(storage) == 0
+
+        success, _ = await storage.delete(m1.content_hash)
+        assert success
+        assert self._count_edges(storage) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_preserves_unrelated_edges(self, storage):
+        """Deleting one memory must not affect edges between other memories (#632)."""
+        m1 = Memory(content="To delete", content_hash=generate_content_hash("To delete"), tags=["test"])
+        m2 = Memory(content="Survivor A", content_hash=generate_content_hash("Survivor A"), tags=["test"])
+        m3 = Memory(content="Survivor B", content_hash=generate_content_hash("Survivor B"), tags=["test"])
+        await storage.store(m1)
+        await storage.store(m2)
+        await storage.store(m3)
+
+        # m1<->m2 edge and independent m2<->m3 edge
+        self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+
+        success, _ = await storage.delete(m1.content_hash)
+        assert success
+
+        # m2<->m3 edges must survive
+        assert self._count_edges(storage, m2.content_hash) == 2
+        assert self._count_edges(storage, m3.content_hash) == 2
+        assert self._count_edges(storage) == 2

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -2078,23 +2078,27 @@ class TestGraphEdgeCleanupOnDelete:
             storage.conn.close()
         shutil.rmtree(temp_dir, ignore_errors=True)
 
-    def _insert_edge(self, storage, source, target, similarity=0.8):
-        """Helper to insert a graph edge."""
-        storage.conn.execute(
-            'INSERT INTO memory_graph (source_hash, target_hash, similarity, connection_types, relationship_type, created_at) '
-            'VALUES (?, ?, ?, ?, ?, ?)',
-            (source, target, similarity, 'semantic', 'related', time.time())
-        )
-        storage.conn.commit()
+    async def _insert_edge(self, storage, source, target, similarity=0.8):
+        """Helper to insert a graph edge (async to avoid blocking event loop)."""
+        def sync_insert():
+            storage.conn.execute(
+                'INSERT INTO memory_graph (source_hash, target_hash, similarity, connection_types, relationship_type, created_at) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                (source, target, similarity, 'semantic', 'related', time.time())
+            )
+            storage.conn.commit()
+        await asyncio.to_thread(sync_insert)
 
-    def _count_edges(self, storage, content_hash=None):
-        """Count graph edges, optionally filtered by hash."""
-        if content_hash:
-            return storage.conn.execute(
-                'SELECT COUNT(*) FROM memory_graph WHERE source_hash = ? OR target_hash = ?',
-                (content_hash, content_hash)
-            ).fetchone()[0]
-        return storage.conn.execute('SELECT COUNT(*) FROM memory_graph').fetchone()[0]
+    async def _count_edges(self, storage, content_hash=None):
+        """Count graph edges (async to avoid blocking event loop)."""
+        def sync_count():
+            if content_hash:
+                return storage.conn.execute(
+                    'SELECT COUNT(*) FROM memory_graph WHERE source_hash = ? OR target_hash = ?',
+                    (content_hash, content_hash)
+                ).fetchone()[0]
+            return storage.conn.execute('SELECT COUNT(*) FROM memory_graph').fetchone()[0]
+        return await asyncio.to_thread(sync_count)
 
     @pytest.mark.asyncio
     async def test_delete_removes_graph_edges(self, storage):
@@ -2107,21 +2111,21 @@ class TestGraphEdgeCleanupOnDelete:
         await storage.store(m3)
 
         # Create edges: m1<->m2, m1<->m3, m2<->m3
-        self._insert_edge(storage, m1.content_hash, m2.content_hash)
-        self._insert_edge(storage, m2.content_hash, m1.content_hash)
-        self._insert_edge(storage, m1.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m1.content_hash)
-        self._insert_edge(storage, m2.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m2.content_hash)
 
-        assert self._count_edges(storage) == 6
+        assert await self._count_edges(storage) == 6
 
         # Delete m1 — should remove 4 edges (m1<->m2 and m1<->m3, both directions)
         success, _ = await storage.delete(m1.content_hash)
         assert success
 
-        assert self._count_edges(storage, m1.content_hash) == 0, "Deleted memory should have no graph edges"
-        assert self._count_edges(storage) == 2, "Only m2<->m3 edges should remain"
+        assert await self._count_edges(storage, m1.content_hash) == 0, "Deleted memory should have no graph edges"
+        assert await self._count_edges(storage) == 2, "Only m2<->m3 edges should remain"
 
     @pytest.mark.asyncio
     async def test_delete_by_tag_removes_graph_edges(self, storage):
@@ -2134,23 +2138,23 @@ class TestGraphEdgeCleanupOnDelete:
         await storage.store(m3)
 
         # Edges between all three
-        self._insert_edge(storage, m1.content_hash, m2.content_hash)
-        self._insert_edge(storage, m2.content_hash, m1.content_hash)
-        self._insert_edge(storage, m1.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m1.content_hash)
-        self._insert_edge(storage, m2.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m2.content_hash)
 
-        assert self._count_edges(storage) == 6
+        assert await self._count_edges(storage) == 6
 
         # Delete by "cleanup" tag — m1 and m2 go, m3 stays
         count, _ = await storage.delete_by_tag("cleanup")
         assert count == 2
 
         # All edges involving m1 or m2 should be gone
-        assert self._count_edges(storage, m1.content_hash) == 0
-        assert self._count_edges(storage, m2.content_hash) == 0
-        assert self._count_edges(storage) == 0, "No edges should remain (m3 had edges only to deleted memories)"
+        assert await self._count_edges(storage, m1.content_hash) == 0
+        assert await self._count_edges(storage, m2.content_hash) == 0
+        assert await self._count_edges(storage) == 0, "No edges should remain (m3 had edges only to deleted memories)"
 
     @pytest.mark.asyncio
     async def test_delete_by_tags_removes_graph_edges(self, storage):
@@ -2162,20 +2166,20 @@ class TestGraphEdgeCleanupOnDelete:
         await storage.store(m2)
         await storage.store(m3)
 
-        self._insert_edge(storage, m1.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m1.content_hash)
-        self._insert_edge(storage, m2.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m2.content_hash)
 
-        assert self._count_edges(storage) == 4
+        assert await self._count_edges(storage) == 4
 
         # Delete by both alpha and beta tags
         count, _, _ = await storage.delete_by_tags(["alpha", "beta"])
         assert count == 2
 
-        assert self._count_edges(storage, m1.content_hash) == 0
-        assert self._count_edges(storage, m2.content_hash) == 0
-        assert self._count_edges(storage) == 0
+        assert await self._count_edges(storage, m1.content_hash) == 0
+        assert await self._count_edges(storage, m2.content_hash) == 0
+        assert await self._count_edges(storage) == 0
 
     @pytest.mark.asyncio
     async def test_delete_memory_without_edges_succeeds(self, storage):
@@ -2183,11 +2187,11 @@ class TestGraphEdgeCleanupOnDelete:
         m1 = Memory(content="Lone memory", content_hash=generate_content_hash("Lone memory"), tags=["test"])
         await storage.store(m1)
 
-        assert self._count_edges(storage) == 0
+        assert await self._count_edges(storage) == 0
 
         success, _ = await storage.delete(m1.content_hash)
         assert success
-        assert self._count_edges(storage) == 0
+        assert await self._count_edges(storage) == 0
 
     @pytest.mark.asyncio
     async def test_delete_preserves_unrelated_edges(self, storage):
@@ -2200,15 +2204,15 @@ class TestGraphEdgeCleanupOnDelete:
         await storage.store(m3)
 
         # m1<->m2 edge and independent m2<->m3 edge
-        self._insert_edge(storage, m1.content_hash, m2.content_hash)
-        self._insert_edge(storage, m2.content_hash, m1.content_hash)
-        self._insert_edge(storage, m2.content_hash, m3.content_hash)
-        self._insert_edge(storage, m3.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m1.content_hash, m2.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m1.content_hash)
+        await self._insert_edge(storage, m2.content_hash, m3.content_hash)
+        await self._insert_edge(storage, m3.content_hash, m2.content_hash)
 
         success, _ = await storage.delete(m1.content_hash)
         assert success
 
         # m2<->m3 edges must survive
-        assert self._count_edges(storage, m2.content_hash) == 2
-        assert self._count_edges(storage, m3.content_hash) == 2
-        assert self._count_edges(storage) == 2
+        assert await self._count_edges(storage, m2.content_hash) == 2
+        assert await self._count_edges(storage, m3.content_hash) == 2
+        assert await self._count_edges(storage) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.29.0"
+version = "10.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **[#632] Orphaned graph edge cleanup**: When memories are deleted, their associated `memory_graph` edges are now removed in the same operation. Previously these edges accumulated as dead references, polluting graph queries and consuming space.
- **Cascade deletion in sqlite_vec.py**: `delete()`, `delete_by_tag()`, and `delete_by_tags()` now include explicit edge removal.
- **Periodic orphan pruning in consolidation**: The forgetting phase performs a post-archival orphan sweep, catching edges left by any other deletion path.

## Version Bump

PATCH release: v10.29.0 → v10.29.1

## Motivation

Issue #632 reported that the `memory_graph` table grew without bound as memories were deleted without cleaning up their edges. Graph traversals would encounter dead references and return unexpected results.

## Files Changed (version bump)

- `src/mcp_memory_service/_version.py`: 10.29.0 → 10.29.1
- `pyproject.toml`: 10.29.0 → 10.29.1
- `CHANGELOG.md`: Added [10.29.1] entry
- `README.md`: Updated Latest Release section; v10.29.0 moved to Previous Releases
- `CLAUDE.md`: Updated Current Version reference
- `uv.lock`: Updated for new version

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (new entry at top, no duplicates)
- [x] `README.md` Latest Release section updated; previous version added to Previous Releases
- [x] `CLAUDE.md` version reference updated
- [x] PATCH classification correct (bug fix, no new API, backward compatible)

Fixes #632