### PR TITLE
feat: transport health endpoint, configurable timeouts, optional DCR registration key (v10.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.32.0] - 2026-04-06
+
 ### Added
-- Added `/health` endpoint to SSE and Streamable HTTP transports (port `MCP_SSE_PORT`, default 8765) for external monitoring (load balancers, Docker healthchecks, K8s probes) (PR #656, contributor: @Lobster-Armlock)
-- Added `MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE` (default 5s) and `MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN` (default 30s) configurable env vars for MCP transport uvicorn instances (PR #656, contributor: @Lobster-Armlock)
+- **[#656] `/health` endpoint on SSE and Streamable HTTP transports**: Added a `/health` endpoint to the SSE and Streamable HTTP transport servers (port `MCP_SSE_PORT`, default 8765) for external monitoring — load balancers, Docker healthchecks, and Kubernetes liveness/readiness probes can now query transport health independently of the main HTTP API. (PR #656, contributor: @Lobster-Armlock)
+- **[#656] Configurable transport timeouts**: Added `MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE` (default 5s) and `MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN` (default 30s) environment variables to control uvicorn timeouts for MCP transport instances, enabling tuning for different deployment environments. (PR #656, contributor: @Lobster-Armlock)
+- **[#657] Optional DCR registration key protection**: Added `MCP_DCR_REGISTRATION_KEY` environment variable to optionally protect the `/oauth/register` Dynamic Client Registration endpoint. When set, requests must include `Authorization: Bearer <key>` (timing-safe comparison via `secrets.compare_digest`). Backward-compatible — when unset, DCR remains open per RFC 7591. (PR #657, contributor: @irizzant)
 
 ## [10.31.2] - 2026-04-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.31.2 - fix: consistent metadata parsing, non-JSON error handling, upload progress tracking (#648, #649, #650) — 1,521 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.32.0 - feat: transport health endpoint, configurable timeouts, optional DCR registration key protection (community PRs #656, #657) — 1,520 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -376,22 +376,22 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.31.2** (April 3, 2026)
+## Latest Release: **v10.32.0** (April 6, 2026)
 
-**fix: storage consistency, error handling, and upload progress (community PRs #648, #649, #650)**
+**feat: transport health endpoint + configurable timeouts + optional DCR registration key protection (community PRs #656, #657)**
 
 **What's New:**
-- **Consistent `_safe_json_loads` usage (#648)**: Replaced remaining bare `json.loads` calls in `get_largest_memories()` and `get_graph_visualization_data()` with the `_safe_json_loads` helper for consistent error handling.
-- **Non-JSON error response handling (#649)**: HTTP client and embedding API now gracefully handle non-JSON error responses (e.g. HTML from reverse proxies) instead of crashing.
-- **Upload progress tracking (#650)**: Fixed broken single-file progress formula and added per-file batch progress updates for smooth 0→100% tracking.
-- **Repo & agent cleanup**: Moved 8 legacy docs to archive, cleaned up `.claude/` config, consolidated agents (84% size reduction: 2,507 → 412 lines).
-- **1,503 tests** passing.
+- **Transport `/health` endpoint (#656)**: SSE and Streamable HTTP transports now expose a `/health` endpoint (on `MCP_SSE_PORT`, default 8765) for load balancers, Docker healthchecks, and Kubernetes liveness/readiness probes.
+- **Configurable transport timeouts (#656)**: New `MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE` (default 5s) and `MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN` (default 30s) env vars for fine-tuning uvicorn transport instances.
+- **Optional DCR registration key protection (#657)**: Set `MCP_DCR_REGISTRATION_KEY` to protect the `/oauth/register` endpoint with Bearer token auth (timing-safe via `secrets.compare_digest`). Backward-compatible — unset means open DCR per RFC 7591.
+- **1,520 tests** passing.
 
-Thanks to @lawrence3699 for contributing PRs #648, #649, and #650!
+Thanks to @Lobster-Armlock (PR #656) and @irizzant (PR #657) for these community contributions!
 
 ---
 
 **Previous Releases**:
+- **v10.31.2** - fix: storage consistency, error handling, and upload progress — `_safe_json_loads` consistency, non-JSON error handling, upload progress tracking (community PRs #648, #649, #650, 1,503 tests)
 - **v10.31.1** - fix: tombstone blocks re-insertion after delete of same content (#644) — `_purge_tombstone()` before INSERT (1,521 tests)
 - **v10.31.0** - feat: Harvest Evolution (P4) + Sync-in-Async Refactoring — harvest dedup via `update_memory_versioned()`, `asyncio.to_thread()` in `_execute_with_retry` (1,520 tests)
 - **v10.30.0** - feat: Memory Evolution (P1+P2+P3) — non-destructive versioned updates, staleness scoring, conflict detection + resolution (1,514 tests)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.30 — Persistent Memory for AI Agents</title>
+<title>MCP Memory Service v10.32 — Persistent Memory for AI Agents</title>
 <meta name="description" content="Self-hosted persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation. Now with Streamable HTTP + OAuth 2.1 for Claude.ai.">
-<meta property="og:title" content="MCP Memory Service v10.30">
-<meta property="og:description" content="Your self-hosted memory server now connects to Claude.ai. Streamable HTTP + OAuth 2.1 + PKCE.">
+<meta property="og:title" content="MCP Memory Service v10.32">
+<meta property="og:description" content="Your self-hosted memory server now connects to Claude.ai. Streamable HTTP + OAuth 2.1 + PKCE. Transport health endpoint, configurable timeouts, DCR registration key protection.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.30 &mdash; Now Available</span>
+  <span class="hero-badge">v10.32 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.30</h2>
-    <p class="section-subtitle">Memory Evolution: non-destructive updates, lineage tracking, staleness scoring, and automatic conflict detection.</p>
+    <h2 class="section-title">What's New in v10.32</h2>
+    <p class="section-subtitle">Transport health monitoring, configurable timeouts, and optional OAuth DCR endpoint protection — all community-contributed.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon http">&#128257;</div>
-        <h3>Non-Destructive Versioned Updates</h3>
-        <p>Update a memory without losing its history. <code>update_memory_versioned()</code> creates a child node atomically and marks the parent as superseded &mdash; full lineage preserved, active queries see only current versions.</p>
+        <div class="feature-icon http">&#10084;</div>
+        <h3>Transport Health Endpoint</h3>
+        <p>SSE and Streamable HTTP transports now expose a <code>/health</code> endpoint on <code>MCP_SSE_PORT</code> (default 8765). Load balancers, Docker healthchecks, and Kubernetes liveness/readiness probes can now monitor transport health independently.</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon oauth">&#128336;</div>
-        <h3>Staleness Scoring &amp; Decay</h3>
-        <p>Time-decayed confidence: memories grow stale automatically. Configure decay window via <code>MEMORY_DECAY_WINDOW_DAYS</code>. <code>min_confidence</code> filtering on all backends keeps retrieval results fresh.</p>
+        <div class="feature-icon oauth">&#9201;</div>
+        <h3>Configurable Transport Timeouts</h3>
+        <p>Fine-tune uvicorn timeouts for your deployment: <code>MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE</code> (default 5s) and <code>MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN</code> (default 30s). Essential for high-throughput and cloud environments.</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon privacy">&#9889;</div>
-        <h3>Automatic Conflict Detection</h3>
-        <p>Every store operation checks for contradictions (cosine > 0.95 + Levenshtein divergence > 20%). New <code>memory_conflicts</code> and <code>memory_resolve</code> MCP tools. REST: <code>GET /api/conflicts</code>, <code>POST /api/conflicts/resolve</code>.</p>
+        <div class="feature-icon privacy">&#128274;</div>
+        <h3>Optional DCR Registration Key</h3>
+        <p>Set <code>MCP_DCR_REGISTRATION_KEY</code> to protect the OAuth <code>/register</code> endpoint with Bearer token auth (timing-safe via <code>secrets.compare_digest</code>). Backward-compatible &mdash; unset means open DCR per RFC 7591.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1514">0</div>
+        <div class="stat-number" data-target="1520">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.30.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.32.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MCP Memory Service v10.32 — Persistent Memory for AI Agents</title>
-<meta name="description" content="Self-hosted persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation. Now with Streamable HTTP + OAuth 2.1 for Claude.ai.">
+<meta name="description" content="Self-hosted persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation. Now with transport health monitoring, configurable timeouts, and optional DCR registration key protection.">
 <meta property="og:title" content="MCP Memory Service v10.32">
 <meta property="og:description" content="Your self-hosted memory server now connects to Claude.ai. Streamable HTTP + OAuth 2.1 + PKCE. Transport health endpoint, configurable timeouts, DCR registration key protection.">
 <meta property="og:type" content="website">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.31.2"
+version = "10.32.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.31.2"
+__version__ = "10.32.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.31.1"
+version = "10.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Changes

- **[#656] Transport `/health` endpoint** (contributor: @Lobster-Armlock): SSE and Streamable HTTP transports now expose `/health` on `MCP_SSE_PORT` (default 8765) for load balancers, Docker healthchecks, and Kubernetes probes.
- **[#656] Configurable transport timeouts** (contributor: @Lobster-Armlock): New `MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE` (default 5s) and `MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN` (default 30s) env vars for uvicorn transport instances.
- **[#657] Optional DCR registration key protection** (contributor: @irizzant): `MCP_DCR_REGISTRATION_KEY` env var optionally protects `/oauth/register` with Bearer token auth via `secrets.compare_digest`. Backward-compatible — unset means open DCR per RFC 7591.

## Motivation

Community-contributed improvements to production deployability: transport health observability for orchestration platforms (K8s, Docker Swarm, load balancers) and security hardening for OAuth DCR endpoint.

## Version Bump

MINOR bump: v10.31.2 → v10.32.0 (new features, backward-compatible)

## Checklist

- [x] Version bumped in `_version.py`, `pyproject.toml`, `README.md`
- [x] `uv.lock` updated
- [x] `CHANGELOG.md` updated (PR #657 entry added, [Unreleased] moved to [10.32.0])
- [x] `README.md` "Latest Release" section updated, v10.31.2 added to Previous Releases
- [x] `CLAUDE.md` Current Version line updated
- [x] `docs/index.html` updated (v10.32 badge, feature cards, test count 1520, release notes URL)
- [x] Pre-PR quality gate: PASS (no Python files changed, complexity/security checks passed)

## Special Thanks

- @Lobster-Armlock for PR #656 (transport health + timeouts)
- @irizzant for PR #657 (DCR registration key protection)