### PR TITLE
fix(dashboard): restore version badge after v10.21.0 security hardening

### DIFF
--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -79,6 +79,46 @@ function Get-McpServerConfig {
     return $config
 }
 
+function Get-McpApiKey {
+    <#
+    .SYNOPSIS
+        Reads MCP_API_KEY from the project's .env file.
+
+    .DESCRIPTION
+        Parses .env line-by-line and extracts MCP_API_KEY. Returns $null if
+        the key is not defined. Used by scripts that need to call
+        authenticated endpoints such as /api/server/status or
+        /api/health/detailed (required since the v10.21.0 security hardening
+        in GHSA-73hc-m4hx-79pj removed version/uptime from the public
+        /api/health response).
+
+    .OUTPUTS
+        System.String - the API key, or $null if not found.
+    #>
+    param(
+        [string]$ProjectRoot = (Get-McpProjectRoot)
+    )
+
+    $EnvFile = Join-Path $ProjectRoot ".env"
+    if (-not (Test-Path $EnvFile)) {
+        return $null
+    }
+
+    $apiKey = $null
+    Get-Content $EnvFile | ForEach-Object {
+        $line = $_
+        if ($line -match '^\s*#' -or $line -notmatch '=') { return }
+        if ($line -match '^\s*MCP_API_KEY\s*=\s*(.*?)\s*(?:#.*)?$') {
+            $apiKey = $matches[1].Trim().Trim('"').Trim("'")
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($apiKey)) {
+        return $null
+    }
+    return $apiKey
+}
+
 function Enable-McpSelfSignedCertBypass {
     <#
     .SYNOPSIS

--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -105,11 +105,14 @@ function Get-McpApiKey {
     }
 
     $apiKey = $null
-    Get-Content $EnvFile | ForEach-Object {
-        $line = $_
-        if ($line -match '^\s*#' -or $line -notmatch '=') { return }
-        if ($line -match '^\s*MCP_API_KEY\s*=\s*(.*?)\s*(?:#.*)?$') {
-            $apiKey = $matches[1].Trim().Trim('"').Trim("'")
+    foreach ($line in Get-Content $EnvFile -Encoding UTF8) {
+        if ($line -match '^\s*#' -or $line -notmatch '=') { continue }
+        # Regex handles quoted values (which may contain '#') and unquoted values
+        # (stripped of trailing comments). Capture groups: 1=double-quoted,
+        # 2=single-quoted, 3=unquoted (no '#' or whitespace allowed).
+        if ($line -match '^\s*MCP_API_KEY\s*=\s*(?:"([^"]*)"|''([^'']*)''|([^#\s]*))') {
+            $apiKey = ($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]
+            break
         }
     }
 

--- a/scripts/service/windows/manage_service.ps1
+++ b/scripts/service/windows/manage_service.ps1
@@ -99,7 +99,7 @@ function Get-ServerStatus {
         }
     }
 
-    # Check HTTP health
+    # Check HTTP health (public, no auth — fast liveness check)
     $HttpHealthy = $false
     $HealthResponse = $null
     try {
@@ -118,6 +118,29 @@ function Get-ServerStatus {
         # Server not responding
     }
 
+    # Fetch version + backend from the authenticated /api/health/detailed
+    # endpoint. The public /api/health response only contains status since the
+    # v10.21.0 security hardening (GHSA-73hc-m4hx-79pj), so the human-readable
+    # status display needs the authenticated endpoint for version/backend.
+    # Degrades gracefully if MCP_API_KEY is not set in .env.
+    $DetailedHealth = $null
+    if ($HttpHealthy) {
+        $ApiKey = Get-McpApiKey
+        if ($ApiKey) {
+            try {
+                $DetailedUrl = "$($ServerConfig.BaseUrl)/api/health/detailed"
+                $DetailedResponse = Invoke-WebRequest -Uri $DetailedUrl `
+                    -Headers @{ "Authorization" = "Bearer $ApiKey" } `
+                    -TimeoutSec 3 -UseBasicParsing -ErrorAction SilentlyContinue
+                if ($DetailedResponse.StatusCode -eq 200) {
+                    $DetailedHealth = $DetailedResponse.Content | ConvertFrom-Json
+                }
+            } catch {
+                # /health/detailed unreachable — keep fields empty, don't fail status
+            }
+        }
+    }
+
     return @{
         Task = $Task
         TaskInfo = $TaskInfo
@@ -125,6 +148,7 @@ function Get-ServerStatus {
         ProcessPid = $ProcessPid
         HttpHealthy = $HttpHealthy
         HealthResponse = $HealthResponse
+        DetailedHealth = $DetailedHealth
     }
 }
 
@@ -178,9 +202,18 @@ function Show-Status {
         Write-Host "  Status:  " -NoNewline
         Write-Host "HEALTHY" -ForegroundColor Green
         Write-Host "  URL:     $DashboardUrl"
-        if ($Status.HealthResponse) {
-            Write-Host "  Version: $($Status.HealthResponse.version)"
-            Write-Host "  Backend: $($Status.HealthResponse.storage_backend)"
+        # Version + backend come from /api/health/detailed (authenticated).
+        # Public /api/health has not exposed these since v10.21.0.
+        if ($Status.DetailedHealth) {
+            $backendValue = $null
+            if ($Status.DetailedHealth.storage) {
+                $backendValue = $Status.DetailedHealth.storage.storage_backend
+            }
+            Write-Host "  Version: $($Status.DetailedHealth.version)"
+            Write-Host "  Backend: $backendValue"
+        } else {
+            Write-Host "  Version: (unavailable - set MCP_API_KEY in .env for details)" -ForegroundColor DarkGray
+            Write-Host "  Backend: (unavailable - set MCP_API_KEY in .env for details)" -ForegroundColor DarkGray
         }
     } else {
         Write-Host "  Status: " -NoNewline

--- a/scripts/service/windows/manage_service.ps1
+++ b/scripts/service/windows/manage_service.ps1
@@ -207,7 +207,12 @@ function Show-Status {
         if ($Status.DetailedHealth) {
             $backendValue = $null
             if ($Status.DetailedHealth.storage) {
-                $backendValue = $Status.DetailedHealth.storage.storage_backend
+                # 'backend' is the canonical field per DetailedHealthResponse schema.
+                # 'storage_backend' may appear in backend-specific stats as a fallback.
+                $backendValue = $Status.DetailedHealth.storage.backend
+                if (-not $backendValue) {
+                    $backendValue = $Status.DetailedHealth.storage.storage_backend
+                }
             }
             Write-Host "  Version: $($Status.DetailedHealth.version)"
             Write-Host "  Backend: $backendValue"

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -12,7 +12,12 @@ class MemoryDashboard {
     // Static configuration for settings modal system information
     static SYSTEM_INFO_CONFIG = {
         settingsVersion: {
-            sources: [{ path: 'version', api: 'health' }],
+            // Since v10.21.0 (GHSA-73hc-m4hx-79pj), /api/health no longer
+            // returns version/uptime/timestamp as a defense-in-depth measure
+            // against info disclosure. The version is only exposed via the
+            // authenticated /api/health/detailed endpoint, which is already
+            // fetched by loadSystemInfo().
+            sources: [{ path: 'version', api: 'detailedHealth' }],
             formatter: (value) => value || 'N/A'
         },
         settingsBackend: {
@@ -847,7 +852,9 @@ class MemoryDashboard {
     }
 
     /**
-     * Load application version from health endpoint
+     * Load application version from the authenticated /health/detailed endpoint.
+     * Note: /health is intentionally minimal since v10.21.0 (GHSA-73hc-m4hx-79pj)
+     * and no longer exposes version information without authentication.
      */
     async loadVersion() {
         try {


### PR DESCRIPTION
## Summary

Fixes a latent regression introduced with the v10.21.0 security hardening (GHSA-73hc-m4hx-79pj). That fix correctly removed `version`, `timestamp`, and `uptime_seconds` from the public `/api/health` response to avoid info disclosure — but two clients of the old contract were not updated:

1. **Dashboard Settings modal** — `SYSTEM_INFO_CONFIG.settingsVersion` still resolved against `api: 'health'`, so the Version row was effectively dead (displayed `N/A` or `Loading...` forever, no matter what version was running). The header badge (`loadVersion()`) had already been migrated to `/health/detailed` separately, leaving the Settings modal as an orphaned regression.
2. **`scripts/service/windows/manage_service.ps1`** — `Get-ServerStatus` parsed the public `/api/health` response for `version` and `storage_backend`, which have not existed there for four months. `manage_service.ps1 status` displayed blank `Version:` and `Backend:` lines against a perfectly healthy server.

Both are the same class of bug: a client of `/api/health` expecting fields that were moved to `/api/health/detailed` and never updated.

## Changes

### `src/mcp_memory_service/web/static/app.js`
- `SYSTEM_INFO_CONFIG.settingsVersion`: `api: 'health'` → `api: 'detailedHealth'`. The resolver in `loadSystemInfo()` already fetches both endpoints via `Promise.allSettled`, so no new network call is added.
- `loadVersion()` docstring updated to document the v10.21.0 constraint inline, so the next person touching this code does not revert the fix.

### `scripts/service/windows/lib/server-config.ps1`
- New `Get-McpApiKey` helper that parses `MCP_API_KEY` from `.env` with support for trailing comments, quoting, and whitespace. Returns `$null` when the key is missing so callers can degrade gracefully.

### `scripts/service/windows/manage_service.ps1`
- `Get-ServerStatus` now fetches `/api/health/detailed` with a Bearer token (when `MCP_API_KEY` is available) to populate version and backend fields.
- `Show-Status` displays the real values, or a clear `(unavailable - set MCP_API_KEY in .env for details)` hint instead of silently rendering blank rows.

## Test plan

- [x] **JS syntax**: `node --check src/mcp_memory_service/web/static/app.js` → OK
- [x] **PowerShell syntax**: `[System.Management.Automation.Language.Parser]::ParseFile()` → no errors on both modified `.ps1` files
- [x] **Live verification** against local v10.36.2 server:
  ```
  MCP Memory HTTP Server Status
  =============================
  HTTP Endpoint:
    Status:  HEALTHY
    URL:     https://127.0.0.1:8001/
    Version: 10.36.2                              ← previously empty
    Backend: Hybrid (SQLite-vec + Cloudflare)     ← previously empty
  ```
- [x] **Graceful degradation**: If `MCP_API_KEY` is not set in `.env`, `Get-McpApiKey` returns `$null` and `Show-Status` shows the `(unavailable)` hint instead of failing.
- [ ] **Manual browser verification** (Settings modal) — should be done by reviewer or in follow-up screenshot before merge, per the CLAUDE.md dashboard testing policy.

## Compatibility

Fully backward-compatible:
- Dashboard already fetches `/health/detailed` via authenticated `apiCall()` in `loadSystemInfo()`, so the Settings modal fix reuses an existing response — no new network call, no new auth requirement.
- `manage_service.ps1` degrades gracefully without `MCP_API_KEY`, preserving the previous `HEALTHY` status behavior.

## Background

This bug affected any user who upgraded past v10.21.0 and looked at the Settings modal or `manage_service.ps1 status`, including the reporter who saw `v10.36.0` in a dashboard against a freshly-updated server. While investigating, we also discovered that the reporter's MacMini was likely running an older Python process (version cached in `sys.modules` at process start) — a separate concern not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)