### PR TITLE
fix(storage): wrap pragma + hash fallback in asyncio.to_thread (#664)

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -712,9 +712,10 @@ SOLUTIONS:
             if not extension_supported:
                 self._handle_extension_loading_failure()
 
-            # Connect to database and load extension (runs in worker thread —
-            # sqlite3.connect + extension load + pragma application all block I/O; #664)
-            await asyncio.to_thread(self._connect_and_load_extension)
+            # Connect to database and load extension (runs in worker thread under
+            # _conn_lock — sqlite3.connect + extension load + pragma application all
+            # block I/O, and the sqlite-vec extension is not thread-safe; #664)
+            await self._run_in_thread(self._connect_and_load_extension)
 
             # Check if database is already initialized by another process
             # This prevents DDL lock conflicts when multiple servers start concurrently
@@ -1233,7 +1234,7 @@ SOLUTIONS:
         The dimension lookup reads from SQLite, so it must run in a worker thread to avoid
         blocking the event loop during startup (#664).
         """
-        existing_dim = await asyncio.to_thread(self._get_existing_db_embedding_dimension)
+        existing_dim = await self._run_in_thread(self._get_existing_db_embedding_dimension)
         if existing_dim and existing_dim != self.embedding_dimension:
             logger.warning(
                 f"Adjusting hash embedding dimension from {self.embedding_dimension} to "

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -712,8 +712,9 @@ SOLUTIONS:
             if not extension_supported:
                 self._handle_extension_loading_failure()
 
-            # Connect to database and load extension
-            self._connect_and_load_extension()
+            # Connect to database and load extension (runs in worker thread —
+            # sqlite3.connect + extension load + pragma application all block I/O; #664)
+            await asyncio.to_thread(self._connect_and_load_extension)
 
             # Check if database is already initialized by another process
             # This prevents DDL lock conflicts when multiple servers start concurrently
@@ -1104,7 +1105,7 @@ SOLUTIONS:
                 logger.warning(
                     "Neither ONNX nor sentence-transformers available; using pure-Python hash embeddings (quality reduced)."
                 )
-                self._initialize_hash_embedding_fallback()
+                await self._initialize_hash_embedding_fallback()
                 return
 
             # Check cache first
@@ -1224,11 +1225,15 @@ SOLUTIONS:
             logger.warning(
                 "Falling back to pure-Python hash embeddings due to embedding init failure (quality reduced)."
             )
-            self._initialize_hash_embedding_fallback()
+            await self._initialize_hash_embedding_fallback()
 
-    def _initialize_hash_embedding_fallback(self):
-        """Initialize hash embedding model, matching existing DB dimension if possible (#608)."""
-        existing_dim = self._get_existing_db_embedding_dimension()
+    async def _initialize_hash_embedding_fallback(self):
+        """Initialize hash embedding model, matching existing DB dimension if possible (#608).
+
+        The dimension lookup reads from SQLite, so it must run in a worker thread to avoid
+        blocking the event loop during startup (#664).
+        """
+        existing_dim = await asyncio.to_thread(self._get_existing_db_embedding_dimension)
         if existing_dim and existing_dim != self.embedding_dimension:
             logger.warning(
                 f"Adjusting hash embedding dimension from {self.embedding_dimension} to "


### PR DESCRIPTION
## Summary

Closes #664 — two remaining startup paths in `SqliteVecMemoryStorage.initialize()` ran SQLite calls on the event loop thread, inconsistent with the thread-safety model established in #663.

### Fix 1 — Pragma application in `_connect_and_load_extension`
`sqlite3.connect` + extension loading + WAL/cache pragma application now run entirely in a worker thread via `asyncio.to_thread(self._connect_and_load_extension)`.

### Fix 2 — Hash fallback dimension lookup
`_initialize_hash_embedding_fallback` is now `async def` and wraps `_get_existing_db_embedding_dimension` in `asyncio.to_thread`. Both callers (no-lib path + exception handler inside `_initialize_embedding_model`) updated to `await`.

## Changes
- `src/mcp_memory_service/storage/sqlite_vec.py`: 12 insertions, 7 deletions

## Test plan
- [x] `pytest tests/test_issues_603_to_608.py tests/test_sqlite_vec_storage.py tests/test_timestamp_preservation.py tests/test_external_embeddings.py` — 111 passed, 3 skipped
- [x] Syntax check via `ast.parse` — clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)