### PR TITLE
feat(oauth): add optional registration key protection for DCR endpoint

### DIFF
--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -727,6 +727,15 @@ if CONSOLIDATION_ENABLED:
 # OAuth 2.1 Configuration
 OAUTH_ENABLED = safe_get_bool_env('MCP_OAUTH_ENABLED', False)
 
+# DCR Registration Key (optional endpoint protection for /oauth/register)
+# WARNING: RFC 7591 DCR is intentionally open by design to allow dynamic clients.
+# Setting this key restricts registration to callers who supply
+# Authorization: Bearer <key>. Use only for self-hosted deployments where open
+# registration is unacceptable (e.g., internet-facing instances without VPN).
+# Leave unset (default) to preserve standard RFC 7591 open-registration behavior.
+# Rotate via your secret manager; the service reads the env var on each request.
+DCR_REGISTRATION_KEY: str | None = os.getenv('MCP_DCR_REGISTRATION_KEY')
+
 # OAuth Storage Backend Configuration
 OAUTH_STORAGE_BACKEND = os.getenv("MCP_OAUTH_STORAGE_BACKEND", "memory").lower()
 """

--- a/src/mcp_memory_service/web/oauth/registration.py
+++ b/src/mcp_memory_service/web/oauth/registration.py
@@ -18,11 +18,13 @@ OAuth 2.1 Dynamic Client Registration implementation for MCP Memory Service.
 Implements RFC 7591 - OAuth 2.0 Dynamic Client Registration Protocol.
 """
 
+import os
+import secrets
 import time
 import logging
 from typing import List, Optional
 from urllib.parse import urlparse, ParseResult
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import ValidationError
 
 from .models import (
@@ -198,17 +200,56 @@ def validate_response_types(response_types: List[str]) -> None:
             )
 
 
+def _validate_registration_key(request: Request) -> None:
+    """
+    Validate the optional DCR registration key.
+
+    When MCP_DCR_REGISTRATION_KEY is set, the /oauth/register endpoint
+    requires Authorization: Bearer <key>. When unset, DCR remains open
+    (backward compatible with RFC 7591 default behavior).
+    """
+    registration_key = os.environ.get("MCP_DCR_REGISTRATION_KEY")
+    if not registration_key:
+        return
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "error": "invalid_token",
+                "error_description": "Registration key required. Provide Authorization: Bearer <registration-key>"
+            }
+        )
+
+    provided_key = auth_header[len("Bearer "):]
+    if not secrets.compare_digest(provided_key, registration_key):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "access_denied",
+                "error_description": "Invalid registration key"
+            }
+        )
+
+
 @router.post("/register", response_model=ClientRegistrationResponse, status_code=status.HTTP_201_CREATED)
-async def register_client(request: ClientRegistrationRequest) -> ClientRegistrationResponse:
+async def register_client(request: ClientRegistrationRequest, raw_request: Request) -> ClientRegistrationResponse:
     """
     OAuth 2.1 Dynamic Client Registration endpoint.
 
     Implements RFC 7591 - OAuth 2.0 Dynamic Client Registration Protocol.
     Allows clients to register dynamically with the authorization server.
+
+    When MCP_DCR_REGISTRATION_KEY env var is set, requests must include
+    Authorization: Bearer <key> header. When unset, registration is open.
     """
     logger.info("OAuth client registration request received")
 
     try:
+        # Validate optional registration key protection
+        _validate_registration_key(raw_request)
+
         # Validate client metadata
         if request.redirect_uris:
             validate_redirect_uris([str(uri) for uri in request.redirect_uris])

--- a/src/mcp_memory_service/web/oauth/registration.py
+++ b/src/mcp_memory_service/web/oauth/registration.py
@@ -18,13 +18,12 @@ OAuth 2.1 Dynamic Client Registration implementation for MCP Memory Service.
 Implements RFC 7591 - OAuth 2.0 Dynamic Client Registration Protocol.
 """
 
-import os
 import secrets
 import time
 import logging
 from typing import List, Optional
 from urllib.parse import urlparse, ParseResult
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import ValidationError
 
 from .models import (
@@ -33,6 +32,7 @@ from .models import (
     RegisteredClient
 )
 from .storage import get_oauth_storage
+from mcp_memory_service.config import DCR_REGISTRATION_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -200,41 +200,49 @@ def validate_response_types(response_types: List[str]) -> None:
             )
 
 
-def _validate_registration_key(request: Request) -> None:
+def _validate_registration_key(raw_request: Request) -> None:
     """
-    Validate the optional DCR registration key.
+    FastAPI dependency that enforces the optional DCR registration key.
 
     When MCP_DCR_REGISTRATION_KEY is set, the /oauth/register endpoint
     requires Authorization: Bearer <key>. When unset, DCR remains open
     (backward compatible with RFC 7591 default behavior).
+
+    Raises:
+        HTTPException 401: Header missing or not Bearer scheme (RFC 7235).
+        HTTPException 401: Provided key is invalid (RFC 6750 §3.1).
     """
-    registration_key = os.environ.get("MCP_DCR_REGISTRATION_KEY")
-    if not registration_key:
+    if not DCR_REGISTRATION_KEY:
         return
 
-    auth_header = request.headers.get("authorization", "")
+    auth_header = raw_request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
                 "error": "invalid_token",
                 "error_description": "Registration key required. Provide Authorization: Bearer <registration-key>"
-            }
+            },
+            headers={"WWW-Authenticate": "Bearer"},
         )
 
     provided_key = auth_header[len("Bearer "):]
-    if not secrets.compare_digest(provided_key, registration_key):
+    if not secrets.compare_digest(provided_key, DCR_REGISTRATION_KEY):
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
-                "error": "access_denied",
+                "error": "invalid_token",
                 "error_description": "Invalid registration key"
-            }
+            },
+            headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
         )
 
 
 @router.post("/register", response_model=ClientRegistrationResponse, status_code=status.HTTP_201_CREATED)
-async def register_client(request: ClientRegistrationRequest, raw_request: Request) -> ClientRegistrationResponse:
+async def register_client(
+    request: ClientRegistrationRequest,
+    _: None = Depends(_validate_registration_key),
+) -> ClientRegistrationResponse:
     """
     OAuth 2.1 Dynamic Client Registration endpoint.
 
@@ -247,9 +255,6 @@ async def register_client(request: ClientRegistrationRequest, raw_request: Reque
     logger.info("OAuth client registration request received")
 
     try:
-        # Validate optional registration key protection
-        _validate_registration_key(raw_request)
-
         # Validate client metadata
         if request.redirect_uris:
             validate_redirect_uris([str(uri) for uri in request.redirect_uris])

--- a/tests/unit/test_dcr_registration_key.py
+++ b/tests/unit/test_dcr_registration_key.py
@@ -5,9 +5,8 @@ When MCP_DCR_REGISTRATION_KEY is set, the /oauth/register endpoint
 requires Authorization: Bearer <key>. When unset, DCR remains open.
 """
 
-import os
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 
 from mcp_memory_service.web.oauth.registration import _validate_registration_key
@@ -23,58 +22,64 @@ def _make_request(auth_header: str | None = None) -> MagicMock:
     return request
 
 
+# Patch target: the name as imported into the registration module
+_DCR_KEY_PATCH = "mcp_memory_service.web.oauth.registration.DCR_REGISTRATION_KEY"
+
+
 class TestRegistrationKeyValidation:
     """Tests for _validate_registration_key."""
 
-    def test_no_env_var_allows_open_registration(self):
-        """When MCP_DCR_REGISTRATION_KEY is not set, registration is open."""
-        with patch.dict(os.environ, {}, clear=True):
-            # Should not raise
+    def test_no_key_configured_allows_open_registration(self):
+        """When DCR_REGISTRATION_KEY is None (unset), registration is open."""
+        with patch(_DCR_KEY_PATCH, None):
             _validate_registration_key(_make_request())
 
-    def test_no_env_var_ignores_any_header(self):
-        """When env var is unset, any Authorization header is ignored."""
-        with patch.dict(os.environ, {}, clear=True):
+    def test_no_key_configured_ignores_any_header(self):
+        """When key is unset, any Authorization header is silently ignored."""
+        with patch(_DCR_KEY_PATCH, None):
             _validate_registration_key(_make_request("Bearer some-key"))
 
     def test_valid_key_passes(self):
-        """Correct registration key is accepted."""
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+        """Correct registration key is accepted without raising."""
+        with patch(_DCR_KEY_PATCH, "secret-reg-key"):
             _validate_registration_key(_make_request("Bearer secret-reg-key"))
 
-    def test_missing_header_returns_401(self):
-        """Missing Authorization header returns 401 when key is required."""
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+    def test_missing_header_returns_401_with_www_authenticate(self):
+        """Missing Authorization header → 401 + WWW-Authenticate: Bearer (RFC 7235)."""
+        with patch(_DCR_KEY_PATCH, "secret-reg-key"):
             with pytest.raises(HTTPException) as exc_info:
                 _validate_registration_key(_make_request())
             assert exc_info.value.status_code == 401
+            assert "WWW-Authenticate" in exc_info.value.headers
+            assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
 
-    def test_wrong_key_returns_403(self):
-        """Invalid registration key returns 403."""
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+    def test_wrong_key_returns_401_with_invalid_token_header(self):
+        """Invalid registration key → 401 with WWW-Authenticate error (RFC 6750 §3.1)."""
+        with patch(_DCR_KEY_PATCH, "secret-reg-key"):
             with pytest.raises(HTTPException) as exc_info:
                 _validate_registration_key(_make_request("Bearer wrong-key"))
-            assert exc_info.value.status_code == 403
+            assert exc_info.value.status_code == 401
+            assert "WWW-Authenticate" in exc_info.value.headers
+            assert 'invalid_token' in exc_info.value.headers["WWW-Authenticate"]
 
     def test_non_bearer_scheme_returns_401(self):
-        """Non-Bearer auth scheme returns 401."""
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+        """Non-Bearer auth scheme → 401 with WWW-Authenticate header."""
+        with patch(_DCR_KEY_PATCH, "secret-reg-key"):
             with pytest.raises(HTTPException) as exc_info:
                 _validate_registration_key(_make_request("Basic dXNlcjpwYXNz"))
             assert exc_info.value.status_code == 401
+            assert "WWW-Authenticate" in exc_info.value.headers
 
-    def test_empty_bearer_returns_403(self):
-        """Empty Bearer token returns 403."""
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+    def test_empty_bearer_returns_401(self):
+        """Empty Bearer token → 401 (RFC 6750 §3.1)."""
+        with patch(_DCR_KEY_PATCH, "secret-reg-key"):
             with pytest.raises(HTTPException) as exc_info:
                 _validate_registration_key(_make_request("Bearer "))
-            assert exc_info.value.status_code == 403
+            assert exc_info.value.status_code == 401
 
     def test_timing_safe_comparison(self):
         """Validation uses constant-time comparison (secrets.compare_digest)."""
-        # This test verifies the function works with similar keys
-        # (actual timing safety is guaranteed by secrets.compare_digest)
-        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "abc123"}):
+        with patch(_DCR_KEY_PATCH, "abc123"):
             with pytest.raises(HTTPException) as exc_info:
                 _validate_registration_key(_make_request("Bearer abc124"))
-            assert exc_info.value.status_code == 403
+            assert exc_info.value.status_code == 401

--- a/tests/unit/test_dcr_registration_key.py
+++ b/tests/unit/test_dcr_registration_key.py
@@ -1,0 +1,80 @@
+"""
+Tests for optional DCR registration key protection.
+
+When MCP_DCR_REGISTRATION_KEY is set, the /oauth/register endpoint
+requires Authorization: Bearer <key>. When unset, DCR remains open.
+"""
+
+import os
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from fastapi import HTTPException
+
+from mcp_memory_service.web.oauth.registration import _validate_registration_key
+
+
+def _make_request(auth_header: str | None = None) -> MagicMock:
+    """Create a mock FastAPI Request with optional Authorization header."""
+    request = MagicMock()
+    headers = {}
+    if auth_header is not None:
+        headers["authorization"] = auth_header
+    request.headers = headers
+    return request
+
+
+class TestRegistrationKeyValidation:
+    """Tests for _validate_registration_key."""
+
+    def test_no_env_var_allows_open_registration(self):
+        """When MCP_DCR_REGISTRATION_KEY is not set, registration is open."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Should not raise
+            _validate_registration_key(_make_request())
+
+    def test_no_env_var_ignores_any_header(self):
+        """When env var is unset, any Authorization header is ignored."""
+        with patch.dict(os.environ, {}, clear=True):
+            _validate_registration_key(_make_request("Bearer some-key"))
+
+    def test_valid_key_passes(self):
+        """Correct registration key is accepted."""
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+            _validate_registration_key(_make_request("Bearer secret-reg-key"))
+
+    def test_missing_header_returns_401(self):
+        """Missing Authorization header returns 401 when key is required."""
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_registration_key(_make_request())
+            assert exc_info.value.status_code == 401
+
+    def test_wrong_key_returns_403(self):
+        """Invalid registration key returns 403."""
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_registration_key(_make_request("Bearer wrong-key"))
+            assert exc_info.value.status_code == 403
+
+    def test_non_bearer_scheme_returns_401(self):
+        """Non-Bearer auth scheme returns 401."""
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_registration_key(_make_request("Basic dXNlcjpwYXNz"))
+            assert exc_info.value.status_code == 401
+
+    def test_empty_bearer_returns_403(self):
+        """Empty Bearer token returns 403."""
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "secret-reg-key"}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_registration_key(_make_request("Bearer "))
+            assert exc_info.value.status_code == 403
+
+    def test_timing_safe_comparison(self):
+        """Validation uses constant-time comparison (secrets.compare_digest)."""
+        # This test verifies the function works with similar keys
+        # (actual timing safety is guaranteed by secrets.compare_digest)
+        with patch.dict(os.environ, {"MCP_DCR_REGISTRATION_KEY": "abc123"}):
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_registration_key(_make_request("Bearer abc124"))
+            assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

- Adds optional protection for the `/oauth/register` DCR endpoint via `MCP_DCR_REGISTRATION_KEY` env var
- When set, requests must include `Authorization: Bearer <key>` header
- When unset, DCR remains fully open (backward compatible with current behavior per RFC 7591)
- Uses `secrets.compare_digest` for constant-time comparison (prevents timing attacks)

## Motivation

RFC 7591 DCR is public by design, but for self-hosted deployments exposed to the internet without VPN, an optional registration key adds a layer of protection against unauthorized client registration. This is a common hardening pattern for production deployments.

## Changes

- `src/mcp_memory_service/web/oauth/registration.py`: Added `_validate_registration_key()` function and integrated it into the `register_client` endpoint
- `tests/unit/test_dcr_registration_key.py`: 8 unit tests covering all scenarios (open registration, valid key, missing header, wrong key, non-Bearer scheme, empty token, timing safety)

## Test plan

- [x] All 8 new unit tests pass
- [ ] Existing OAuth flow tests still pass (no breaking changes)
- [ ] Manual test: start server without `MCP_DCR_REGISTRATION_KEY` → registration works as before
- [ ] Manual test: start server with `MCP_DCR_REGISTRATION_KEY=secret` → registration requires Bearer header