### PR TITLE
chore: release v10.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Added English-language policy to issue templates (bug, feature, performance) and CONTRIBUTING.md (PR #683)
 
+## [10.36.2] - 2026-04-10
+
+### Fixed
+
+- **[#682] Hardcoded server URLs in Windows management scripts**: All 5 Windows PowerShell management scripts (`manage_service.ps1`, `run_http_server_background.ps1`, `install_scheduled_task.ps1`, `uninstall_scheduled_task.ps1`, `update_and_restart.ps1`) used a hardcoded `http://127.0.0.1:8000` URL regardless of `.env` configuration. Health checks failed silently as soon as a user enabled HTTPS (`MCP_HTTPS_ENABLED=true`) or changed the port (`MCP_HTTP_PORT`). Introduced `scripts/service/windows/lib/server-config.ps1` as a shared helper that parses `.env` for `MCP_HTTP_HOST`, `MCP_HTTP_PORT`, and `MCP_HTTPS_ENABLED` and returns a `BaseUrl`/`HealthUrl` hashtable. All scripts now dot-source this helper. Falls back to `http://127.0.0.1:8000` if `.env` is absent or variables are unset — fully backward-compatible. (PR #682)
+- **[#682] Silent Python stdout/stderr dropout in background server wrapper**: `run_http_server_background.ps1` used .NET `OutputDataReceived` event handlers that referenced `$script:LogFile`, a variable not captured in the event handler runspace. Every line of Python stdout and stderr was silently discarded. When Python crashed during initialization, no error was ever surfaced in the log. Replaced with `Start-Process -RedirectStandardOutput`/`-RedirectStandardError` which writes directly to `http-server-python.log` and a `.err` sidecar, eliminating the runspace capture problem entirely. (PR #682)
+- **[#682] Log overwrite destroys crash evidence in restart loop**: `Start-Process` overwrites the redirect target file on each invocation. The previous size-based rotation (`> 10MB`) meant that on a crash-restart cycle, the crash output from attempt N was silently destroyed by attempt N+1 before it could be inspected. Rotation is now unconditional at the start of each loop iteration: the current log is renamed to `.old` before `Start-Process` is called, preserving the most recent crash output. (PR #682, Gemini review feedback)
+
+### Changed
+
+- **[#682] `.env` regex strips trailing inline comments**: The `.env` parser in `server-config.ps1` now uses `([^#\r\n]*?)` to capture values, so `MCP_HTTP_PORT=8001 # my custom port` parses correctly as `8001` rather than failing `[int]::TryParse`. (PR #682, Gemini review feedback)
+- **[#682] TLS protocol uses additive `-bor` instead of replacement**: `Enable-McpSelfSignedCertBypass` previously replaced the session's `SecurityProtocol` with `Tls12` outright, which would have disabled TLS 1.3 if already enabled. Now uses `-bor` to add `Tls12` to the existing protocol set without removing newer protocols. (PR #682, Gemini review feedback)
+
 ## [10.36.1] - 2026-04-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.36.0 - feat: OpenCode memory awareness integration (@irizzant, PR #673) + lite package version sync fix (PR #675) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.36.2 - fix(windows): env-aware management scripts + reliable stdout logging (PR #682) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -434,18 +434,21 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.36.0** (April 9, 2026)
+## Latest Release: **v10.36.2** (April 10, 2026)
 
-**feat: OpenCode memory awareness integration + lite package version sync fix**
+**fix(windows): env-aware management scripts + reliable stdout logging**
 
-**What's New:**
-- **OpenCode integration** (`opencode/memory-plugin.js`): New community-contributed plugin that injects memories into OpenCode sessions via the HTTP API — session-start retrieval, system-context injection, and compaction-context injection. Includes setup docs and example config. (by @irizzant)
-- **Lite package version sync fix**: `mcp-memory-service-lite` was stuck at 8.76.0 on PyPI. Synced to current version, added `pyproject-lite.toml` to release automation, and added CI fallback sync step.
-- **1,537 tests** passing.
+**What's Fixed:**
+- **Hardcoded URLs eliminated**: All 5 Windows management scripts now derive the server URL from `.env` (`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTPS_ENABLED`) via a shared `lib/server-config.ps1` helper. Health checks no longer fail when HTTPS is enabled or the port is changed.
+- **Python stdout/stderr reliably captured**: `run_http_server_background.ps1` replaces broken .NET event handlers (where `$script:LogFile` was silently dropped in the handler runspace) with `Start-Process -RedirectStandardOutput`. Logs now surface immediately on startup and during crash loops.
+- **Log rotation per restart**: Previous crash output is preserved as `.old` before each restart iteration — `Start-Process` overwrites the target file, so without rotation the prior crash evidence was destroyed.
+- **1,537 tests** passing. (PR #682)
 
 ---
 
 **Previous Releases**:
+- **v10.36.1** - fix: SQLite-vec segfault under concurrent worker-thread access + use-after-close crash on hybrid shutdown + corrupt connection_types in conflict graph edges (PR #678, 1,537 tests)
+- **v10.36.0** - feat: OpenCode memory awareness integration (@irizzant, PR #673) + lite package version sync fix (PR #675, 1,537 tests)
 - **v10.35.0** - feat: session-level memory ingestion — `memory_store_session` MCP tool + `POST /api/sessions` — LongMemEval R@5 86.0% (+5.6%) (PR #666, 1,537 tests)
 - **v10.34.0** - feat: LongMemEval benchmark — R@5 80.4%, R@10 90.4%, NDCG@10 82.2%, MRR 89.1% (PR #665, 1,520 tests)
 - **v10.33.0** - refactor: eliminate event-loop blocking + fix silent conflict data loss in SQLite storage (PR #663, 1,520 tests)

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "10.36.1"
+version = "10.36.2"
 description = "Lightweight semantic memory service with ONNX embeddings - no PyTorch required. 80% smaller install size. REST API + MCP transport."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.1"
+version = "10.36.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.1"
+__version__ = "10.36.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'linux'",
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.1"
+version = "10.36.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.36.2 (PATCH)

Promotes the changes from PR #682 (`fix/windows-scripts-env-aware`) into a versioned release.

### What changed

**PR #682** fixed two bugs in the Windows Scheduled Task wrapper scripts that made them unreliable as soon as a user enabled HTTPS or changed the default port:

1. **Hardcoded URLs** - All 5 PowerShell management scripts used `http://127.0.0.1:8000` unconditionally. Introduced `scripts/service/windows/lib/server-config.ps1` to parse `.env` for `MCP_HTTP_HOST`/`MCP_HTTP_PORT`/`MCP_HTTPS_ENABLED`. Fully backward-compatible (falls back to previous defaults).

2. **Silent stdout dropout** - `run_http_server_background.ps1` used .NET `OutputDataReceived` event handlers that referenced `$script:LogFile`, which is not captured in the handler runspace. Every line of Python output was silently discarded. Replaced with `Start-Process -RedirectStandardOutput`.

**Gemini review feedback** addressed in follow-up commit `6cc7752`:

3. Log rotation is now unconditional per restart iteration (not size-gated) so crash output from attempt N is not overwritten by attempt N+1.
4. `.env` regex now strips trailing inline comments (`MCP_HTTP_PORT=8001 # comment` parses as `8001`).
5. TLS protocol set via `-bor` to preserve TLS 1.3 alongside TLS 1.2.

### Classification: PATCH

Zero Python code changes, zero runtime/API changes, zero test changes. Windows-only PowerShell scripts.

### Manual test evidence (verified by author)

- `manage_service.ps1 status` reports `HEALTHY` on `https://127.0.0.1:8001/` after fix (previously: `NOT RESPONDING`)
- `http-server-python.log` gains 15 stdout lines + 174 stderr lines within seconds of startup (previously: always 0 lines)
- Post-reboot Scheduled Task auto-starts, server listens on correct port, sync active
- PowerShell parser validates all modified scripts (no syntax errors)
- `grep` confirms zero hardcoded `8000`/`http://127.0.0.1` references remain in `scripts/service/windows/`

### Landing page

Skipped per CLAUDE.md policy: landing page updates are MINOR/MAJOR only. This is a PATCH release.

### Version bump

| File | Before | After |
|------|--------|-------|
| `src/mcp_memory_service/_version.py` | 10.36.1 | 10.36.2 |
| `pyproject.toml` | 10.36.1 | 10.36.2 |
| `pyproject-lite.toml` | 10.36.1 | 10.36.2 |
| `uv.lock` | regenerated | - |