### PR TITLE
chore: release v10.36.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **[#685] Dashboard Settings modal version row showed N/A permanently**: `SYSTEM_INFO_CONFIG.settingsVersion` in `app.js` was still configured to fetch from `api: 'health'` (the public endpoint). The v10.21.0 security hardening (GHSA-73hc-m4hx-79pj) removed `version`, `timestamp`, and `uptime_seconds` from `/api/health`, so the Settings modal Version row had been displaying `N/A` for ~4 months. Fixed by pointing the config entry to `'detailedHealth'`, consistent with the header version badge which was already migrated. (PR #685)
 - **[#685] `manage_service.ps1 status` showed blank Version and Backend**: `Get-ServerStatus` parsed `version` and `storage_backend` from the public `/api/health` response, fields that no longer exist since v10.21.0. Migrated to `/api/health/detailed` with Bearer auth when `MCP_API_KEY` is available; `Show-Status` now displays real version/backend values or a clear hint when the key is not configured. Introduced `Get-McpApiKey` helper in `lib/server-config.ps1` that parses `MCP_API_KEY` from `.env` with support for trailing comments, quoting, and whitespace — keys containing `#` inside quoted values are handled correctly. Falls back to `$null` gracefully when key is absent. (PR #685, regression introduced by GHSA-73hc-m4hx-79pj)
 
+### Documentation
+
+- Added English-language policy to issue templates (bug, feature, performance) and CONTRIBUTING.md (PR #683)
+
 ## [10.36.2] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Documentation
+## [10.36.3] - 2026-04-10
 
-- Added English-language policy to issue templates (bug, feature, performance) and CONTRIBUTING.md (PR #683)
+### Fixed
+
+- **[#685] Dashboard Settings modal version row showed N/A permanently**: `SYSTEM_INFO_CONFIG.settingsVersion` in `app.js` was still configured to fetch from `api: 'health'` (the public endpoint). The v10.21.0 security hardening (GHSA-73hc-m4hx-79pj) removed `version`, `timestamp`, and `uptime_seconds` from `/api/health`, so the Settings modal Version row had been displaying `N/A` for ~4 months. Fixed by pointing the config entry to `'detailedHealth'`, consistent with the header version badge which was already migrated. (PR #685)
+- **[#685] `manage_service.ps1 status` showed blank Version and Backend**: `Get-ServerStatus` parsed `version` and `storage_backend` from the public `/api/health` response, fields that no longer exist since v10.21.0. Migrated to `/api/health/detailed` with Bearer auth when `MCP_API_KEY` is available; `Show-Status` now displays real version/backend values or a clear hint when the key is not configured. Introduced `Get-McpApiKey` helper in `lib/server-config.ps1` that parses `MCP_API_KEY` from `.env` with support for trailing comments, quoting, and whitespace — keys containing `#` inside quoted values are handled correctly. Falls back to `$null` gracefully when key is absent. (PR #685, regression introduced by GHSA-73hc-m4hx-79pj)
 
 ## [10.36.2] - 2026-04-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.36.2 - fix(windows): env-aware management scripts + reliable stdout logging (PR #682) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.36.3 - fix(dashboard): restore version badge after v10.21.0 security hardening (PR #685) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -434,19 +434,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.36.2** (April 10, 2026)
+## Latest Release: **v10.36.3** (April 10, 2026)
 
-**fix(windows): env-aware management scripts + reliable stdout logging**
+**fix(dashboard): restore version badge after v10.21.0 security hardening**
 
 **What's Fixed:**
-- **Hardcoded URLs eliminated**: All 5 Windows management scripts now derive the server URL from `.env` (`MCP_HTTP_HOST`, `MCP_HTTP_PORT`, `MCP_HTTPS_ENABLED`) via a shared `lib/server-config.ps1` helper. Health checks no longer fail when HTTPS is enabled or the port is changed.
-- **Python stdout/stderr reliably captured**: `run_http_server_background.ps1` replaces broken .NET event handlers (where `$script:LogFile` was silently dropped in the handler runspace) with `Start-Process -RedirectStandardOutput`. Logs now surface immediately on startup and during crash loops.
-- **Log rotation per restart**: Previous crash output is preserved as `.old` before each restart iteration — `Start-Process` overwrites the target file, so without rotation the prior crash evidence was destroyed.
-- **1,537 tests** passing. (PR #682)
+- **Dashboard Settings modal version row showed N/A permanently**: `SYSTEM_INFO_CONFIG.settingsVersion` pointed at the public `/api/health` endpoint, which has not exposed `version` since the v10.21.0 security hardening (GHSA-73hc-m4hx-79pj). Migrated to `/api/health/detailed`, consistent with the header badge.
+- **`manage_service.ps1 status` showed blank Version and Backend**: `Get-ServerStatus` parsed fields removed from `/api/health` since v10.21.0. Now fetches `/api/health/detailed` with Bearer auth; introduces `Get-McpApiKey` helper in `lib/server-config.ps1` that robustly parses `MCP_API_KEY` from `.env` (handles quoting, trailing comments, keys containing `#`).
+- **1,537 tests** passing. (PR #685)
 
 ---
 
 **Previous Releases**:
+- **v10.36.2** - fix(windows): env-aware management scripts + reliable stdout logging — hardcoded URLs eliminated, Python stdout reliably captured, log rotation per restart (PR #682, 1,537 tests)
 - **v10.36.1** - fix: SQLite-vec segfault under concurrent worker-thread access + use-after-close crash on hybrid shutdown + corrupt connection_types in conflict graph edges (PR #678, 1,537 tests)
 - **v10.36.0** - feat: OpenCode memory awareness integration (@irizzant, PR #673) + lite package version sync fix (PR #675, 1,537 tests)
 - **v10.35.0** - feat: session-level memory ingestion — `memory_store_session` MCP tool + `POST /api/sessions` — LongMemEval R@5 86.0% (+5.6%) (PR #666, 1,537 tests)

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "10.36.2"
+version = "10.36.3"
 description = "Lightweight semantic memory service with ONNX embeddings - no PyTorch required. 80% smaller install size. REST API + MCP transport."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.2"
+version = "10.36.3"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.2"
+__version__ = "10.36.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.2"
+version = "10.36.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

PATCH release restoring user-visible functionality broken since v10.21.0 (GHSA-73hc-m4hx-79pj), which correctly removed `version`, `timestamp`, and `uptime_seconds` from `/api/health` but left two callers of the old contract unupdated for ~4 months.

**Fixes included (via PR #685):**
- Dashboard Settings modal Version row displayed `N/A` permanently — `SYSTEM_INFO_CONFIG.settingsVersion` pointed at `api: 'health'`; migrated to `'detailedHealth'`
- `manage_service.ps1 status` showed blank Version/Backend — `Get-ServerStatus` parsed fields no longer in `/api/health`; migrated to `/api/health/detailed` with Bearer auth via new `Get-McpApiKey` helper
- Gemini review fixes applied: robust `.env` parser using `foreach` + capture-group regex (handles `#` inside quoted values), canonical `backend` field checked before `storage_backend` fallback

**Version bump delta:**
| File | Change |
|------|--------|
| `src/mcp_memory_service/_version.py` | `10.36.2` → `10.36.3` |
| `pyproject.toml` | `10.36.2` → `10.36.3` |
| `pyproject-lite.toml` | `10.36.2` → `10.36.3` |
| `uv.lock` | updated by `uv lock` |
| `CHANGELOG.md` | new `[10.36.3]` section added |
| `README.md` | Latest Release updated, v10.36.2 moved to Previous Releases |
| `CLAUDE.md` | Current Version callout updated |

**Landing page skipped**: PATCH release — policy (CLAUDE.md) is MINOR/MAJOR only.

## Test plan

- [x] CI green on PR #685 (4/4 checks: Main CI/CD Pipeline, CodeQL, Claude Code Review — all passed on commit `0637e0f`)
- [x] PowerShell syntax check passed (`[System.Management.Automation.Language.Parser]::ParseFile()` — no errors on all 3 changed `.ps1` files)
- [x] JS syntax check passed (`node --check src/mcp_memory_service/web/static/app.js`)
- [x] Live verification against local v10.36.2 server: `Version: 10.36.2` and `Backend: Hybrid (SQLite-vec + Cloudflare)` now displayed correctly (previously empty)
- [x] `Get-McpApiKey` tested independently: returns key or `$null`, respects comments and quoting in `.env`
- [x] `uv lock` ran cleanly: `Updated mcp-memory-service v10.36.2 -> v10.36.3`
- [x] Version consistent across all 3 version files + CHANGELOG + README + CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)