### PR TITLE
feat(benchmarks): add LongMemEval benchmark — R@5 80.4%, R@10 90.4% (500 questions, zero LLM)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ certs/key.pem
 
 # LoCoMo benchmark data (downloaded on demand)
 data/locomo/
+results/benchmarks/

--- a/README.md
+++ b/README.md
@@ -503,7 +503,18 @@ result = storage.find_connected(
 
 ### Retrieval Benchmarks
 
-Two benchmarks measure retrieval quality (all-MiniLM-L6-v2, 384d embeddings):
+Three benchmarks measure retrieval quality (all-MiniLM-L6-v2, 384d embeddings, zero LLM API calls):
+
+**LongMemEval** ([500 questions](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned), ~45–62 distractor sessions per question):
+
+| Question Type | R@5 | R@10 | NDCG@10 | MRR |
+|---------------|-----|------|---------|-----|
+| **Overall** | **80.4%** | **90.4%** | **82.2%** | **89.1%** |
+| single-session-assistant | 100.0% | 100.0% | 99.3% | 99.1% |
+| knowledge-update | 84.6% | 96.8% | 86.2% | 95.5% |
+| single-session-user | 91.4% | 92.9% | 86.0% | 83.8% |
+| temporal-reasoning | 72.0% | 84.1% | 75.1% | 85.7% |
+| multi-session | 70.7% | 86.0% | 77.6% | 89.4% |
 
 **DevBench** (practical developer workflow queries):
 
@@ -522,7 +533,7 @@ Two benchmarks measure retrieval quality (all-MiniLM-L6-v2, 384d embeddings):
 | multi-hop | 72.0% | 0.600 |
 | temporal | 33.5% | 0.274 |
 
-Run benchmarks: `python scripts/benchmarks/benchmark_devbench.py` and `python scripts/benchmarks/benchmark_locomo.py`
+Run benchmarks: `python scripts/benchmarks/benchmark_longmemeval.py`, `python scripts/benchmarks/benchmark_devbench.py`, `python scripts/benchmarks/benchmark_locomo.py`
 
 ### Performance Improvements
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,58 @@
+# MCP Memory Service — Benchmark Results
+
+Retrieval quality benchmarks comparing MCP Memory Service against other memory systems.
+All results use zero LLM API calls (retrieval-only mode) unless noted.
+
+---
+
+## LongMemEval
+
+**Dataset:** [LongMemEval-S](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned) — 500 questions, ~45–62 sessions per question (distractor haystack)  
+**Mode:** Retrieval only (zero LLM API calls)  
+**Ingestion:** Turn-level (each conversation turn stored as one memory)  
+**Backend:** SQLite-Vec with all-MiniLM-L6-v2 ONNX embeddings  
+**Date:** 2026-04-07 · **Version:** v10.33.0
+
+### Overall Metrics
+
+| System | R@5 | R@10 | NDCG@10 | MRR | LLM calls |
+|--------|-----|------|---------|-----|-----------|
+| **MCP Memory Service** | **80.4%** | **90.4%** | **82.2%** | **89.1%** | 0 |
+| mempalace (raw) | 96.6% | — | — | — | 0 |
+| mempalace (hybrid v4 + Haiku) | 100% | — | — | — | ~500 |
+| Mem0 | ~85% | — | — | — | — |
+
+### By Question Type
+
+| Question Type | R@5 | R@10 | NDCG@10 | MRR |
+|---------------|-----|------|---------|-----|
+| single-session-assistant | 100.0% | 100.0% | 99.3% | 99.1% |
+| single-session-user | 91.4% | 92.9% | 86.0% | 83.8% |
+| single-session-preference | 86.7% | 96.7% | 83.4% | 79.2% |
+| knowledge-update | 84.6% | 96.8% | 86.2% | 95.5% |
+| temporal-reasoning | 72.0% | 84.1% | 75.1% | 85.7% |
+| multi-session | 70.7% | 86.0% | 77.6% | 89.4% |
+
+### Running the Benchmark
+
+```bash
+# Quick test (5 items)
+python scripts/benchmarks/benchmark_longmemeval.py --limit 5
+
+# Full run (500 items, ~10-15 minutes)
+python scripts/benchmarks/benchmark_longmemeval.py --top-k 5 10 --markdown --output-dir results/benchmarks/
+
+# Ablation (compare baseline vs quality boost)
+python scripts/benchmarks/benchmark_longmemeval.py --mode ablation --limit 50
+```
+
+---
+
+## LoCoMo
+
+See [LoCoMo benchmark](../scripts/benchmarks/benchmark_locomo.py) for retrieval evaluation on the [LoCoMo10 dataset](https://github.com/snap-research/locomo).
+
+Run with:
+```bash
+python scripts/benchmarks/benchmark_locomo.py
+```

--- a/docs/plans/2026-04-07-longmemeval-benchmark-design.md
+++ b/docs/plans/2026-04-07-longmemeval-benchmark-design.md
@@ -1,0 +1,164 @@
+# LongMemEval Benchmark — Design Document
+
+**Date:** 2026-04-07
+**Status:** Approved
+**Context:** Analogous benchmark coverage to [mempalace](https://github.com/milla-jovovich/mempalace)
+
+---
+
+## Background
+
+mempalace (released April 2026, 1.2K stars) achieved significant community attention by publishing
+benchmark scores on four conversational memory datasets. Their headline claim: **96.6% R@5 on
+LongMemEval** with zero LLM API calls.
+
+MCP Memory Service already has a LoCoMo benchmark (Recall@K, Precision@K, MRR, Token-F1). The goal
+of this initiative is to add **LongMemEval** as the next benchmark — enabling direct, apples-to-apples
+comparison with mempalace on the same dataset with the same primary metrics.
+
+---
+
+## Goal
+
+1. **External comparison** — Publish R@5/R@10/NDCG@10 scores on LongMemEval that are directly
+   comparable to mempalace's reported numbers.
+2. **Internal evaluation** — Use the benchmark during development to measure the impact of retrieval
+   improvements (quality boost, decay, re-ranking).
+
+---
+
+## Approach: LongMemEval-First (Ansatz A)
+
+Implement LongMemEval as a standalone benchmark following the established LoCoMo pattern exactly.
+MemBench ACL 2025 and ConvoMem are deferred to subsequent PRs.
+
+---
+
+## Architecture & Files
+
+```
+scripts/benchmarks/
+├── benchmark_longmemeval.py      ← CLI orchestrator (entry point)
+├── longmemeval_dataset.py        ← Dataset loader (HuggingFace auto-download + local cache)
+└── longmemeval_evaluator.py      ← Metrics: R@5, R@10, NDCG@10, per-type breakdown
+
+tests/benchmarks/
+└── test_benchmark_longmemeval.py ← Smoke test (10 questions, no HuggingFace required)
+
+data/longmemeval/                 ← Local cache (covered by existing data/ .gitignore entry)
+└── longmemeval_s.json            ← Cached dataset
+```
+
+No new base classes. The LoCoMo pattern is the template, not a framework.
+
+---
+
+## Dataset Loading (`longmemeval_dataset.py`)
+
+- **Primary source:** HuggingFace `xiaowu0162/longmemeval-cleaned` via `datasets` library
+- **Fallback:** Direct JSON download (same pattern as LoCoMo)
+- **Local cache:** `data/longmemeval/` (already in `.gitignore`)
+- **Variants:**
+  - `longmemeval_s` (500 questions, single context per question) — **default**
+  - `longmemeval_m` (multi-session variant) — via `--variant m` flag, deferred
+
+---
+
+## Ingestion Strategy
+
+- **Per-question isolated SQLite-Vec DB** — no cross-contamination between questions
+- Each conversation turn stored as one Memory
+- Tags: `["longmemeval", question_id, session_id, speaker]`
+- Evidence matching: retrieved Memory's `session_id` tag checked against ground-truth evidence session IDs
+- **Granularity** (CLI flag `--granularity`):
+  - `turn` (default) — one Memory per turn
+  - `session` — entire session text as one Memory
+
+This mirrors the mempalace ingestion strategy exactly, ensuring directly comparable numbers.
+
+---
+
+## Metrics (`longmemeval_evaluator.py`)
+
+| Metric | Description | mempalace parity |
+|---|---|---|
+| R@5 | Recall in Top-5 | Primary metric |
+| R@10 | Recall in Top-10 | Yes |
+| NDCG@10 | Ranking quality | Yes |
+| Per-type breakdown | Single-hop, Multi-hop, Temporal, etc. | Yes |
+
+No new metric implementations needed — existing `recall_at_k` and `ndcg_at_k` from the evaluator
+utilities are reused.
+
+---
+
+## Evaluation Modes
+
+| Mode | LLM required | Purpose |
+|---|---|---|
+| `retrieval` (default) | No | Deterministic, comparable to mempalace "zero API calls" |
+| `qa` | Yes | LLM-based answer generation with F1 scoring |
+
+---
+
+## Ablation (built-in)
+
+| Configuration | Description |
+|---|---|
+| `baseline` | Standard cosine similarity retrieval |
+| `+quality_boost` | Quality-scoring re-ranking |
+
+---
+
+## CLI Interface
+
+```bash
+# Basic run (comparable to mempalace)
+python scripts/benchmarks/benchmark_longmemeval.py
+
+# Full options
+python scripts/benchmarks/benchmark_longmemeval.py \
+  --data-path data/longmemeval/longmemeval_s.json \
+  --granularity turn \
+  --top-k 5 10 \
+  --mode retrieval \
+  --limit 50 \
+  --markdown \
+  --output-dir results/benchmarks/
+```
+
+Flag naming is consistent with the existing LoCoMo CLI runner.
+
+---
+
+## Smoke Test (`test_benchmark_longmemeval.py`)
+
+- Uses 10 hardcoded questions (no HuggingFace dependency)
+- Runs in `pytest -m benchmark` (fast, CI-safe)
+- Verifies pipeline does not break after code changes
+- Does NOT assert specific metric values (avoids brittleness)
+
+---
+
+## Output
+
+- JSON file with timestamp → versionable, comparable over time
+- `--markdown` flag → ready for copy-paste into `docs/BENCHMARKS.md`
+
+---
+
+## Out of Scope (this PR)
+
+- `longmemeval_m` (multi-session variant)
+- MemBench ACL 2025
+- ConvoMem (Salesforce, 75K+ QA pairs)
+- LLM-based re-ranking (optional `--llm` flag can be added later)
+
+---
+
+## Success Criteria
+
+1. `python scripts/benchmarks/benchmark_longmemeval.py --limit 50` completes without errors
+2. R@5 score is computed and matches expected range for our retrieval quality
+3. Smoke test passes in CI (`pytest tests/benchmarks/test_benchmark_longmemeval.py`)
+4. `--markdown` output is copy-paste ready for BENCHMARKS.md

--- a/docs/plans/2026-04-07-longmemeval-benchmark.md
+++ b/docs/plans/2026-04-07-longmemeval-benchmark.md
@@ -1,0 +1,1053 @@
+# LongMemEval Benchmark Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a LongMemEval benchmark (R@5, R@10, NDCG@10) to directly compare MCP Memory Service against mempalace's headline 96.6% R@5 score.
+
+**Architecture:** Three new modules under `scripts/benchmarks/` following the LoCoMo pattern exactly: `longmemeval_dataset.py` (loader), `longmemeval_evaluator.py` (metrics), `benchmark_longmemeval.py` (CLI orchestrator). One smoke test in `tests/benchmarks/`. No new base classes.
+
+**Tech Stack:** Python 3.10+, `datasets` library (HuggingFace), `sqlite-vec`, existing `SqliteVecMemoryStorage`, existing `recall_at_k`/`mrr`/`precision_at_k` from `locomo_evaluator.py`.
+
+---
+
+## Context: LongMemEval Dataset Structure
+
+The HuggingFace dataset `xiaowu0162/longmemeval-cleaned` contains ~500 questions. Each item has:
+
+```python
+{
+  "qa_id": "q001",
+  "question": "What city did the user say they grew up in?",
+  "answer": "Portland",
+  "question_type": "single-session-user",  # category for per-type breakdown
+  "sessions": [
+    {
+      "session_id": "s1",
+      "turns": [
+        {"role": "user", "content": "I grew up in Portland."},
+        {"role": "assistant", "content": "That's a great city!"}
+      ]
+    },
+    ...
+  ],
+  "evidence_session_ids": ["s1"]  # which session(s) contain the answer
+}
+```
+
+**Evidence matching:** A retrieved memory is a hit if its `session_id` tag is in `evidence_session_ids`. Per question: R@K = 1 if any hit in top-K, else 0 (binary, since evidence is session-level). NDCG: relevance=1 for hit sessions, 0 otherwise.
+
+**Important:** The actual HuggingFace field names may differ slightly from the above. Task 1 includes a step to inspect the real data before writing the parser.
+
+---
+
+## Task 1: Inspect Real Dataset Structure
+
+**Files:**
+- No new files — discovery step only
+
+**Step 1: Install datasets library if needed**
+
+```bash
+pip install datasets
+```
+
+**Step 2: Inspect the real data structure**
+
+```python
+# Run this in a Python REPL or one-off script:
+from datasets import load_dataset
+ds = load_dataset("xiaowu0162/longmemeval-cleaned", split="test")
+print(ds.column_names)
+print(ds[0].keys())
+import json; print(json.dumps(dict(ds[0]), indent=2, default=str)[:3000])
+```
+
+Write down the actual field names before proceeding. The plan uses assumed names — adjust all subsequent tasks to match what you observe.
+
+**Step 3: Note the question_type values**
+
+```python
+types = set(item["question_type"] for item in ds)
+print(sorted(types))
+```
+
+These become the categories for per-type breakdown.
+
+**Step 4: Commit nothing** — this is discovery only.
+
+---
+
+## Task 2: Dataset Loader (`longmemeval_dataset.py`)
+
+**Files:**
+- Create: `scripts/benchmarks/longmemeval_dataset.py`
+
+**Step 1: Write a failing test first**
+
+Create `tests/benchmarks/test_longmemeval_dataset.py`:
+
+```python
+"""Tests for LongMemEval dataset loader."""
+import os
+import sys
+import json
+import tempfile
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+
+from longmemeval_dataset import (
+    LongMemEvalTurn,
+    LongMemEvalSession,
+    LongMemEvalItem,
+    parse_item,
+    load_dataset_from_file,
+)
+
+
+SAMPLE_ITEM = {
+    "qa_id": "q001",
+    "question": "What city did the user say they grew up in?",
+    "answer": "Portland",
+    "question_type": "single-session-user",
+    "sessions": [
+        {
+            "session_id": "s1",
+            "turns": [
+                {"role": "user", "content": "I grew up in Portland."},
+                {"role": "assistant", "content": "That's a great city!"},
+            ],
+        }
+    ],
+    "evidence_session_ids": ["s1"],
+}
+
+
+class TestParseItem:
+    def test_parses_qa_id(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.qa_id == "q001"
+
+    def test_parses_question(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.question == "What city did the user say they grew up in?"
+
+    def test_parses_answer(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.answer == "Portland"
+
+    def test_parses_question_type(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.question_type == "single-session-user"
+
+    def test_parses_sessions(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert len(item.sessions) == 1
+        assert item.sessions[0].session_id == "s1"
+        assert len(item.sessions[0].turns) == 2
+
+    def test_parses_evidence_session_ids(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.evidence_session_ids == ["s1"]
+
+    def test_parses_turns(self):
+        item = parse_item(SAMPLE_ITEM)
+        turn = item.sessions[0].turns[0]
+        assert turn.role == "user"
+        assert turn.content == "I grew up in Portland."
+
+
+class TestLoadDatasetFromFile:
+    def test_loads_list_of_items(self):
+        data = [SAMPLE_ITEM]
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            items = load_dataset_from_file(path)
+            assert len(items) == 1
+            assert items[0].qa_id == "q001"
+        finally:
+            os.unlink(path)
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/hkr/GitHub/mcp-memory-service
+pytest tests/benchmarks/test_longmemeval_dataset.py -v
+```
+
+Expected: `ImportError: No module named 'longmemeval_dataset'`
+
+**Step 3: Implement `longmemeval_dataset.py`**
+
+```python
+"""LongMemEval dataset loader and parser.
+
+Loads the LongMemEval benchmark dataset and provides typed data structures
+for benchmarking memory retrieval.
+
+Reference: https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned
+"""
+import json
+import logging
+import os
+import urllib.request
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# NOTE: adjust these field names if Task 1 inspection reveals different names
+HUGGINGFACE_DATASET = "xiaowu0162/longmemeval-cleaned"
+DEFAULT_DATA_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "data", "longmemeval"
+)
+DEFAULT_DATA_PATH = os.path.join(DEFAULT_DATA_DIR, "longmemeval_s.json")
+
+
+@dataclass
+class LongMemEvalTurn:
+    """A single turn in a conversation session."""
+    role: str      # "user" or "assistant"
+    content: str
+
+
+@dataclass
+class LongMemEvalSession:
+    """A conversation session containing multiple turns."""
+    session_id: str
+    turns: List[LongMemEvalTurn] = field(default_factory=list)
+
+
+@dataclass
+class LongMemEvalItem:
+    """A single benchmark question with its conversation context."""
+    qa_id: str
+    question: str
+    answer: str
+    question_type: str
+    sessions: List[LongMemEvalSession] = field(default_factory=list)
+    evidence_session_ids: List[str] = field(default_factory=list)
+
+
+def parse_item(raw: dict) -> LongMemEvalItem:
+    """Parse a single raw dict into a LongMemEvalItem.
+
+    NOTE: Adjust field names here if the real HuggingFace schema differs
+    from what was assumed in this plan.
+    """
+    sessions = []
+    for raw_session in raw.get("sessions", []):
+        turns = [
+            LongMemEvalTurn(role=t["role"], content=t["content"])
+            for t in raw_session.get("turns", [])
+        ]
+        sessions.append(LongMemEvalSession(
+            session_id=raw_session["session_id"],
+            turns=turns,
+        ))
+
+    return LongMemEvalItem(
+        qa_id=raw["qa_id"],
+        question=raw["question"],
+        answer=raw.get("answer", ""),
+        question_type=raw.get("question_type", "unknown"),
+        sessions=sessions,
+        evidence_session_ids=raw.get("evidence_session_ids", []),
+    )
+
+
+def load_dataset_from_file(path: str) -> List[LongMemEvalItem]:
+    """Load LongMemEval items from a local JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    return [parse_item(item) for item in raw]
+
+
+def _download_from_huggingface(target_path: str) -> None:
+    """Download dataset via HuggingFace datasets library and save as JSON."""
+    try:
+        from datasets import load_dataset as hf_load
+    except ImportError:
+        raise ImportError(
+            "Install 'datasets' to auto-download LongMemEval: pip install datasets"
+        )
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    logger.info("Downloading LongMemEval from HuggingFace (%s)...", HUGGINGFACE_DATASET)
+    ds = hf_load(HUGGINGFACE_DATASET, split="test")
+    data = [dict(item) for item in ds]
+    with open(target_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    logger.info("Saved %d items to %s", len(data), target_path)
+
+
+def load_dataset(
+    data_path: Optional[str] = None,
+    auto_download: bool = True,
+    limit: Optional[int] = None,
+) -> List[LongMemEvalItem]:
+    """Load the LongMemEval dataset.
+
+    Args:
+        data_path: Path to local JSON file. Defaults to data/longmemeval/longmemeval_s.json.
+        auto_download: If True, download from HuggingFace if not found locally.
+        limit: If set, return only the first N items.
+
+    Returns:
+        List of parsed LongMemEvalItem objects.
+    """
+    path = data_path or DEFAULT_DATA_PATH
+
+    if not os.path.exists(path):
+        if auto_download:
+            _download_from_huggingface(path)
+        else:
+            raise FileNotFoundError(f"Dataset not found: {path}")
+
+    items = load_dataset_from_file(path)
+    if limit is not None:
+        items = items[:limit]
+    return items
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/benchmarks/test_longmemeval_dataset.py -v
+```
+
+Expected: All tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/benchmarks/longmemeval_dataset.py tests/benchmarks/test_longmemeval_dataset.py
+git commit -m "feat(benchmarks): add LongMemEval dataset loader"
+```
+
+---
+
+## Task 3: Evaluator — NDCG@K metric
+
+**Files:**
+- Modify: `scripts/benchmarks/locomo_evaluator.py` — add `ndcg_at_k` function
+- Test: `tests/benchmarks/test_locomo_evaluator.py` (already exists — add to it, or create `test_longmemeval_evaluator.py`)
+
+**Background:** `recall_at_k`, `precision_at_k`, and `mrr` already exist in `locomo_evaluator.py`. We only need to add `ndcg_at_k`. Adding it to `locomo_evaluator.py` keeps metrics in one place (DRY).
+
+**Step 1: Write the failing test**
+
+Append to a new file `tests/benchmarks/test_ndcg.py`:
+
+```python
+"""Tests for ndcg_at_k metric."""
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+
+from locomo_evaluator import ndcg_at_k
+
+
+class TestNdcgAtK:
+    def test_perfect_ranking_returns_1(self):
+        # All relevant items at top
+        retrieved = ["a", "b", "c", "d", "e"]
+        relevant = {"a", "b"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == pytest.approx(1.0)
+
+    def test_no_relevant_items_returns_1(self):
+        # Edge case: no relevant items → perfect by convention (nothing to find)
+        assert ndcg_at_k([], set(), k=5) == 1.0
+
+    def test_relevant_at_bottom_returns_low_score(self):
+        retrieved = ["x", "x2", "x3", "x4", "a"]
+        relevant = {"a"}
+        score = ndcg_at_k(retrieved, relevant, k=5)
+        assert score < 0.5  # penalized for late position
+
+    def test_relevant_not_in_top_k_returns_0(self):
+        retrieved = ["x1", "x2", "x3", "x4", "x5", "a"]
+        relevant = {"a"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == 0.0
+
+    def test_single_relevant_at_top_returns_1(self):
+        retrieved = ["a", "x", "y"]
+        relevant = {"a"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == pytest.approx(1.0)
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/benchmarks/test_ndcg.py -v
+```
+
+Expected: `ImportError: cannot import name 'ndcg_at_k'`
+
+**Step 3: Add `ndcg_at_k` to `locomo_evaluator.py`**
+
+Add after the existing `mrr` function (around line 37):
+
+```python
+import math
+
+def ndcg_at_k(retrieved: List[str], relevant: Set[str], k: int) -> float:
+    """Normalized Discounted Cumulative Gain @K.
+
+    Relevance is binary (1 if item is relevant, 0 otherwise).
+    IDCG is computed assuming all relevant items appear at top positions.
+    Returns 1.0 when there are no relevant items (nothing to find = perfect).
+    """
+    if not relevant:
+        return 1.0
+
+    top_k = retrieved[:k]
+    dcg = sum(
+        1.0 / math.log2(i + 2)
+        for i, item in enumerate(top_k)
+        if item in relevant
+    )
+
+    # Ideal DCG: all relevant items placed at top positions (up to k)
+    ideal_hits = min(len(relevant), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(ideal_hits))
+
+    if idcg == 0.0:
+        return 1.0
+    return dcg / idcg
+```
+
+Also add `math` to the imports at the top of `locomo_evaluator.py` if not already present.
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+pytest tests/benchmarks/test_ndcg.py -v
+```
+
+Expected: All PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/benchmarks/locomo_evaluator.py tests/benchmarks/test_ndcg.py
+git commit -m "feat(benchmarks): add ndcg_at_k metric to locomo_evaluator"
+```
+
+---
+
+## Task 4: CLI Orchestrator (`benchmark_longmemeval.py`)
+
+**Files:**
+- Create: `scripts/benchmarks/benchmark_longmemeval.py`
+
+**Step 1: Write the smoke test first**
+
+Create `tests/benchmarks/test_benchmark_longmemeval.py`:
+
+```python
+"""Smoke tests for LongMemEval benchmark orchestrator.
+
+Uses hardcoded fixture data — no HuggingFace download required.
+"""
+import asyncio
+import os
+import shutil
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from longmemeval_dataset import (
+    LongMemEvalItem,
+    LongMemEvalSession,
+    LongMemEvalTurn,
+)
+from benchmark_longmemeval import (
+    create_isolated_storage,
+    ingest_item,
+    evaluate_retrieval,
+    run_ablation,
+)
+
+
+def _make_test_item() -> LongMemEvalItem:
+    return LongMemEvalItem(
+        qa_id="q001",
+        question="What city did the user say they grew up in?",
+        answer="Portland",
+        question_type="single-session-user",
+        sessions=[
+            LongMemEvalSession(
+                session_id="s1",
+                turns=[
+                    LongMemEvalTurn("user", "I grew up in Portland."),
+                    LongMemEvalTurn("assistant", "Portland is a great city!"),
+                ],
+            ),
+            LongMemEvalSession(
+                session_id="s2",
+                turns=[
+                    LongMemEvalTurn("user", "I enjoy hiking on weekends."),
+                    LongMemEvalTurn("assistant", "That sounds fun!"),
+                ],
+            ),
+        ],
+        evidence_session_ids=["s1"],
+    )
+
+
+class TestCreateIsolatedStorage:
+    def test_creates_storage(self):
+        storage, tmp_dir = create_isolated_storage()
+        assert storage is not None
+        assert os.path.isdir(tmp_dir)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+class TestIngestItem:
+    def test_ingest_stores_all_turns(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            count = asyncio.run(self._run(storage, item))
+            assert count == 4  # 2 sessions × 2 turns
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run(self, storage, item):
+        await storage.initialize()
+        return await ingest_item(storage, item)
+
+
+class TestEvaluateRetrieval:
+    def test_returns_metrics_dict(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            metrics = asyncio.run(self._run(storage, item))
+            assert "question_type" in metrics
+            assert "recall_at_5" in metrics
+            assert "recall_at_10" in metrics
+            assert "ndcg_at_10" in metrics
+            assert metrics["question_type"] == "single-session-user"
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run(self, storage, item):
+        await storage.initialize()
+        await ingest_item(storage, item)
+        return await evaluate_retrieval(storage, item, top_k=[5, 10])
+
+
+class TestAblation:
+    def test_returns_multiple_configs(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            results = asyncio.run(self._run(storage, item))
+            config_names = {r["config_name"] for r in results}
+            assert "baseline" in config_names
+            assert "+quality_boost" in config_names
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run(self, storage, item):
+        await storage.initialize()
+        await ingest_item(storage, item)
+        return await run_ablation(storage, item, top_k=[5])
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/benchmarks/test_benchmark_longmemeval.py -v
+```
+
+Expected: `ImportError: No module named 'benchmark_longmemeval'`
+
+**Step 3: Implement `benchmark_longmemeval.py`**
+
+```python
+#!/usr/bin/env python3
+"""LongMemEval Benchmark for MCP Memory Service.
+
+Measures R@5, R@10, NDCG@10 on the LongMemEval dataset for direct
+comparison with mempalace benchmark scores.
+
+Reference: https://github.com/milla-jovovich/mempalace
+"""
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+from longmemeval_dataset import LongMemEvalItem, load_dataset
+from locomo_evaluator import (
+    BenchmarkResult,
+    aggregate_results,
+    mrr,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_isolated_storage() -> Tuple[SqliteVecMemoryStorage, str]:
+    """Create isolated SQLite-Vec storage in temp dir. Returns (storage, tmp_dir)."""
+    tmp_dir = tempfile.mkdtemp(prefix="longmemeval-bench-")
+    db_path = os.path.join(tmp_dir, "memories.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    return storage, tmp_dir
+
+
+async def ingest_item(storage: SqliteVecMemoryStorage, item: LongMemEvalItem) -> int:
+    """Store all turns from all sessions as memories. Returns count stored."""
+    stored = 0
+    for session in item.sessions:
+        for turn_idx, turn in enumerate(session.turns):
+            content = turn.content.strip()
+            if not content:
+                continue
+            content_hash = hashlib.sha256(
+                f"{item.qa_id}:{session.session_id}:{turn_idx}:{content}".encode()
+            ).hexdigest()
+            memory = Memory(
+                content=content,
+                content_hash=content_hash,
+                tags=["longmemeval", item.qa_id, session.session_id, turn.role],
+                memory_type="conversation_turn",
+            )
+            success, _ = await storage.store(memory, skip_semantic_dedup=True)
+            if success:
+                stored += 1
+    return stored
+
+
+def _match_evidence(
+    retrieved_results,
+    evidence_session_ids: List[str],
+) -> Tuple[List[str], set]:
+    """Match retrieved memories against evidence via session_id tags.
+
+    Returns (retrieved_labels, relevant_labels).
+    A memory is a hit if its session_id tag matches any evidence_session_id.
+    """
+    relevant_labels = set(evidence_session_ids)
+    retrieved_labels = []
+    for result in retrieved_results:
+        tags = result.memory.tags or []
+        matched = None
+        for sid in evidence_session_ids:
+            if sid in tags:
+                matched = sid
+                break
+        retrieved_labels.append(matched if matched else f"irrelevant_{len(retrieved_labels)}")
+    return retrieved_labels, relevant_labels
+
+
+async def evaluate_retrieval(
+    storage: SqliteVecMemoryStorage,
+    item: LongMemEvalItem,
+    top_k: Optional[List[int]] = None,
+) -> Dict:
+    """Retrieve memories for the question and compute metrics. Returns metrics dict."""
+    if top_k is None:
+        top_k = [5, 10]
+    max_k = max(top_k)
+
+    results = await storage.retrieve(item.question, n_results=max_k)
+    retrieved_labels, relevant_labels = _match_evidence(results, item.evidence_session_ids)
+
+    metrics: Dict = {"question_type": item.question_type}
+    for k in top_k:
+        metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+        metrics[f"precision_at_{k}"] = precision_at_k(retrieved_labels, relevant_labels, k)
+    metrics["ndcg_at_10"] = ndcg_at_k(retrieved_labels, relevant_labels, k=10)
+    metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+    return metrics
+
+
+async def run_ablation(
+    storage: SqliteVecMemoryStorage,
+    item: LongMemEvalItem,
+    top_k: Optional[List[int]] = None,
+) -> List[Dict]:
+    """Compare retrieval configurations: baseline vs quality_boost."""
+    if top_k is None:
+        top_k = [5, 10]
+    max_k = max(top_k)
+
+    configs = [
+        ("baseline", "retrieve", {}),
+        ("+quality_boost", "retrieve_with_quality_boost", {}),
+        ("+quality_w0.5", "retrieve_with_quality_boost", {"quality_weight": 0.5}),
+    ]
+
+    all_results: List[Dict] = []
+    for config_name, method_name, extra_kwargs in configs:
+        retrieve_fn = getattr(storage, method_name)
+        results = await retrieve_fn(item.question, n_results=max_k, **extra_kwargs)
+        retrieved_labels, relevant_labels = _match_evidence(results, item.evidence_session_ids)
+        metrics: Dict = {"config_name": config_name, "question_type": item.question_type}
+        for k in top_k:
+            metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+        metrics["ndcg_at_10"] = ndcg_at_k(retrieved_labels, relevant_labels, k=10)
+        metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+        all_results.append(metrics)
+    return all_results
+
+
+def format_results_table(result: BenchmarkResult) -> str:
+    """Terminal table output."""
+    lines = [
+        "\n" + "=" * 60,
+        f"  LongMemEval Benchmark — {result.mode.upper()} mode",
+        "=" * 60,
+        "\nOverall Metrics:",
+        f"  {'Metric':<25} {'Value':>10}",
+        "  " + "-" * 35,
+    ]
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"  {key:<25} {val:>10.4f}")
+
+    if result.by_category:
+        lines.append("\nBy Question Type:")
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        header = f"  {'Type':<30}" + "".join(f"  {k:<18}" for k in all_metric_keys)
+        lines.append(header)
+        lines.append("  " + "-" * (30 + 20 * len(all_metric_keys)))
+        for cat, metrics in sorted(result.by_category.items()):
+            row = f"  {cat:<30}" + "".join(
+                f"  {metrics.get(k, 0.0):<18.4f}" for k in all_metric_keys
+            )
+            lines.append(row)
+
+    lines.append("\n" + "=" * 60 + "\n")
+    return "\n".join(lines)
+
+
+def format_results_markdown(result: BenchmarkResult) -> str:
+    """Markdown table output — ready for copy-paste into BENCHMARKS.md."""
+    lines = [
+        f"## LongMemEval Benchmark — {result.mode.upper()} mode",
+        "",
+        "### Overall Metrics",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+    ]
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"| {key} | {val:.4f} |")
+    lines.append("")
+
+    if result.by_category:
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        lines.append("### By Question Type")
+        lines.append("")
+        header = "| Type | " + " | ".join(all_metric_keys) + " |"
+        separator = "|------|" + "|".join(["--------"] * len(all_metric_keys)) + "|"
+        lines.append(header)
+        lines.append(separator)
+        for cat, metrics in sorted(result.by_category.items()):
+            row = (
+                f"| {cat} | "
+                + " | ".join(f"{metrics.get(k, 0.0):.4f}" for k in all_metric_keys)
+                + " |"
+            )
+            lines.append(row)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_results(result: BenchmarkResult, output_dir: str) -> str:
+    """Save results as JSON. Returns filepath."""
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"longmemeval_{result.mode}_{timestamp}.json"
+    filepath = os.path.join(output_dir, filename)
+    data = {
+        "mode": result.mode,
+        "overall": result.overall,
+        "by_category": result.by_category,
+        "config": result.config,
+        "timestamp": timestamp,
+    }
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    logger.info("Results saved to %s", filepath)
+    return filepath
+
+
+async def run_benchmark(args: argparse.Namespace) -> BenchmarkResult:
+    """Full pipeline: load dataset, per-item ingest+evaluate, aggregate."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    top_k = args.top_k if args.top_k else [5, 10]
+    limit = getattr(args, "limit", None)
+    data_path = getattr(args, "data_path", None)
+
+    logger.info("Loading LongMemEval dataset...")
+    items = load_dataset(data_path=data_path, limit=limit)
+    logger.info("Loaded %d items", len(items))
+
+    all_per_question: List[Dict] = []
+
+    for i, item in enumerate(items):
+        if i % 50 == 0:
+            logger.info("Progress: %d/%d", i, len(items))
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            await storage.initialize()
+            await ingest_item(storage, item)
+
+            if args.mode == "retrieval":
+                metrics = await evaluate_retrieval(storage, item, top_k=top_k)
+                # rename question_type → category for aggregate_results compatibility
+                metrics["category"] = metrics.pop("question_type")
+                all_per_question.append(metrics)
+            elif args.mode == "ablation":
+                ablation_results = await run_ablation(storage, item, top_k=top_k)
+                for r in ablation_results:
+                    r["category"] = r.pop("question_type")
+                all_per_question.extend(ablation_results)
+            else:
+                raise ValueError(f"Unknown mode: {args.mode}")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    config = {"mode": args.mode, "top_k": top_k, "num_items": len(items)}
+
+    if args.mode == "ablation":
+        from collections import defaultdict
+        by_config = defaultdict(list)
+        for q in all_per_question:
+            by_config[q["config_name"]].append(q)
+        results = []
+        for config_name, questions in by_config.items():
+            r = aggregate_results(
+                questions, conversation_id="all",
+                mode=f"ablation:{config_name}", config=config,
+            )
+            results.append(r)
+        return results
+
+    return aggregate_results(
+        all_per_question, conversation_id="all", mode=args.mode, config=config,
+    )
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the LongMemEval benchmark against MCP Memory Service.",
+    )
+    parser.add_argument("--data-path", type=str, default=None,
+                        help="Path to local JSON file. Auto-downloads if not specified.")
+    parser.add_argument("--mode", choices=["retrieval", "ablation"], default="retrieval",
+                        help="Benchmark mode (default: retrieval)")
+    parser.add_argument("--top-k", type=int, nargs="+", default=[5, 10],
+                        help="Top-K values (default: 5 10)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit to first N items (for quick tests)")
+    parser.add_argument("--granularity", choices=["turn", "session"], default="turn",
+                        help="Ingestion granularity (default: turn)")
+    parser.add_argument("--markdown", action="store_true", default=False,
+                        help="Output results as Markdown table")
+    parser.add_argument("--output-dir", type=str, default=None,
+                        help="Directory to save JSON results")
+    return parser.parse_args(argv)
+
+
+def main():
+    args = parse_args()
+    result = asyncio.run(run_benchmark(args))
+
+    results = result if isinstance(result, list) else [result]
+    for r in results:
+        if args.markdown:
+            print(format_results_markdown(r))
+        else:
+            print(format_results_table(r))
+
+    if args.output_dir:
+        filepath = None
+        for r in results:
+            filepath = save_results(r, args.output_dir)
+        if filepath:
+            print(f"Results saved to: {filepath}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 4: Run smoke tests**
+
+```bash
+pytest tests/benchmarks/test_benchmark_longmemeval.py -v
+```
+
+Expected: All PASS.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/benchmarks/benchmark_longmemeval.py tests/benchmarks/test_benchmark_longmemeval.py
+git commit -m "feat(benchmarks): add LongMemEval benchmark orchestrator"
+```
+
+---
+
+## Task 5: End-to-End Smoke Run
+
+**Files:** No new files.
+
+**Step 1: Run with --limit 5 to verify the full pipeline**
+
+```bash
+cd /Users/hkr/GitHub/mcp-memory-service
+python scripts/benchmarks/benchmark_longmemeval.py --limit 5
+```
+
+Expected: Processes 5 items, prints a metrics table. No errors.
+
+**Step 2: Test --markdown flag**
+
+```bash
+python scripts/benchmarks/benchmark_longmemeval.py --limit 5 --markdown
+```
+
+Expected: Markdown table output.
+
+**Step 3: Test --output-dir**
+
+```bash
+mkdir -p /tmp/lme-results
+python scripts/benchmarks/benchmark_longmemeval.py --limit 5 --output-dir /tmp/lme-results
+ls /tmp/lme-results/
+```
+
+Expected: JSON file created.
+
+**Step 4: Run full pytest suite to verify nothing is broken**
+
+```bash
+pytest tests/ -x -q --ignore=tests/benchmarks
+```
+
+Expected: All existing tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add .
+git commit -m "test(benchmarks): verify LongMemEval end-to-end smoke run"
+```
+
+---
+
+## Task 6: Adjust Field Names (if needed)
+
+If Task 1 revealed that the real HuggingFace field names differ from the plan's assumptions, update `longmemeval_dataset.py`'s `parse_item()` function accordingly.
+
+Common differences to check:
+- `evidence_session_ids` might be `evidence_sessions`, `answer_session_ids`, or similar
+- `question_type` might be `type`, `category`, or similar
+- `role` in turns might be `speaker`
+
+After adjusting:
+```bash
+pytest tests/benchmarks/test_longmemeval_dataset.py -v
+python scripts/benchmarks/benchmark_longmemeval.py --limit 5
+git add scripts/benchmarks/longmemeval_dataset.py
+git commit -m "fix(benchmarks): adjust LongMemEval field names to match real dataset schema"
+```
+
+---
+
+## Task 7: Full 500-Question Run & Document Results
+
+**Files:**
+- Modify: `docs/BENCHMARKS.md` (create if it doesn't exist)
+
+**Step 1: Run the full benchmark**
+
+```bash
+python scripts/benchmarks/benchmark_longmemeval.py \
+  --top-k 5 10 \
+  --markdown \
+  --output-dir results/benchmarks/ \
+  2>&1 | tee /tmp/longmemeval_run.log
+```
+
+This will take several minutes (500 items × ingest + retrieve per item).
+
+**Step 2: Check if BENCHMARKS.md exists**
+
+```bash
+ls docs/BENCHMARKS.md 2>/dev/null || echo "does not exist"
+```
+
+**Step 3: Create or update docs/BENCHMARKS.md**
+
+Add a section with the `--markdown` output from Step 1. Include:
+- Date of run
+- Number of items evaluated
+- MCP Memory Service version
+- Comparison note: "mempalace baseline: 96.6% R@5 (zero API calls)"
+
+**Step 4: Commit results**
+
+```bash
+git add docs/BENCHMARKS.md results/benchmarks/
+git commit -m "docs(benchmarks): add LongMemEval benchmark results"
+```
+
+---
+
+## Success Criteria
+
+1. `pytest tests/benchmarks/test_longmemeval_dataset.py` — PASS
+2. `pytest tests/benchmarks/test_benchmark_longmemeval.py` — PASS
+3. `pytest tests/benchmarks/test_ndcg.py` — PASS
+4. `python scripts/benchmarks/benchmark_longmemeval.py --limit 5` — completes without errors
+5. `python scripts/benchmarks/benchmark_longmemeval.py --markdown` — produces copy-paste ready output
+6. R@5 and R@10 scores are computed and documented in `docs/BENCHMARKS.md`
+
+---
+
+## Notes for Implementer
+
+- **Always inspect real data first** (Task 1) before writing the parser — CLAUDE.md explicitly warns: "Never trust API docs or project pages alone — real JSON structures often differ from descriptions."
+- The `--limit` flag is your friend during development. Use `--limit 10` for fast iteration.
+- The `datasets` library download may take a minute on first run — it caches locally under `data/longmemeval/`.
+- If `retrieve_with_quality_boost` doesn't exist on `SqliteVecMemoryStorage`, check the actual method name with `dir(storage)` or grep the source.

--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""LongMemEval Benchmark for MCP Memory Service."""
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+from longmemeval_dataset import LongMemEvalItem, load_dataset
+from locomo_evaluator import (
+    BenchmarkResult,
+    aggregate_results,
+    mrr,
+    ndcg_at_k,
+    recall_at_k,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_isolated_storage() -> Tuple[SqliteVecMemoryStorage, str]:
+    """Create isolated SQLite-Vec storage in temp dir. Returns (storage, tmp_dir)."""
+    tmp_dir = tempfile.mkdtemp(prefix="longmemeval-bench-")
+    db_path = os.path.join(tmp_dir, "memories.db")
+    storage = SqliteVecMemoryStorage(db_path)
+    return storage, tmp_dir
+
+
+async def ingest_item(storage: SqliteVecMemoryStorage, item: LongMemEvalItem) -> int:
+    """Store conversation turns as memories. Returns count of stored memories."""
+    stored = 0
+    for session in item.sessions:
+        for turn_idx, turn in enumerate(session.turns):
+            content = turn.content
+            if not content or not content.strip():
+                continue
+            content_hash = hashlib.sha256(
+                f"{item.question_id}:{session.session_id}:{turn_idx}:{content}".encode()
+            ).hexdigest()
+            tags = ["longmemeval", item.question_id, session.session_id, turn.role]
+            memory = Memory(
+                content=content,
+                content_hash=content_hash,
+                tags=tags,
+                memory_type="conversation_turn",
+            )
+            success, _ = await storage.store(memory, skip_semantic_dedup=True)
+            if success:
+                stored += 1
+    return stored
+
+
+def _match_evidence(
+    retrieved_results,
+    answer_session_ids: List[str],
+) -> Tuple[List[str], set]:
+    """Match retrieved memories against evidence via session_id tags.
+
+    A retrieved memory is a hit if any answer_session_id appears in its tags.
+
+    Returns (retrieved_labels, relevant_labels).
+    """
+    relevant_labels = set(answer_session_ids)
+
+    retrieved_labels = []
+    for i, result in enumerate(retrieved_results):
+        tags = result.memory.tags or []
+        matched_label = None
+        for session_id in answer_session_ids:
+            if session_id in tags:
+                matched_label = session_id
+                break
+        if matched_label:
+            retrieved_labels.append(matched_label)
+        else:
+            retrieved_labels.append(f"irrelevant_{i}")
+
+    return retrieved_labels, relevant_labels
+
+
+async def evaluate_retrieval(
+    storage: SqliteVecMemoryStorage,
+    item: LongMemEvalItem,
+    top_k: Optional[List[int]] = None,
+) -> Dict:
+    """Search memories for the question, compute retrieval metrics.
+
+    Returns a dict with question_type and recall/ndcg/mrr metrics.
+    """
+    if top_k is None:
+        top_k = [5, 10]
+    max_k = max(top_k)
+
+    results = await storage.retrieve(item.question, n_results=max_k)
+    retrieved_labels, relevant_labels = _match_evidence(results, item.answer_session_ids)
+
+    metrics: Dict = {"question_type": item.question_type}
+    for k in top_k:
+        metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+    metrics["ndcg_at_10"] = ndcg_at_k(retrieved_labels, relevant_labels, 10)
+    metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+
+    return metrics
+
+
+async def run_ablation(
+    storage: SqliteVecMemoryStorage,
+    item: LongMemEvalItem,
+    top_k: Optional[List[int]] = None,
+) -> List[Dict]:
+    """Compare retrieval configurations: baseline, +quality_boost, +quality_w0.5.
+
+    Returns list of dicts each with config_name, question_type, and metrics.
+    """
+    if top_k is None:
+        top_k = [5, 10]
+    max_k = max(top_k)
+
+    configs = [
+        ("baseline", "retrieve", {}),
+        ("+quality_boost", "retrieve_with_quality_boost", {}),
+        ("+quality_w0.5", "retrieve_with_quality_boost", {"quality_weight": 0.5}),
+    ]
+
+    all_results: List[Dict] = []
+
+    for config_name, method_name, extra_kwargs in configs:
+        retrieve_fn = getattr(storage, method_name)
+        results = await retrieve_fn(item.question, n_results=max_k, **extra_kwargs)
+        retrieved_labels, relevant_labels = _match_evidence(results, item.answer_session_ids)
+
+        metrics: Dict = {"config_name": config_name, "question_type": item.question_type}
+        for k in top_k:
+            metrics[f"recall_at_{k}"] = recall_at_k(retrieved_labels, relevant_labels, k)
+        metrics["ndcg_at_10"] = ndcg_at_k(retrieved_labels, relevant_labels, 10)
+        metrics["mrr"] = mrr(retrieved_labels, relevant_labels)
+
+        all_results.append(metrics)
+
+    return all_results
+
+
+def format_results_table(result: BenchmarkResult) -> str:
+    """Terminal table output."""
+    lines = []
+    lines.append("\n" + "=" * 60)
+    lines.append(f"  LongMemEval Benchmark — {result.mode.upper()} mode")
+    lines.append(f"  Dataset: {result.conversation_id}")
+    lines.append("=" * 60)
+
+    lines.append("\nOverall Metrics:")
+    lines.append(f"  {'Metric':<25} {'Value':>10}")
+    lines.append("  " + "-" * 35)
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"  {key:<25} {val:>10.4f}")
+
+    if result.by_category:
+        lines.append("\nBy Question Type:")
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        header = f"  {'Question Type':<25}" + "".join(f"  {k:<18}" for k in all_metric_keys)
+        lines.append(header)
+        lines.append("  " + "-" * (25 + 20 * len(all_metric_keys)))
+        for cat, metrics in sorted(result.by_category.items()):
+            row = f"  {cat:<25}" + "".join(
+                f"  {metrics.get(k, 0.0):<18.4f}" for k in all_metric_keys
+            )
+            lines.append(row)
+
+    lines.append("\n" + "=" * 60 + "\n")
+    return "\n".join(lines)
+
+
+def format_results_markdown(result: BenchmarkResult) -> str:
+    """Markdown table output."""
+    lines = []
+    lines.append(f"## LongMemEval Benchmark — {result.mode.upper()} mode")
+    lines.append(f"**Dataset:** {result.conversation_id}  ")
+    lines.append("")
+    lines.append("### Overall Metrics")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    for key, val in sorted(result.overall.items()):
+        lines.append(f"| {key} | {val:.4f} |")
+    lines.append("")
+
+    if result.by_category:
+        all_metric_keys = sorted(
+            {k for cat_metrics in result.by_category.values() for k in cat_metrics}
+        )
+        lines.append("### By Question Type")
+        lines.append("")
+        header = "| Question Type | " + " | ".join(all_metric_keys) + " |"
+        separator = "|---------------|" + "|".join(["--------"] * len(all_metric_keys)) + "|"
+        lines.append(header)
+        lines.append(separator)
+        for cat, metrics in sorted(result.by_category.items()):
+            row = (
+                f"| {cat} | "
+                + " | ".join(f"{metrics.get(k, 0.0):.4f}" for k in all_metric_keys)
+                + " |"
+            )
+            lines.append(row)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_results(result: BenchmarkResult, output_dir: str) -> str:
+    """Save results as JSON. Returns filepath."""
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"longmemeval_{result.mode}_{timestamp}.json"
+    filepath = os.path.join(output_dir, filename)
+    data = {
+        "conversation_id": result.conversation_id,
+        "mode": result.mode,
+        "overall": result.overall,
+        "by_category": result.by_category,
+        "by_conversation": result.by_conversation,
+        "config": result.config,
+    }
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    logger.info("Results saved to %s", filepath)
+    return filepath
+
+
+async def run_benchmark(args: argparse.Namespace):
+    """Full pipeline: load dataset, per-item ingest+evaluate, aggregate."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    top_k = args.top_k if args.top_k else [5, 10]
+    data_path = getattr(args, "data_path", None)
+    limit = getattr(args, "limit", None)
+
+    logger.info("Loading LongMemEval dataset...")
+    items = load_dataset(data_path=data_path, limit=limit)
+    logger.info("Loaded %d items", len(items))
+
+    all_per_item: List[Dict] = []
+
+    for i, item in enumerate(items):
+        if i > 0 and i % 50 == 0:
+            logger.info("Progress: %d/%d items processed", i, len(items))
+
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            await storage.initialize()
+            count = await ingest_item(storage, item)
+            logger.debug("Ingested %d turns for item %s", count, item.question_id)
+
+            if args.mode == "retrieval":
+                metrics = await evaluate_retrieval(storage, item, top_k=top_k)
+                # rename question_type -> category for aggregate_results compatibility
+                metrics["category"] = metrics.pop("question_type")
+                all_per_item.append(metrics)
+            elif args.mode == "ablation":
+                per_config = await run_ablation(storage, item, top_k=top_k)
+                for m in per_config:
+                    m["category"] = m.pop("question_type")
+                all_per_item.extend(per_config)
+            else:
+                raise ValueError(f"Unknown mode: {args.mode}")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    config = {
+        "mode": args.mode,
+        "top_k": top_k,
+        "num_items": len(items),
+    }
+
+    if args.mode == "ablation":
+        by_config: Dict[str, List[Dict]] = defaultdict(list)
+        for q in all_per_item:
+            by_config[q["config_name"]].append(q)
+        results = []
+        for config_name, questions in by_config.items():
+            r = aggregate_results(
+                questions,
+                conversation_id="all",
+                mode=f"ablation:{config_name}",
+                config=config,
+            )
+            results.append(r)
+        return results
+
+    result = aggregate_results(
+        all_per_item,
+        conversation_id="all",
+        mode=args.mode,
+        config=config,
+    )
+    return result
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """CLI args."""
+    parser = argparse.ArgumentParser(
+        description="Run the LongMemEval benchmark against MCP Memory Service.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=None,
+        help="Path to longmemeval_s.json. Auto-downloads if not specified.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["retrieval", "ablation"],
+        default="retrieval",
+        help="Benchmark mode (default: retrieval)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        nargs="+",
+        default=[5, 10],
+        help="Top-K values for retrieval metrics (default: 5 10)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of items to evaluate (default: all)",
+    )
+    parser.add_argument(
+        "--granularity",
+        choices=["turn", "session"],
+        default="turn",
+        help="Storage granularity: turn (default) or session (reserved for future use)",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        default=False,
+        help="Output results as Markdown table",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Directory to save JSON results (optional)",
+    )
+    return parser.parse_args(argv)
+
+
+def main():
+    """Entry point."""
+    args = parse_args()
+    result = asyncio.run(run_benchmark(args))
+
+    # Ablation returns a list of results (one per config)
+    results = result if isinstance(result, list) else [result]
+
+    for r in results:
+        if args.markdown:
+            print(format_results_markdown(r))
+        else:
+            print(format_results_table(r))
+
+    if args.output_dir:
+        for r in results:
+            filepath = save_results(r, args.output_dir)
+        print(f"Results saved to: {filepath}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
@@ -65,7 +65,7 @@ async def ingest_item(storage: SqliteVecMemoryStorage, item: LongMemEvalItem) ->
 def _match_evidence(
     retrieved_results,
     answer_session_ids: List[str],
-) -> Tuple[List[str], set]:
+) -> Tuple[List[str], Set[str]]:
     """Match retrieved memories against evidence via session_id tags.
 
     A retrieved memory is a hit if any answer_session_id appears in its tags.
@@ -137,6 +137,9 @@ async def run_ablation(
     all_results: List[Dict] = []
 
     for config_name, method_name, extra_kwargs in configs:
+        if not hasattr(storage, method_name):
+            logger.warning("Storage does not support method %s, skipping config %s", method_name, config_name)
+            continue
         retrieve_fn = getattr(storage, method_name)
         results = await retrieve_fn(item.question, n_results=max_k, **extra_kwargs)
         retrieved_labels, relevant_labels = _match_evidence(results, item.answer_session_ids)
@@ -227,6 +230,7 @@ def save_results(result: BenchmarkResult, output_dir: str) -> str:
     filename = f"longmemeval_{result.mode}_{timestamp}.json"
     filepath = os.path.join(output_dir, filename)
     data = {
+        "timestamp": timestamp,
         "conversation_id": result.conversation_id,
         "mode": result.mode,
         "overall": result.overall,

--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -66,21 +66,25 @@ def _match_evidence(
     retrieved_results,
     answer_session_ids: List[str],
 ) -> Tuple[List[str], Set[str]]:
-    """Match retrieved memories against evidence via session_id tags.
+    """Match retrieved memories against evidence session IDs.
 
-    A retrieved memory is a hit if any answer_session_id appears in its tags.
+    Each evidence session can only be credited once (first occurrence in top-K).
+    Subsequent retrieval of the same session are counted as irrelevant to avoid
+    recall > 1.0 when multiple turns from the same session are retrieved.
 
     Returns (retrieved_labels, relevant_labels).
     """
     relevant_labels = set(answer_session_ids)
 
     retrieved_labels = []
+    already_matched: Set[str] = set()
     for i, result in enumerate(retrieved_results):
         tags = result.memory.tags or []
         matched_label = None
         for session_id in answer_session_ids:
-            if session_id in tags:
+            if session_id in tags and session_id not in already_matched:
                 matched_label = session_id
+                already_matched.add(session_id)
                 break
         if matched_label:
             retrieved_labels.append(matched_label)

--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -389,7 +389,7 @@ def main():
     if args.output_dir:
         for r in results:
             filepath = save_results(r, args.output_dir)
-        print(f"Results saved to: {filepath}")
+            print(f"Results saved to: {filepath}")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/locomo_evaluator.py
+++ b/scripts/benchmarks/locomo_evaluator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Set
@@ -33,6 +34,33 @@ def mrr(retrieved: List[str], relevant: Set[str]) -> float:
         if item in relevant:
             return 1.0 / i
     return 0.0
+
+
+def ndcg_at_k(retrieved: List[str], relevant: Set[str], k: int) -> float:
+    """Normalized Discounted Cumulative Gain @K.
+
+    Relevance is binary (1 if item in relevant set, 0 otherwise).
+    IDCG assumes all relevant items appear at top positions (ideal ranking).
+    Returns 1.0 when relevant is empty (nothing to find = perfect by convention).
+    """
+    if not relevant:
+        return 1.0
+    if k == 0:
+        return 1.0 if not relevant else 0.0
+
+    top_k = retrieved[:k]
+    dcg = sum(
+        1.0 / math.log2(i + 2)
+        for i, item in enumerate(top_k)
+        if item in relevant
+    )
+
+    ideal_hits = min(len(relevant), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(ideal_hits))
+
+    if idcg == 0.0:
+        return 1.0
+    return dcg / idcg
 
 
 def token_f1(predicted: str, gold: str) -> float:

--- a/scripts/benchmarks/longmemeval_dataset.py
+++ b/scripts/benchmarks/longmemeval_dataset.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +68,11 @@ def parse_item(raw: dict) -> LongMemEvalItem:
     """
     session_ids = raw.get("haystack_session_ids", [])
     raw_sessions = raw.get("haystack_sessions", [])
+    if len(session_ids) != len(raw_sessions):
+        logger.warning(
+            "question_id %s: haystack_session_ids length (%d) != haystack_sessions length (%d)",
+            raw.get("question_id", "unknown"), len(session_ids), len(raw_sessions),
+        )
 
     sessions: List[LongMemEvalSession] = []
     for sid, raw_session in zip(session_ids, raw_sessions):

--- a/scripts/benchmarks/longmemeval_dataset.py
+++ b/scripts/benchmarks/longmemeval_dataset.py
@@ -1,0 +1,156 @@
+"""LongMemEval dataset loader and parser.
+
+Loads the LongMemEval benchmark dataset from HuggingFace or a local JSON file
+and provides typed data structures for benchmarking memory retrieval.
+
+Reference: https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned
+"""
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+HUGGINGFACE_DATASET = "xiaowu0162/longmemeval-cleaned"
+DEFAULT_DATA_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "data", "longmemeval"
+)
+DEFAULT_DATA_PATH = os.path.join(DEFAULT_DATA_DIR, "longmemeval_s.json")
+
+
+@dataclass
+class LongMemEvalTurn:
+    """A single conversation turn."""
+    role: str       # "user" or "assistant"
+    content: str
+
+
+@dataclass
+class LongMemEvalSession:
+    """A single conversation session with an ID and list of turns."""
+    session_id: str
+    turns: List[LongMemEvalTurn] = field(default_factory=list)
+
+
+@dataclass
+class LongMemEvalItem:
+    """A single LongMemEval benchmark item (question + haystack sessions)."""
+    question_id: str
+    question: str
+    answer: str
+    question_type: str
+    sessions: List[LongMemEvalSession] = field(default_factory=list)
+    answer_session_ids: List[str] = field(default_factory=list)
+
+
+def _parse_turn(raw_turn) -> LongMemEvalTurn:
+    """Parse a turn from either a JSON string or a dict."""
+    if isinstance(raw_turn, str):
+        turn_data = json.loads(raw_turn)
+    else:
+        turn_data = raw_turn
+    return LongMemEvalTurn(
+        role=turn_data["role"],
+        content=turn_data["content"],
+    )
+
+
+def parse_item(raw: dict) -> LongMemEvalItem:
+    """Parse a raw HuggingFace item into a LongMemEvalItem.
+
+    The raw item has:
+    - ``haystack_session_ids``: list of session ID strings
+    - ``haystack_sessions``: list of sessions, each a list of turns.
+      Turns may be JSON-encoded strings (longmemeval_s_cleaned split)
+      or plain dicts (oracle split).
+    """
+    session_ids = raw.get("haystack_session_ids", [])
+    raw_sessions = raw.get("haystack_sessions", [])
+
+    sessions: List[LongMemEvalSession] = []
+    for sid, raw_session in zip(session_ids, raw_sessions):
+        turns = [_parse_turn(t) for t in raw_session]
+        sessions.append(LongMemEvalSession(session_id=sid, turns=turns))
+
+    return LongMemEvalItem(
+        question_id=raw["question_id"],
+        question=raw["question"],
+        answer=raw["answer"],
+        question_type=raw["question_type"],
+        sessions=sessions,
+        answer_session_ids=list(raw.get("answer_session_ids", [])),
+    )
+
+
+def load_dataset_from_file(path: str) -> List[LongMemEvalItem]:
+    """Load LongMemEval items from a local JSON file.
+
+    Args:
+        path: Path to a JSON file containing a list of raw items.
+
+    Returns:
+        List of parsed LongMemEvalItem objects.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Dataset file not found: {path}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        raw_items = json.load(f)
+
+    return [parse_item(item) for item in raw_items]
+
+
+def _download_from_huggingface(target_path: str) -> None:
+    """Download the dataset from HuggingFace and save as JSON."""
+    try:
+        from datasets import load_dataset as hf_load_dataset
+    except ImportError as exc:
+        raise ImportError(
+            "The 'datasets' package is required to auto-download from HuggingFace. "
+            "Install it with: pip install datasets"
+        ) from exc
+
+    logger.info("Downloading %s (split=longmemeval_s_cleaned) ...", HUGGINGFACE_DATASET)
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    ds = hf_load_dataset(HUGGINGFACE_DATASET, split="longmemeval_s_cleaned")
+    with open(target_path, "w", encoding="utf-8") as f:
+        json.dump([dict(item) for item in ds], f)
+    logger.info("Saved to %s (%d items)", target_path, len(ds))
+
+
+def load_dataset(
+    data_path: Optional[str] = None,
+    auto_download: bool = True,
+    limit: Optional[int] = None,
+) -> List[LongMemEvalItem]:
+    """Load the LongMemEval dataset.
+
+    Args:
+        data_path: Path to a local JSON file. Defaults to
+            ``data/longmemeval/longmemeval_s.json``.
+        auto_download: If True (default), auto-download from HuggingFace when
+            the file is not found locally.
+        limit: If set, return only the first ``limit`` items.
+
+    Returns:
+        List of parsed LongMemEvalItem objects.
+    """
+    path = data_path or DEFAULT_DATA_PATH
+
+    if not os.path.exists(path):
+        if auto_download:
+            _download_from_huggingface(path)
+        else:
+            raise FileNotFoundError(f"Dataset not found: {path}")
+
+    items = load_dataset_from_file(path)
+
+    if limit is not None:
+        items = items[:limit]
+
+    return items

--- a/scripts/benchmarks/longmemeval_dataset.py
+++ b/scripts/benchmarks/longmemeval_dataset.py
@@ -111,21 +111,25 @@ def load_dataset_from_file(path: str) -> List[LongMemEvalItem]:
 
 
 def _download_from_huggingface(target_path: str) -> None:
-    """Download the dataset from HuggingFace and save as JSON."""
+    """Download dataset via HuggingFace datasets library and save as JSON."""
     try:
-        from datasets import load_dataset as hf_load_dataset
-    except ImportError as exc:
+        from datasets import load_dataset as hf_load
+    except ImportError:
         raise ImportError(
-            "The 'datasets' package is required to auto-download from HuggingFace. "
-            "Install it with: pip install datasets"
-        ) from exc
-
-    logger.info("Downloading %s (split=longmemeval_s_cleaned) ...", HUGGINGFACE_DATASET)
+            "Install 'datasets' to auto-download LongMemEval: pip install datasets"
+        )
     os.makedirs(os.path.dirname(target_path), exist_ok=True)
-    ds = hf_load_dataset(HUGGINGFACE_DATASET, split="longmemeval_s_cleaned")
+    logger.info(
+        "Downloading LongMemEval from HuggingFace (%s, split=%s)...",
+        HUGGINGFACE_DATASET, "longmemeval_s_cleaned",
+    )
+    # streaming=True avoids building the full Arrow cache for all splits,
+    # which prevents a pyarrow int32 overflow on the large longmemeval_m_cleaned split.
+    ds = hf_load(HUGGINGFACE_DATASET, split="longmemeval_s_cleaned", streaming=True)
+    data = [dict(item) for item in ds]
     with open(target_path, "w", encoding="utf-8") as f:
-        json.dump([dict(item) for item in ds], f)
-    logger.info("Saved to %s (%d items)", target_path, len(ds))
+        json.dump(data, f)
+    logger.info("Saved %d items to %s", len(data), target_path)
 
 
 def load_dataset(

--- a/tests/benchmarks/test_benchmark_longmemeval.py
+++ b/tests/benchmarks/test_benchmark_longmemeval.py
@@ -1,0 +1,110 @@
+"""Tests for the LongMemEval benchmark orchestrator."""
+import asyncio
+import os
+import shutil
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from longmemeval_dataset import LongMemEvalItem, LongMemEvalSession, LongMemEvalTurn
+from benchmark_longmemeval import (
+    create_isolated_storage,
+    ingest_item,
+    evaluate_retrieval,
+    run_ablation,
+)
+
+
+def _make_test_item() -> LongMemEvalItem:
+    return LongMemEvalItem(
+        question_id="q001",
+        question="What city did the user say they grew up in?",
+        answer="Portland",
+        question_type="single-session-user",
+        sessions=[
+            LongMemEvalSession(
+                session_id="session_001",
+                turns=[
+                    LongMemEvalTurn("user", "I grew up in Portland."),
+                    LongMemEvalTurn("assistant", "Portland is a great city!"),
+                ],
+            ),
+            LongMemEvalSession(
+                session_id="session_002",
+                turns=[
+                    LongMemEvalTurn("user", "I enjoy hiking on weekends."),
+                    LongMemEvalTurn("assistant", "That sounds fun!"),
+                ],
+            ),
+        ],
+        answer_session_ids=["session_001"],
+    )
+
+
+class TestCreateIsolatedStorage:
+    def test_creates_storage_and_tmpdir(self):
+        storage, tmp_dir = create_isolated_storage()
+        assert storage is not None
+        assert os.path.isdir(tmp_dir)
+        assert "longmemeval-bench-" in tmp_dir
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+class TestIngestItem:
+    def test_ingest_stores_all_turns(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            count = asyncio.run(self._run_ingest(storage, item))
+            # 2 sessions × 2 turns each = 4 turns total
+            assert count == 4
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_ingest(self, storage, item):
+        await storage.initialize()
+        return await ingest_item(storage, item)
+
+
+class TestEvaluateRetrieval:
+    def test_retrieval_returns_expected_keys(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            result = asyncio.run(self._run_retrieval(storage, item))
+            assert "question_type" in result
+            assert result["question_type"] == "single-session-user"
+            assert "recall_at_5" in result
+            assert "recall_at_10" in result
+            assert "ndcg_at_10" in result
+            assert "mrr" in result
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_retrieval(self, storage, item):
+        await storage.initialize()
+        await ingest_item(storage, item)
+        return await evaluate_retrieval(storage, item, top_k=[5, 10])
+
+
+class TestRunAblation:
+    def test_ablation_returns_list_with_config_names(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            results = asyncio.run(self._run_ablation(storage, item))
+            assert isinstance(results, list)
+            assert len(results) >= 2
+            assert all("config_name" in r for r in results)
+            config_names = {r["config_name"] for r in results}
+            assert "baseline" in config_names
+            assert "+quality_boost" in config_names
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_ablation(self, storage, item):
+        await storage.initialize()
+        await ingest_item(storage, item)
+        return await run_ablation(storage, item, top_k=[5, 10])

--- a/tests/benchmarks/test_benchmark_longmemeval.py
+++ b/tests/benchmarks/test_benchmark_longmemeval.py
@@ -10,11 +10,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from longmemeval_dataset import LongMemEvalItem, LongMemEvalSession, LongMemEvalTurn
 from benchmark_longmemeval import (
+    _match_evidence,
     create_isolated_storage,
     ingest_item,
     evaluate_retrieval,
     run_ablation,
 )
+from locomo_evaluator import recall_at_k
 
 
 def _make_test_item() -> LongMemEvalItem:
@@ -109,3 +111,54 @@ class TestRunAblation:
         await storage.initialize()
         await ingest_item(storage, item)
         return await run_ablation(storage, item, top_k=[5, 10])
+
+
+class TestMatchEvidence:
+    """Tests for _match_evidence de-duplication behavior."""
+
+    class _FakeMemory:
+        def __init__(self, tags):
+            self.tags = tags
+
+    class _FakeResult:
+        def __init__(self, tags):
+            self.memory = None
+
+        @classmethod
+        def make(cls, tags):
+            obj = cls.__new__(cls)
+            obj.memory = TestMatchEvidence._FakeMemory(tags)
+            return obj
+
+    def test_multiple_hits_same_session_count_once(self):
+        """Prevents recall > 1.0 when multiple turns from same session are retrieved."""
+        results = [
+            self._FakeResult.make(["longmemeval", "q1", "session_001", "user"]),
+            self._FakeResult.make(["longmemeval", "q1", "session_001", "assistant"]),
+            self._FakeResult.make(["longmemeval", "q1", "session_002", "user"]),
+        ]
+        retrieved, relevant = _match_evidence(results, ["session_001"])
+
+        # Only 1 hit (first occurrence of session_001), despite 2 results from it
+        hits = sum(1 for label in retrieved if label in relevant)
+        assert hits == 1
+
+    def test_recall_stays_between_0_and_1(self):
+        """Recall must not exceed 1.0 regardless of how many turns are retrieved."""
+        # 5 results all from the single evidence session
+        results = [self._FakeResult.make(["session_001"]) for _ in range(5)]
+        retrieved, relevant = _match_evidence(results, ["session_001"])
+        r = recall_at_k(retrieved, relevant, k=5)
+        assert 0.0 <= r <= 1.0
+
+    def test_multiple_sessions_each_credited_once(self):
+        """When multiple evidence sessions are retrieved, each is credited at most once."""
+        results = [
+            self._FakeResult.make(["session_001"]),
+            self._FakeResult.make(["session_001"]),  # duplicate — should be ignored
+            self._FakeResult.make(["session_002"]),
+            self._FakeResult.make(["session_002"]),  # duplicate — should be ignored
+        ]
+        retrieved, relevant = _match_evidence(results, ["session_001", "session_002"])
+        hits = sum(1 for label in retrieved if label in relevant)
+        assert hits == 2  # one hit per evidence session, not four

--- a/tests/benchmarks/test_benchmark_longmemeval.py
+++ b/tests/benchmarks/test_benchmark_longmemeval.py
@@ -96,11 +96,12 @@ class TestRunAblation:
         try:
             results = asyncio.run(self._run_ablation(storage, item))
             assert isinstance(results, list)
-            assert len(results) >= 2
+            assert len(results) == 3
             assert all("config_name" in r for r in results)
             config_names = {r["config_name"] for r in results}
             assert "baseline" in config_names
             assert "+quality_boost" in config_names
+            assert "+quality_w0.5" in config_names
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 

--- a/tests/benchmarks/test_longmemeval_dataset.py
+++ b/tests/benchmarks/test_longmemeval_dataset.py
@@ -1,0 +1,165 @@
+"""Tests for LongMemEval dataset loader."""
+import json
+import os
+import sys
+import pytest
+import tempfile
+
+# sys.path is set by conftest.py; this allows running the file standalone too
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from longmemeval_dataset import (
+    LongMemEvalTurn,
+    LongMemEvalSession,
+    LongMemEvalItem,
+    parse_item,
+    load_dataset_from_file,
+)
+
+# Sample item matching the REAL HuggingFace dataset structure
+SAMPLE_ITEM = {
+    "question_id": "gpt4_2655b836",
+    "question": "What was the first issue the user encountered?",
+    "answer": '"GPS system not functioning correctly"',
+    "question_type": "single-session-user",
+    "question_date": "2023/04/10 (Mon) 23:07",
+    "haystack_dates": ["2023/01/01", "2023/02/01"],
+    "haystack_session_ids": ["session_001", "session_002"],
+    "haystack_sessions": [
+        [
+            '{"role": "user", "content": "My GPS is broken."}',
+            '{"role": "assistant", "content": "Let me help with that."}',
+        ],
+        [
+            '{"role": "user", "content": "Also my screen flickers."}',
+        ],
+    ],
+    "answer_session_ids": ["session_001"],
+}
+
+
+class TestDataStructures:
+    def test_turn_fields(self):
+        turn = LongMemEvalTurn(role="user", content="Hello world")
+        assert turn.role == "user"
+        assert turn.content == "Hello world"
+
+    def test_session_fields(self):
+        turn = LongMemEvalTurn(role="user", content="Hello")
+        session = LongMemEvalSession(session_id="session_001", turns=[turn])
+        assert session.session_id == "session_001"
+        assert len(session.turns) == 1
+
+    def test_item_fields(self):
+        item = LongMemEvalItem(
+            question_id="q1",
+            question="What happened?",
+            answer="Something",
+            question_type="single-session-user",
+            sessions=[],
+            answer_session_ids=["session_001"],
+        )
+        assert item.question_id == "q1"
+        assert item.answer_session_ids == ["session_001"]
+
+
+class TestParseItem:
+    def test_extracts_question_id(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.question_id == "gpt4_2655b836"
+
+    def test_extracts_question(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.question == "What was the first issue the user encountered?"
+
+    def test_extracts_answer(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.answer == '"GPS system not functioning correctly"'
+
+    def test_extracts_question_type(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.question_type == "single-session-user"
+
+    def test_extracts_answer_session_ids(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.answer_session_ids == ["session_001"]
+
+    def test_builds_correct_number_of_sessions(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert len(item.sessions) == 2
+
+    def test_session_ids_from_parallel_list(self):
+        item = parse_item(SAMPLE_ITEM)
+        assert item.sessions[0].session_id == "session_001"
+        assert item.sessions[1].session_id == "session_002"
+
+    def test_session_turns_parsed_from_json_strings(self):
+        item = parse_item(SAMPLE_ITEM)
+        session0 = item.sessions[0]
+        assert len(session0.turns) == 2
+
+    def test_first_turn_role_and_content(self):
+        item = parse_item(SAMPLE_ITEM)
+        turn = item.sessions[0].turns[0]
+        assert turn.role == "user"
+        assert turn.content == "My GPS is broken."
+
+    def test_second_turn_role_and_content(self):
+        item = parse_item(SAMPLE_ITEM)
+        turn = item.sessions[0].turns[1]
+        assert turn.role == "assistant"
+        assert turn.content == "Let me help with that."
+
+    def test_second_session_turns(self):
+        item = parse_item(SAMPLE_ITEM)
+        session1 = item.sessions[1]
+        assert len(session1.turns) == 1
+        assert session1.turns[0].role == "user"
+        assert session1.turns[0].content == "Also my screen flickers."
+
+    def test_handles_turns_as_dicts(self):
+        """Oracle split may have turns as dicts instead of JSON strings."""
+        item_with_dicts = dict(SAMPLE_ITEM)
+        item_with_dicts["haystack_sessions"] = [
+            [
+                {"role": "user", "content": "My GPS is broken."},
+                {"role": "assistant", "content": "Let me help with that."},
+            ],
+            [
+                {"role": "user", "content": "Also my screen flickers."},
+            ],
+        ]
+        item = parse_item(item_with_dicts)
+        assert len(item.sessions) == 2
+        assert item.sessions[0].turns[0].role == "user"
+        assert item.sessions[0].turns[0].content == "My GPS is broken."
+
+
+class TestLoadDatasetFromFile:
+    def test_load_single_item(self, tmp_path):
+        data_file = tmp_path / "longmemeval_s.json"
+        data_file.write_text(json.dumps([SAMPLE_ITEM]))
+        items = load_dataset_from_file(str(data_file))
+        assert len(items) == 1
+        assert items[0].question_id == "gpt4_2655b836"
+
+    def test_load_multiple_items(self, tmp_path):
+        second_item = dict(SAMPLE_ITEM)
+        second_item["question_id"] = "gpt4_second"
+        data_file = tmp_path / "longmemeval_s.json"
+        data_file.write_text(json.dumps([SAMPLE_ITEM, second_item]))
+        items = load_dataset_from_file(str(data_file))
+        assert len(items) == 2
+        assert items[1].question_id == "gpt4_second"
+
+    def test_load_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_dataset_from_file("/nonexistent/path/longmemeval_s.json")
+
+    def test_loaded_items_have_sessions(self, tmp_path):
+        data_file = tmp_path / "longmemeval_s.json"
+        data_file.write_text(json.dumps([SAMPLE_ITEM]))
+        items = load_dataset_from_file(str(data_file))
+        assert len(items[0].sessions) == 2
+        assert items[0].sessions[0].session_id == "session_001"

--- a/tests/benchmarks/test_longmemeval_dataset.py
+++ b/tests/benchmarks/test_longmemeval_dataset.py
@@ -3,7 +3,6 @@ import json
 import os
 import sys
 import pytest
-import tempfile
 
 # sys.path is set by conftest.py; this allows running the file standalone too
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))

--- a/tests/benchmarks/test_ndcg.py
+++ b/tests/benchmarks/test_ndcg.py
@@ -1,0 +1,53 @@
+"""Tests for ndcg_at_k metric."""
+import math
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "benchmarks"))
+
+from locomo_evaluator import ndcg_at_k
+
+
+class TestNdcgAtK:
+    def test_perfect_ranking_single_relevant_returns_1(self):
+        retrieved = ["a", "b", "c", "d", "e"]
+        relevant = {"a"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == pytest.approx(1.0)
+
+    def test_perfect_ranking_two_relevant_returns_1(self):
+        retrieved = ["a", "b", "c", "d", "e"]
+        relevant = {"a", "b"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == pytest.approx(1.0)
+
+    def test_no_relevant_items_returns_1(self):
+        # Nothing to find = perfect score by convention
+        assert ndcg_at_k([], set(), k=5) == 1.0
+        assert ndcg_at_k(["a", "b"], set(), k=5) == 1.0
+
+    def test_relevant_not_in_top_k_returns_0(self):
+        retrieved = ["x1", "x2", "x3", "x4", "x5", "a"]
+        relevant = {"a"}
+        assert ndcg_at_k(retrieved, relevant, k=5) == 0.0
+
+    def test_relevant_at_bottom_of_top_k_scores_lower_than_top(self):
+        # "a" at position 1 (first)
+        top_score = ndcg_at_k(["a", "x", "y", "z", "w"], {"a"}, k=5)
+        # "a" at position 5 (last in top-5)
+        bottom_score = ndcg_at_k(["x", "y", "z", "w", "a"], {"a"}, k=5)
+        assert top_score > bottom_score
+
+    def test_empty_retrieved_with_relevant_returns_0(self):
+        assert ndcg_at_k([], {"a"}, k=5) == 0.0
+
+    def test_k_0_returns_1_for_empty_relevant(self):
+        assert ndcg_at_k([], set(), k=0) == 1.0
+
+    def test_uses_log2_discounting(self):
+        # Manual calculation: single relevant item at position 1
+        # DCG = 1/log2(2) = 1.0; IDCG = 1/log2(2) = 1.0; NDCG = 1.0
+        assert ndcg_at_k(["a"], {"a"}, k=1) == pytest.approx(1.0)
+        # Single relevant item at position 2 (0-indexed)
+        # DCG = 1/log2(3); IDCG = 1/log2(2); NDCG = log2(2)/log2(3)
+        expected = math.log2(2) / math.log2(3)
+        assert ndcg_at_k(["x", "a"], {"a"}, k=2) == pytest.approx(expected)


### PR DESCRIPTION
## Summary

- Implements the [LongMemEval](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned) benchmark (500 questions, ~45–62 distractor sessions per question) for direct comparison with other memory systems (e.g. mempalace)
- Adds `ndcg_at_k` metric to the shared evaluator (`locomo_evaluator.py`)
- Documents results in `docs/BENCHMARKS.md` and `README.md`

## Results (v10.33.0, zero LLM API calls)

| Metric | Score |
|--------|-------|
| R@5 | **80.4%** |
| R@10 | **90.4%** |
| NDCG@10 | **82.2%** |
| MRR | **89.1%** |

Comparison: mempalace (zero-LLM baseline) reports 96.6% R@5.

## New Files

- `scripts/benchmarks/longmemeval_dataset.py` — HuggingFace loader + data structures
- `scripts/benchmarks/benchmark_longmemeval.py` — CLI orchestrator (mirrors LoCoMo pattern)
- `tests/benchmarks/test_longmemeval_dataset.py` — 19 tests
- `tests/benchmarks/test_benchmark_longmemeval.py` — 8 smoke tests
- `tests/benchmarks/test_ndcg.py` — 8 metric tests
- `docs/BENCHMARKS.md` — benchmark results documentation

## Test Plan

- [x] 90/90 benchmark tests pass
- [x] 121/121 storage tests pass
- [x] Full 500-question run completed successfully
- [x] `--markdown`, `--limit`, `--output-dir` flags verified
- [x] Metrics correctly bounded to [0, 1]

🤖 Generated with [Claude Code](https://claude.ai/claude-code)