### PR TITLE
docs: contextualize MemPalace benchmark claims per Issue #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,13 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 
 ### vs. MCP-Native Alternatives
 
-[MemPalace](https://github.com/milla-jovovich/mempalace) (~20k ⭐) is a strong MCP-native alternative worth knowing about.
+[MemPalace](https://github.com/milla-jovovich/mempalace) is an MCP-native alternative that went viral in April 2026 with strong LongMemEval claims. A [community code review (Issue #27)](https://github.com/milla-jovovich/mempalace/issues/27) subsequently showed that the headline numbers reflect the underlying vector store rather than the advertised Palace architecture, and the maintainers acknowledged most points. We keep the comparison here for transparency, but readers should interpret the scores with that context in mind.
 
 | | **MemPalace** | **mcp-memory-service** |
 |---|---|---|
-| LongMemEval R@5 (zero LLM) | **96.6%** | 86.0% (session) / 80.4% (turn) |
-| LongMemEval R@5 (with reranking) | **100%**¹ | — |
-| Storage granularity | Session-level | **Turn-level** |
+| LongMemEval R@5 (raw ChromaDB, zero LLM) | 96.6%¹ | 86.0% (session) / 80.4% (turn) |
+| LongMemEval R@5 (with reranking) | 100%² | — |
+| Storage granularity | Session-level | **Turn-level + session-level** |
 | Team / multi-device sync | ❌ Local only | **✅ Cloudflare sync** |
 | REST API / Web dashboard | ❌ | **✅** |
 | OAuth 2.1 + multi-user | ❌ | **✅** |
@@ -197,9 +197,14 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 | Compatible AI tools | Claude-focused | **13+ tools** |
 | License | MIT | **Apache 2.0** |
 
-**Why the benchmark gap?** MemPalace stores each conversation as a single unit (session-level). LongMemEval asks "which session contains the answer?" — a question that session-level storage answers structurally. mcp-memory-service defaults to turn-level storage (one entry per message), which enables fine-grained retrieval ("what exactly did the user say about X?") but spreads a session's signal across many entries. Using `memory_store_session` (session-level ingestion, added in v10.35.0) brings our score to **86.0% R@5** — closing the gap significantly. The remaining difference is primarily due to MemPalace's larger embedding model.
+**Why the benchmark gap?** Two independent factors:
 
-> ¹ 100% result uses optional LLM reranking (~500 API calls) and includes a partially tuned test set. Clean held-out score: **98.4% R@5**.
+1. **Ingestion granularity.** MemPalace stores each conversation as a single unit (session-level). LongMemEval asks "which session contains the answer?" — a question that session-level storage answers structurally. mcp-memory-service defaults to turn-level storage (one entry per message), which enables fine-grained retrieval ("what exactly did the user say about X?") but spreads a session's signal across many entries. Using `memory_store_session` (added in v10.35.0) brings our score to **86.0% R@5**.
+2. **What the 96.6% actually measures.** Per Issue #27, MemPalace's headline number is produced in "raw mode" — plain text stored in ChromaDB with default embeddings. The Palace architecture (Wings, Rooms, Halls) is **not active** in that configuration; "Halls" exist only as metadata strings with no effect on ranking. The 96.6% is therefore a ChromaDB + default-embedding baseline, not a measurement of MemPalace's retrieval features. A direct "apples-to-apples" architectural comparison is not possible with the published numbers.
+
+> ¹ Measured in MemPalace "raw mode" (plain text in ChromaDB with default embeddings). Per [Issue #27](https://github.com/milla-jovovich/mempalace/issues/27), the Palace structural features are bypassed in this configuration.
+>
+> ² 100% result uses optional LLM reranking (~500 API calls) on a partially tuned test set. Clean held-out score (as reported by the maintainers): **98.4% R@5**.
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -18,11 +18,13 @@ All results use zero LLM API calls (retrieval-only mode) unless noted.
 |--------|-----------|-----|------|---------|-----|-----------|
 | **MCP Memory Service** | **session** | **86.0%** | **93.0%** | **82.9%** | **82.8%** | 0 |
 | **MCP Memory Service** | turn (baseline) | 80.4% | 90.4% | 82.2% | 89.1% | 0 |
-| mempalace (raw) | session | 96.6% | — | — | — | 0 |
-| mempalace (hybrid v4 + Haiku) | session | 100%¹ | — | — | — | ~500 |
+| mempalace (raw ChromaDB) | session | 96.6%¹ | — | — | — | 0 |
+| mempalace (hybrid v4 + Haiku) | session | 100%² | — | — | — | ~500 |
 | Mem0 | — | ~85% | — | — | — | — |
 
-> ¹ 100% result uses optional LLM reranking on a partially tuned test set. Clean held-out score: 98.4% R@5.
+> ¹ MemPalace's "raw mode" stores plain text in ChromaDB with default embeddings. Per [MemPalace Issue #27](https://github.com/milla-jovovich/mempalace/issues/27), the Palace architecture (Wings, Rooms, Halls) is not active in this configuration — "Halls" exist only as metadata strings with no effect on ranking. The 96.6% is therefore a ChromaDB + default-embedding baseline rather than a measurement of MemPalace's structural retrieval features. Maintainers have publicly acknowledged this.
+>
+> ² 100% result uses optional LLM reranking (~500 API calls) on a partially tuned test set. Clean held-out score as reported by the maintainers: 98.4% R@5.
 
 **Ingestion modes explained:**
 - **turn**: each conversation turn stored as a separate memory (one entry per message)


### PR DESCRIPTION
## Summary

Updates the MemPalace comparison in [README.md](README.md) and [docs/BENCHMARKS.md](docs/BENCHMARKS.md) to reflect findings from [MemPalace Issue #27](https://github.com/milla-jovovich/mempalace/issues/27).

## Why

MemPalace went viral in April 2026 with a claimed **96.6% R@5** on LongMemEval. We had added this as a comparison point in our README and BENCHMARKS docs to frame the gap honestly.

A community code review (Issue #27) subsequently showed:

- The **96.6%** is measured in "raw mode" — plain text in ChromaDB with default embeddings. The Palace architecture (Wings, Rooms, Halls) is **not active** in that configuration.
- **"Halls"** exist only as metadata strings with no effect on ranking.
- **"30x lossless compression"** is regex-based abbreviation with sentence truncation (recall drops 96.6% → 84.2%).
- The **100%** number uses LLM reranking on a partially tuned test set.
- MemPalace maintainers have publicly acknowledged most of these points.

Our previous framing ("Why the benchmark gap? — session vs. turn level") was technically correct but incomplete: it implied the 96.6% measured MemPalace's architecture, when in fact it measures a ChromaDB + default-embedding baseline.

## Changes

- **README.md**: Reframe the intro to the MemPalace section, relabel the 96.6% row as "raw ChromaDB", expand "Why the benchmark gap?" into two factors (ingestion granularity + what the 96.6% actually measures), sharpen both footnotes.
- **docs/BENCHMARKS.md**: Relabel tabular row to "mempalace (raw ChromaDB)", add explanatory footnote pointing to Issue #27 and explicitly noting that the Palace structural features are inactive.
- **CHANGELOG.md**: Untouched — the v10.35.0 historical entry stays as-is.

We kept the comparison rather than removing it, because transparency about competitor claims (and how they evolved) is more valuable than quietly deleting the section.

## Test plan

- [ ] Visual review of the MemPalace section in rendered README on GitHub
- [ ] Visual review of docs/BENCHMARKS.md table and footnotes
- [ ] Verify Issue #27 link resolves
- [ ] Confirm no other MemPalace references remain unaddressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)