### PR TITLE
feat: LoCoMo benchmark for memory retrieval evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,9 @@ social-media/
 # Python version compatibility marker
 venv/.python312_compat
 docs/.herenow/
+certs/cert.pem
+.gitignore
+certs/key.pem
+
+# LoCoMo benchmark data (downloaded on demand)
+data/locomo/

--- a/README.md
+++ b/README.md
@@ -488,6 +488,29 @@ result = storage.find_connected(
 - Asymmetric: causes, fixes, supports, follows (A→B ≠ B→A)
 - Symmetric: related, contradicts (A↔B)
 
+### Retrieval Benchmarks
+
+Two benchmarks measure retrieval quality (all-MiniLM-L6-v2, 384d embeddings):
+
+**DevBench** (practical developer workflow queries):
+
+| Category | Recall@5 | MRR |
+|----------|----------|-----|
+| **Overall** | **91.1%** | **0.861** |
+| exact | 100% | 1.000 |
+| semantic | 80.0% | 0.700 |
+| cross-type | 90.0% | 0.867 |
+
+**LoCoMo** ([ACL 2024](https://github.com/snap-research/locomo) long-term conversational memory):
+
+| Category | Recall@5 | MRR |
+|----------|----------|-----|
+| **Overall** | **49.7%** | **0.414** |
+| multi-hop | 72.0% | 0.600 |
+| temporal | 33.5% | 0.274 |
+
+Run benchmarks: `python scripts/benchmarks/benchmark_devbench.py` and `python scripts/benchmarks/benchmark_locomo.py`
+
 ### Performance Improvements
 
 - ontology validation: 97.5x faster (module-level caching)

--- a/scripts/benchmarks/benchmark_devbench.py
+++ b/scripts/benchmarks/benchmark_devbench.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""DevBench: Practical benchmark for MCP Memory Service using project-derived memories."""
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple, Union
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+from locomo_evaluator import (
+    BenchmarkResult,
+    aggregate_results,
+    mrr,
+    precision_at_k,
+    recall_at_k,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATASET_PATH = os.path.join(os.path.dirname(__file__), "devbench_dataset.json")
+
+
+def load_devbench_dataset(path=None):
+    """Load DevBench dataset from JSON. Returns dict with 'memories' and 'queries'."""
+    dataset_path = path or _DATASET_PATH
+    with open(dataset_path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def create_isolated_storage():
+    """Create isolated SQLite-Vec storage in temp dir. Returns (storage, tmp_dir)."""
+    tmp_dir = tempfile.mkdtemp(prefix="devbench-")
+    db_path = os.path.join(tmp_dir, "memories.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    return storage, tmp_dir
+
+
+async def ingest_memories(storage, memories):
+    """Ingest all memories into storage. Returns count of successfully stored memories."""
+    stored = 0
+    for mem in memories:
+        content_hash = hashlib.sha256(mem["content"].encode("utf-8")).hexdigest()
+        created_at = None
+        if mem.get("created_at_iso"):
+            try:
+                dt = datetime.fromisoformat(mem["created_at_iso"].replace("Z", "+00:00"))
+                created_at = int(dt.timestamp())
+            except ValueError:
+                pass
+
+        memory = Memory(
+            content=mem["content"],
+            content_hash=content_hash,
+            tags=mem.get("tags", []),
+            memory_type=mem.get("memory_type"),
+            created_at=created_at,
+        )
+        success, _msg = await storage.store(memory, skip_semantic_dedup=True)
+        if success:
+            stored += 1
+    return stored
+
+
+def match_by_tags(retrieved_results, expected_tags):
+    """Match retrieved memories against expected bench tags.
+
+    Returns (retrieved_labels, relevant_labels).
+    relevant_labels is the set of expected bench: tags.
+    retrieved_labels maps each result to a matched tag or irrelevant_N.
+    """
+    relevant_labels = set(expected_tags)
+    retrieved_labels = []
+    for i, result in enumerate(retrieved_results):
+        tags = result.memory.tags or []
+        matched_label = None
+        for expected_tag in expected_tags:
+            if expected_tag in tags:
+                matched_label = expected_tag
+                break
+        if matched_label:
+            retrieved_labels.append(matched_label)
+        else:
+            retrieved_labels.append(f"irrelevant_{i}")
+    return retrieved_labels, relevant_labels
+
+
+def false_positive_rate(retrieved_results, k):
+    """Fraction of top-K results that contain any bench: tag.
+
+    Used for negative queries where expected_tags is empty.
+    """
+    top_k = retrieved_results[:k]
+    if not top_k:
+        return 0.0
+    false_positives = sum(
+        1
+        for r in top_k
+        if any(t.startswith("bench:") for t in (r.memory.tags or []))
+    )
+    return false_positives / k
+
+
+async def evaluate_retrieval(storage, queries, top_k=None):
+    """For each query: search memories, match by tags, compute metrics.
+
+    Negative queries use false_positive_rate. Returns list of per-query metric dicts.
+    """
+    if top_k is None:
+        top_k = [5]
+    max_k = max(top_k)
+    per_query = []
+
+    for query in queries:
+        category = query["category"]
+        expected_tags = query.get("expected_tags", [])
+        results = await storage.retrieve(query["question"], n_results=max_k)
+
+        if category == "negative":
+            metrics = {"category": category}
+            for k in top_k:
+                metrics[f"false_positive_rate_at_{k}"] = false_positive_rate(results, k)
+        else:
+            retrieved_labels, relevant_labels = match_by_tags(results, expected_tags)
+            metrics = {"category": category}
+            for k in top_k:
+                metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+                metrics[f"precision_at_{k}"] = precision_at_k(retrieved_labels, relevant_labels, k)
+            metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+
+        per_query.append(metrics)
+
+    return per_query
+
+
+async def evaluate_ablation(storage, queries, top_k=None):
+    """Compare retrieval configurations: baseline, +quality_boost, +quality_w0.5.
+
+    Returns list of per-query metric dicts with 'config_name' key.
+    """
+    if top_k is None:
+        top_k = [5]
+    max_k = max(top_k)
+
+    configs = [
+        ("baseline", "retrieve", {}),
+        ("+quality_boost", "retrieve_with_quality_boost", {}),
+        ("+quality_w0.5", "retrieve_with_quality_boost", {"quality_weight": 0.5}),
+    ]
+
+    all_results = []
+
+    for config_name, method_name, extra_kwargs in configs:
+        retrieve_fn = getattr(storage, method_name)
+        for query in queries:
+            category = query["category"]
+            expected_tags = query.get("expected_tags", [])
+            results = await retrieve_fn(query["question"], n_results=max_k, **extra_kwargs)
+
+            if category == "negative":
+                metrics = {"config_name": config_name, "category": category}
+                for k in top_k:
+                    metrics[f"false_positive_rate_at_{k}"] = false_positive_rate(results, k)
+            else:
+                retrieved_labels, relevant_labels = match_by_tags(results, expected_tags)
+                metrics = {"config_name": config_name, "category": category}
+                for k in top_k:
+                    metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+                    metrics[f"precision_at_{k}"] = precision_at_k(
+                        retrieved_labels, relevant_labels, k
+                    )
+                metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+
+            all_results.append(metrics)
+
+    return all_results
+
+
+def _separate_negative(per_query):
+    """Split per-query results into normal and negative lists."""
+    normal = [q for q in per_query if q.get("category") != "negative"]
+    negative = [q for q in per_query if q.get("category") == "negative"]
+    return normal, negative
+
+
+def _aggregate_negative(negative_results, top_k):
+    """Average false_positive_rate across negative queries."""
+    if not negative_results:
+        return {}
+    agg = {}
+    for k in top_k:
+        key = f"false_positive_rate_at_{k}"
+        vals = [q[key] for q in negative_results if key in q]
+        agg[key] = sum(vals) / len(vals) if vals else 0.0
+    return agg
+
+
+def format_results_table(result):
+    """Terminal table output."""
+    lines = []
+    lines.append("\n" + "=" * 60)
+    lines.append(f"  DevBench Practical Benchmark -- {result.mode.upper()} mode")
+    lines.append("=" * 60)
+
+    lines.append("\nOverall Metrics:")
+    lines.append(f"  {'Metric':<30} {'Value':>10}")
+    lines.append("  " + "-" * 42)
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"  {key:<30} {val:>10.4f}")
+
+    if result.config.get("negative_metrics"):
+        lines.append("\nNegative Query Metrics:")
+        lines.append(f"  {'Metric':<30} {'Value':>10}")
+        lines.append("  " + "-" * 42)
+        for key, val in sorted(result.config["negative_metrics"].items()):
+            lines.append(f"  {key:<30} {val:>10.4f}")
+
+    if result.by_category:
+        lines.append("\nBy Category:")
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        header = f"  {'Category':<20}" + "".join(f"  {k:<22}" for k in all_metric_keys)
+        lines.append(header)
+        lines.append("  " + "-" * (20 + 24 * len(all_metric_keys)))
+        for cat, metrics in sorted(result.by_category.items()):
+            row = f"  {cat:<20}" + "".join(
+                f"  {metrics.get(k, 0.0):<22.4f}" for k in all_metric_keys
+            )
+            lines.append(row)
+
+    lines.append("\n" + "=" * 60 + "\n")
+    return "\n".join(lines)
+
+
+def format_results_markdown(result):
+    """Markdown table output."""
+    lines = []
+    lines.append(f"## DevBench Practical Benchmark -- {result.mode.upper()} mode")
+    lines.append("")
+    lines.append("### Overall Metrics")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"| {key} | {val:.4f} |")
+    lines.append("")
+
+    if result.config.get("negative_metrics"):
+        lines.append("### Negative Query Metrics")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        for key, val in sorted(result.config["negative_metrics"].items()):
+            lines.append(f"| {key} | {val:.4f} |")
+        lines.append("")
+
+    if result.by_category:
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        lines.append("### By Category")
+        lines.append("")
+        header = "| Category | " + " | ".join(all_metric_keys) + " |"
+        separator = "|----------|" + "|".join(["--------"] * len(all_metric_keys)) + "|"
+        lines.append(header)
+        lines.append(separator)
+        for cat, metrics in sorted(result.by_category.items()):
+            row = (
+                f"| {cat} | "
+                + " | ".join(f"{metrics.get(k, 0.0):.4f}" for k in all_metric_keys)
+                + " |"
+            )
+            lines.append(row)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+async def run_benchmark(args):
+    """Full pipeline: load dataset, ingest memories, evaluate queries, aggregate."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    top_k = args.top_k if args.top_k else [5]
+    data_path = getattr(args, "data_path", None)
+
+    logger.info("Loading DevBench dataset...")
+    dataset = load_devbench_dataset(data_path)
+    memories = dataset["memories"]
+    queries = dataset["queries"]
+    logger.info("Loaded %d memories, %d queries", len(memories), len(queries))
+
+    storage, tmp_dir = create_isolated_storage()
+    try:
+        await storage.initialize()
+        count = await ingest_memories(storage, memories)
+        logger.info("Ingested %d memories", count)
+
+        ablation = getattr(args, "ablation", False)
+
+        if ablation:
+            per_query = await evaluate_ablation(storage, queries, top_k=top_k)
+        else:
+            per_query = await evaluate_retrieval(storage, queries, top_k=top_k)
+
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    config = {
+        "top_k": top_k,
+        "num_memories": len(memories),
+        "num_queries": len(queries),
+        "mode": "ablation" if ablation else "retrieval",
+    }
+
+    if ablation:
+        from collections import defaultdict
+
+        by_config = defaultdict(list)
+        for q in per_query:
+            by_config[q["config_name"]].append(q)
+
+        results = []
+        for config_name, questions in by_config.items():
+            normal, negative = _separate_negative(questions)
+            neg_metrics = _aggregate_negative(negative, top_k)
+            cfg = dict(config)
+            cfg["negative_metrics"] = neg_metrics
+            r = aggregate_results(
+                normal,
+                conversation_id="devbench",
+                mode=f"ablation:{config_name}",
+                config=cfg,
+            )
+            results.append(r)
+        return results
+
+    normal, negative = _separate_negative(per_query)
+    neg_metrics = _aggregate_negative(negative, top_k)
+    config["negative_metrics"] = neg_metrics
+
+    result = aggregate_results(
+        normal,
+        conversation_id="devbench",
+        mode="retrieval",
+        config=config,
+    )
+    return result
+
+
+def parse_args(argv=None):
+    """CLI args: --data-path, --top-k, --ablation, --markdown, --output-dir"""
+    parser = argparse.ArgumentParser(
+        description="Run the DevBench practical benchmark against MCP Memory Service.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=None,
+        help="Path to devbench_dataset.json. Defaults to bundled dataset.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        nargs="+",
+        default=[5],
+        help="Top-K values for retrieval metrics (default: 5)",
+    )
+    parser.add_argument(
+        "--ablation",
+        action="store_true",
+        default=False,
+        help="Run ablation study comparing retrieval configurations",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        default=False,
+        help="Output results as Markdown table",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Directory to save JSON results (optional)",
+    )
+    return parser.parse_args(argv)
+
+
+def main():
+    """Entry point."""
+    args = parse_args()
+    result = asyncio.run(run_benchmark(args))
+
+    results = result if isinstance(result, list) else [result]
+
+    for r in results:
+        if args.markdown:
+            print(format_results_markdown(r))
+        else:
+            print(format_results_table(r))
+
+    if args.output_dir:
+        import datetime as dt_module
+
+        os.makedirs(args.output_dir, exist_ok=True)
+        for r in results:
+            timestamp = dt_module.datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"devbench_{r.mode}_{timestamp}.json"
+            filepath = os.path.join(args.output_dir, filename)
+            data = {
+                "mode": r.mode,
+                "overall": r.overall,
+                "by_category": r.by_category,
+                "config": r.config,
+            }
+            with open(filepath, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2)
+            print(f"Results saved to: {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/benchmark_locomo.py
+++ b/scripts/benchmarks/benchmark_locomo.py
@@ -43,6 +43,39 @@ def build_evidence_map(conv: LocomoConversation) -> Dict[str, str]:
     return {turn.dia_id: turn.text for turn in conv.turns}
 
 
+def _match_evidence(
+    retrieved_texts: List[str],
+    evidence_map: Dict[str, str],
+    evidence_ids: List[str],
+) -> Tuple[List[str], set]:
+    """Match retrieved texts against evidence via substring containment.
+
+    Returns (retrieved_labels, relevant_labels) where each evidence item
+    gets a unique label so multi-evidence recall is computed correctly.
+    """
+    # Build per-evidence-item labels
+    evidence_items = {}  # label -> text
+    for dia_id in evidence_ids:
+        if dia_id in evidence_map:
+            evidence_items[f"ev_{dia_id}"] = evidence_map[dia_id]
+
+    relevant_labels = set(evidence_items.keys())
+
+    retrieved_labels = []
+    for text in retrieved_texts:
+        matched_label = None
+        for label, ev_text in evidence_items.items():
+            if ev_text in text or text in ev_text:
+                matched_label = label
+                break
+        if matched_label:
+            retrieved_labels.append(matched_label)
+        else:
+            retrieved_labels.append(f"irrelevant_{len(retrieved_labels)}")
+
+    return retrieved_labels, relevant_labels
+
+
 def _parse_session_date(date_str: str) -> float:
     """Parse LoCoMo date string to Unix timestamp."""
     for fmt in ("%B %d, %Y", "%b %d, %Y", "%Y-%m-%d"):
@@ -91,20 +124,14 @@ async def evaluate_retrieval(
     for qa in conv.qa_pairs:
         results = await storage.retrieve(qa.question, n_results=max_k)
         retrieved_texts = [r.memory.content for r in results]
-        relevant_evidence = set()
-        for dia_id in qa.evidence:
-            if dia_id in evidence_map:
-                relevant_evidence.add(evidence_map[dia_id])
-        binary_retrieved = []
-        for text in retrieved_texts:
-            is_match = any(ev in text or text in ev for ev in relevant_evidence)
-            binary_retrieved.append("relevant" if is_match else f"irrelevant_{len(binary_retrieved)}")
-        relevant_labels = {"relevant"}
+        retrieved_labels, relevant_labels = _match_evidence(
+            retrieved_texts, evidence_map, qa.evidence,
+        )
         metrics: Dict = {"category": qa.category}
         for k in top_k:
-            metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
-            metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
-        metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+            metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+            metrics[f"precision_at_{k}"] = precision_at_k(retrieved_labels, relevant_labels, k)
+        metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
         per_question.append(metrics)
     return per_question
 
@@ -115,39 +142,38 @@ async def run_ablation(
     evidence_map: Dict[str, str],
     top_k: Optional[List[int]] = None,
 ) -> List[Dict]:
-    """Compare: baseline retrieve() vs retrieve_with_quality_boost()."""
+    """Compare retrieval configurations: baseline, +quality, +quality+decay.
+
+    Configurations:
+    1. baseline — retrieve() with cosine similarity only
+    2. +quality_boost — retrieve_with_quality_boost()
+    3. +quality+min_confidence — quality boost with min_confidence filtering
+    """
     if top_k is None:
         top_k = [5]
     max_k = max(top_k)
 
     configs = [
-        ("baseline", "retrieve"),
-        ("+quality_boost", "retrieve_with_quality_boost"),
+        ("baseline", "retrieve", {}),
+        ("+quality_boost", "retrieve_with_quality_boost", {}),
+        ("+quality_w0.5", "retrieve_with_quality_boost", {"quality_weight": 0.5}),
     ]
 
     all_results: List[Dict] = []
 
-    for config_name, method_name in configs:
+    for config_name, method_name, extra_kwargs in configs:
         retrieve_fn = getattr(storage, method_name)
         for qa in conv.qa_pairs:
-            results = await retrieve_fn(qa.question, n_results=max_k)
+            results = await retrieve_fn(qa.question, n_results=max_k, **extra_kwargs)
             retrieved_texts = [r.memory.content for r in results]
-            relevant_evidence = set()
-            for dia_id in qa.evidence:
-                if dia_id in evidence_map:
-                    relevant_evidence.add(evidence_map[dia_id])
-            binary_retrieved = []
-            for text in retrieved_texts:
-                is_match = any(ev in text or text in ev for ev in relevant_evidence)
-                binary_retrieved.append(
-                    "relevant" if is_match else f"irrelevant_{len(binary_retrieved)}"
-                )
-            relevant_labels = {"relevant"}
+            retrieved_labels, relevant_labels = _match_evidence(
+                retrieved_texts, evidence_map, qa.evidence,
+            )
             metrics: Dict = {"config_name": config_name, "category": qa.category}
             for k in top_k:
-                metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
-                metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
-            metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+                metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+                metrics[f"precision_at_{k}"] = precision_at_k(retrieved_labels, relevant_labels, k)
+            metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
             all_results.append(metrics)
 
     return all_results
@@ -259,21 +285,15 @@ async def evaluate_qa(
         predicted = await adapter.generate_answer(qa.question, context_texts)
         f1 = token_f1(predicted, qa.answer)
 
-        relevant_evidence = set()
-        for dia_id in qa.evidence:
-            if dia_id in evidence_map:
-                relevant_evidence.add(evidence_map[dia_id])
-        binary_retrieved = []
-        for text in context_texts:
-            is_match = any(ev in text or text in ev for ev in relevant_evidence)
-            binary_retrieved.append("relevant" if is_match else f"irrelevant_{len(binary_retrieved)}")
-        relevant_labels = {"relevant"}
+        retrieved_labels, relevant_labels = _match_evidence(
+            context_texts, evidence_map, qa.evidence,
+        )
 
         metrics: Dict = {"category": qa.category, "token_f1": f1}
         for k in top_k:
-            metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
-            metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
-        metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+            metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+            metrics[f"precision_at_{k}"] = precision_at_k(retrieved_labels, relevant_labels, k)
+        metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
         per_question.append(metrics)
     return per_question
 
@@ -293,13 +313,12 @@ async def run_benchmark(args: argparse.Namespace) -> BenchmarkResult:
     logger.info("Loaded %d conversations", len(conversations))
 
     all_per_question: List[Dict] = []
-    storage, tmp_dir = create_isolated_storage()
 
-    try:
-        await storage.initialize()
-
-        for conv in conversations:
-            logger.info("Processing conversation: %s", conv.sample_id)
+    for conv in conversations:
+        logger.info("Processing conversation: %s", conv.sample_id)
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            await storage.initialize()
             count = await ingest_conversation(storage, conv)
             logger.info("Ingested %d observations for %s", count, conv.sample_id)
             evidence_map = build_evidence_map(conv)
@@ -318,20 +337,20 @@ async def run_benchmark(args: argparse.Namespace) -> BenchmarkResult:
                 raise ValueError(f"Unknown mode: {args.mode}")
 
             all_per_question.extend(per_question)
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
-        config = {
-            "mode": args.mode,
-            "top_k": top_k,
-            "num_conversations": len(conversations),
-        }
-        result = aggregate_results(
-            all_per_question,
-            conversation_id="all",
-            mode=args.mode,
-            config=config,
-        )
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+    config = {
+        "mode": args.mode,
+        "top_k": top_k,
+        "num_conversations": len(conversations),
+    }
+    result = aggregate_results(
+        all_per_question,
+        conversation_id="all",
+        mode=args.mode,
+        config=config,
+    )
 
     return result
 

--- a/scripts/benchmarks/benchmark_locomo.py
+++ b/scripts/benchmarks/benchmark_locomo.py
@@ -80,7 +80,8 @@ def _parse_session_date(date_str: str) -> float:
             return datetime.strptime(date_str, fmt).timestamp()
         except ValueError:
             continue
-    return datetime.now().timestamp()
+    logger.warning("Could not parse session date: %s", date_str)
+    return 0.0
 
 
 async def ingest_conversation(storage: SqliteVecMemoryStorage, conv: LocomoConversation) -> int:
@@ -102,7 +103,7 @@ async def ingest_conversation(storage: SqliteVecMemoryStorage, conv: LocomoConve
             content_hash=content_hash,
             tags=tags,
             memory_type="observation",
-            created_at=int(created_at) if created_at else None,
+            created_at=created_at if created_at else None,
         )
         success, msg = await storage.store(memory, skip_semantic_dedup=True)
         if success:

--- a/scripts/benchmarks/benchmark_locomo.py
+++ b/scripts/benchmarks/benchmark_locomo.py
@@ -337,13 +337,28 @@ async def run_benchmark(args: argparse.Namespace) -> BenchmarkResult:
         "top_k": top_k,
         "num_conversations": len(conversations),
     }
+
+    if args.mode == "ablation":
+        # Group by config_name and return list of results
+        from collections import defaultdict
+        by_config = defaultdict(list)
+        for q in all_per_question:
+            by_config[q["config_name"]].append(q)
+        results = []
+        for config_name, questions in by_config.items():
+            r = aggregate_results(
+                questions, conversation_id="all",
+                mode=f"ablation:{config_name}", config=config,
+            )
+            results.append(r)
+        return results
+
     result = aggregate_results(
         all_per_question,
         conversation_id="all",
         mode=args.mode,
         config=config,
     )
-
     return result
 
 
@@ -405,13 +420,18 @@ def main():
     args = parse_args()
     result = asyncio.run(run_benchmark(args))
 
-    if args.markdown:
-        print(format_results_markdown(result))
-    else:
-        print(format_results_table(result))
+    # Ablation returns a list of results (one per config)
+    results = result if isinstance(result, list) else [result]
+
+    for r in results:
+        if args.markdown:
+            print(format_results_markdown(r))
+        else:
+            print(format_results_table(r))
 
     if args.output_dir:
-        filepath = save_results(result, args.output_dir)
+        for r in results:
+            filepath = save_results(r, args.output_dir)
         print(f"Results saved to: {filepath}")
 
 

--- a/scripts/benchmarks/benchmark_locomo.py
+++ b/scripts/benchmarks/benchmark_locomo.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""LoCoMo Benchmark for MCP Memory Service."""
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+from locomo_dataset import LocomoConversation, load_dataset
+from locomo_evaluator import (
+    BenchmarkResult,
+    aggregate_results,
+    mrr,
+    precision_at_k,
+    recall_at_k,
+    token_f1,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_isolated_storage() -> Tuple[SqliteVecMemoryStorage, str]:
+    """Create isolated SQLite-Vec storage in temp dir. Returns (storage, tmp_dir)."""
+    tmp_dir = tempfile.mkdtemp(prefix="locomo-bench-")
+    db_path = os.path.join(tmp_dir, "memories.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    return storage, tmp_dir
+
+
+def build_evidence_map(conv: LocomoConversation) -> Dict[str, str]:
+    """Map dia_id -> turn text."""
+    return {turn.dia_id: turn.text for turn in conv.turns}
+
+
+def _parse_session_date(date_str: str) -> float:
+    """Parse LoCoMo date string to Unix timestamp."""
+    for fmt in ("%B %d, %Y", "%b %d, %Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(date_str, fmt).timestamp()
+        except ValueError:
+            continue
+    return datetime.now().timestamp()
+
+
+async def ingest_conversation(storage: SqliteVecMemoryStorage, conv: LocomoConversation) -> int:
+    """Store observations as memories. Returns count of stored memories."""
+    stored = 0
+    for obs in conv.observations:
+        session_date = ""
+        for turn in conv.turns:
+            if turn.session_id == obs.session_id:
+                session_date = turn.session_date
+                break
+        created_at = _parse_session_date(session_date) if session_date else None
+        content_hash = hashlib.sha256(obs.text.encode("utf-8")).hexdigest()
+        memory = Memory(
+            content=obs.text,
+            content_hash=content_hash,
+            tags=["locomo", conv.sample_id, obs.speaker, obs.session_id],
+            memory_type="observation",
+            created_at=int(created_at) if created_at else None,
+        )
+        success, msg = await storage.store(memory, skip_semantic_dedup=True)
+        if success:
+            stored += 1
+    return stored
+
+
+async def evaluate_retrieval(
+    storage: SqliteVecMemoryStorage,
+    conv: LocomoConversation,
+    evidence_map: Dict[str, str],
+    top_k: Optional[List[int]] = None,
+) -> List[Dict]:
+    """For each QA pair: search memories, check if evidence found, compute metrics."""
+    if top_k is None:
+        top_k = [5]
+    max_k = max(top_k)
+    per_question = []
+    for qa in conv.qa_pairs:
+        results = await storage.retrieve(qa.question, n_results=max_k)
+        retrieved_texts = [r.memory.content for r in results]
+        relevant_evidence = set()
+        for dia_id in qa.evidence:
+            if dia_id in evidence_map:
+                relevant_evidence.add(evidence_map[dia_id])
+        binary_retrieved = []
+        for text in retrieved_texts:
+            is_match = any(ev in text or text in ev for ev in relevant_evidence)
+            binary_retrieved.append("relevant" if is_match else f"irrelevant_{len(binary_retrieved)}")
+        relevant_labels = {"relevant"}
+        metrics: Dict = {"category": qa.category}
+        for k in top_k:
+            metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
+            metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
+        metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+        per_question.append(metrics)
+    return per_question
+
+
+async def run_ablation(
+    storage: SqliteVecMemoryStorage,
+    conv: LocomoConversation,
+    evidence_map: Dict[str, str],
+    top_k: Optional[List[int]] = None,
+) -> List[Dict]:
+    """Compare: baseline retrieve() vs retrieve_with_quality_boost()."""
+    if top_k is None:
+        top_k = [5]
+    max_k = max(top_k)
+
+    configs = [
+        ("baseline", "retrieve"),
+        ("+quality_boost", "retrieve_with_quality_boost"),
+    ]
+
+    all_results: List[Dict] = []
+
+    for config_name, method_name in configs:
+        retrieve_fn = getattr(storage, method_name)
+        for qa in conv.qa_pairs:
+            results = await retrieve_fn(qa.question, n_results=max_k)
+            retrieved_texts = [r.memory.content for r in results]
+            relevant_evidence = set()
+            for dia_id in qa.evidence:
+                if dia_id in evidence_map:
+                    relevant_evidence.add(evidence_map[dia_id])
+            binary_retrieved = []
+            for text in retrieved_texts:
+                is_match = any(ev in text or text in ev for ev in relevant_evidence)
+                binary_retrieved.append(
+                    "relevant" if is_match else f"irrelevant_{len(binary_retrieved)}"
+                )
+            relevant_labels = {"relevant"}
+            metrics: Dict = {"config_name": config_name, "category": qa.category}
+            for k in top_k:
+                metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
+                metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
+            metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+            all_results.append(metrics)
+
+    return all_results
+
+
+def format_results_table(result: BenchmarkResult) -> str:
+    """Terminal table output."""
+    lines = []
+    lines.append("\n" + "=" * 60)
+    lines.append(f"  LoCoMo Benchmark — {result.mode.upper()} mode")
+    lines.append(f"  Conversation: {result.conversation_id}")
+    lines.append("=" * 60)
+
+    lines.append("\nOverall Metrics:")
+    lines.append(f"  {'Metric':<25} {'Value':>10}")
+    lines.append("  " + "-" * 35)
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"  {key:<25} {val:>10.4f}")
+
+    if result.by_category:
+        lines.append("\nBy Category:")
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        header = f"  {'Category':<20}" + "".join(f"  {k:<18}" for k in all_metric_keys)
+        lines.append(header)
+        lines.append("  " + "-" * (20 + 20 * len(all_metric_keys)))
+        for cat, metrics in sorted(result.by_category.items()):
+            row = f"  {cat:<20}" + "".join(
+                f"  {metrics.get(k, 0.0):<18.4f}" for k in all_metric_keys
+            )
+            lines.append(row)
+
+    lines.append("\n" + "=" * 60 + "\n")
+    return "\n".join(lines)
+
+
+def format_results_markdown(result: BenchmarkResult) -> str:
+    """Markdown table output."""
+    lines = []
+    lines.append(f"## LoCoMo Benchmark — {result.mode.upper()} mode")
+    lines.append(f"**Conversation:** {result.conversation_id}  ")
+    lines.append("")
+    lines.append("### Overall Metrics")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"| {key} | {val:.4f} |")
+    lines.append("")
+
+    if result.by_category:
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        lines.append("### By Category")
+        lines.append("")
+        header = "| Category | " + " | ".join(all_metric_keys) + " |"
+        separator = "|----------|" + "|".join(["--------"] * len(all_metric_keys)) + "|"
+        lines.append(header)
+        lines.append(separator)
+        for cat, metrics in sorted(result.by_category.items()):
+            row = (
+                f"| {cat} | "
+                + " | ".join(f"{metrics.get(k, 0.0):.4f}" for k in all_metric_keys)
+                + " |"
+            )
+            lines.append(row)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_results(result: BenchmarkResult, output_dir: str) -> str:
+    """Save results as JSON. Returns filepath."""
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"locomo_{result.mode}_{result.conversation_id}_{timestamp}.json"
+    filepath = os.path.join(output_dir, filename)
+    data = {
+        "conversation_id": result.conversation_id,
+        "mode": result.mode,
+        "overall": result.overall,
+        "by_category": result.by_category,
+        "by_conversation": result.by_conversation,
+        "config": result.config,
+    }
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    logger.info("Results saved to %s", filepath)
+    return filepath
+
+
+async def evaluate_qa(
+    storage: SqliteVecMemoryStorage,
+    conv: LocomoConversation,
+    evidence_map: Dict[str, str],
+    adapter,
+    top_k: Optional[List[int]] = None,
+) -> List[Dict]:
+    """QA evaluation: retrieve + LLM answer + F1."""
+    if top_k is None:
+        top_k = [5]
+    max_k = max(top_k)
+    per_question = []
+    for qa in conv.qa_pairs:
+        results = await storage.retrieve(qa.question, n_results=max_k)
+        context_texts = [r.memory.content for r in results]
+        predicted = await adapter.generate_answer(qa.question, context_texts)
+        f1 = token_f1(predicted, qa.answer)
+
+        relevant_evidence = set()
+        for dia_id in qa.evidence:
+            if dia_id in evidence_map:
+                relevant_evidence.add(evidence_map[dia_id])
+        binary_retrieved = []
+        for text in context_texts:
+            is_match = any(ev in text or text in ev for ev in relevant_evidence)
+            binary_retrieved.append("relevant" if is_match else f"irrelevant_{len(binary_retrieved)}")
+        relevant_labels = {"relevant"}
+
+        metrics: Dict = {"category": qa.category, "token_f1": f1}
+        for k in top_k:
+            metrics[f"recall_at_{k}"] = recall_at_k(binary_retrieved, relevant_labels, k)
+            metrics[f"precision_at_{k}"] = precision_at_k(binary_retrieved, relevant_labels, k)
+        metrics["mrr"] = mrr(binary_retrieved, relevant_labels)
+        per_question.append(metrics)
+    return per_question
+
+
+async def run_benchmark(args: argparse.Namespace) -> BenchmarkResult:
+    """Full pipeline: load dataset, per-conversation ingest+evaluate, aggregate."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    top_k = args.top_k if args.top_k else [5]
+    data_path = getattr(args, "data_path", None)
+
+    logger.info("Loading LoCoMo dataset...")
+    conversations = load_dataset(data_path=data_path)
+    logger.info("Loaded %d conversations", len(conversations))
+
+    all_per_question: List[Dict] = []
+    storage, tmp_dir = create_isolated_storage()
+
+    try:
+        await storage.initialize()
+
+        for conv in conversations:
+            logger.info("Processing conversation: %s", conv.sample_id)
+            count = await ingest_conversation(storage, conv)
+            logger.info("Ingested %d observations for %s", count, conv.sample_id)
+            evidence_map = build_evidence_map(conv)
+
+            if args.mode == "retrieval":
+                per_question = await evaluate_retrieval(storage, conv, evidence_map, top_k=top_k)
+            elif args.mode == "qa":
+                from locomo_llm import create_adapter
+                llm_model = getattr(args, "llm_model", "") or ""
+                llm_name = getattr(args, "llm", "mock") or "mock"
+                adapter = create_adapter(llm_name, model=llm_model)
+                per_question = await evaluate_qa(storage, conv, evidence_map, adapter, top_k=top_k)
+            elif args.mode == "ablation":
+                per_question = await run_ablation(storage, conv, evidence_map, top_k=top_k)
+            else:
+                raise ValueError(f"Unknown mode: {args.mode}")
+
+            all_per_question.extend(per_question)
+
+        config = {
+            "mode": args.mode,
+            "top_k": top_k,
+            "num_conversations": len(conversations),
+        }
+        result = aggregate_results(
+            all_per_question,
+            conversation_id="all",
+            mode=args.mode,
+            config=config,
+        )
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    return result
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """CLI args: --data-path, --mode, --top-k, --llm, --llm-model, --markdown, --output-dir"""
+    parser = argparse.ArgumentParser(
+        description="Run the LoCoMo benchmark against MCP Memory Service.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=None,
+        help="Path to locomo10.json. Auto-downloads if not specified.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["retrieval", "qa", "ablation"],
+        default="retrieval",
+        help="Benchmark mode (default: retrieval)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        nargs="+",
+        default=[5],
+        help="Top-K values for retrieval metrics (default: 5)",
+    )
+    parser.add_argument(
+        "--llm",
+        type=str,
+        default="mock",
+        choices=["mock", "claude", "ollama"],
+        help="LLM adapter for QA mode (default: mock)",
+    )
+    parser.add_argument(
+        "--llm-model",
+        type=str,
+        default="",
+        help="LLM model name override",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        default=False,
+        help="Output results as Markdown table",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Directory to save JSON results (optional)",
+    )
+    return parser.parse_args(argv)
+
+
+def main():
+    """Entry point."""
+    args = parse_args()
+    result = asyncio.run(run_benchmark(args))
+
+    if args.markdown:
+        print(format_results_markdown(result))
+    else:
+        print(format_results_table(result))
+
+    if args.output_dir:
+        filepath = save_results(result, args.output_dir)
+        print(f"Results saved to: {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/benchmark_locomo.py
+++ b/scripts/benchmarks/benchmark_locomo.py
@@ -44,29 +44,26 @@ def build_evidence_map(conv: LocomoConversation) -> Dict[str, str]:
 
 
 def _match_evidence(
-    retrieved_texts: List[str],
-    evidence_map: Dict[str, str],
+    retrieved_results,
     evidence_ids: List[str],
 ) -> Tuple[List[str], set]:
-    """Match retrieved texts against evidence via substring containment.
+    """Match retrieved memories against evidence via dia_ref tags.
+
+    Each observation is tagged with 'dia:D1:3' etc. during ingestion.
+    We check if a retrieved memory's tags contain any evidence dia_id.
 
     Returns (retrieved_labels, relevant_labels) where each evidence item
     gets a unique label so multi-evidence recall is computed correctly.
     """
-    # Build per-evidence-item labels
-    evidence_items = {}  # label -> text
-    for dia_id in evidence_ids:
-        if dia_id in evidence_map:
-            evidence_items[f"ev_{dia_id}"] = evidence_map[dia_id]
-
-    relevant_labels = set(evidence_items.keys())
+    relevant_labels = {f"ev_{dia_id}" for dia_id in evidence_ids}
 
     retrieved_labels = []
-    for text in retrieved_texts:
+    for result in retrieved_results:
+        tags = result.memory.tags or []
         matched_label = None
-        for label, ev_text in evidence_items.items():
-            if ev_text in text or text in ev_text:
-                matched_label = label
+        for dia_id in evidence_ids:
+            if f"dia:{dia_id}" in tags:
+                matched_label = f"ev_{dia_id}"
                 break
         if matched_label:
             retrieved_labels.append(matched_label)
@@ -97,10 +94,13 @@ async def ingest_conversation(storage: SqliteVecMemoryStorage, conv: LocomoConve
                 break
         created_at = _parse_session_date(session_date) if session_date else None
         content_hash = hashlib.sha256(obs.text.encode("utf-8")).hexdigest()
+        tags = ["locomo", conv.sample_id, obs.speaker, obs.session_id]
+        if obs.dia_ref:
+            tags.append(f"dia:{obs.dia_ref}")
         memory = Memory(
             content=obs.text,
             content_hash=content_hash,
-            tags=["locomo", conv.sample_id, obs.speaker, obs.session_id],
+            tags=tags,
             memory_type="observation",
             created_at=int(created_at) if created_at else None,
         )
@@ -123,10 +123,7 @@ async def evaluate_retrieval(
     per_question = []
     for qa in conv.qa_pairs:
         results = await storage.retrieve(qa.question, n_results=max_k)
-        retrieved_texts = [r.memory.content for r in results]
-        retrieved_labels, relevant_labels = _match_evidence(
-            retrieved_texts, evidence_map, qa.evidence,
-        )
+        retrieved_labels, relevant_labels = _match_evidence(results, qa.evidence)
         metrics: Dict = {"category": qa.category}
         for k in top_k:
             metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
@@ -165,10 +162,7 @@ async def run_ablation(
         retrieve_fn = getattr(storage, method_name)
         for qa in conv.qa_pairs:
             results = await retrieve_fn(qa.question, n_results=max_k, **extra_kwargs)
-            retrieved_texts = [r.memory.content for r in results]
-            retrieved_labels, relevant_labels = _match_evidence(
-                retrieved_texts, evidence_map, qa.evidence,
-            )
+            retrieved_labels, relevant_labels = _match_evidence(results, qa.evidence)
             metrics: Dict = {"config_name": config_name, "category": qa.category}
             for k in top_k:
                 metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
@@ -285,9 +279,7 @@ async def evaluate_qa(
         predicted = await adapter.generate_answer(qa.question, context_texts)
         f1 = token_f1(predicted, qa.answer)
 
-        retrieved_labels, relevant_labels = _match_evidence(
-            context_texts, evidence_map, qa.evidence,
-        )
+        retrieved_labels, relevant_labels = _match_evidence(results, qa.evidence)
 
         metrics: Dict = {"category": qa.category, "token_f1": f1}
         for k in top_k:

--- a/scripts/benchmarks/devbench_dataset.json
+++ b/scripts/benchmarks/devbench_dataset.json
@@ -1,0 +1,336 @@
+{
+  "memories": [
+    {
+      "id": "bench:decision-1",
+      "content": "Chose SQLite-Vec over FAISS for the storage backend because it is serverless, requires no separate process, supports KNN vector search natively, and works well for single-user development deployments.",
+      "tags": ["devbench", "bench:decision-1", "storage", "sqlite-vec"],
+      "memory_type": "decision",
+      "created_at_iso": "2025-06-12T09:15:00Z"
+    },
+    {
+      "id": "bench:decision-2",
+      "content": "Selected the Hybrid storage backend as the recommended production configuration. It combines local SQLite-Vec for fast reads with background Cloudflare sync for cloud backup and team collaboration.",
+      "tags": ["devbench", "bench:decision-2", "storage", "hybrid", "cloudflare"],
+      "memory_type": "decision",
+      "created_at_iso": "2025-07-03T14:22:00Z"
+    },
+    {
+      "id": "bench:decision-3",
+      "content": "Decided to use ONNX Runtime with all-MiniLM-L6-v2 for embeddings instead of PyTorch-based models. This keeps the dependency footprint small and avoids requiring a GPU for basic operation.",
+      "tags": ["devbench", "bench:decision-3", "embeddings", "onnx"],
+      "memory_type": "decision",
+      "created_at_iso": "2025-06-28T11:05:00Z"
+    },
+    {
+      "id": "bench:decision-4",
+      "content": "Adopted the Strategy Pattern for storage backends with a BaseStorage abstract class. All backends (SQLite-Vec, Cloudflare, Hybrid) implement the same interface, making them interchangeable via configuration.",
+      "tags": ["devbench", "bench:decision-4", "architecture", "storage"],
+      "memory_type": "decision",
+      "created_at_iso": "2025-08-15T16:30:00Z"
+    },
+    {
+      "id": "bench:decision-5",
+      "content": "Consolidated 34 MCP tools into 12 unified tools in v10.0.0. Deprecated tools continue working with warnings until v11.0. This simplifies the API surface while maintaining backward compatibility.",
+      "tags": ["devbench", "bench:decision-5", "api", "v10"],
+      "memory_type": "decision",
+      "created_at_iso": "2025-11-20T10:00:00Z"
+    },
+    {
+      "id": "bench:decision-6",
+      "content": "Chose OAuth 2.1 with Dynamic Client Registration for team collaboration. Public clients like claude.ai use PKCE without client_secret. The token_endpoint_auth_method on the client object determines auth behavior.",
+      "tags": ["devbench", "bench:decision-6", "oauth", "security"],
+      "memory_type": "decision",
+      "created_at_iso": "2026-01-08T13:45:00Z"
+    },
+    {
+      "id": "bench:learning-1",
+      "content": "Always use direct attribute access on Memory dataclass objects. Never access tags or memory_type via metadata dict. memory.tags returns the actual list, memory.metadata.get('tags') always returns empty default. This anti-pattern caused 3 production bugs in v10.13.1.",
+      "tags": ["devbench", "bench:learning-1", "memory", "dataclass", "anti-pattern"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-12-05T08:20:00Z"
+    },
+    {
+      "id": "bench:learning-2",
+      "content": "The quality scoring system has three tiers: Tier 1 is local ONNX (80-150ms, free), Tier 2 is Groq/Llama3 (500-800ms), Tier 3 is Gemini 1.5 Flash (1-2s). Default is Tier 1 for privacy and speed.",
+      "tags": ["devbench", "bench:learning-2", "quality", "scoring"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-10-14T15:10:00Z"
+    },
+    {
+      "id": "bench:learning-3",
+      "content": "The consolidation system is inspired by how human memory works during sleep. It runs decay scoring, association discovery, semantic clustering, and quality-based forgetting on a configurable schedule.",
+      "tags": ["devbench", "bench:learning-3", "consolidation", "memory-maintenance"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-09-22T17:00:00Z"
+    },
+    {
+      "id": "bench:learning-4",
+      "content": "Global singleton caching in the MCP server layer prevents redundant storage initialization across tool calls. This optimization achieved a 534,628x performance improvement in v8.26.0.",
+      "tags": ["devbench", "bench:learning-4", "performance", "caching"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-08-30T12:00:00Z"
+    },
+    {
+      "id": "bench:learning-5",
+      "content": "When running both HTTP server and MCP server simultaneously, set MCP_HYBRID_SYNC_OWNER=http so only the HTTP server syncs to Cloudflare. The MCP server then uses SQLite-Vec directly without needing Cloudflare credentials.",
+      "tags": ["devbench", "bench:learning-5", "hybrid", "sync", "deployment"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-11-07T09:30:00Z"
+    },
+    {
+      "id": "bench:learning-6",
+      "content": "Document ingestion uses a pluggable loader architecture with a Registry pattern. Loaders for PDF, text, JSON, and CSV auto-register by file extension. New formats require implementing DocumentLoader interface and registering in the registry.",
+      "tags": ["devbench", "bench:learning-6", "ingestion", "architecture"],
+      "memory_type": "learning",
+      "created_at_iso": "2025-10-01T14:45:00Z"
+    },
+    {
+      "id": "bench:bugfix-1",
+      "content": "Test cleanup accidentally deleted 8,663 production memories on February 8, 2026. Root cause: conftest.py cleanup ran against the production database path. Fixed with triple safety system in PR #438: forced test DB path, pre-test verification, and triple-check cleanup.",
+      "tags": ["devbench", "bench:bugfix-1", "testing", "safety", "incident"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2026-02-10T11:00:00Z"
+    },
+    {
+      "id": "bench:bugfix-2",
+      "content": "retrieve_memories() broke the REST API — all filtered queries returned 0 results. Cause: accessing tags via memory.metadata.get('tags') instead of memory.tags directly. Fixed in PR #466.",
+      "tags": ["devbench", "bench:bugfix-2", "api", "memory", "metadata"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2025-12-18T10:30:00Z"
+    },
+    {
+      "id": "bench:bugfix-3",
+      "content": "Tags displayed as individual characters in the dashboard — 'python' showed as 'p,y,t,h,o,n'. Cause: same metadata.get('tags') anti-pattern returning a string instead of a list. Fixed in PR #467.",
+      "tags": ["devbench", "bench:bugfix-3", "dashboard", "tags", "display"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2025-12-20T14:15:00Z"
+    },
+    {
+      "id": "bench:bugfix-4",
+      "content": "Cloudflare sync failed with 401 errors after upgrading. Root cause: Python prefers IPv6 but the Cloudflare API token IP allowlist only had IPv4 addresses. Fix: add IPv6 /64 network to token filtering or remove IP filtering.",
+      "tags": ["devbench", "bench:bugfix-4", "cloudflare", "ipv6", "authentication"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2026-01-25T16:00:00Z"
+    },
+    {
+      "id": "bench:bugfix-5",
+      "content": "Database locked errors when HTTP and MCP servers run simultaneously. Cause: missing WAL journal mode. Fix: set MCP_MEMORY_SQLITE_PRAGMAS=journal_mode=WAL,busy_timeout=15000 in .env file.",
+      "tags": ["devbench", "bench:bugfix-5", "sqlite", "concurrency", "wal"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2025-09-10T09:00:00Z"
+    },
+    {
+      "id": "bench:bugfix-6",
+      "content": "Strict stdio MCP clients like Codex timed out during handshake because storage initialization took too long. Fix: set MCP_INIT_TIMEOUT=5 to force lazy loading — storage initializes on first tool call instead of startup.",
+      "tags": ["devbench", "bench:bugfix-6", "mcp", "timeout", "codex"],
+      "memory_type": "bug-fix",
+      "created_at_iso": "2026-02-28T13:20:00Z"
+    },
+    {
+      "id": "bench:arch-1",
+      "content": "The MCP server was refactored from a monolithic 5000+ line server.py into a modular architecture in v8.59.0. Components: server_impl.py for handlers, cache_manager.py for caching, client_detection.py for adapting behavior, and handlers/ directory for modular request handlers.",
+      "tags": ["devbench", "bench:arch-1", "server", "refactoring", "modular"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-08-05T10:00:00Z"
+    },
+    {
+      "id": "bench:arch-2",
+      "content": "Storage backends follow the Strategy Pattern: BaseStorage defines the abstract interface, with three concrete implementations — SqliteVecMemoryStorage for local development, CloudflareMemoryStorage for edge deployment, and HybridMemoryStorage combining both.",
+      "tags": ["devbench", "bench:arch-2", "storage", "strategy-pattern"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-07-18T14:30:00Z"
+    },
+    {
+      "id": "bench:arch-3",
+      "content": "The web layer is built with FastAPI providing REST endpoints that mirror MCP tools, OAuth 2.1 for authentication, SSE for real-time updates, and a single-page dashboard application in static files.",
+      "tags": ["devbench", "bench:arch-3", "web", "fastapi", "dashboard"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-09-05T11:00:00Z"
+    },
+    {
+      "id": "bench:arch-4",
+      "content": "Graph storage was added in v8.51.0 for relationship tracking between memories. It achieves 30x query performance improvement for relationship-based lookups. Relationship types are automatically inferred using multi-factor analysis.",
+      "tags": ["devbench", "bench:arch-4", "graph", "relationships", "performance"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-08-22T15:00:00Z"
+    },
+    {
+      "id": "bench:arch-5",
+      "content": "The relationship inference engine classifies connections between memories using content semantics, temporal patterns, and memory type combinations. It supports types: causes, fixes, contradicts, supports, follows, related. Confidence threshold defaults to 0.6.",
+      "tags": ["devbench", "bench:arch-5", "graph", "inference", "relationships"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-10-10T09:45:00Z"
+    },
+    {
+      "id": "bench:arch-6",
+      "content": "Utility modules follow four patterns established in v8.61.0: Strategy Pattern for health checks (5 strategies), Orchestrator Pattern for startup (3 orchestrators), Processor Pattern for ingestion (3 processors), and Analyzer Pattern for quality analytics (3 analyzers).",
+      "tags": ["devbench", "bench:arch-6", "patterns", "utilities", "refactoring"],
+      "memory_type": "architecture",
+      "created_at_iso": "2025-09-15T16:30:00Z"
+    },
+    {
+      "id": "bench:config-1",
+      "content": "MCP_MEMORY_SQLITE_PRAGMAS environment variable controls SQLite performance. Must include journal_mode=WAL for concurrent access. Recommended: journal_mode=WAL,busy_timeout=15000,cache_size=20000. Omitting WAL causes database locked errors.",
+      "tags": ["devbench", "bench:config-1", "sqlite", "pragmas", "wal"],
+      "memory_type": "configuration",
+      "created_at_iso": "2025-09-12T08:00:00Z"
+    },
+    {
+      "id": "bench:config-2",
+      "content": "MCP_MEMORY_STORAGE_BACKEND selects the storage backend: sqlite_vec for development, cloudflare for cloud-only, hybrid for production. The hybrid backend is recommended as it provides local speed with cloud backup.",
+      "tags": ["devbench", "bench:config-2", "storage", "backend", "environment"],
+      "memory_type": "configuration",
+      "created_at_iso": "2025-07-25T13:00:00Z"
+    },
+    {
+      "id": "bench:config-3",
+      "content": "MCP_INIT_TIMEOUT controls how long the server waits for storage initialization. Default: 30s on Windows, 15s on Linux/macOS. Set to 5 for strict stdio clients that have short handshake budgets. Auto-doubled on first run when model needs downloading.",
+      "tags": ["devbench", "bench:config-3", "timeout", "initialization"],
+      "memory_type": "configuration",
+      "created_at_iso": "2026-02-20T10:00:00Z"
+    },
+    {
+      "id": "bench:config-4",
+      "content": "External embedding APIs are configured via MCP_EXTERNAL_EMBEDDING_URL, MCP_EXTERNAL_EMBEDDING_MODEL, and MCP_EXTERNAL_EMBEDDING_API_KEY. Supports vLLM, Ollama, TEI, or any OpenAI-compatible endpoint. Only works with sqlite_vec backend, not hybrid or cloudflare.",
+      "tags": ["devbench", "bench:config-4", "embeddings", "external", "api"],
+      "memory_type": "configuration",
+      "created_at_iso": "2025-11-30T14:00:00Z"
+    },
+    {
+      "id": "bench:config-5",
+      "content": "OAuth configuration uses MCP_OAUTH_STORAGE_BACKEND (memory or sqlite) and MCP_OAUTH_SQLITE_PATH for persistent token storage. The sqlite backend is required for production to survive server restarts.",
+      "tags": ["devbench", "bench:config-5", "oauth", "configuration"],
+      "memory_type": "configuration",
+      "created_at_iso": "2026-01-15T11:30:00Z"
+    },
+    {
+      "id": "bench:config-6",
+      "content": "Claude Desktop integration uses python -m mcp_memory_service.server as the command. Set MCP_MEMORY_STORAGE_BACKEND in the env block. For hybrid mode with sync delegation, also set MCP_HYBRID_SYNC_OWNER=http so MCP server skips Cloudflare initialization.",
+      "tags": ["devbench", "bench:config-6", "claude-desktop", "mcp", "setup"],
+      "memory_type": "configuration",
+      "created_at_iso": "2025-12-10T09:00:00Z"
+    }
+  ],
+  "queries": [
+    {
+      "id": "exact-1",
+      "category": "exact",
+      "question": "Why did we choose SQLite-Vec for storage?",
+      "expected_tags": ["bench:decision-1"]
+    },
+    {
+      "id": "exact-2",
+      "category": "exact",
+      "question": "What embedding model does the service use?",
+      "expected_tags": ["bench:decision-3"]
+    },
+    {
+      "id": "exact-3",
+      "category": "exact",
+      "question": "How many MCP tools were consolidated in v10?",
+      "expected_tags": ["bench:decision-5"]
+    },
+    {
+      "id": "exact-4",
+      "category": "exact",
+      "question": "What is the recommended storage backend for production?",
+      "expected_tags": ["bench:decision-2", "bench:config-2"]
+    },
+    {
+      "id": "exact-5",
+      "category": "exact",
+      "question": "How do I configure Claude Desktop to use the memory service?",
+      "expected_tags": ["bench:config-6"]
+    },
+    {
+      "id": "semantic-1",
+      "category": "semantic",
+      "question": "Why do I get database locked errors?",
+      "expected_tags": ["bench:bugfix-5", "bench:config-1"]
+    },
+    {
+      "id": "semantic-2",
+      "category": "semantic",
+      "question": "How does the memory quality system work?",
+      "expected_tags": ["bench:learning-2"]
+    },
+    {
+      "id": "semantic-3",
+      "category": "semantic",
+      "question": "What happened with the production data loss?",
+      "expected_tags": ["bench:bugfix-1"]
+    },
+    {
+      "id": "semantic-4",
+      "category": "semantic",
+      "question": "How can I use a different embedding model?",
+      "expected_tags": ["bench:config-4"]
+    },
+    {
+      "id": "semantic-5",
+      "category": "semantic",
+      "question": "Why does Codex timeout when connecting?",
+      "expected_tags": ["bench:bugfix-6", "bench:config-3"]
+    },
+    {
+      "id": "cross-1",
+      "category": "cross_type",
+      "question": "What design patterns does the codebase use?",
+      "expected_tags": ["bench:decision-4", "bench:arch-2", "bench:arch-6"]
+    },
+    {
+      "id": "cross-2",
+      "category": "cross_type",
+      "question": "Tell me about the Cloudflare integration issues and setup",
+      "expected_tags": ["bench:bugfix-4", "bench:decision-2", "bench:learning-5"]
+    },
+    {
+      "id": "cross-3",
+      "category": "cross_type",
+      "question": "How was the server architecture improved over time?",
+      "expected_tags": ["bench:arch-1", "bench:learning-4"]
+    },
+    {
+      "id": "cross-4",
+      "category": "cross_type",
+      "question": "What problems did the metadata access pattern cause?",
+      "expected_tags": ["bench:learning-1", "bench:bugfix-2", "bench:bugfix-3"]
+    },
+    {
+      "id": "cross-5",
+      "category": "cross_type",
+      "question": "How do memory relationships and associations work?",
+      "expected_tags": ["bench:arch-4", "bench:arch-5"]
+    },
+    {
+      "id": "negative-1",
+      "category": "negative",
+      "question": "How does the billing system handle payments?",
+      "expected_tags": []
+    },
+    {
+      "id": "negative-2",
+      "category": "negative",
+      "question": "What Kubernetes deployment configuration do we use?",
+      "expected_tags": []
+    },
+    {
+      "id": "negative-3",
+      "category": "negative",
+      "question": "How is the mobile app implemented?",
+      "expected_tags": []
+    },
+    {
+      "id": "negative-4",
+      "category": "negative",
+      "question": "What machine learning training pipeline do we have?",
+      "expected_tags": []
+    },
+    {
+      "id": "negative-5",
+      "category": "negative",
+      "question": "How does the real-time video processing module work?",
+      "expected_tags": []
+    }
+  ]
+}

--- a/scripts/benchmarks/locomo_dataset.py
+++ b/scripts/benchmarks/locomo_dataset.py
@@ -1,0 +1,165 @@
+"""LoCoMo dataset loader and parser.
+
+Loads the LoCoMo benchmark dataset (locomo10.json) and provides
+typed data structures for benchmarking memory retrieval.
+
+Reference: https://github.com/snap-research/locomo
+"""
+import json
+import logging
+import os
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+LOCOMO_RAW_URL = (
+    "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json"
+)
+DEFAULT_DATA_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "data", "locomo"
+)
+DEFAULT_DATA_PATH = os.path.join(DEFAULT_DATA_DIR, "locomo10.json")
+
+
+@dataclass
+class LocomoTurn:
+    """A single dialog turn in a conversation session."""
+    speaker: str
+    dia_id: str
+    text: str
+    session_id: str
+    session_date: str
+
+
+@dataclass
+class LocomoObservation:
+    """A factual assertion extracted from a conversation session."""
+    session_id: str
+    text: str
+    speaker: str
+
+
+@dataclass
+class LocomoQA:
+    """A question-answer pair with category and evidence annotations."""
+    question: str
+    answer: str
+    category: str
+    evidence: List[str]
+
+
+@dataclass
+class LocomoConversation:
+    """A complete LoCoMo conversation with all annotations."""
+    sample_id: str
+    turns: List[LocomoTurn] = field(default_factory=list)
+    observations: List[LocomoObservation] = field(default_factory=list)
+    summaries: Dict[str, str] = field(default_factory=dict)
+    qa_pairs: List[LocomoQA] = field(default_factory=list)
+
+
+def _extract_session_ids(conversation: dict) -> List[str]:
+    """Extract sorted session IDs from conversation dict."""
+    session_ids = []
+    for key in conversation:
+        if key.startswith("session_") and not key.endswith(("_date_time",)):
+            session_ids.append(key)
+    return sorted(session_ids, key=lambda s: int(s.split("_")[1]))
+
+
+def parse_conversation(entry: dict) -> LocomoConversation:
+    """Parse a single LoCoMo JSON entry into a LocomoConversation."""
+    conv_data = entry["conversation"]
+    session_ids = _extract_session_ids(conv_data)
+
+    turns: List[LocomoTurn] = []
+    for sid in session_ids:
+        session_date = conv_data.get(f"{sid}_date_time", "")
+        for turn_data in conv_data[sid]:
+            turns.append(LocomoTurn(
+                speaker=turn_data["speaker"],
+                dia_id=turn_data["dia_id"],
+                text=turn_data["text"],
+                session_id=sid,
+                session_date=session_date,
+            ))
+
+    observations: List[LocomoObservation] = []
+    obs_data = entry.get("observation", {})
+    for sid in session_ids:
+        obs_key = f"{sid}_observation"
+        if obs_key not in obs_data:
+            continue
+        raw_text = obs_data[obs_key]
+        for line in raw_text.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            speaker = ""
+            for turn in turns:
+                if turn.session_id == sid and turn.speaker.split()[0] in line:
+                    speaker = turn.speaker
+                    break
+            observations.append(LocomoObservation(
+                session_id=sid, text=line, speaker=speaker,
+            ))
+
+    summaries: Dict[str, str] = {}
+    for sid in session_ids:
+        sum_key = f"{sid}_summary"
+        if sum_key in entry.get("session_summary", {}):
+            summaries[sid] = entry["session_summary"][sum_key]
+
+    qa_pairs: List[LocomoQA] = []
+    for qa in entry.get("qa", []):
+        qa_pairs.append(LocomoQA(
+            question=qa["question"],
+            answer=qa["answer"],
+            category=qa.get("category", "unknown"),
+            evidence=qa.get("evidence", []),
+        ))
+
+    return LocomoConversation(
+        sample_id=entry.get("sample_id", "unknown"),
+        turns=turns,
+        observations=observations,
+        summaries=summaries,
+        qa_pairs=qa_pairs,
+    )
+
+
+def _download_dataset(target_path: str) -> None:
+    """Download locomo10.json from GitHub."""
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    logger.info("Downloading LoCoMo dataset from %s ...", LOCOMO_RAW_URL)
+    urllib.request.urlretrieve(LOCOMO_RAW_URL, target_path)
+    logger.info("Saved to %s", target_path)
+
+
+def load_dataset(
+    data_path: Optional[str] = None,
+    auto_download: bool = True,
+) -> List[LocomoConversation]:
+    """Load the LoCoMo dataset from a JSON file.
+
+    Args:
+        data_path: Path to locomo10.json. Defaults to data/locomo/locomo10.json.
+        auto_download: If True, download the dataset if not found locally.
+
+    Returns:
+        List of parsed LocomoConversation objects.
+    """
+    path = data_path or DEFAULT_DATA_PATH
+
+    if not os.path.exists(path):
+        if auto_download:
+            _download_dataset(path)
+        else:
+            raise FileNotFoundError(f"Dataset not found: {path}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    return [parse_conversation(entry) for entry in raw]

--- a/scripts/benchmarks/locomo_dataset.py
+++ b/scripts/benchmarks/locomo_dataset.py
@@ -39,6 +39,7 @@ class LocomoObservation:
     session_id: str
     text: str
     speaker: str
+    dia_ref: str = ""  # Dialog turn reference (e.g. "D1:3")
 
 
 @dataclass
@@ -58,6 +59,16 @@ class LocomoConversation:
     observations: List[LocomoObservation] = field(default_factory=list)
     summaries: Dict[str, str] = field(default_factory=dict)
     qa_pairs: List[LocomoQA] = field(default_factory=list)
+
+
+# LoCoMo uses integer category IDs; map to human-readable names
+CATEGORY_MAP = {
+    1: "single-hop",
+    2: "multi-hop",
+    3: "temporal",
+    4: "open-domain",
+    5: "adversarial",
+}
 
 
 def _extract_session_ids(conversation: dict) -> List[str]:
@@ -92,19 +103,33 @@ def parse_conversation(entry: dict) -> LocomoConversation:
         obs_key = f"{sid}_observation"
         if obs_key not in obs_data:
             continue
-        raw_text = obs_data[obs_key]
-        for line in raw_text.strip().split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            speaker = ""
-            for turn in turns:
-                if turn.session_id == sid and turn.speaker.split()[0] in line:
-                    speaker = turn.speaker
-                    break
-            observations.append(LocomoObservation(
-                session_id=sid, text=line, speaker=speaker,
-            ))
+        raw_obs = obs_data[obs_key]
+        if isinstance(raw_obs, dict):
+            # Real format: {speaker: [[text, dia_ref], ...]}
+            for speaker, items in raw_obs.items():
+                for item in items:
+                    if isinstance(item, list) and len(item) >= 2:
+                        text, dia_ref = item[0], item[1]
+                    else:
+                        text, dia_ref = str(item), ""
+                    observations.append(LocomoObservation(
+                        session_id=sid, text=text, speaker=speaker,
+                        dia_ref=dia_ref,
+                    ))
+        elif isinstance(raw_obs, str):
+            # Test/legacy format: newline-separated text
+            for line in raw_obs.strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                speaker = ""
+                for turn in turns:
+                    if turn.session_id == sid and turn.speaker.split()[0] in line:
+                        speaker = turn.speaker
+                        break
+                observations.append(LocomoObservation(
+                    session_id=sid, text=line, speaker=speaker,
+                ))
 
     summaries: Dict[str, str] = {}
     for sid in session_ids:
@@ -114,11 +139,19 @@ def parse_conversation(entry: dict) -> LocomoConversation:
 
     qa_pairs: List[LocomoQA] = []
     for qa in entry.get("qa", []):
+        raw_cat = qa.get("category", "unknown")
+        category = CATEGORY_MAP.get(raw_cat, str(raw_cat)) if isinstance(raw_cat, int) else str(raw_cat)
+        # Adversarial questions (category 5) use 'adversarial_answer' instead of 'answer'
+        answer = qa.get("answer", qa.get("adversarial_answer", ""))
+        evidence = qa.get("evidence", [])
+        # Evidence may be a stringified list in some dataset versions
+        if isinstance(evidence, str):
+            evidence = json.loads(evidence.replace("'", '"'))
         qa_pairs.append(LocomoQA(
             question=qa["question"],
-            answer=qa["answer"],
-            category=qa.get("category", "unknown"),
-            evidence=qa.get("evidence", []),
+            answer=answer,
+            category=category,
+            evidence=evidence,
         ))
 
     return LocomoConversation(

--- a/scripts/benchmarks/locomo_evaluator.py
+++ b/scripts/benchmarks/locomo_evaluator.py
@@ -41,8 +41,8 @@ def token_f1(predicted: str, gold: str) -> float:
     Uses token count overlap (min of counts per shared token), not just set
     overlap, for correct F1 with repeated tokens.
     """
-    pred_tokens = predicted.lower().split()
-    gold_tokens = gold.lower().split()
+    pred_tokens = str(predicted).lower().split()
+    gold_tokens = str(gold).lower().split()
 
     if not pred_tokens or not gold_tokens:
         return 0.0

--- a/scripts/benchmarks/locomo_evaluator.py
+++ b/scripts/benchmarks/locomo_evaluator.py
@@ -1,0 +1,134 @@
+"""LoCoMo benchmark evaluator: Retrieval and QA metrics."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set
+
+
+def recall_at_k(retrieved: List[str], relevant: Set[str], k: int) -> float:
+    """Recall@K: fraction of relevant items found in top-K retrieved."""
+    if not relevant:
+        return 1.0
+    top_k = retrieved[:k]
+    hits = sum(1 for item in top_k if item in relevant)
+    return hits / len(relevant)
+
+
+def precision_at_k(retrieved: List[str], relevant: Set[str], k: int) -> float:
+    """Precision@K: fraction of top-K retrieved items that are relevant."""
+    if k == 0:
+        return 0.0
+    top_k = retrieved[:k]
+    if not top_k:
+        return 0.0
+    hits = sum(1 for item in top_k if item in relevant)
+    return hits / k
+
+
+def mrr(retrieved: List[str], relevant: Set[str]) -> float:
+    """Mean Reciprocal Rank: 1/position of first relevant item."""
+    for i, item in enumerate(retrieved, start=1):
+        if item in relevant:
+            return 1.0 / i
+    return 0.0
+
+
+def token_f1(predicted: str, gold: str) -> float:
+    """Token-level F1 score. Case-insensitive, whitespace tokenized.
+
+    Uses token count overlap (min of counts per shared token), not just set
+    overlap, for correct F1 with repeated tokens.
+    """
+    pred_tokens = predicted.lower().split()
+    gold_tokens = gold.lower().split()
+
+    if not pred_tokens or not gold_tokens:
+        return 0.0
+
+    pred_counts = Counter(pred_tokens)
+    gold_counts = Counter(gold_tokens)
+
+    # Count overlapping tokens (by count, not just set membership)
+    overlap = sum(min(pred_counts[t], gold_counts[t]) for t in pred_counts if t in gold_counts)
+
+    if overlap == 0:
+        return 0.0
+
+    precision = overlap / len(pred_tokens)
+    recall = overlap / len(gold_tokens)
+    f1 = 2 * precision * recall / (precision + recall)
+    return f1
+
+
+@dataclass
+class BenchmarkResult:
+    conversation_id: str
+    mode: str
+    overall: Dict[str, float]
+    by_category: Dict[str, Dict[str, float]]
+    by_conversation: Dict[str, Dict[str, float]]
+    config: Dict[str, Any] = field(default_factory=dict)
+
+
+def aggregate_results(
+    per_question: List[Dict[str, Any]],
+    conversation_id: str,
+    mode: str,
+    config: Dict[str, Any],
+) -> BenchmarkResult:
+    """Aggregate per-question metrics into a BenchmarkResult.
+
+    Each question dict must have a 'category' key plus numeric metric keys.
+    Averages are computed per-category and overall.
+    """
+    if not per_question:
+        return BenchmarkResult(
+            conversation_id=conversation_id,
+            mode=mode,
+            overall={},
+            by_category={},
+            by_conversation={},
+            config=config,
+        )
+
+    # Identify metric keys (all keys except 'category' and non-numeric values)
+    sample = per_question[0]
+    metric_keys = [
+        k for k, v in sample.items()
+        if k != "category" and isinstance(v, (int, float))
+    ]
+
+    # Aggregate by category
+    category_buckets: Dict[str, List[Dict[str, Any]]] = {}
+    for q in per_question:
+        cat = q.get("category", "unknown")
+        category_buckets.setdefault(cat, []).append(q)
+
+    by_category: Dict[str, Dict[str, float]] = {}
+    for cat, questions in category_buckets.items():
+        by_category[cat] = {
+            key: sum(q[key] for q in questions if key in q) / len(questions)
+            for key in metric_keys
+        }
+
+    # Overall averages
+    overall: Dict[str, float] = {
+        key: sum(q[key] for q in per_question if key in q) / len(per_question)
+        for key in metric_keys
+    }
+
+    # by_conversation uses conversation_id as the single key
+    by_conversation: Dict[str, Dict[str, float]] = {
+        conversation_id: overall
+    }
+
+    return BenchmarkResult(
+        conversation_id=conversation_id,
+        mode=mode,
+        overall=overall,
+        by_category=by_category,
+        by_conversation=by_conversation,
+        config=config,
+    )

--- a/scripts/benchmarks/locomo_llm.py
+++ b/scripts/benchmarks/locomo_llm.py
@@ -1,0 +1,108 @@
+"""Pluggable LLM adapter module for LoCoMo QA benchmark evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Protocol, runtime_checkable
+
+QA_PROMPT_TEMPLATE = """Answer the following question based ONLY on the provided context.
+Give a brief, concise answer. If the answer is not in the context, say "not mentioned".
+
+Context:
+{context}
+
+Question: {question}
+
+Answer:"""
+
+
+def build_qa_prompt(question: str, context: List[str]) -> str:
+    """Build QA prompt. Format context as bullet list."""
+    bullet_list = "\n".join(f"- {item}" for item in context)
+    return QA_PROMPT_TEMPLATE.format(context=bullet_list, question=question)
+
+
+@runtime_checkable
+class LLMAdapter(Protocol):
+    async def generate_answer(self, question: str, context: List[str]) -> str:
+        ...
+
+
+class MockAdapter:
+    """Returns first context line, or 'not mentioned' if empty."""
+
+    async def generate_answer(self, question: str, context: List[str]) -> str:
+        if not context:
+            return "not mentioned"
+        return context[0]
+
+
+class ClaudeAdapter:
+    """Uses anthropic SDK. Import anthropic lazily in __init__."""
+
+    def __init__(self, model: str = "claude-sonnet-4-20250514") -> None:
+        try:
+            import anthropic  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "anthropic package is required for ClaudeAdapter. "
+                "Install it with: pip install anthropic"
+            ) from e
+        self.model = model
+        self._anthropic = anthropic
+
+    async def generate_answer(self, question: str, context: List[str]) -> str:
+        client = self._anthropic.AsyncAnthropic()
+        prompt = build_qa_prompt(question, context)
+        message = await client.messages.create(
+            model=self.model,
+            max_tokens=256,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text.strip()
+
+
+class OllamaAdapter:
+    """Uses aiohttp to call Ollama HTTP API. Import aiohttp lazily."""
+
+    def __init__(
+        self, model: str = "llama3", base_url: str = "http://localhost:11434"
+    ) -> None:
+        try:
+            import aiohttp  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "aiohttp package is required for OllamaAdapter. "
+                "Install it with: pip install aiohttp"
+            ) from e
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self._aiohttp = aiohttp
+
+    async def generate_answer(self, question: str, context: List[str]) -> str:
+        prompt = build_qa_prompt(question, context)
+        url = f"{self.base_url}/api/generate"
+        payload = {"model": self.model, "prompt": prompt, "stream": False}
+        async with self._aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                return data.get("response", "").strip()
+
+
+def create_adapter(llm_name: str, model: str = "") -> LLMAdapter:
+    """Factory. Supports 'claude', 'ollama', 'mock'. Raises ValueError for unknown."""
+    name = llm_name.lower().strip()
+    if name == "mock":
+        return MockAdapter()
+    if name == "claude":
+        if model:
+            return ClaudeAdapter(model=model)
+        return ClaudeAdapter()
+    if name == "ollama":
+        if model:
+            return OllamaAdapter(model=model)
+        return OllamaAdapter()
+    raise ValueError(
+        f"Unknown LLM adapter: {llm_name!r}. Supported: 'claude', 'ollama', 'mock'."
+    )

--- a/scripts/benchmarks/locomo_llm.py
+++ b/scripts/benchmarks/locomo_llm.py
@@ -52,9 +52,10 @@ class ClaudeAdapter:
         self._anthropic = anthropic
 
     async def generate_answer(self, question: str, context: List[str]) -> str:
-        client = self._anthropic.AsyncAnthropic()
+        if not hasattr(self, "_client"):
+            self._client = self._anthropic.AsyncAnthropic()
         prompt = build_qa_prompt(question, context)
-        message = await client.messages.create(
+        message = await self._client.messages.create(
             model=self.model,
             max_tokens=256,
             messages=[{"role": "user", "content": prompt}],
@@ -83,11 +84,12 @@ class OllamaAdapter:
         prompt = build_qa_prompt(question, context)
         url = f"{self.base_url}/api/generate"
         payload = {"model": self.model, "prompt": prompt, "stream": False}
-        async with self._aiohttp.ClientSession() as session:
-            async with session.post(url, json=payload) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
-                return data.get("response", "").strip()
+        if not hasattr(self, "_session") or self._session.closed:
+            self._session = self._aiohttp.ClientSession()
+        async with self._session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            return data.get("response", "").strip()
 
 
 def create_adapter(llm_name: str, model: str = "") -> LLMAdapter:

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,5 @@
+"""Configure sys.path for benchmark tests."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))

--- a/tests/benchmarks/test_benchmark_devbench.py
+++ b/tests/benchmarks/test_benchmark_devbench.py
@@ -1,0 +1,167 @@
+"""Tests for DevBench practical benchmark."""
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from benchmark_devbench import (
+    create_isolated_storage,
+    ingest_memories,
+    load_devbench_dataset,
+    match_by_tags,
+)
+
+
+class TestLoadDataset:
+    def test_loads_30_memories(self):
+        dataset = load_devbench_dataset()
+        assert len(dataset["memories"]) == 30
+
+    def test_loads_20_queries(self):
+        dataset = load_devbench_dataset()
+        assert len(dataset["queries"]) == 20
+
+    def test_all_bench_tags_present(self):
+        dataset = load_devbench_dataset()
+        ids = {m["id"] for m in dataset["memories"]}
+        expected_prefixes = [
+            "bench:decision-", "bench:learning-", "bench:bugfix-",
+            "bench:arch-", "bench:config-",
+        ]
+        for prefix in expected_prefixes:
+            matches = [i for i in ids if i.startswith(prefix)]
+            assert len(matches) == 6, f"Expected 6 memories for {prefix}, got {len(matches)}"
+
+    def test_four_query_categories(self):
+        dataset = load_devbench_dataset()
+        categories = {q["category"] for q in dataset["queries"]}
+        assert categories == {"exact", "semantic", "cross_type", "negative"}
+
+    def test_five_queries_per_category(self):
+        dataset = load_devbench_dataset()
+        from collections import Counter
+        counts = Counter(q["category"] for q in dataset["queries"])
+        for cat in ("exact", "semantic", "cross_type", "negative"):
+            assert counts[cat] == 5, f"Expected 5 {cat} queries, got {counts[cat]}"
+
+    def test_negative_queries_have_empty_expected_tags(self):
+        dataset = load_devbench_dataset()
+        for q in dataset["queries"]:
+            if q["category"] == "negative":
+                assert q["expected_tags"] == []
+
+
+class TestMatchByTags:
+    def _make_result(self, tags):
+        """Create a minimal mock result with memory.tags."""
+        class FakeMemory:
+            def __init__(self, t):
+                self.tags = t
+        class FakeResult:
+            def __init__(self, t):
+                self.memory = FakeMemory(t)
+        return FakeResult(tags)
+
+    def test_match_found(self):
+        results = [
+            self._make_result(["devbench", "bench:decision-1", "storage"]),
+            self._make_result(["devbench", "bench:learning-1"]),
+        ]
+        retrieved_labels, relevant_labels = match_by_tags(results, ["bench:decision-1"])
+        assert "bench:decision-1" in retrieved_labels
+        assert relevant_labels == {"bench:decision-1"}
+
+    def test_no_match(self):
+        results = [
+            self._make_result(["devbench", "bench:arch-1"]),
+        ]
+        retrieved_labels, relevant_labels = match_by_tags(results, ["bench:decision-1"])
+        assert retrieved_labels[0].startswith("irrelevant_")
+        assert relevant_labels == {"bench:decision-1"}
+
+    def test_negative_query_empty_expected(self):
+        results = [
+            self._make_result(["devbench", "bench:decision-1"]),
+        ]
+        retrieved_labels, relevant_labels = match_by_tags(results, [])
+        # relevant_labels is empty set for negative queries
+        assert relevant_labels == set()
+        # retrieved label is irrelevant since no expected tags to match
+        assert retrieved_labels[0].startswith("irrelevant_")
+
+    def test_multiple_expected_tags(self):
+        results = [
+            self._make_result(["bench:decision-2", "storage"]),
+            self._make_result(["bench:config-2", "environment"]),
+            self._make_result(["unrelated"]),
+        ]
+        retrieved_labels, relevant_labels = match_by_tags(
+            results, ["bench:decision-2", "bench:config-2"]
+        )
+        assert "bench:decision-2" in retrieved_labels
+        assert "bench:config-2" in retrieved_labels
+        assert retrieved_labels[2].startswith("irrelevant_")
+        assert relevant_labels == {"bench:decision-2", "bench:config-2"}
+
+
+class TestIngestAndRetrieve:
+    def test_ingest_all_30_memories(self):
+        async def _run():
+            dataset = load_devbench_dataset()
+            storage, tmp_dir = create_isolated_storage()
+            try:
+                await storage.initialize()
+                count = await ingest_memories(storage, dataset["memories"])
+                return count
+            finally:
+                import shutil
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        count = asyncio.run(_run())
+        assert count == 30
+
+    def test_retrieve_exact_query_finds_something(self):
+        async def _run():
+            dataset = load_devbench_dataset()
+            storage, tmp_dir = create_isolated_storage()
+            try:
+                await storage.initialize()
+                await ingest_memories(storage, dataset["memories"])
+                results = await storage.retrieve(
+                    "Why did we choose SQLite-Vec for storage?", n_results=5
+                )
+                return results
+            finally:
+                import shutil
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        results = asyncio.run(_run())
+        assert len(results) > 0
+        # Top result should include bench:decision-1
+        all_tags = [t for r in results for t in (r.memory.tags or [])]
+        assert "bench:decision-1" in all_tags
+
+    def test_retrieve_negative_query_returns_results(self):
+        """Negative query should return results but none should be about billing/payments."""
+        async def _run():
+            dataset = load_devbench_dataset()
+            storage, tmp_dir = create_isolated_storage()
+            try:
+                await storage.initialize()
+                await ingest_memories(storage, dataset["memories"])
+                results = await storage.retrieve(
+                    "How does the billing system handle payments?", n_results=5
+                )
+                return results
+            finally:
+                import shutil
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        results = asyncio.run(_run())
+        # Results exist (storage always returns something), but content shouldn't mention billing
+        for r in results:
+            assert "billing" not in r.memory.content.lower()
+            assert "payment" not in r.memory.content.lower()

--- a/tests/benchmarks/test_benchmark_locomo.py
+++ b/tests/benchmarks/test_benchmark_locomo.py
@@ -1,0 +1,114 @@
+"""Tests for the main LoCoMo benchmark orchestrator."""
+import asyncio
+import os
+import shutil
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from locomo_dataset import LocomoConversation, LocomoObservation, LocomoTurn, LocomoQA
+from benchmark_locomo import (
+    ingest_conversation,
+    build_evidence_map,
+    create_isolated_storage,
+    evaluate_retrieval,
+    run_ablation,
+)
+
+
+def _make_test_conversation() -> LocomoConversation:
+    return LocomoConversation(
+        sample_id="test_1",
+        turns=[
+            LocomoTurn("Alice", "d1_1", "I work at Google.", "session_1", "January 15, 2024"),
+            LocomoTurn("Bob", "d1_2", "Nice!", "session_1", "January 15, 2024"),
+        ],
+        observations=[
+            LocomoObservation("session_1", "Alice works at Google.", "Alice"),
+            LocomoObservation("session_1", "Bob congratulated Alice.", "Bob"),
+        ],
+        summaries={"session_1": "Alice told Bob about her job at Google."},
+        qa_pairs=[LocomoQA("Where does Alice work?", "Google", "single-hop", ["d1_1"])],
+    )
+
+
+class TestBuildEvidenceMap:
+    def test_maps_dia_ids_to_turns(self):
+        conv = _make_test_conversation()
+        emap = build_evidence_map(conv)
+        assert "d1_1" in emap
+        assert "I work at Google." in emap["d1_1"]
+
+    def test_all_dia_ids_present(self):
+        conv = _make_test_conversation()
+        emap = build_evidence_map(conv)
+        assert "d1_1" in emap
+        assert "d1_2" in emap
+
+
+class TestCreateIsolatedStorage:
+    def test_creates_storage(self):
+        storage, tmp_dir = create_isolated_storage()
+        assert storage is not None
+        assert os.path.isdir(tmp_dir)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+class TestIngestConversation:
+    def test_ingest_stores_observations(self):
+        conv = _make_test_conversation()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            count = asyncio.run(self._run_ingest(storage, conv))
+            assert count == 2
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_ingest(self, storage, conv):
+        await storage.initialize()
+        return await ingest_conversation(storage, conv)
+
+
+class TestEvaluateRetrieval:
+    def test_retrieval_returns_per_question_results(self):
+        conv = _make_test_conversation()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            results = asyncio.run(self._run_retrieval(storage, conv))
+            assert len(results) == 1
+            assert "category" in results[0]
+            assert "recall_at_5" in results[0]
+            assert "precision_at_5" in results[0]
+            assert "mrr" in results[0]
+            assert results[0]["category"] == "single-hop"
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_retrieval(self, storage, conv):
+        await storage.initialize()
+        await ingest_conversation(storage, conv)
+        evidence_map = build_evidence_map(conv)
+        return await evaluate_retrieval(storage, conv, evidence_map, top_k=[5])
+
+
+class TestAblation:
+    def test_ablation_returns_multiple_configs(self):
+        conv = _make_test_conversation()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            results = asyncio.run(self._run_ablation(storage, conv))
+            assert len(results) >= 2
+            assert all("config_name" in r for r in results)
+            config_names = {r["config_name"] for r in results}
+            assert "baseline" in config_names
+            assert "+quality_boost" in config_names
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_ablation(self, storage, conv):
+        await storage.initialize()
+        await ingest_conversation(storage, conv)
+        evidence_map = build_evidence_map(conv)
+        return await run_ablation(storage, conv, evidence_map, top_k=[5])

--- a/tests/benchmarks/test_locomo_dataset.py
+++ b/tests/benchmarks/test_locomo_dataset.py
@@ -1,0 +1,121 @@
+"""Tests for LoCoMo dataset loader."""
+import json
+import os
+import pytest
+import tempfile
+
+from locomo_dataset import (
+    LocomoTurn,
+    LocomoObservation,
+    LocomoQA,
+    LocomoConversation,
+    parse_conversation,
+    load_dataset,
+)
+
+SAMPLE_LOCOMO_ENTRY = {
+    "sample_id": "test_conv_1",
+    "conversation": {
+        "session_1": [
+            {"speaker": "Alice", "dia_id": "d1_1", "text": "I just got a new job at Google."},
+            {"speaker": "Bob", "dia_id": "d1_2", "text": "That's amazing! Congrats!"},
+        ],
+        "session_1_date_time": "January 15, 2024",
+        "session_2": [
+            {"speaker": "Alice", "dia_id": "d2_1", "text": "Work is going well at Google."},
+            {"speaker": "Bob", "dia_id": "d2_2", "text": "How's the team?"},
+        ],
+        "session_2_date_time": "February 20, 2024",
+    },
+    "observation": {
+        "session_1_observation": "Alice got a new job at Google.\nBob congratulated Alice.",
+        "session_2_observation": "Alice says work is going well at Google.",
+    },
+    "session_summary": {
+        "session_1_summary": "Alice shared she got a new job at Google. Bob congratulated her.",
+        "session_2_summary": "Alice updated Bob about her job at Google.",
+    },
+    "event_summary": {},
+    "qa": [
+        {
+            "question": "Where does Alice work?",
+            "answer": "Google",
+            "category": "single-hop",
+            "evidence": ["d1_1"],
+        },
+        {
+            "question": "What happened first, Alice getting the job or Alice saying work is going well?",
+            "answer": "Alice getting the job",
+            "category": "temporal",
+            "evidence": ["d1_1", "d2_1"],
+        },
+    ],
+}
+
+
+class TestDataStructures:
+    def test_locomo_turn_fields(self):
+        turn = LocomoTurn(
+            speaker="Alice", dia_id="d1_1", text="Hello",
+            session_id="session_1", session_date="January 15, 2024",
+        )
+        assert turn.speaker == "Alice"
+        assert turn.dia_id == "d1_1"
+        assert turn.text == "Hello"
+        assert turn.session_id == "session_1"
+        assert turn.session_date == "January 15, 2024"
+
+    def test_locomo_observation_fields(self):
+        obs = LocomoObservation(
+            session_id="session_1", text="Alice got a job.", speaker="Alice",
+        )
+        assert obs.session_id == "session_1"
+
+    def test_locomo_qa_fields(self):
+        qa = LocomoQA(
+            question="Where?", answer="Google",
+            category="single-hop", evidence=["d1_1"],
+        )
+        assert qa.category == "single-hop"
+        assert qa.evidence == ["d1_1"]
+
+
+class TestParseConversation:
+    def test_parse_turns(self):
+        conv = parse_conversation(SAMPLE_LOCOMO_ENTRY)
+        assert conv.sample_id == "test_conv_1"
+        assert len(conv.turns) == 4
+        assert conv.turns[0].speaker == "Alice"
+        assert conv.turns[0].dia_id == "d1_1"
+        assert conv.turns[0].session_id == "session_1"
+        assert conv.turns[0].session_date == "January 15, 2024"
+
+    def test_parse_observations(self):
+        conv = parse_conversation(SAMPLE_LOCOMO_ENTRY)
+        assert len(conv.observations) >= 2
+        obs_texts = [o.text for o in conv.observations]
+        assert "Alice got a new job at Google." in obs_texts
+
+    def test_parse_qa_pairs(self):
+        conv = parse_conversation(SAMPLE_LOCOMO_ENTRY)
+        assert len(conv.qa_pairs) == 2
+        assert conv.qa_pairs[0].category == "single-hop"
+        assert conv.qa_pairs[0].evidence == ["d1_1"]
+
+    def test_parse_summaries(self):
+        conv = parse_conversation(SAMPLE_LOCOMO_ENTRY)
+        assert "session_1" in conv.summaries
+        assert "session_2" in conv.summaries
+
+
+class TestLoadDataset:
+    def test_load_from_file(self, tmp_path):
+        data_file = tmp_path / "locomo10.json"
+        data_file.write_text(json.dumps([SAMPLE_LOCOMO_ENTRY]))
+        conversations = load_dataset(str(data_file))
+        assert len(conversations) == 1
+        assert conversations[0].sample_id == "test_conv_1"
+
+    def test_load_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_dataset("/nonexistent/path/locomo10.json", auto_download=False)

--- a/tests/benchmarks/test_locomo_evaluator.py
+++ b/tests/benchmarks/test_locomo_evaluator.py
@@ -1,0 +1,111 @@
+"""Tests for LoCoMo benchmark evaluator metrics."""
+
+import pytest
+from locomo_evaluator import (
+    BenchmarkResult,
+    aggregate_results,
+    mrr,
+    precision_at_k,
+    recall_at_k,
+    token_f1,
+)
+
+
+class TestRecallAtK:
+    def test_perfect_recall(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "b"}, k=3) == 1.0
+
+    def test_partial_recall(self):
+        assert recall_at_k(["a", "x", "y"], {"a", "b"}, k=3) == 0.5
+
+    def test_zero_recall(self):
+        assert recall_at_k(["x", "y", "z"], {"a", "b"}, k=3) == 0.0
+
+    def test_k_limits_results(self):
+        # k=2 misses "c" (relevant); k=4 finds both relevant items
+        assert recall_at_k(["x", "y", "a", "b"], {"a", "b"}, k=2) == 0.0
+        assert recall_at_k(["x", "y", "a", "b"], {"a", "b"}, k=4) == 1.0
+
+    def test_empty_relevant_returns_one(self):
+        assert recall_at_k(["a", "b", "c"], set(), k=3) == 1.0
+
+
+class TestPrecisionAtK:
+    def test_perfect_precision(self):
+        assert precision_at_k(["a", "b"], {"a", "b"}, k=2) == 1.0
+
+    def test_half_precision(self):
+        assert precision_at_k(["a", "x"], {"a", "b"}, k=2) == 0.5
+
+    def test_zero_precision(self):
+        assert precision_at_k(["x", "y"], {"a", "b"}, k=2) == 0.0
+
+
+class TestMRR:
+    def test_first_position(self):
+        assert mrr(["a", "b", "c"], {"a"}) == 1.0
+
+    def test_second_position(self):
+        assert mrr(["x", "a", "b"], {"a"}) == 0.5
+
+    def test_not_found(self):
+        assert mrr(["x", "y", "z"], {"a"}) == 0.0
+
+    def test_multiple_relevant_uses_first(self):
+        # "b" is at position 2, "c" is at position 3 — first hit is "b" -> 0.5
+        assert mrr(["x", "b", "c"], {"b", "c"}) == 0.5
+
+
+class TestTokenF1:
+    def test_exact_match(self):
+        assert token_f1("hello world", "hello world") == 1.0
+
+    def test_partial_overlap(self):
+        # "she works at Google" (4 tokens) vs "Google" (1 token)
+        # overlap=1, precision=1/4=0.25, recall=1/1=1.0, F1=2*0.25*1.0/1.25=0.4
+        result = token_f1("she works at Google", "Google")
+        assert abs(result - 0.4) < 1e-9
+
+    def test_no_overlap(self):
+        assert token_f1("hello world", "foo bar") == 0.0
+
+    def test_case_insensitive(self):
+        assert token_f1("Hello World", "hello world") == 1.0
+
+    def test_empty_prediction(self):
+        assert token_f1("", "hello world") == 0.0
+
+    def test_empty_gold(self):
+        assert token_f1("hello world", "") == 0.0
+
+
+class TestAggregateResults:
+    def test_aggregate_by_category(self):
+        per_question = [
+            {"category": "single", "f1": 1.0, "recall": 1.0},
+            {"category": "single", "f1": 0.5, "recall": 0.5},
+            {"category": "multi", "f1": 0.8, "recall": 0.6},
+        ]
+        result = aggregate_results(per_question, "conv1", "baseline", {"k": 5})
+
+        assert isinstance(result, BenchmarkResult)
+        assert result.conversation_id == "conv1"
+        assert result.mode == "baseline"
+        assert result.config == {"k": 5}
+
+        # Overall averages: f1=(1.0+0.5+0.8)/3, recall=(1.0+0.5+0.6)/3
+        assert abs(result.overall["f1"] - (1.0 + 0.5 + 0.8) / 3) < 1e-9
+        assert abs(result.overall["recall"] - (1.0 + 0.5 + 0.6) / 3) < 1e-9
+
+        # By category
+        assert abs(result.by_category["single"]["f1"] - 0.75) < 1e-9
+        assert abs(result.by_category["multi"]["f1"] - 0.8) < 1e-9
+
+        # by_conversation keyed by conversation_id
+        assert "conv1" in result.by_conversation
+
+    def test_aggregate_empty(self):
+        result = aggregate_results([], "conv_empty", "test", {})
+        assert result.overall == {}
+        assert result.by_category == {}
+        assert result.by_conversation == {}

--- a/tests/benchmarks/test_locomo_llm.py
+++ b/tests/benchmarks/test_locomo_llm.py
@@ -1,0 +1,53 @@
+"""Tests for the LoCoMo LLM adapter module."""
+
+import asyncio
+
+import pytest
+
+from locomo_llm import (
+    MockAdapter,
+    build_qa_prompt,
+    create_adapter,
+)
+
+
+class TestBuildQAPrompt:
+    def test_includes_question(self):
+        prompt = build_qa_prompt("What is the capital?", ["Paris is the capital."])
+        assert "What is the capital?" in prompt
+
+    def test_includes_context(self):
+        prompt = build_qa_prompt("Who wrote it?", ["Alice wrote the book.", "It was published in 2020."])
+        assert "Alice wrote the book." in prompt
+        assert "It was published in 2020." in prompt
+
+    def test_instructs_concise_answer(self):
+        prompt = build_qa_prompt("Any question?", ["Some context."])
+        lower = prompt.lower()
+        assert any(word in lower for word in ("concise", "short", "brief"))
+
+
+class TestMockAdapter:
+    def test_mock_returns_first_context(self):
+        adapter = MockAdapter()
+        result = asyncio.run(adapter.generate_answer("Q?", ["first line", "second line"]))
+        assert result == "first line"
+
+    def test_mock_returns_not_mentioned_when_empty(self):
+        adapter = MockAdapter()
+        result = asyncio.run(adapter.generate_answer("Q?", []))
+        assert result == "not mentioned"
+
+
+class TestCreateAdapter:
+    def test_create_mock(self):
+        adapter = create_adapter("mock")
+        assert isinstance(adapter, MockAdapter)
+
+    def test_create_mock_case_insensitive(self):
+        adapter = create_adapter("Mock")
+        assert isinstance(adapter, MockAdapter)
+
+    def test_create_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown LLM adapter"):
+            create_adapter("gpt4")


### PR DESCRIPTION
## Summary

- Add LoCoMo benchmark suite (ACL 2024) to evaluate memory retrieval quality across 10 long-term conversations (~300 turns each)
- 4 modular scripts: dataset loader, evaluation metrics, pluggable LLM adapter, main orchestrator
- 3 evaluation modes: retrieval-only (default, free), QA with LLM, and ablation (feature comparison)
- 43 tests, all passing

## First Results (Retrieval Mode, all-MiniLM-L6-v2)

| Category | Recall@5 | Recall@10 | MRR |
|-----------|----------|-----------|-----|
| **Overall** | **0.497** | **0.562** | **0.414** |
| multi-hop | 0.720 | 0.775 | 0.600 |
| open-domain | 0.585 | 0.650 | 0.464 |
| single-hop | 0.368 | 0.466 | 0.456 |
| temporal | 0.335 | 0.370 | 0.274 |
| adversarial | 0.286 | 0.346 | 0.189 |

## Usage

```bash
python scripts/benchmarks/benchmark_locomo.py                        # retrieval-only
python scripts/benchmarks/benchmark_locomo.py --top-k 3 5 10        # multiple K values
python scripts/benchmarks/benchmark_locomo.py --mode qa --llm claude # QA with Claude
python scripts/benchmarks/benchmark_locomo.py --mode ablation        # feature comparison
```

## Test plan

- [x] 43 unit tests passing (`pytest tests/benchmarks/ -v`)
- [x] Real benchmark run on full LoCoMo dataset (10 conversations)
- [x] CLI smoke test (`--help`)
- [x] Dataset auto-download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)