### PR TITLE
chore: release v10.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.36.0] - 2026-04-09
+
 ### Added
 
-- **OpenCode memory awareness integration**: Added an official `opencode/` integration with a minimal read-only plugin for session-start retrieval, system-context injection, and compaction-context injection via the documented HTTP API. Includes setup docs and example config for local OpenCode plugin installation.
+- **[#673] OpenCode memory awareness integration**: Added an official `opencode/` integration with a minimal read-only plugin for session-start retrieval, system-context injection, and compaction-context injection via the documented HTTP API. Includes setup docs and example config for local OpenCode plugin installation. (PR #673, contributor: @irizzant, closes #671)
 
 ### Fixed
 
-- **[#672] Lite package version sync**: `mcp-memory-service-lite` was stuck at 8.76.0 on PyPI because `pyproject-lite.toml` was never updated by the release automation. Synced to 10.35.0, added `pyproject-lite.toml` to semantic-release `version_variable` list, and added fallback sync step in CI workflow. (Issue #672)
+- **[#675] Lite package version sync**: `mcp-memory-service-lite` was stuck at 8.76.0 on PyPI because `pyproject-lite.toml` was never updated by the release automation. Synced to 10.35.0, added `pyproject-lite.toml` to semantic-release `version_variable` list, and added fallback sync step in CI workflow. (PR #675, closes #672)
 
 ## [10.35.0] - 2026-04-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a Model Context Protocol server providing semantic memory and persistent storage for Claude Desktop and 13+ AI applications. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.35.0 - feat: session-level memory ingestion — `memory_store_session` MCP tool + `POST /api/sessions` HTTP endpoint — LongMemEval R@5 86.0% (+5.6%) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.36.0 - feat: OpenCode memory awareness integration (@irizzant, PR #673) + lite package version sync fix (PR #675) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -429,21 +429,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.35.0** (April 8, 2026)
+## Latest Release: **v10.36.0** (April 9, 2026)
 
-**feat: session-level memory ingestion — LongMemEval R@5 86.0% (+5.6% vs turn-level)**
+**feat: OpenCode memory awareness integration + lite package version sync fix**
 
 **What's New:**
-- **`memory_store_session` MCP tool**: Stores a full conversation as a single memory unit — all turns concatenated as `[role] content`, stored with `memory_type=session` and auto-tagged `session:<id>`.
-- **`POST /api/sessions` HTTP endpoint**: REST endpoint for session-level ingestion mirroring the MCP tool.
-- **LongMemEval session-mode results**: R@5 86.0% (+5.6% vs turn-level), with biggest gains in multi-session (+15.2%) and temporal-reasoning (+10.6%) categories.
-- **`--ingestion-mode session|turn|both`** flag for LongMemEval benchmark for direct strategy comparison.
-- **`session` and `conversation_turn` memory types** added to the ontology.
-- **1,537 tests** passing (+17 new: 10 handler + 7 HTTP endpoint tests).
+- **OpenCode integration** (`opencode/memory-plugin.js`): New community-contributed plugin that injects memories into OpenCode sessions via the HTTP API — session-start retrieval, system-context injection, and compaction-context injection. Includes setup docs and example config. (by @irizzant)
+- **Lite package version sync fix**: `mcp-memory-service-lite` was stuck at 8.76.0 on PyPI. Synced to current version, added `pyproject-lite.toml` to release automation, and added CI fallback sync step.
+- **1,537 tests** passing.
 
 ---
 
 **Previous Releases**:
+- **v10.35.0** - feat: session-level memory ingestion — `memory_store_session` MCP tool + `POST /api/sessions` — LongMemEval R@5 86.0% (+5.6%) (PR #666, 1,537 tests)
 - **v10.34.0** - feat: LongMemEval benchmark — R@5 80.4%, R@10 90.4%, NDCG@10 82.2%, MRR 89.1% (PR #665, 1,520 tests)
 - **v10.33.0** - refactor: eliminate event-loop blocking + fix silent conflict data loss in SQLite storage (PR #663, 1,520 tests)
 - **v10.32.0** - feat: transport health endpoint + configurable timeouts + optional DCR registration key protection (community PRs #656, #657, 1,520 tests)

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "10.35.0"
+version = "10.36.0"
 description = "Lightweight MCP memory service with ONNX embeddings - no PyTorch required. 80% smaller install size."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.35.0"
+version = "10.36.0"
 description = "Open-source persistent memory for AI agent pipelines and Claude. REST API + semantic search + knowledge graph + autonomous consolidation. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.35.0"
+__version__ = "10.36.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.31.2"
+version = "10.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to **v10.36.0** across `pyproject.toml`, `pyproject-lite.toml`, `src/mcp_memory_service/_version.py`, and `uv.lock`
- Update CHANGELOG.md: move `[Unreleased]` entries into `[10.36.0] - 2026-04-09` section
- Update README.md: new "Latest Release" entry for v10.36.0, v10.35.0 moved to Previous Releases
- Update CLAUDE.md: version callout updated to v10.36.0

## Changes since v10.35.0

### feat: OpenCode memory awareness integration (PR #673, @irizzant, closes #671)
New `opencode/memory-plugin.js` plugin that injects memories into OpenCode sessions via the HTTP API — session-start retrieval, system-context injection, and compaction-context injection. Includes setup docs and example config.

### fix: Lite package version sync (PR #675, closes #672)
`mcp-memory-service-lite` was stuck at 8.76.0 on PyPI because `pyproject-lite.toml` was never included in release automation. Synced to current version, added to `semantic-release version_variable` list, and added CI fallback sync step.

## Version bump type: MINOR (new feature in PR #673)

## Test plan
- [ ] CI passes on this branch
- [ ] Version is consistent across all 3 package files + `_version.py`
- [ ] CHANGELOG has no duplicate version entries
- [ ] `[Unreleased]` section is empty after version move

🙏 Special Thanks to @irizzant for the OpenCode integration (PR #673)!

🤖 Generated with [Claude Code](https://claude.com/claude-code)