### PR TITLE
chore: release v10.36.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.36.8] - 2026-04-14
+
+### Fixed
+
+- **[#664] Event-loop blocking paths in `SqliteVecMemoryStorage.initialize()`**: Pragma application in `_connect_and_load_extension` now runs in a worker thread under `_conn_lock` via `_run_in_thread` instead of executing synchronously on the event loop. `_initialize_hash_embedding_fallback` is now async and wraps `_get_existing_db_embedding_dimension` in `_run_in_thread`. The sqlite-vec extension is not thread-safe so `asyncio.to_thread` (used in an earlier iteration) was replaced with `_run_in_thread` to ensure proper `_conn_lock` protection. (PR #700)
+
 ## [10.36.7] - 2026-04-14
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.36.7"
+version = "10.36.8"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.36.7"
+__version__ = "10.36.8"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.36.7"
+version = "10.36.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to v10.36.8 (patch)
- Add CHANGELOG entry for PR #700 / issue #664 fix
- Update uv.lock

## What Changed

**Fix: Event-loop blocking paths in `SqliteVecMemoryStorage.initialize()` (PR #700, closes #664)**

Two remaining synchronous operations in the async initialization path were blocking the event loop:

1. Pragma application in `_connect_and_load_extension` now runs in a worker thread under `_conn_lock` via `_run_in_thread`
2. `_initialize_hash_embedding_fallback` is now async and wraps `_get_existing_db_embedding_dimension` in `_run_in_thread`

The initial fix used `asyncio.to_thread` but was corrected to use `_run_in_thread` during Gemini review to ensure proper `_conn_lock` protection (sqlite-vec extension is not thread-safe).

## Test plan

- [ ] CI green on this branch
- [ ] No API or behavior changes — 1,537 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)