### PR TITLE
fix: sync lite package version with main release automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,14 @@ jobs:
             echo "tag=v$AFTER_VERSION"
           } >> $GITHUB_OUTPUT
           
+          # Sync lite package version
+          if [ -f pyproject-lite.toml ]; then
+            sed -i "s/^version = \".*\"/version = \"$AFTER_VERSION\"/" pyproject-lite.toml
+            git add pyproject-lite.toml
+            git commit --amend --no-edit
+            echo "✅ Synced pyproject-lite.toml to $AFTER_VERSION"
+          fi
+
           # Create tag manually
           git tag "v$AFTER_VERSION"
           echo "✅ Tag v$AFTER_VERSION created locally"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **[#672] Lite package version sync**: `mcp-memory-service-lite` was stuck at 8.76.0 on PyPI because `pyproject-lite.toml` was never updated by the release automation. Synced to 10.35.0, added `pyproject-lite.toml` to semantic-release `version_variable` list, and added fallback sync step in CI workflow. (Issue #672)
+
 ## [10.35.0] - 2026-04-08
 
 ### Added

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "8.76.0"
+version = "10.35.0"
 description = "Lightweight MCP memory service with ONNX embeddings - no PyTorch required. 80% smaller install size."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ path = "src/mcp_memory_service/__init__.py"
 [tool.semantic_release]
 version_variable = [
     "src/mcp_memory_service/_version.py:__version__",
-    "pyproject.toml:version"
+    "pyproject.toml:version",
+    "pyproject-lite.toml:version"
 ]
 branch = "main"
 changelog_file = "CHANGELOG.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.35.0"
+version = "10.31.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Syncs `pyproject-lite.toml` from 8.76.0 to 10.35.0
- Adds `pyproject-lite.toml` to semantic-release `version_variable` so future releases auto-bump the lite version
- Adds fallback sync step in `.github/workflows/main.yml` after version bump

## Root cause

`pyproject-lite.toml` was never included in the release automation. The `publish-dual.yml` workflow built the lite package on every release, but since the version stayed at 8.76.0 and `--skip-existing` was set, uploads were silently skipped.

## Test plan

- [ ] Merge this PR
- [ ] Trigger `publish-dual.yml` manually to publish `mcp-memory-service-lite` 10.35.0 to PyPI
- [ ] Verify with `pip index versions mcp-memory-service-lite` that 10.35.0 is available
- [ ] Confirm next release auto-bumps `pyproject-lite.toml` via semantic-release

Closes #672

🤖 Generated with [Claude Code](https://claude.ai/code)