### PR TITLE
fix: repair broken badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ context in 5ms — without cloud lock-in or API costs.
 [![Works with Claude](https://img.shields.io/badge/Works%20with-Claude-blue)](https://claude.ai)
 [![Works with Cursor](https://img.shields.io/badge/Works%20with-Cursor-orange)](https://cursor.sh)
 [![Remote MCP](https://img.shields.io/badge/MCP-Remote%20Support-blue?logo=anthropic)](docs/remote-mcp-setup.md)
-[![claude.ai](https://img.shields.io/badge/claude.ai-Browser%20Compatible-orange?logo=anthropic)](docs/remote-mcp-setup.md)
+[![claude.ai Browser Compatible](https://img.shields.io/badge/claude.ai-Browser%20Compatible-orange?logo=anthropic)](docs/remote-mcp-setup.md)
 [![OAuth 2.0](https://img.shields.io/badge/Auth-OAuth%202.0%20%2B%20DCR-green)](docs/oauth-setup.md)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/doobidoo)
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ context in 5ms — without cloud lock-in or API costs.
 [![Works with Claude](https://img.shields.io/badge/Works%20with-Claude-blue)](https://claude.ai)
 [![Works with Cursor](https://img.shields.io/badge/Works%20with-Cursor-orange)](https://cursor.sh)
 [![Remote MCP](https://img.shields.io/badge/MCP-Remote%20Support-blue?logo=anthropic)](docs/remote-mcp-setup.md)
-[![claude.ai](https://img.shields.io/badge/claude.ai-Browser%20Compatible-orange?logo=anthropic)](docs/remote-mcp-setu
-p.md)
+[![claude.ai](https://img.shields.io/badge/claude.ai-Browser%20Compatible-orange?logo=anthropic)](docs/remote-mcp-setup.md)
 [![OAuth 2.0](https://img.shields.io/badge/Auth-OAuth%202.0%20%2B%20DCR-green)](docs/oauth-setup.md)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/doobidoo)
 


### PR DESCRIPTION
## Summary

- Fix line wrap issue in README.md causing broken link for claude.ai badge
- The link `docs/remote-mcp-setu<newline>p.md` is now correctly `docs/remote-mcp-setup.md`

## Problem

Line 23-24 of README.md had a broken markdown link due to an unintended line wrap:

```markdown
[![claude.ai](...)](docs/remote-mcp-setu
p.md)
```

This caused the badge link to not work properly.

## Solution

Joined the split line into a single properly formatted link:

```markdown
[![claude.ai](...)](docs/remote-mcp-setup.md)
```

## Test plan

- [x] Verified the link renders correctly in markdown preview
- [x] Confirmed no other formatting issues introduced