### PR TITLE
docs: add English-language policy to issue templates and CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thank you for reporting a bug! Please fill out the sections below to help us diagnose and fix the issue.
 
+        > 🌐 **Please write your issue in English.** This keeps the project accessible to our international community and makes problems searchable for others hitting the same issue. If English isn't your first language, tools like DeepL or Google Translate work well — we appreciate the effort!
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thank you for suggesting a feature! Please provide details about your use case and proposed solution.
 
+        > 🌐 **Please write your issue in English.** This keeps the project accessible to our international community and makes problems searchable for others hitting the same issue. If English isn't your first language, tools like DeepL or Google Translate work well — we appreciate the effort!
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Thank you for reporting a performance issue! Detailed metrics help us diagnose and optimize the system.
 
+        > 🌐 **Please write your issue in English.** This keeps the project accessible to our international community and makes problems searchable for others hitting the same issue. If English isn't your first language, tools like DeepL or Google Translate work well — we appreciate the effort!
+
   - type: textarea
     id: description
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Documentation
+
+- Added English-language policy to issue templates (bug, feature, performance) and CONTRIBUTING.md (PR #683)
+
 ## [10.36.1] - 2026-04-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ When adding features or making significant changes:
 
 All issues, pull requests, and discussions should be written in **English**. This keeps the project accessible to our international community of contributors and ensures problems are searchable for others hitting the same issue. If English isn't your first language, tools like DeepL or Google Translate work well — we genuinely appreciate the effort.
 
-Issues opened in other languages may be translated by a maintainer, or closed with a polite request to resubmit in English.
+Contributions opened in other languages may be translated by a maintainer, or redirected with a polite request to resubmit in English.
 
 ### Bug Reports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,12 @@ When adding features or making significant changes:
 
 ## Reporting Issues
 
+### Language
+
+All issues, pull requests, and discussions should be written in **English**. This keeps the project accessible to our international community of contributors and ensures problems are searchable for others hitting the same issue. If English isn't your first language, tools like DeepL or Google Translate work well — we genuinely appreciate the effort.
+
+Issues opened in other languages may be translated by a maintainer, or closed with a polite request to resubmit in English.
+
 ### Bug Reports
 
 When reporting bugs, include:


### PR DESCRIPTION
## Summary

- Add a friendly "please write in English" notice to all three issue templates (`bug_report.yml`, `feature_request.yml`, `performance_issue.yml`)
- Add a dedicated **Language** subsection under "Reporting Issues" in `CONTRIBUTING.md`

## Motivation

Several issues have been opened in non-English languages recently (most recently #677 in Chinese). While we value our international community, issues written in languages other than English:

- Limit which maintainers can respond quickly
- Are not searchable for other users hitting the same problem
- Slow down triage because translation is required first

## Tone

The policy is intentionally **welcoming, not gatekeeping**:

- Translation tools (DeepL, Google Translate) are explicitly encouraged
- We acknowledge that not everyone is a native English speaker
- Non-English issues will be translated by a maintainer *or* politely redirected — not closed outright

## Test plan

- [x] YAML syntax validates (GitHub will reject malformed templates)
- [ ] Verify the notice renders as a markdown blockquote in the issue form preview after merge
- [ ] No automated test coverage needed (documentation only)

## Related

- Triggered by #677 discussion