### PR TITLE
fix(storage): purge tombstone before re-insert (#644)

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1466,6 +1466,12 @@ SOLUTIONS:
                 try:
                     self.conn.execute('SAVEPOINT batch_item')
 
+                    # Purge any soft-deleted tombstone (#644)
+                    self.conn.execute(
+                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
+                        (memory.content_hash,)
+                    )
+
                     cur = self.conn.execute('''
                         INSERT INTO memories (
                             content_hash, content, tags, memory_type,
@@ -4010,6 +4016,11 @@ SOLUTIONS:
             def versioned_insert():
                 self.conn.execute('SAVEPOINT evolve_memory')
                 try:
+                    # Purge any soft-deleted tombstone (#644)
+                    self.conn.execute(
+                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
+                        (new_hash,)
+                    )
                     cursor = self.conn.execute('''
                         INSERT INTO memories (
                             content_hash, content, tags, memory_type, metadata,

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1338,6 +1338,13 @@ SOLUTIONS:
             def insert_memory_and_embedding():
                 self.conn.execute('SAVEPOINT store_memory')
                 try:
+                    # Purge any soft-deleted tombstone with the same hash so
+                    # the UNIQUE constraint on content_hash does not block
+                    # re-insertion (#644).
+                    self.conn.execute(
+                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
+                        (memory.content_hash,)
+                    )
                     cursor = self.conn.execute('''
                         INSERT INTO memories (
                             content_hash, content, tags, memory_type,

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1242,6 +1242,13 @@ SOLUTIONS:
             logger.error(f"Failed to generate embedding: {str(e)}")
             raise RuntimeError(f"Failed to generate embedding: {str(e)}") from e
 
+    def _purge_tombstone(self, content_hash: str) -> None:
+        """Remove a soft-deleted tombstone so the UNIQUE constraint allows re-insert (#644)."""
+        self.conn.execute(
+            'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
+            (content_hash,)
+        )
+
     async def _check_semantic_duplicate(
         self,
         content: str,
@@ -1338,13 +1345,7 @@ SOLUTIONS:
             def insert_memory_and_embedding():
                 self.conn.execute('SAVEPOINT store_memory')
                 try:
-                    # Purge any soft-deleted tombstone with the same hash so
-                    # the UNIQUE constraint on content_hash does not block
-                    # re-insertion (#644).
-                    self.conn.execute(
-                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
-                        (memory.content_hash,)
-                    )
+                    self._purge_tombstone(memory.content_hash)
                     cursor = self.conn.execute('''
                         INSERT INTO memories (
                             content_hash, content, tags, memory_type,
@@ -1466,11 +1467,7 @@ SOLUTIONS:
                 try:
                     self.conn.execute('SAVEPOINT batch_item')
 
-                    # Purge any soft-deleted tombstone (#644)
-                    self.conn.execute(
-                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
-                        (memory.content_hash,)
-                    )
+                    self._purge_tombstone(memory.content_hash)
 
                     cur = self.conn.execute('''
                         INSERT INTO memories (
@@ -4016,11 +4013,7 @@ SOLUTIONS:
             def versioned_insert():
                 self.conn.execute('SAVEPOINT evolve_memory')
                 try:
-                    # Purge any soft-deleted tombstone (#644)
-                    self.conn.execute(
-                        'DELETE FROM memories WHERE content_hash = ? AND deleted_at IS NOT NULL',
-                        (new_hash,)
-                    )
+                    self._purge_tombstone(new_hash)
                     cursor = self.conn.execute('''
                         INSERT INTO memories (
                             content_hash, content, tags, memory_type, metadata,

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -256,6 +256,36 @@ class TestSqliteVecStorage:
         assert memory is None, "Deleted memory should not be returned by get_by_hash"
     
     @pytest.mark.asyncio
+    async def test_store_after_delete_same_content(self, storage, sample_memory):
+        """Test that re-storing content after soft-delete succeeds (#644).
+
+        The UNIQUE constraint on content_hash must not block re-insertion
+        when the previous row was soft-deleted (tombstone).
+        """
+        # Store → delete → re-store must succeed
+        success, _ = await storage.store(sample_memory)
+        assert success
+
+        success, _ = await storage.delete(sample_memory.content_hash)
+        assert success
+
+        # Re-store the same content — this failed before the fix
+        success, msg = await storage.store(sample_memory)
+        assert success, f"Re-store after delete should succeed, got: {msg}"
+
+        # Verify the re-stored memory is retrievable
+        retrieved = await storage.get_by_hash(sample_memory.content_hash)
+        assert retrieved is not None
+        assert retrieved.content == sample_memory.content
+
+        # Verify tombstone was removed (only one row with this hash)
+        cursor = storage.conn.execute(
+            'SELECT COUNT(*) FROM memories WHERE content_hash = ?',
+            (sample_memory.content_hash,)
+        )
+        assert cursor.fetchone()[0] == 1, "Should have exactly one row, no leftover tombstone"
+
+    @pytest.mark.asyncio
     async def test_delete_nonexistent_memory(self, storage):
         """Test deleting a non-existent memory."""
         nonexistent_hash = "nonexistent123456789"


### PR DESCRIPTION
## Summary
- **Fixes** #644 — `store()` failed with `UNIQUE constraint failed: memories.content_hash` when re-storing content that was previously soft-deleted
- **Root cause:** The `INSERT INTO memories` hit the UNIQUE constraint on `content_hash` because the soft-deleted tombstone row was still present
- **Fix:** Purge the tombstone (`DELETE ... WHERE content_hash = ? AND deleted_at IS NOT NULL`) inside the `insert_memory_and_embedding()` savepoint, right before the INSERT

## Test plan
- [x] New test `test_store_after_delete_same_content` — store → delete → re-store cycle succeeds
- [x] Verifies re-stored memory is retrievable via `get_by_hash()`
- [x] Verifies no leftover tombstone row remains
- [x] All 29 existing delete-related tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)