### PR TITLE
fix(storage): handle non-JSON error responses in HTTP client and embedding API

### DIFF
--- a/src/mcp_memory_service/embeddings/external_api.py
+++ b/src/mcp_memory_service/embeddings/external_api.py
@@ -113,7 +113,12 @@ class ExternalEmbeddingModel:
             )
 
             if response.status_code == 200:
-                data = response.json()
+                try:
+                    data = response.json()
+                except (ValueError, requests.exceptions.JSONDecodeError) as e:
+                    raise ConnectionError(
+                        f"API returned 200 but response is not valid JSON: {e}"
+                    )
                 if 'data' in data and len(data['data']) > 0:
                     self.embedding_dimension = len(data['data'][0]['embedding'])
                     logger.info(
@@ -195,7 +200,12 @@ class ExternalEmbeddingModel:
                     timeout=self.timeout
                 )
                 response.raise_for_status()
-                data = response.json()
+                try:
+                    data = response.json()
+                except (ValueError, requests.exceptions.JSONDecodeError) as e:
+                    raise RuntimeError(
+                        f"API returned invalid JSON response: {e}"
+                    )
 
                 # Extract embeddings in order (API may return out of order)
                 batch_embeddings = [None] * len(batch)

--- a/src/mcp_memory_service/storage/http_client.py
+++ b/src/mcp_memory_service/storage/http_client.py
@@ -135,11 +135,14 @@ class HTTPClientStorage(MemoryStorage):
                     logger.info(f"Successfully stored memory via HTTP: {result.get('content_hash')}")
                     return True, f"Memory stored successfully: {result.get('content_hash')}"
                 else:
-                    error_data = await response.json()
-                    error_msg = error_data.get('detail', f'HTTP {response.status}')
+                    try:
+                        error_data = await response.json()
+                        error_msg = error_data.get('detail', f'HTTP {response.status}')
+                    except (aiohttp.ContentTypeError, ValueError):
+                        error_msg = f'HTTP {response.status}: {await response.text()}'
                     logger.error(f"Failed to store memory via HTTP: {error_msg}")
                     return False, error_msg
-                    
+
         except Exception as e:
             return self._handle_http_error(e, "store")
     
@@ -311,11 +314,14 @@ class HTTPClientStorage(MemoryStorage):
                 elif response.status == 404:
                     return False, f"Memory with hash {content_hash} not found"
                 else:
-                    error_data = await response.json()
-                    error_msg = error_data.get('detail', f'HTTP {response.status}')
+                    try:
+                        error_data = await response.json()
+                        error_msg = error_data.get('detail', f'HTTP {response.status}')
+                    except (aiohttp.ContentTypeError, ValueError):
+                        error_msg = f'HTTP {response.status}: {await response.text()}'
                     logger.error(f"Failed to delete memory via HTTP: {error_msg}")
                     return False, error_msg
-                    
+
         except Exception as e:
             return self._handle_http_error(e, "delete")
     


### PR DESCRIPTION
## Problem

Was reading through the HTTP client adapter and noticed that `response.json()` is called directly on error responses without handling the case where the server returns non-JSON content. Ran into this while testing against a self-hosted deployment behind an nginx reverse proxy — when the upstream was down, nginx returned an HTML 502 page, which caused `aiohttp.ContentTypeError` to propagate up instead of returning a clean error tuple.

The same pattern exists in `ExternalEmbeddingModel` where `response.json()` is called on the success path without protection. If the embedding API returns a 200 with a truncated or corrupt body (seen this happen with flaky network proxies), `json.JSONDecodeError` propagates uncaught past the `requests.exceptions.Timeout` and `requests.exceptions.ConnectionError` handlers, crashing initialization.

## Changes

**`storage/http_client.py`** — `store()` and `delete()` methods:
- Wrapped `await response.json()` on non-success status codes in `try-except` catching `aiohttp.ContentTypeError` and `ValueError`
- Falls back to `await response.text()` to build a meaningful error message

**`embeddings/external_api.py`** — `_verify_connection()` and `encode()` methods:
- Wrapped `response.json()` in `try-except` catching `ValueError` and `requests.exceptions.JSONDecodeError`
- Raises `ConnectionError` / `RuntimeError` with context about the malformed response

## How I found it

The HTTP client's `delete()` method already handles the 404 case gracefully (line 311-312) by returning a tuple without parsing JSON. But the generic error branch right below it assumes the response body is always valid JSON — inconsistent within the same method.

Similarly, the error-path JSON parsing at line 127-139 in `external_api.py` correctly wraps `response.json()` in try-except, but the success-path parsing at line 116 does not — inconsistent within the same function.