### PR TITLE
chore: release v10.36.7 — security: bump pygments to 2.20.0 (CVE-2026-4539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.36.7] - 2026-04-14
+
+### Security
+
+- **[#698] Bumped pygments to 2.20.0**: Resolves CVE-2026-4539 (GHSA-5239-wwwm-4pmq, ReDoS via inefficient regex for GUID matching). Transitive dependency via rich. (PR #698)
+
 ## [10.36.6] - 2026-04-14
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.36.6 - security: bump cryptography to 46.0.7 to fix CVE-2026-39892 (PR #690) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.36.7 - security: bump pygments to 2.20.0 to fix CVE-2026-4539/GHSA-5239-wwwm-4pmq (PR #698) — 1,537 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -434,17 +434,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.36.6** (April 14, 2026)
+## Latest Release: **v10.36.7** (April 14, 2026)
 
-**security: Bump cryptography to 46.0.7 (CVE-2026-39892)**
+**security: Bump pygments to 2.20.0 (CVE-2026-4539)**
 
 **What's Fixed:**
-- **CVE-2026-39892**: Bumped `cryptography` to 46.0.7 to fix a buffer overflow in non-contiguous buffer handling. (PR #690)
+- **CVE-2026-4539** (GHSA-5239-wwwm-4pmq): Bumped `pygments` to 2.20.0 to fix a ReDoS vulnerability via inefficient regex for GUID matching. Transitive dependency via rich. (PR #698)
 - **1,537 tests** passing.
 
 ---
 
 **Previous Releases**:
+- **v10.36.6** - security: bump cryptography to 46.0.7 (CVE-2026-39892) — buffer overflow fix in non-contiguous buffer handling (PR #690, 1,537 tests)
 - **v10.36.5** - fix: Cloudflare Vectorize API v1 to v2 + test script fixes — fixed error 1010 "incorrect_api_version", content_hash arg, sys.path correction (PR #689, @mychaelgo, 1,537 tests)
 - **v10.36.4** - fix(windows): hotfix for Get-McpApiKey returning first char instead of full API key — PowerShell array-enumeration trap fixed (PR #687, 1,537 tests)
 - **v10.36.3** - fix(dashboard): restore version badge after v10.21.0 security hardening — Settings modal version row fixed, `manage_service.ps1 status` shows real Version/Backend (PR #685, 1,537 tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.6"
+version = "10.36.7"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.6"
+__version__ = "10.36.7"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.6"
+version = "10.36.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -2046,11 +2046,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `pygments` to 2.20.0 to fix CVE-2026-4539 (GHSA-5239-wwwm-4pmq): ReDoS via inefficient regex for GUID matching, transitive dependency via `rich`
- Version bumped: `10.36.6` → `10.36.7` in `_version.py`, `pyproject.toml`, `uv.lock`
- CHANGELOG, README Latest Release, and CLAUDE.md version callout updated

## Test plan

- [ ] CI passes (PyPI publish triggered by tag push)
- [ ] 1,537 tests continue to pass
- [ ] No landing page update needed (PATCH release)

Ref: CVE-2026-4539, GHSA-5239-wwwm-4pmq, PR #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)