### PR TITLE
Add agent add install 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,6 @@ It automatically captures your project context, architecture decisions, and code
 
 > Not sure which setup fits your needs? See the **[Setup Guide](docs/setup-guide.md)** — a decision tree walks you to the right path in under a minute.
 
-**0. Quick install via agent-add (optional):**
-
-Install to any supported AI host (Claude Code, Cursor, Claude Desktop, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)) with one command:
-
-```bash
-npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
-```
-
-> Requires [Node.js](https://nodejs.org/) 18+ and [pip install mcp-memory-service](https://pypi.org/project/mcp-memory-service/). `agent-add` auto-detects your AI host and writes the config to the correct location — no need to find config file paths manually.
-
-
 **1. Install:**
 
 ```bash
@@ -266,6 +255,13 @@ pip install mcp-memory-service
 ```
 
 **2. Configure your AI client:**
+
+Or auto-configure any supported host with [agent-add](https://github.com/pea3nut/agent-get) (supports [18 AI hosts](https://github.com/pea3nut/agent-get) including Cursor, Windsurf, GitHub Copilot, and more):
+
+```bash
+npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
+```
+
 
 <details open>
 <summary><strong>Claude Desktop</strong></summary>

--- a/README.md
+++ b/README.md
@@ -264,12 +264,12 @@ npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
 
 Or configure manually for your specific client:
 
-<details>
+<details open>
 <summary><strong>Claude Desktop</strong></summary>
 
 Add to your config file:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%Claudeclaude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 ```json
@@ -335,6 +335,7 @@ Choose from:
 
 </details>
 
+---
 ## 💡 Why You Need This
 
 ### The Problem

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ pip install mcp-memory-service
 npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
 ```
 
-> Requires [Node.js](https://nodejs.org/) 18+. [agent-add](https://github.com/pea3nut/agent-get) auto-detects your AI host (Cursor, Windsurf, GitHub Copilot, and [15+ more](https://github.com/pea3nut/agent-get)) and writes the config to the correct file.
+> Requires [Node.js](https://nodejs.org/) 18+. [agent-add](https://github.com/pea3nut/agent-add) auto-detects your AI host (Cursor, Windsurf, GitHub Copilot, and [15+ more](https://github.com/pea3nut/agent-add)) and writes the config to the correct file.
 
 Or configure manually for your specific client:
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ It automatically captures your project context, architecture decisions, and code
 
 > Not sure which setup fits your needs? See the **[Setup Guide](docs/setup-guide.md)** — a decision tree walks you to the right path in under a minute.
 
+**0. Quick install via agent-add (optional):**
+
+Install to any supported AI host (Claude Code, Cursor, Claude Desktop, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)) with one command:
+
+```bash
+npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
+```
+
+> Requires [Node.js](https://nodejs.org/) 18+ and [pip install mcp-memory-service](https://pypi.org/project/mcp-memory-service/). `agent-add` auto-detects your AI host and writes the config to the correct location — no need to find config file paths manually.
+
+
 **1. Install:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -256,19 +256,20 @@ pip install mcp-memory-service
 
 **2. Configure your AI client:**
 
-Or auto-configure any supported host with [agent-add](https://github.com/pea3nut/agent-get) (supports [18 AI hosts](https://github.com/pea3nut/agent-get) including Cursor, Windsurf, GitHub Copilot, and more):
-
 ```bash
 npx -y agent-add --mcp '{"memory":{"command":"memory","args":["server"]}}'
 ```
 
+> Requires [Node.js](https://nodejs.org/) 18+. [agent-add](https://github.com/pea3nut/agent-get) auto-detects your AI host (Cursor, Windsurf, GitHub Copilot, and [15+ more](https://github.com/pea3nut/agent-get)) and writes the config to the correct file.
 
-<details open>
+Or configure manually for your specific client:
+
+<details>
 <summary><strong>Claude Desktop</strong></summary>
 
 Add to your config file:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Windows**: `%APPDATA%Claudeclaude_desktop_config.json`
 - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 ```json
@@ -333,8 +334,6 @@ Choose from:
 - **Hybrid** (best of both: 5ms local + background cloud sync)
 
 </details>
-
----
 
 ## 💡 Why You Need This
 


### PR DESCRIPTION
## Summary

Restructures the "Configure your AI client" step to lead with a one-command [agent-add](https://github.com/pea3nut/agent-get) install, followed by manual per-client configuration as a fallback. agent-add auto-detects the user's AI host and writes the config — covering Cursor, Windsurf, GitHub Copilot, and 15+ more hosts beyond the currently listed Claude Desktop and Claude Code.

## What changed

- **Reordered**: agent-add command is now the primary method under "**2. Configure your AI client:**"
- **Kept**: All per-client `<details>` blocks (Claude Desktop, Claude Code, claude.ai, Advanced) moved under "Or configure manually"
- **Kept**: All other sections unchanged