### PR TITLE
chore: release v10.36.4 (hotfix for Get-McpApiKey char enumeration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.36.4] - 2026-04-10
+
+### Fixed
+
+- **[#687] `Get-McpApiKey` returned first character of API key instead of full key**: A Gemini-suggested refactor in v10.36.3 replaced a working implementation with `($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]`. Unmatched regex capture groups are absent from `$matches` (not `$null`), so when only one group matched the comma expression produced a single-element string, which PowerShell enumerated to its `Char` array — making `[0]` return `'b'` instead of `bxvWZwrI...`. This broke `manage_service.ps1 status` for all Windows users: Version and Backend showed `(unavailable - set MCP_API_KEY in .env for details)` even when the key was correctly configured. Fixed by replacing the comma expression with an explicit `if/elseif` chain using `$matches.ContainsKey(N)` and `[string]` casts. Verified live: returns full 43-character key string, `manage_service.ps1 status` correctly displays Version and Backend.
+
 ## [10.36.3] - 2026-04-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.36.3 - fix(dashboard): restore version badge after v10.21.0 security hardening (PR #685) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.36.4 - fix(windows): hotfix for Get-McpApiKey char-enumeration regression (PR #687) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -434,18 +434,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.36.3** (April 10, 2026)
+## Latest Release: **v10.36.4** (April 10, 2026)
 
-**fix(dashboard): restore version badge after v10.21.0 security hardening**
+**fix(windows): hotfix for Get-McpApiKey returning first char instead of full API key**
 
 **What's Fixed:**
-- **Dashboard Settings modal version row showed N/A permanently**: `SYSTEM_INFO_CONFIG.settingsVersion` pointed at the public `/api/health` endpoint, which has not exposed `version` since the v10.21.0 security hardening (GHSA-73hc-m4hx-79pj). Migrated to `/api/health/detailed`, consistent with the header badge.
-- **`manage_service.ps1 status` showed blank Version and Backend**: `Get-ServerStatus` parsed fields removed from `/api/health` since v10.21.0. Now fetches `/api/health/detailed` with Bearer auth; introduces `Get-McpApiKey` helper in `lib/server-config.ps1` that robustly parses `MCP_API_KEY` from `.env` (handles quoting, trailing comments, keys containing `#`).
-- **1,537 tests** passing. (PR #685)
+- **`Get-McpApiKey` returned first character of API key (regression from v10.36.3)**: A Gemini-suggested refactor introduced a PowerShell array-enumeration trap — `($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]` returned `'b'` instead of the full key. Fixed with an explicit `if/elseif` chain using `$matches.ContainsKey()` and `[string]` casts. `manage_service.ps1 status` now correctly shows Version and Backend for all Windows users.
+- **1,537 tests** passing. (PR #687)
 
 ---
 
 **Previous Releases**:
+- **v10.36.3** - fix(dashboard): restore version badge after v10.21.0 security hardening — Settings modal version row fixed, `manage_service.ps1 status` shows real Version/Backend (PR #685, 1,537 tests)
 - **v10.36.2** - fix(windows): env-aware management scripts + reliable stdout logging — hardcoded URLs eliminated, Python stdout reliably captured, log rotation per restart (PR #682, 1,537 tests)
 - **v10.36.1** - fix: SQLite-vec segfault under concurrent worker-thread access + use-after-close crash on hybrid shutdown + corrupt connection_types in conflict graph edges (PR #678, 1,537 tests)
 - **v10.36.0** - feat: OpenCode memory awareness integration (@irizzant, PR #673) + lite package version sync fix (PR #675, 1,537 tests)

--- a/pyproject-lite.toml
+++ b/pyproject-lite.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service-lite"
-version = "10.36.3"
+version = "10.36.4"
 description = "Lightweight semantic memory service with ONNX embeddings - no PyTorch required. 80% smaller install size. REST API + MCP transport."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.3"
+version = "10.36.4"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -110,8 +110,19 @@ function Get-McpApiKey {
         # Regex handles quoted values (which may contain '#') and unquoted values
         # (stripped of trailing comments). Capture groups: 1=double-quoted,
         # 2=single-quoted, 3=unquoted (no '#' or whitespace allowed).
+        # NOTE: $matches uses ContainsKey() because unmatched capture groups
+        # are absent from the hashtable, not $null. A previous implementation
+        # used ($matches[1], $matches[2], $matches[3] | Where {$_ -ne $null})[0]
+        # which collapsed a single-element string result to its first Char via
+        # PowerShell's array-enumeration behavior.
         if ($line -match '^\s*MCP_API_KEY\s*=\s*(?:"([^"]*)"|''([^'']*)''|([^#\s]*))') {
-            $apiKey = ($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]
+            if ($matches.ContainsKey(1) -and -not [string]::IsNullOrEmpty($matches[1])) {
+                $apiKey = [string]$matches[1]
+            } elseif ($matches.ContainsKey(2) -and -not [string]::IsNullOrEmpty($matches[2])) {
+                $apiKey = [string]$matches[2]
+            } elseif ($matches.ContainsKey(3) -and -not [string]::IsNullOrEmpty($matches[3])) {
+                $apiKey = [string]$matches[3]
+            }
             break
         }
     }

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.3"
+__version__ = "10.36.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.3"
+version = "10.36.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Hotfix for a critical regression introduced in v10.36.3 (PR #685) by a Gemini-suggested refactor of the `Get-McpApiKey` helper in `scripts/service/windows/lib/server-config.ps1`.

### The Bug

The refactored code used:
```powershell
$apiKey = ($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]
```

PowerShell's `$matches` hashtable omits unmatched capture groups entirely (they are **absent**, not `$null`). When only group 3 matched (the unquoted case), the comma expression created a pipeline with a single string element. `Where-Object` passed it through unchanged, but PowerShell's array-enumeration behavior then caused `[0]` to index into the string's `Char` array — returning `'b'` instead of the full 43-character API key.

**Impact**: `manage_service.ps1 status` showed `(unavailable - set MCP_API_KEY in .env for details)` for all Windows users, even when `MCP_API_KEY` was correctly set in `.env`. This is a regression from the pre-v10.36.3 state where Version and Backend were at least blank rather than actively misleading.

### The Fix

Replaced with an explicit `if/elseif` chain:
```powershell
if ($matches.ContainsKey(1) -and -not [string]::IsNullOrEmpty($matches[1])) {
    $apiKey = [string]$matches[1]
} elseif ($matches.ContainsKey(2) -and -not [string]::IsNullOrEmpty($matches[2])) {
    $apiKey = [string]$matches[2]
} elseif ($matches.ContainsKey(3) -and -not [string]::IsNullOrEmpty($matches[3])) {
    $apiKey = [string]$matches[3]
}
```

### Verification

Tested live on a real `.env` file with an unquoted API key (the affected case):
- Before fix: `Get-McpApiKey` returns `Char, value: 'b'`
- After fix: `Get-McpApiKey` returns `String, length: 43, preview: bxvWZwrI...`
- `manage_service.ps1 status` correctly displays `Version: 10.36.4, Backend: sqlite-vec`

### Version bump

`10.36.3` -> `10.36.4` (PATCH - hotfix only, no feature changes)

### Lesson learned

Any Gemini-suggested refactor touching `Get-McpApiKey` logic must be live-tested with a real `.env` file before accepting. The v10.36.3 refactor looked clean but was not tested against actual PowerShell behavior.

## Test plan

- [x] Verified `Get-McpApiKey` returns full 43-char API key string (not first char)
- [x] Verified `manage_service.ps1 status` shows correct Version and Backend
- [x] `uv.lock` updated via `uv lock`
- [x] Version bumped in `_version.py`, `pyproject.toml`, `pyproject-lite.toml`
- [x] CHANGELOG, README, CLAUDE.md updated
- [x] `.claude/settings.json` NOT staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)