### PR TITLE
chore: release v10.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.36.1] - 2026-04-10
+
+### Fixed
+
+- **[#678] SQLite-vec segfault under concurrent worker-thread access**: The `sqlite-vec` extension is not thread-safe; `check_same_thread=False` only disables Python's safety check. Concurrent calls to `self.conn` from multiple `asyncio.to_thread()` workers could crash inside the C extension. Added a per-storage `threading.Lock` (`_conn_lock`) and a `_run_in_thread()` helper that serializes every worker-thread DB call. Routed `_execute_with_retry`, migrations, FTS5 init, embedding-dimension probe, and conflict detection through the new helper. Observed as `Fatal Python error: Segmentation fault` in `_get_stats` on Ubuntu CI. (PR #678)
+- **[#678] SQLite-vec use-after-close segfault on hybrid shutdown**: `HybridStorage.close()` cancels background sync tasks, but cancellation only delivers `CancelledError` to the outer coroutine — an `asyncio.to_thread()` worker mid-query keeps running. The subsequent `primary.close()` then freed the connection underneath the worker, crashing sqlite3/sqlite-vec. `SqliteVecMemoryStorage.close()` now acquires `_conn_lock` before closing, so any in-flight worker finishes first. (PR #678)
+- **[#678] Corrupt `connection_types` in conflict graph edges**: `_record_conflicts` stored `connection_types` as the bare string `"semantic"` instead of a JSON-encoded list, which then crashed downstream graph readers with `JSONDecodeError`. Encoded as `json.dumps(["semantic"])` and hardened `GraphStorage.get_subgraph()` to tolerate legacy corrupt rows instead of crashing the request. (PR #678)
+
+### Tests
+
+- **[#678] Thread-safety test rewrite**: `test_execute_with_retry_does_not_block_loop` previously asserted that two DB operations run truly in parallel on a shared connection — exactly the pattern that caused the segfault. Rewritten to verify the actual property (the asyncio event loop stays responsive while a slow DB op runs in a worker thread), using a 5×50 ms `asyncio.sleep` probe. (PR #678)
+- **[#678] Stale ontology type count**: Bumped `test_total_type_count` from 75 → 77 after new burst types were added without updating the assertion. (PR #678)
+- **[#678] Semantic dedup collision in graph edge cleanup test**: `test_delete_by_tag_removes_graph_edges` stored near-duplicate content ("Tagged mem 1"/"Tagged mem 2") which dedup dropped when the embedding model was loaded by prior tests in the suite. Passed `skip_semantic_dedup=True` since the test's subject is edge cleanup, not dedup semantics. (PR #678)
+
 ## [10.36.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,13 +182,13 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 
 ### vs. MCP-Native Alternatives
 
-[MemPalace](https://github.com/milla-jovovich/mempalace) (~20k ⭐) is a strong MCP-native alternative worth knowing about.
+[MemPalace](https://github.com/milla-jovovich/mempalace) is an MCP-native alternative that went viral in April 2026 with strong LongMemEval claims. A [community code review (Issue #27)](https://github.com/milla-jovovich/mempalace/issues/27) subsequently showed that the headline numbers reflect the underlying vector store rather than the advertised Palace architecture, and the maintainers acknowledged most points. We keep the comparison here for transparency, but readers should interpret the scores with that context in mind.
 
 | | **MemPalace** | **mcp-memory-service** |
 |---|---|---|
-| LongMemEval R@5 (zero LLM) | **96.6%** | 86.0% (session) / 80.4% (turn) |
-| LongMemEval R@5 (with reranking) | **100%**¹ | — |
-| Storage granularity | Session-level | **Turn-level** |
+| LongMemEval R@5 (raw ChromaDB, zero LLM) | 96.6%¹ | 86.0% (session) / 80.4% (turn) |
+| LongMemEval R@5 (with reranking) | 100%² | — |
+| Storage granularity | Session-level | **Turn-level + session-level** |
 | Team / multi-device sync | ❌ Local only | **✅ Cloudflare sync** |
 | REST API / Web dashboard | ❌ | **✅** |
 | OAuth 2.1 + multi-user | ❌ | **✅** |
@@ -197,9 +197,14 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 | Compatible AI tools | Claude-focused | **13+ tools** |
 | License | MIT | **Apache 2.0** |
 
-**Why the benchmark gap?** MemPalace stores each conversation as a single unit (session-level). LongMemEval asks "which session contains the answer?" — a question that session-level storage answers structurally. mcp-memory-service defaults to turn-level storage (one entry per message), which enables fine-grained retrieval ("what exactly did the user say about X?") but spreads a session's signal across many entries. Using `memory_store_session` (session-level ingestion, added in v10.35.0) brings our score to **86.0% R@5** — closing the gap significantly. The remaining difference is primarily due to MemPalace's larger embedding model.
+**Why the benchmark gap?** Two independent factors:
 
-> ¹ 100% result uses optional LLM reranking (~500 API calls) and includes a partially tuned test set. Clean held-out score: **98.4% R@5**.
+1. **Ingestion granularity.** MemPalace stores each conversation as a single unit (session-level). LongMemEval asks "which session contains the answer?" — a question that session-level storage answers structurally. mcp-memory-service defaults to turn-level storage (one entry per message), which enables fine-grained retrieval ("what exactly did the user say about X?") but spreads a session's signal across many entries. Using `memory_store_session` (added in v10.35.0) brings our score to **86.0% R@5**.
+2. **What the 96.6% actually measures.** Per Issue #27, MemPalace's headline number is produced in "raw mode" — plain text stored in ChromaDB with default embeddings. The Palace architecture (Wings, Rooms, Halls) is **not active** in that configuration; "Halls" exist only as metadata strings with no effect on ranking. The 96.6% is therefore a ChromaDB + default-embedding baseline, not a measurement of MemPalace's retrieval features. A direct "apples-to-apples" architectural comparison is not possible with the published numbers.
+
+> ¹ Measured in MemPalace "raw mode" (plain text in ChromaDB with default embeddings). Per [Issue #27](https://github.com/milla-jovovich/mempalace/issues/27), the Palace structural features are bypassed in this configuration.
+>
+> ² 100% result uses optional LLM reranking (~500 API calls) on a partially tuned test set. Clean held-out score (as reported by the maintainers): **98.4% R@5**.
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -18,11 +18,13 @@ All results use zero LLM API calls (retrieval-only mode) unless noted.
 |--------|-----------|-----|------|---------|-----|-----------|
 | **MCP Memory Service** | **session** | **86.0%** | **93.0%** | **82.9%** | **82.8%** | 0 |
 | **MCP Memory Service** | turn (baseline) | 80.4% | 90.4% | 82.2% | 89.1% | 0 |
-| mempalace (raw) | session | 96.6% | — | — | — | 0 |
-| mempalace (hybrid v4 + Haiku) | session | 100%¹ | — | — | — | ~500 |
+| mempalace (raw ChromaDB) | session | 96.6%¹ | — | — | — | 0 |
+| mempalace (hybrid v4 + Haiku) | session | 100%² | — | — | — | ~500 |
 | Mem0 | — | ~85% | — | — | — | — |
 
-> ¹ 100% result uses optional LLM reranking on a partially tuned test set. Clean held-out score: 98.4% R@5.
+> ¹ MemPalace's "raw mode" stores plain text in ChromaDB with default embeddings. Per [MemPalace Issue #27](https://github.com/milla-jovovich/mempalace/issues/27), the Palace architecture (Wings, Rooms, Halls) is not active in this configuration — "Halls" exist only as metadata strings with no effect on ranking. The 96.6% is therefore a ChromaDB + default-embedding baseline rather than a measurement of MemPalace's structural retrieval features. Maintainers have publicly acknowledged this.
+>
+> ² 100% result uses optional LLM reranking (~500 API calls) on a partially tuned test set. Clean held-out score as reported by the maintainers: 98.4% R@5.
 
 **Ingestion modes explained:**
 - **turn**: each conversation turn stored as a separate memory (one entry per message)

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "10.36.0"
+version = "10.36.1"
 description = "Lightweight semantic memory service with ONNX embeddings - no PyTorch required. 80% smaller install size. REST API + MCP transport."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.0"
+version = "10.36.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.0"
+__version__ = "10.36.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.0"
+version = "10.36.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Critical patch release fixing two production segfaults and one data-corruption bug in sqlite-vec storage (all landed in PR #678, commit `70d325a`).

- **SQLite-vec concurrent segfault**: Added `threading.Lock` + `_run_in_thread()` helper to serialize all worker-thread DB calls; `sqlite-vec` C extension is not thread-safe and was crashing under concurrent `asyncio.to_thread()` access
- **Use-after-close segfault on hybrid shutdown**: `SqliteVecMemoryStorage.close()` now acquires `_conn_lock` before freeing the connection, ensuring any in-flight worker thread finishes first
- **Corrupt `connection_types` graph edges**: `_record_conflicts` now writes `json.dumps(["semantic"])` instead of bare string `"semantic"`; `GraphStorage.get_subgraph()` hardened against legacy corrupt rows

This release also fixes the `Test uvx compatibility` CI job that had been red since the segfault was introduced.

## Version bumps

- `pyproject.toml`: 10.36.0 → 10.36.1
- `pyproject-lite.toml`: 10.36.0 → 10.36.1
- `src/mcp_memory_service/_version.py`: 10.36.0 → 10.36.1
- `uv.lock`: updated
- `CHANGELOG.md`: `[Unreleased]` entries moved to `[10.36.1] - 2026-04-10`

## Test plan

- [ ] CI passes (especially `Test uvx compatibility` which was the canary for the segfault)
- [ ] PyPI publish triggered automatically by tag push after merge
- [ ] No unrelated working-tree files included in the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)