### PR TITLE
feat: add OpenCode memory awareness integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **OpenCode memory awareness integration**: Added an official `opencode/` integration with a minimal read-only plugin for session-start retrieval, system-context injection, and compaction-context injection via the documented HTTP API. Includes setup docs and example config for local OpenCode plugin installation.
+
 ## [10.35.0] - 2026-04-08
 
 ### Added
@@ -338,4 +342,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - 23 new regression tests covering all fixed methods
 - Total: 1,420 tests
-

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ OpenCode automatically loads local plugins from `~/.config/opencode/plugins/` an
 See [OpenCode integration guide](opencode/README.md) for configuration, project-local installs, and current limitations.
 
 > The current OpenCode integration ships as repository files for the local plugin directory. If you installed only the PyPI package, clone the repository once to copy the plugin files.
+>
+> The plugin defaults to `http://127.0.0.1:8000`, but `memoryService.endpoint` and `OPENCODE_MEMORY_ENDPOINT` let you target any reachable HTTP deployment.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Open-source memory backend for multi-agent systems.
 Agents store decisions, share causal knowledge graphs, and retrieve
 context in 5ms — without cloud lock-in or API costs.
 
-**Works with LangGraph · CrewAI · AutoGen · any HTTP client · Claude Desktop**
+**Works with LangGraph · CrewAI · AutoGen · any HTTP client · Claude Desktop · OpenCode**
 
 ---
 
@@ -287,6 +287,33 @@ claude mcp add memory -- memory server
 ```
 
 Restart Claude Code. Memory tools will appear automatically.
+
+</details>
+
+<details>
+<summary><strong>OpenCode</strong></summary>
+
+Start the HTTP API:
+
+```bash
+MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
+```
+
+Install the local plugin:
+
+```bash
+git clone https://github.com/doobidoo/mcp-memory-service.git
+cd mcp-memory-service
+mkdir -p ~/.config/opencode/plugins
+cp opencode/memory-plugin.js ~/.config/opencode/plugins/
+cp opencode/memory-plugin.config.example.json ~/.config/opencode/memory-plugin.json
+```
+
+OpenCode automatically loads local plugins from `~/.config/opencode/plugins/` and `.opencode/plugins/`.
+
+See [OpenCode integration guide](opencode/README.md) for configuration, project-local installs, and current limitations.
+
+> The current OpenCode integration ships as repository files for the local plugin directory. If you installed only the PyPI package, clone the repository once to copy the plugin files.
 
 </details>
 
@@ -586,6 +613,7 @@ If you encounter issues during migration:
 ## 📚 Documentation & Resources
 
 - **[Agent Integration Guides](docs/agents/)** 🆕 – LangGraph, CrewAI, AutoGen, HTTP generic
+- **[OpenCode Integration](opencode/README.md)** 🆕 – Local plugin for memory retrieval and context injection
 - **[Remote MCP Setup (claude.ai)](docs/remote-mcp-setup.md)** 🆕 – Browser integration via HTTPS + OAuth
 - **[Setup Guide](docs/setup-guide.md)** – Decision tree + step-by-step paths for all use cases
 - **[Configuration Guide](docs/mastery/configuration-guide.md)** – Backend options and customization

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -10,6 +10,9 @@ What do you need?
 ├─ Connect Claude Desktop or Claude Code via MCP only?
 │   └─ → Path 1: MCP Only (5 min)
 │
+├─ Use OpenCode with memory-aware local plugin?
+│   └─ → Path 1A: OpenCode Plugin (5 min)
+│
 ├─ Also want the web dashboard + REST API?
 │   └─ → Path 2: MCP + HTTP Dashboard (10 min)
 │
@@ -20,7 +23,7 @@ What do you need?
     └─ → Path 4: Full Stack — Hybrid + Dashboard + OAuth (30 min)
 ```
 
-Each path builds on the previous one. If you want Path 3, follow 1 → 2 → 3 in order.
+Each path builds on the previous one where noted. OpenCode users can start with Path 1A directly. If you want Path 3, follow 1 or 1A → 2 → 3 in order.
 
 ---
 
@@ -76,9 +79,55 @@ memory server --help
 
 - [Store your first memory](https://github.com/doobidoo/mcp-memory-service/wiki)
 - [See what else it works with](README.md#works-with-your-favorite-ai-tools)
+- Want OpenCode integration? → [Path 1A](#path-1a-opencode-plugin)
 - Want the dashboard? → [Path 2](#path-2-mcp--http-dashboard)
 
 ---
+
+## Path 1A: OpenCode Plugin
+
+**For whom:** OpenCode users who want memory-aware sessions via a local plugin.
+
+**Prerequisites:** Python 3.10–3.13, pip
+
+**Duration:** ~5 min
+
+### 1. Install
+
+```bash
+pip install mcp-memory-service
+```
+
+### 2. Start the HTTP API
+
+```bash
+MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
+```
+
+> The current OpenCode integration uses the documented HTTP API, not direct MCP transport.
+
+### 3. Install the local plugin
+
+```bash
+git clone https://github.com/doobidoo/mcp-memory-service.git
+cd mcp-memory-service
+mkdir -p ~/.config/opencode/plugins
+cp opencode/memory-plugin.js ~/.config/opencode/plugins/
+cp opencode/memory-plugin.config.example.json ~/.config/opencode/memory-plugin.json
+```
+
+OpenCode loads local plugins automatically from `~/.config/opencode/plugins/` and `.opencode/plugins/`.
+See [opencode/README.md](../opencode/README.md) for configuration and current limitations.
+
+> If you installed only the PyPI package, clone the repository once to copy the plugin files into your OpenCode config directory.
+
+### 4. Verify
+
+Start OpenCode inside a project that already has stored memories, then ask a project-specific question and confirm prior context is available.
+
+### 5. Next Steps
+
+- Want the dashboard too? → [Path 2](#path-2-mcp--http-dashboard)
 
 ## Path 2: MCP + HTTP Dashboard
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -105,6 +105,7 @@ MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
 ```
 
 > The current OpenCode integration uses the documented HTTP API, not direct MCP transport.
+> `http://127.0.0.1:8000` is only the default. Set `memoryService.endpoint` or `OPENCODE_MEMORY_ENDPOINT` to use a remote/shared deployment.
 
 ### 3. Install the local plugin
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,117 @@
+# OpenCode Memory Awareness Plugin
+
+Automatic memory retrieval and context injection for OpenCode using the `mcp-memory-service` HTTP API.
+
+This integration is intentionally minimal in its first upstream form:
+- load relevant memories when an OpenCode session starts
+- inject memory context into `experimental.chat.system.transform`
+- inject condensed memory context into `experimental.session.compacting`
+
+It does **not** do automatic write-back or session harvesting yet. That is deferred to a later step so the first integration stays small, reviewable, and aligned with stable OpenCode plugin hooks.
+
+## Why HTTP Instead of Direct Python Imports?
+
+This plugin uses the documented HTTP API instead of importing Python internals directly.
+
+That keeps the integration:
+- host-agnostic
+- easier to configure across platforms
+- aligned with the public `mcp-memory-service` surface
+
+## Prerequisites
+
+- OpenCode with plugin support
+- `mcp-memory-service` running in HTTP mode
+
+Start the service locally:
+
+```bash
+pip install mcp-memory-service
+MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
+```
+
+If you secure the API with `MCP_API_KEY`, set the same key in the plugin config.
+
+## Install
+
+OpenCode loads local plugins automatically from:
+- `~/.config/opencode/plugins/` for global plugins
+- `.opencode/plugins/` for project-local plugins
+
+Copy the plugin file to one of those locations:
+
+```bash
+git clone https://github.com/doobidoo/mcp-memory-service.git
+cd mcp-memory-service
+mkdir -p ~/.config/opencode/plugins
+cp opencode/memory-plugin.js ~/.config/opencode/plugins/
+```
+
+Optional: install the example config as a starting point:
+
+```bash
+cp opencode/memory-plugin.config.example.json ~/.config/opencode/memory-plugin.json
+```
+
+No `plugin` entry is required in `opencode.json` when loading from the local plugin directory.
+
+## Configuration
+
+The plugin looks for config in this order:
+- `OPENCODE_MEMORY_PLUGIN_CONFIG`
+- `~/.config/opencode/memory-plugin.json`
+- `~/.config/opencode/memory-awareness.json`
+- `.opencode/memory-plugin.json`
+- `.opencode/memory-awareness.json`
+
+Example:
+
+```json
+{
+  "memoryService": {
+    "endpoint": "http://127.0.0.1:8000",
+    "apiKey": "",
+    "maxMemoriesPerSession": 8,
+    "searchTags": ["decision"],
+    "includeProjectTag": false,
+    "projectQueries": [
+      "{project} architecture decisions",
+      "{project} recent work",
+      "{project} open issues"
+    ]
+  },
+  "output": {
+    "verbose": true,
+    "includeTimestamps": true,
+    "maxContentLength": 280
+  }
+}
+```
+
+## How It Works
+
+On `session.created`, the plugin:
+- derives the project name from the working directory
+- runs a few semantic searches against the memory service
+- stores the best matches in per-session plugin state
+
+Then:
+- `experimental.chat.system.transform` injects full memory context into the system prompt
+- `experimental.session.compacting` injects a smaller memory summary into compaction context
+
+## Verification
+
+1. Start `mcp-memory-service` in HTTP mode.
+2. Install the plugin under `~/.config/opencode/plugins/`.
+3. Start OpenCode inside a project you already have memories for.
+4. Ask a question about the project and confirm the assistant can use prior context.
+
+If `verbose` is enabled, the plugin writes structured logs through `client.app.log()` under the `opencode-memory` service name.
+
+## Limitations
+
+- read-only retrieval/injection only
+- depends on the HTTP API being reachable
+- relevance is intentionally simple and project-name driven in the first cut
+
+Future work can add richer retrieval, manual refresh, and safe write-back once the host lifecycle hooks are proven stable for that path.

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -30,7 +30,7 @@ pip install mcp-memory-service
 MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
 ```
 
-If you secure the API with `MCP_API_KEY`, set the same key in the plugin config.
+If you secure the API with `MCP_API_KEY`, set the client-side plugin key explicitly with `memoryService.apiKey` or `OPENCODE_MEMORY_API_KEY`.
 
 `http://127.0.0.1:8000` is only the default fallback. The plugin can target any reachable HTTP deployment of `mcp-memory-service`.
 
@@ -60,6 +60,7 @@ No `plugin` entry is required in `opencode.json` when loading from the local plu
 ## Configuration
 
 The plugin looks for config in this order:
+- `options.configPath` when the plugin is loaded programmatically
 - `OPENCODE_MEMORY_PLUGIN_CONFIG`
 - `~/.config/opencode/memory-plugin.json`
 - `~/.config/opencode/memory-awareness.json`
@@ -68,11 +69,13 @@ The plugin looks for config in this order:
 
 Then it applies environment overrides:
 - `OPENCODE_MEMORY_ENDPOINT` or `OPENCODE_MEMORY_URL`
-- `OPENCODE_MEMORY_API_KEY` or `MCP_API_KEY`
+- `OPENCODE_MEMORY_API_KEY`
 - `OPENCODE_MEMORY_TIMEOUT_MS`
 - `OPENCODE_MEMORY_LOAD_TIMEOUT_MS`
 
 If you load the plugin with explicit plugin options, those win last.
+
+`MCP_API_KEY` is intentionally not consumed by the plugin. That avoids accidentally reusing the server-side secret from a shared shell environment.
 
 Example:
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -32,6 +32,8 @@ MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
 
 If you secure the API with `MCP_API_KEY`, set the same key in the plugin config.
 
+`http://127.0.0.1:8000` is only the default fallback. The plugin can target any reachable HTTP deployment of `mcp-memory-service`.
+
 ## Install
 
 OpenCode loads local plugins automatically from:
@@ -64,12 +66,20 @@ The plugin looks for config in this order:
 - `.opencode/memory-plugin.json`
 - `.opencode/memory-awareness.json`
 
+Then it applies environment overrides:
+- `OPENCODE_MEMORY_ENDPOINT` or `OPENCODE_MEMORY_URL`
+- `OPENCODE_MEMORY_API_KEY` or `MCP_API_KEY`
+- `OPENCODE_MEMORY_TIMEOUT_MS`
+- `OPENCODE_MEMORY_LOAD_TIMEOUT_MS`
+
+If you load the plugin with explicit plugin options, those win last.
+
 Example:
 
 ```json
 {
   "memoryService": {
-    "endpoint": "http://127.0.0.1:8000",
+    "endpoint": "https://memory.example.com",
     "apiKey": "",
     "maxMemoriesPerSession": 8,
     "searchTags": ["decision"],
@@ -86,6 +96,15 @@ Example:
     "maxContentLength": 280
   }
 }
+```
+
+For a purely local setup, change `endpoint` back to `http://127.0.0.1:8000`.
+
+Environment-only example:
+
+```bash
+export OPENCODE_MEMORY_ENDPOINT="https://memory.example.com"
+export OPENCODE_MEMORY_API_KEY="your-api-key"
 ```
 
 ## How It Works

--- a/opencode/memory-plugin.config.example.json
+++ b/opencode/memory-plugin.config.example.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "memoryService": {
+    "endpoint": "http://127.0.0.1:8000",
+    "apiKey": "",
+    "timeoutMs": 5000,
+    "loadTimeoutMs": 2500,
+    "maxMemoriesPerSession": 8,
+    "searchTags": [],
+    "includeProjectTag": false,
+    "projectQueries": [
+      "{project} architecture decisions",
+      "{project} recent work",
+      "{project} open issues"
+    ]
+  },
+  "output": {
+    "verbose": true,
+    "includeTimestamps": true,
+    "maxContentLength": 280
+  }
+}

--- a/opencode/memory-plugin.config.example.json
+++ b/opencode/memory-plugin.config.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "memoryService": {
-    "endpoint": "http://127.0.0.1:8000",
+    "endpoint": "https://memory.example.com",
     "apiKey": "",
     "timeoutMs": 5000,
     "loadTimeoutMs": 2500,

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -318,14 +318,18 @@ async function loadSessionMemories({ config, directory, logInfo, logWarn, health
     }
   }
 
+  const searchResults = await Promise.allSettled(
+    queries.map((query) => searchMemories(config, query, tags, perQueryLimit)),
+  )
+
   const found = []
-  for (const query of queries) {
-    try {
-      const memories = await searchMemories(config, query, tags, perQueryLimit)
-      found.push(...memories)
-    } catch (error) {
-      await logWarn(`Memory search failed for "${query}": ${error.message}`)
+  for (const [index, result] of searchResults.entries()) {
+    if (result.status === "fulfilled") {
+      found.push(...result.value)
+      continue
     }
+
+    await logWarn(`Memory search failed for "${queries[index]}": ${result.reason?.message || result.reason}`)
   }
 
   const deduped = sortMemories(dedupeMemories(found)).slice(0, config.memoryService.maxMemoriesPerSession)
@@ -356,6 +360,9 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
   }
 
   const refreshSession = (sessionID, sessionDirectory) => {
+    const existingState = sessionState.get(sessionID)
+    if (existingState?.promise) return existingState.promise
+
     const loadPromise = loadSessionMemories({
       config,
       directory: sessionDirectory,
@@ -383,6 +390,8 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
       memories: [],
       promise: loadPromise,
     })
+
+    return loadPromise
   }
 
   const waitForSession = async (sessionID, fallbackDirectory) => {

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -24,6 +24,45 @@ const DEFAULT_CONFIG = {
   },
 }
 
+function pluginOptionOverrides(options = {}) {
+  const { configPath: _configPath, ...rest } = options
+  return rest
+}
+
+function parseInteger(value) {
+  if (typeof value !== "string" || !value.trim()) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function environmentOverrides() {
+  const overrides = {
+    memoryService: {},
+  }
+
+  const endpoint = process.env.OPENCODE_MEMORY_ENDPOINT || process.env.OPENCODE_MEMORY_URL
+  if (endpoint) {
+    overrides.memoryService.endpoint = endpoint
+  }
+
+  const apiKey = process.env.OPENCODE_MEMORY_API_KEY || process.env.MCP_API_KEY
+  if (apiKey) {
+    overrides.memoryService.apiKey = apiKey
+  }
+
+  const timeoutMs = parseInteger(process.env.OPENCODE_MEMORY_TIMEOUT_MS)
+  if (timeoutMs !== undefined) {
+    overrides.memoryService.timeoutMs = timeoutMs
+  }
+
+  const loadTimeoutMs = parseInteger(process.env.OPENCODE_MEMORY_LOAD_TIMEOUT_MS)
+  if (loadTimeoutMs !== undefined) {
+    overrides.memoryService.loadTimeoutMs = loadTimeoutMs
+  }
+
+  return overrides
+}
+
 function mergeConfig(base, overrides = {}) {
   return {
     ...base,
@@ -52,7 +91,7 @@ function pluginConfigPaths(directory, options = {}) {
 }
 
 async function loadConfig(directory, options) {
-  let config = mergeConfig(DEFAULT_CONFIG, options)
+  let config = DEFAULT_CONFIG
 
   for (const configPath of pluginConfigPaths(directory, options)) {
     try {
@@ -64,6 +103,9 @@ async function loadConfig(directory, options) {
       // Keep searching for a readable config file.
     }
   }
+
+  config = mergeConfig(config, environmentOverrides())
+  config = mergeConfig(config, pluginOptionOverrides(options))
 
   return config
 }

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -45,7 +45,7 @@ function environmentOverrides() {
     overrides.memoryService.endpoint = endpoint
   }
 
-  const apiKey = process.env.OPENCODE_MEMORY_API_KEY || process.env.MCP_API_KEY
+  const apiKey = process.env.OPENCODE_MEMORY_API_KEY
   if (apiKey) {
     overrides.memoryService.apiKey = apiKey
   }
@@ -403,7 +403,18 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
     }
 
     if (state?.promise) {
-      await Promise.race([state.promise, sleep(config.memoryService.loadTimeoutMs)])
+      const loadTimedOut = Symbol("load-timed-out")
+      const result = await Promise.race([
+        state.promise.then(() => null),
+        sleep(config.memoryService.loadTimeoutMs).then(() => loadTimedOut),
+      ])
+
+      if (result === loadTimedOut) {
+        const latestState = sessionState.get(sessionID)
+        if (latestState?.promise) {
+          return null
+        }
+      }
     }
 
     return sessionState.get(sessionID)
@@ -433,6 +444,8 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
     },
 
     "experimental.session.compacting": async (input, output) => {
+      if (!input.sessionID) return
+
       const state = await waitForSession(input.sessionID, directory)
       if (!state?.memories?.length) return
 

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -1,0 +1,398 @@
+import { readFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+
+const DEFAULT_CONFIG = {
+  memoryService: {
+    endpoint: "http://127.0.0.1:8000",
+    apiKey: "",
+    timeoutMs: 5000,
+    loadTimeoutMs: 2500,
+    maxMemoriesPerSession: 8,
+    searchTags: [],
+    includeProjectTag: false,
+    projectQueries: [
+      "{project} architecture decisions",
+      "{project} recent work",
+      "{project} open issues",
+    ],
+  },
+  output: {
+    verbose: true,
+    includeTimestamps: true,
+    maxContentLength: 280,
+  },
+}
+
+function mergeConfig(base, overrides = {}) {
+  return {
+    ...base,
+    ...overrides,
+    memoryService: {
+      ...base.memoryService,
+      ...(overrides.memoryService || {}),
+    },
+    output: {
+      ...base.output,
+      ...(overrides.output || {}),
+    },
+  }
+}
+
+function pluginConfigPaths(directory, options = {}) {
+  const configDir = path.join(homedir(), ".config", "opencode")
+  return [
+    typeof options.configPath === "string" ? options.configPath : "",
+    process.env.OPENCODE_MEMORY_PLUGIN_CONFIG || "",
+    path.join(configDir, "memory-plugin.json"),
+    path.join(configDir, "memory-awareness.json"),
+    path.join(directory, ".opencode", "memory-plugin.json"),
+    path.join(directory, ".opencode", "memory-awareness.json"),
+  ].filter(Boolean)
+}
+
+async function loadConfig(directory, options) {
+  let config = mergeConfig(DEFAULT_CONFIG, options)
+
+  for (const configPath of pluginConfigPaths(directory, options)) {
+    try {
+      const raw = await readFile(configPath, "utf8")
+      const parsed = JSON.parse(raw)
+      config = mergeConfig(config, parsed)
+      break
+    } catch {
+      // Keep searching for a readable config file.
+    }
+  }
+
+  return config
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function buildUrl(baseUrl, pathname) {
+  const normalizedBase = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+  const normalizedPath = pathname.startsWith("/") ? pathname.slice(1) : pathname
+  return new URL(normalizedPath, normalizedBase).toString()
+}
+
+function buildHeaders(config, extraHeaders = {}) {
+  const headers = {
+    Accept: "application/json",
+    ...extraHeaders,
+  }
+
+  if (config.memoryService.apiKey) {
+    headers.Authorization = `Bearer ${config.memoryService.apiKey}`
+  }
+
+  return headers
+}
+
+async function requestJson(config, pathname, init = {}) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), config.memoryService.timeoutMs)
+
+  try {
+    const response = await fetch(buildUrl(config.memoryService.endpoint, pathname), {
+      ...init,
+      headers: buildHeaders(config, init.headers || {}),
+      signal: controller.signal,
+    })
+
+    const text = await response.text()
+    let body = null
+    if (text) {
+      try {
+        body = JSON.parse(text)
+      } catch {
+        body = { detail: text }
+      }
+    }
+
+    if (!response.ok) {
+      const detail = body?.detail || body?.error || response.statusText
+      throw new Error(`${response.status} ${detail}`)
+    }
+
+    return body
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function projectNameFromDirectory(directory) {
+  return path.basename(directory) || "project"
+}
+
+function buildQueries(projectName, config) {
+  return config.memoryService.projectQueries
+    .map((template) => template.replaceAll("{project}", projectName))
+    .filter(Boolean)
+}
+
+function normalizeMemory(memory) {
+  if (!memory || typeof memory !== "object") return null
+
+  const base = memory.memory && typeof memory.memory === "object" ? memory.memory : memory
+  const content = base.content || base.preview || ""
+  if (!content) return null
+
+  let createdAt = base.created_at_iso || base.created_at || base.created || undefined
+  if (typeof createdAt === "number") {
+    const timestamp = createdAt < 4102444800 ? createdAt * 1000 : createdAt
+    createdAt = new Date(timestamp).toISOString()
+  }
+
+  return {
+    id: base.content_hash || base.hash || base.id || content,
+    content,
+    tags: Array.isArray(base.tags) ? base.tags : [],
+    createdAt,
+    score: memory.similarity_score || base.similarity_score || base.relevanceScore || 0,
+  }
+}
+
+function dedupeMemories(memories) {
+  const seen = new Set()
+  const unique = []
+
+  for (const memory of memories) {
+    if (!memory) continue
+    if (seen.has(memory.id)) continue
+    seen.add(memory.id)
+    unique.push(memory)
+  }
+
+  return unique
+}
+
+function sortMemories(memories) {
+  return [...memories].sort((left, right) => {
+    if ((right.score || 0) !== (left.score || 0)) {
+      return (right.score || 0) - (left.score || 0)
+    }
+
+    const leftTime = left.createdAt ? Date.parse(left.createdAt) : 0
+    const rightTime = right.createdAt ? Date.parse(right.createdAt) : 0
+    return rightTime - leftTime
+  })
+}
+
+function truncateText(content, maxLength) {
+  if (content.length <= maxLength) return content
+  return `${content.slice(0, maxLength - 3).trimEnd()}...`
+}
+
+function formatTimestamp(memory) {
+  if (!memory.createdAt) return ""
+  const date = new Date(memory.createdAt)
+  if (Number.isNaN(date.getTime())) return ""
+  return date.toISOString().slice(0, 10)
+}
+
+function formatMemories(projectName, memories, config, options = {}) {
+  if (!memories.length) return ""
+
+  const includeHeader = options.includeHeader ?? true
+  const limit = options.limit || config.memoryService.maxMemoriesPerSession
+  const lines = []
+
+  if (includeHeader) {
+    lines.push(`# Memory Context - ${projectName}`)
+    lines.push("")
+    lines.push("Use this as supporting background only. The current repository state and user instructions take precedence.")
+    lines.push("")
+  }
+
+  lines.push("## Relevant Memories")
+
+  for (const memory of memories.slice(0, limit)) {
+    const timestamp = config.output.includeTimestamps ? formatTimestamp(memory) : ""
+    const prefix = timestamp ? `- [${timestamp}] ` : "- "
+    lines.push(`${prefix}${truncateText(memory.content.replace(/\s+/g, " ").trim(), config.output.maxContentLength)}`)
+  }
+
+  return lines.join("\n")
+}
+
+async function searchMemories(config, query, tags, limit) {
+  const payload = {
+    query,
+    limit,
+  }
+
+  if (tags.length) {
+    payload.tags = tags
+  }
+
+  const result = await requestJson(config, "/api/memories/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+
+  const memories = Array.isArray(result)
+    ? result
+    : Array.isArray(result?.memories)
+      ? result.memories
+      : Array.isArray(result?.results)
+        ? result.results
+        : []
+
+  return memories.map(normalizeMemory).filter(Boolean)
+}
+
+async function getHealth(config) {
+  return requestJson(config, "/api/health")
+}
+
+function tagsForProject(projectName, config) {
+  const tags = [...config.memoryService.searchTags]
+  if (config.memoryService.includeProjectTag) {
+    tags.push(projectName)
+  }
+  return tags
+}
+
+async function loadSessionMemories({ config, directory, logInfo, logWarn, healthState }) {
+  const projectName = projectNameFromDirectory(directory)
+  const tags = tagsForProject(projectName, config)
+  const queries = buildQueries(projectName, config)
+  const perQueryLimit = Math.max(2, Math.ceil(config.memoryService.maxMemoriesPerSession / Math.max(queries.length, 1)))
+
+  if (!healthState.checked) {
+    healthState.checked = true
+    try {
+      const health = await getHealth(config)
+      const backend = health?.storage_backend || health?.backend || "unknown"
+      await logInfo(`Memory service connected (${backend})`)
+    } catch (error) {
+      await logWarn(`Memory service unavailable: ${error.message}`)
+    }
+  }
+
+  const found = []
+  for (const query of queries) {
+    try {
+      const memories = await searchMemories(config, query, tags, perQueryLimit)
+      found.push(...memories)
+    } catch (error) {
+      await logWarn(`Memory search failed for "${query}": ${error.message}`)
+    }
+  }
+
+  const deduped = sortMemories(dedupeMemories(found)).slice(0, config.memoryService.maxMemoriesPerSession)
+  if (deduped.length) {
+    await logInfo(`Loaded ${deduped.length} memories for ${projectName}`)
+  }
+
+  return {
+    projectName,
+    memories: deduped,
+  }
+}
+
+export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) => {
+  const config = await loadConfig(directory, options)
+  const sessionState = new Map()
+  const healthState = { checked: false }
+  const appLog = client.app.log.bind(client.app)
+
+  const logInfo = async (message) => {
+    if (!config.output.verbose) return
+    await appLog({ body: { service: "opencode-memory", level: "info", message } }).catch(() => {})
+  }
+
+  const logWarn = async (message) => {
+    if (!config.output.verbose) return
+    await appLog({ body: { service: "opencode-memory", level: "warn", message } }).catch(() => {})
+  }
+
+  const refreshSession = (sessionID, sessionDirectory) => {
+    const loadPromise = loadSessionMemories({
+      config,
+      directory: sessionDirectory,
+      logInfo,
+      logWarn,
+      healthState,
+    })
+      .then((result) => {
+        sessionState.set(sessionID, {
+          ...result,
+          promise: null,
+        })
+      })
+      .catch(async (error) => {
+        sessionState.set(sessionID, {
+          projectName: projectNameFromDirectory(sessionDirectory),
+          memories: [],
+          promise: null,
+        })
+        await logWarn(`Memory load failed: ${error.message}`)
+      })
+
+    sessionState.set(sessionID, {
+      projectName: projectNameFromDirectory(sessionDirectory),
+      memories: [],
+      promise: loadPromise,
+    })
+  }
+
+  const waitForSession = async (sessionID, fallbackDirectory) => {
+    let state = sessionState.get(sessionID)
+
+    if (!state) {
+      refreshSession(sessionID, fallbackDirectory)
+      state = sessionState.get(sessionID)
+    }
+
+    if (state?.promise) {
+      await Promise.race([state.promise, sleep(config.memoryService.loadTimeoutMs)])
+    }
+
+    return sessionState.get(sessionID)
+  }
+
+  return {
+    event: async ({ event }) => {
+      if (event.type === "session.created") {
+        refreshSession(event.properties.info.id, event.properties.info.directory || directory)
+      }
+
+      if (event.type === "session.deleted") {
+        sessionState.delete(event.properties.info.id)
+      }
+    },
+
+    "experimental.chat.system.transform": async (input, output) => {
+      if (!input.sessionID) return
+
+      const state = await waitForSession(input.sessionID, directory)
+      if (!state?.memories?.length) return
+
+      const formatted = formatMemories(state.projectName, state.memories, config)
+      if (formatted) {
+        output.system.push(formatted)
+      }
+    },
+
+    "experimental.session.compacting": async (input, output) => {
+      const state = await waitForSession(input.sessionID, directory)
+      if (!state?.memories?.length) return
+
+      const formatted = formatMemories(state.projectName, state.memories, config, {
+        includeHeader: false,
+        limit: Math.min(6, config.memoryService.maxMemoriesPerSession),
+      })
+
+      if (formatted) {
+        output.context.push(formatted)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add a first upstream OpenCode integration under `opencode/` with a minimal read-only local plugin
- inject relevant memories at session start into OpenCode system and compaction context via the documented HTTP API
- document installation, configuration, and current scope/limitations in `README.md`, `docs/setup-guide.md`, and `opencode/README.md`

## Motivation
The repository already maintains host-specific integrations such as `claude-hooks/`. This change adds the OpenCode sibling that was discussed in #671, keeping the first step intentionally small and maintainable.

## What This Includes
- local OpenCode plugin: `opencode/memory-plugin.js`
- example config: `opencode/memory-plugin.config.example.json`
- dedicated OpenCode setup guide: `opencode/README.md`
- top-level docs updates so OpenCode users have a supported path

## What This Does Not Include Yet
- automatic write-back / harvesting
- host-specific workflow heuristics from private/local setups
- npm packaging for the plugin

## Notes
- the plugin uses the documented HTTP API rather than importing Python internals directly
- this keeps the integration host-agnostic and avoids hardcoded local paths
- syntax was validated with `node --check opencode/memory-plugin.js`

Closes #671.