### PR TITLE
docs: clean up dead references in active docs (#662)

### DIFF
--- a/docs/architecture/search-examples.md
+++ b/docs/architecture/search-examples.md
@@ -8,7 +8,7 @@
 
 **REST API Call:**
 ```bash
-curl -X POST "https://localhost:8443/api/search/advanced" \
+curl -X POST "http://localhost:8000/api/search/advanced" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-api-key" \
   -d '{
@@ -161,7 +161,7 @@ curl -X POST "https://localhost:8443/api/search/advanced" \
 
 **REST API Call:**
 ```bash
-curl -X POST "https://localhost:8443/api/search/advanced" \
+curl -X POST "http://localhost:8000/api/search/advanced" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-api-key" \
   -d '{

--- a/docs/development/ai-agent-instructions.md
+++ b/docs/development/ai-agent-instructions.md
@@ -91,8 +91,7 @@ src/mcp_memory_service/
 - `src/mcp_memory_service/server.py` - Entry point and server initialization
 - `src/mcp_memory_service/storage/base.py` - Storage interface all backends must implement
 - `src/mcp_memory_service/web/app.py` - FastAPI application for HTTP mode
-- `pyproject.toml` - Project dependencies and configuration
-- `install.py` - Platform-aware installer script
+- `pyproject.toml` - Project dependencies and configuration (install via `pip install -e .`)
 
 ## Common Development Tasks
 
@@ -151,7 +150,7 @@ python scripts/validation/validate_memories.py
 export LOG_LEVEL=DEBUG
 
 # Check service health
-curl https://localhost:8443/api/health
+curl http://localhost:8000/api/health
 
 # Monitor logs
 tail -f ~/.mcp-memory-service/logs/service.log
@@ -176,7 +175,7 @@ sqlite3 ~/.mcp-memory-service/sqlite_vec.db ".tables"
 
 - **SQLite extension errors on macOS**: Use Homebrew Python or pyenv with `--enable-loadable-sqlite-extensions`
 - **Model download hangs**: Check network connectivity, models are ~25MB
-- **Import errors**: Run `python install.py` to ensure all dependencies installed
+- **Import errors**: Run `pip install -e .` (or `pip install -e ".[full]"` for all extras) to ensure dependencies are installed
 - **MCP connection fails**: Restart Claude Desktop to refresh MCP connections
 - **Memory not persisting**: Check file permissions in `~/.mcp-memory-service/`
 

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -92,13 +92,13 @@ If you encounter sqlite-vec installation failures on Python 3.13:
 brew install python@3.12
 python3.12 -m venv .venv
 source .venv/bin/activate
-python install.py
+pip install -e .
 
 # Ubuntu/Linux
 sudo apt install python3.12 python3.12-venv
 python3.12 -m venv .venv
 source .venv/bin/activate
-python install.py
+pip install -e .
 ```
 
 **Option 2: Manual sqlite-vec Installation**
@@ -131,7 +131,7 @@ hash -r  # Refresh command cache
 python3 --version  # Verify you're using Homebrew Python
 
 # Then install MCP Memory Service
-python3 install.py
+pip install -e .
 ```
 
 **Option 2: pyenv with Extension Support**
@@ -176,7 +176,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # Install the service
-python install.py
+pip install -e .
 
 # Start the service
 uv run memory server

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -92,13 +92,13 @@ If you encounter sqlite-vec installation failures on Python 3.13:
 brew install python@3.12
 python3.12 -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install mcp-memory-service
 
 # Ubuntu/Linux
 sudo apt install python3.12 python3.12-venv
 python3.12 -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install mcp-memory-service
 ```
 
 **Option 2: Manual sqlite-vec Installation**
@@ -131,7 +131,7 @@ hash -r  # Refresh command cache
 python3 --version  # Verify you're using Homebrew Python
 
 # Then install MCP Memory Service
-pip install -e .
+pip install mcp-memory-service
 ```
 
 **Option 2: pyenv with Extension Support**
@@ -176,7 +176,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # Install the service
-pip install -e .
+pip install mcp-memory-service
 
 # Start the service
 uv run memory server

--- a/docs/guides/STORAGE_BACKENDS.md
+++ b/docs/guides/STORAGE_BACKENDS.md
@@ -37,15 +37,17 @@
 
 ### Example Use Cases:
 ```bash
-# 2015 MacBook Pro scenario
-python install.py --legacy-hardware
-# Result: SQLite-vec + Homebrew PyTorch + ONNX
+# 2015 MacBook Pro scenario (SQLite-vec + Homebrew PyTorch + ONNX)
+export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
+export MCP_MEMORY_USE_ONNX=1
+pip install -e .
 
 # Docker deployment
 docker run -e MCP_MEMORY_STORAGE_BACKEND=sqlite_vec ...
 
 # Quick development setup
-python install.py --storage-backend sqlite_vec --dev
+export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
+pip install -e ".[sqlite]"
 ```
 
 ## When to Choose ChromaDB 📦
@@ -68,14 +70,13 @@ python install.py --storage-backend sqlite_vec --dev
 
 ### Example Use Cases:
 ```bash
-# Modern Mac with GPU
-python install.py  # ChromaDB selected automatically
+# Modern Mac with GPU — production deployment with Cloudflare sync
+export MCP_MEMORY_STORAGE_BACKEND=hybrid
+pip install -e ".[full]"
 
-# Production deployment
-python install.py --storage-backend chromadb --production
-
-# Research environment
-python install.py --storage-backend chromadb --enable-advanced-features
+# Cloud-only deployment
+export MCP_MEMORY_STORAGE_BACKEND=cloudflare
+pip install -e ".[full]"
 ```
 
 ## Hardware Compatibility Matrix
@@ -204,9 +205,6 @@ Perfect for upgrading legacy hardware or simplifying deployments:
 ```bash
 # Automated migration
 python scripts/migrate_chroma_to_sqlite.py
-
-# Manual migration with verification
-python install.py --migrate-from-chromadb --storage-backend sqlite_vec
 ```
 
 **Migration preserves:**

--- a/docs/guides/commands-vs-mcp-server.md
+++ b/docs/guides/commands-vs-mcp-server.md
@@ -27,7 +27,7 @@ This guide helps you choose the best integration method for your workflow and ne
 | **Setup Time** | 2 minutes | 5-15 minutes |
 | **Configuration** | Zero config required | Manual MCP server registration |
 | **Prerequisites** | Claude Code CLI only | Claude Code CLI + MCP knowledge |
-| **Installation** | `python install.py --install-claude-commands` | `claude mcp add memory-service spawn -- ...` |
+| **Installation** | `python scripts/installation/install.py --install-claude-commands` | `claude mcp add memory-service spawn -- ...` |
 | **Updates** | Automatic with installer updates | Manual server path updates |
 
 ### User Experience
@@ -139,7 +139,7 @@ claude mcp add memory-service spawn -- /path/to/memory/command
 #### From MCP Server to Commands
 ```bash
 # Install commands alongside existing setup
-python install.py --install-claude-commands
+python scripts/installation/install.py --install-claude-commands
 ```
 
 ### Data Compatibility

--- a/docs/guides/commands-vs-mcp-server.md
+++ b/docs/guides/commands-vs-mcp-server.md
@@ -27,7 +27,7 @@ This guide helps you choose the best integration method for your workflow and ne
 | **Setup Time** | 2 minutes | 5-15 minutes |
 | **Configuration** | Zero config required | Manual MCP server registration |
 | **Prerequisites** | Claude Code CLI only | Claude Code CLI + MCP knowledge |
-| **Installation** | `python scripts/installation/install.py --install-claude-commands` | `claude mcp add memory-service spawn -- ...` |
+| **Installation** | `python scripts/installation/install.py --install-hooks` | `claude mcp add memory-service spawn -- ...` |
 | **Updates** | Automatic with installer updates | Manual server path updates |
 
 ### User Experience
@@ -139,7 +139,7 @@ claude mcp add memory-service spawn -- /path/to/memory/command
 #### From MCP Server to Commands
 ```bash
 # Install commands alongside existing setup
-python scripts/installation/install.py --install-claude-commands
+python scripts/installation/install.py --install-hooks
 ```
 
 ### Data Compatibility

--- a/docs/http-server-management.md
+++ b/docs/http-server-management.md
@@ -50,7 +50,7 @@ Error: [WinError 10061] No connection could be made...
 # HTTP mode (default, port 8000)
 uv run python scripts/server/run_http_server.py
 
-# HTTPS mode (port 8443)
+# HTTPS mode (same port 8000, TLS enabled)
 MCP_HTTPS_ENABLED=true uv run python scripts/server/run_http_server.py
 ```
 
@@ -106,7 +106,7 @@ cat ~/.claude/hooks/config.json | grep -A5 "http"
 
 Should match your server configuration:
 - Default HTTP: `http://localhost:8000` or `http://127.0.0.1:8000`
-- Default HTTPS: `https://localhost:8443`
+- Default HTTPS: `https://localhost:8000` (when `MCP_HTTPS_ENABLED=true`)
 
 **Important:** The HTTP server uses port **8000** by default (configured in `.env`). If your hooks are configured for a different port (e.g., 8889), you need to either:
 1. Update hooks config to match port 8000, OR

--- a/docs/integration/homebrew.md
+++ b/docs/integration/homebrew.md
@@ -84,9 +84,12 @@ cd mcp-memory-service
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install with Homebrew integration (--no-deps skips bundled PyTorch so the Homebrew build is used)
+# Install with Homebrew integration. Normal install pulls all required deps
+# (fastapi, mcp, etc.). An unused torch wheel will also be installed, but at
+# runtime MCP_MEMORY_USE_HOMEBREW_PYTORCH=1 makes the service use Homebrew's
+# torch instead of the bundled one.
 export MCP_MEMORY_USE_HOMEBREW_PYTORCH=1
-pip install -e ".[sqlite]" --no-deps
+pip install -e ".[sqlite]"
 ```
 
 ### 3. Configure Environment Variables

--- a/docs/integration/homebrew.md
+++ b/docs/integration/homebrew.md
@@ -84,10 +84,9 @@ cd mcp-memory-service
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install with Homebrew integration (skips bundled PyTorch so the Homebrew build is used)
+# Install with Homebrew integration (--no-deps skips bundled PyTorch so the Homebrew build is used)
 export MCP_MEMORY_USE_HOMEBREW_PYTORCH=1
 pip install -e ".[sqlite]" --no-deps
-pip install -e "."
 ```
 
 ### 3. Configure Environment Variables

--- a/docs/integration/homebrew.md
+++ b/docs/integration/homebrew.md
@@ -27,8 +27,10 @@ The Homebrew PyTorch integration allows MCP Memory Service to use system-install
 git clone https://github.com/doobidoo/mcp-memory-service.git
 cd mcp-memory-service
 
-# Install with Homebrew PyTorch integration
-python install.py --use-homebrew-pytorch --storage-backend sqlite_vec
+# Install with SQLite-vec backend; Homebrew PyTorch is picked up automatically if present
+export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
+export MCP_MEMORY_USE_HOMEBREW_PYTORCH=1
+pip install -e ".[sqlite]"
 ```
 
 ### Running the Service
@@ -82,8 +84,10 @@ cd mcp-memory-service
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install with Homebrew integration
-python install.py --use-homebrew-pytorch --skip-pytorch
+# Install with Homebrew integration (skips bundled PyTorch so the Homebrew build is used)
+export MCP_MEMORY_USE_HOMEBREW_PYTORCH=1
+pip install -e ".[sqlite]" --no-deps
+pip install -e "."
 ```
 
 ### 3. Configure Environment Variables
@@ -345,11 +349,15 @@ export MCP_MEMORY_ONNX_MODEL_PATH="/path/to/custom/model.onnx"
 For shared access across multiple MCP clients:
 
 ```bash
-# Install with multi-client support
-python install.py --use-homebrew-pytorch --multi-client
+# Install with Homebrew PyTorch, then run the shared HTTP server
+export MCP_MEMORY_USE_HOMEBREW_PYTORCH=1
+pip install -e ".[sqlite]"
 
-# Configure shared database location
+# Configure shared database location and HTTP server for multi-client access
 export MCP_MEMORY_SQLITE_PATH="/shared/mcp_memory/memory.db"
+export MCP_HTTP_ENABLED=true
+export MCP_HTTP_PORT=8000
+python scripts/server/run_http_server.py
 ```
 
 ## Development and Contributions

--- a/docs/integration/multi-client.md
+++ b/docs/integration/multi-client.md
@@ -14,35 +14,25 @@ MCP Memory Service supports multi-client access through several deployment patte
 
 ### During Installation
 
-The easiest way to configure multi-client access is during the initial installation:
+Install the package and enable the HTTP server (all MCP clients can then share the same backend):
 
 ```bash
-# Run the installer - you'll be prompted for multi-client setup
-python install.py
+# Install (user) or editable dev install
+pip install mcp-memory-service        # user
+# pip install -e ".[full]"            # contributor / editable
 
-# When prompted, choose 'y':
-# 🌐 Multi-Client Access Available!
-# Would you like to configure multi-client access? (y/N): y
+# Configure and start the shared HTTP server
+export MCP_HTTP_ENABLED=true
+export MCP_HTTP_PORT=8000
+export MCP_MEMORY_STORAGE_BACKEND=hybrid   # or sqlite_vec
+python scripts/server/run_http_server.py
 ```
 
-**Benefits of integrated setup:**
-- ✅ Automatic detection of Claude Desktop, VS Code, Continue, Cursor, and other MCP clients
+**Benefits of the HTTP-based setup:**
+- ✅ One server process serves Claude Desktop, VS Code, Continue, Cursor, and any HTTP/MCP client
 - ✅ Universal compatibility beyond just Claude applications
-- ✅ Zero manual configuration required
+- ✅ Concurrent access without database locks (SQLite WAL mode)
 - ✅ Future-proof setup for any MCP application
-
-### Command Line Options
-
-```bash
-# Automatic multi-client setup (no prompts)
-python install.py --setup-multi-client
-
-# Skip the multi-client prompt entirely
-python install.py --skip-multi-client-prompt
-
-# Combined with other options
-python install.py --storage-backend sqlite_vec --setup-multi-client
-```
 
 ### Supported Applications
 
@@ -156,7 +146,8 @@ For Claude Desktop on each client machine:
    ```bash
    git clone https://github.com/doobidoo/mcp-memory-service.git
    cd mcp-memory-service
-   python install.py --server-mode --storage-backend sqlite_vec
+   pip install -e ".[sqlite]"
+   export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
    ```
 
 2. **Configure HTTP server:**
@@ -419,12 +410,15 @@ netstat -an | grep :8000
    python scripts/backup_memories.py
    ```
 
-2. **Run multi-client setup:**
+2. **Enable the shared HTTP server:**
    ```bash
-   python install.py --setup-multi-client --migrate-existing
+   export MCP_HTTP_ENABLED=true
+   export MCP_HTTP_PORT=8000
+   export MCP_MEMORY_STORAGE_BACKEND=hybrid   # or sqlite_vec
+   python scripts/server/run_http_server.py
    ```
 
-3. **Update client configurations** as needed.
+3. **Update client configurations** to point at `http://<host>:8000` as needed.
 
 ### Data Migration
 

--- a/docs/integration/multi-client.md
+++ b/docs/integration/multi-client.md
@@ -17,16 +17,18 @@ MCP Memory Service supports multi-client access through several deployment patte
 Install the package and enable the HTTP server (all MCP clients can then share the same backend):
 
 ```bash
-# Install (user) or editable dev install
-pip install mcp-memory-service        # user
-# pip install -e ".[full]"            # contributor / editable
+# Install with HTTP server support
+pip install "mcp-memory-service[full]"    # user install
+# pip install -e ".[full]"                # contributor / editable from cloned repo
 
-# Configure and start the shared HTTP server
+# Configure and start the shared HTTP server via the bundled CLI
 export MCP_HTTP_ENABLED=true
 export MCP_HTTP_PORT=8000
 export MCP_MEMORY_STORAGE_BACKEND=hybrid   # or sqlite_vec
-python scripts/server/run_http_server.py
+memory server --http
 ```
+
+> **Note:** `memory server --http` is the pip-installable CLI entry point. If you cloned the repo, `python scripts/server/run_http_server.py` works equivalently.
 
 **Benefits of the HTTP-based setup:**
 - ✅ One server process serves Claude Desktop, VS Code, Continue, Cursor, and any HTTP/MCP client

--- a/docs/integrations/gemini.md
+++ b/docs/integrations/gemini.md
@@ -28,8 +28,8 @@ cd mcp-memory-service
 python -m venv venv
 source venv/bin/activate # On Windows: venv\Scripts\activate
 
-# Run the intelligent installer
-python install.py
+# Install in editable mode (use the [full] extra to get all optional dependencies)
+pip install -e ".[full]"
 ```
 
 ### Running the Server

--- a/docs/natural-memory-triggers/cli-reference.md
+++ b/docs/natural-memory-triggers/cli-reference.md
@@ -502,7 +502,7 @@ node memory-mode-controller.js reset --force
 **Solution**:
 ```bash
 # Check memory service status
-curl -k https://localhost:8443/api/health
+curl http://localhost:8000/api/health
 
 # Start memory service
 uv run memory server
@@ -536,7 +536,7 @@ node memory-mode-controller.js status
 [DEBUG] Initializing TieredConversationMonitor
 [DEBUG] PerformanceManager initialized with profile: balanced
 [DEBUG] GitAnalyzer detecting repository context
-[DEBUG] MCP Client connecting to https://localhost:8443
+[DEBUG] MCP Client connecting to http://localhost:8000
 [DEBUG] Status command executed successfully
 ```
 

--- a/docs/natural-memory-triggers/installation-guide.md
+++ b/docs/natural-memory-triggers/installation-guide.md
@@ -8,7 +8,7 @@ Before installing Natural Memory Triggers, ensure you have:
 
 - ✅ **Claude Code CLI** installed and working (`claude --version`)
 - ✅ **Node.js 14+** for hook execution (`node --version`)
-- ✅ **MCP Memory Service** running (`curl -k https://localhost:8443/api/health`)
+- ✅ **MCP Memory Service** running (`curl http://localhost:8000/api/health`)
 - ✅ **Valid configuration** at `~/.claude/hooks/config.json`
 
 ## Installation Methods
@@ -333,7 +333,7 @@ chmod -R 644 ~/.claude/hooks/*.json
 **Diagnosis**:
 ```bash
 # Test memory service directly
-curl -k https://localhost:8443/api/health
+curl http://localhost:8000/api/health
 
 # Check configuration
 cat ~/.claude/hooks/config.json | grep -A 5 "memoryService"
@@ -342,7 +342,7 @@ cat ~/.claude/hooks/config.json | grep -A 5 "memoryService"
 **Solutions**:
 1. **Start Memory Service**: `uv run memory server`
 2. **Check API Key**: Ensure valid API key in configuration
-3. **Firewall Settings**: Verify port 8443 is accessible
+3. **Firewall Settings**: Verify port 8000 is accessible
 4. **SSL Issues**: Self-signed certificates may need special handling
 
 ### Issue 4: Configuration Conflicts

--- a/docs/natural-memory-triggers/performance-optimization.md
+++ b/docs/natural-memory-triggers/performance-optimization.md
@@ -402,7 +402,7 @@ node memory-mode-controller.js config set performance.maxConcurrentAnalysis 3
 node memory-mode-controller.js metrics --breakdown
 
 # Test memory service directly
-curl -w "@curl-format.txt" -k https://localhost:8443/api/health
+curl -w "@curl-format.txt" http://localhost:8000/api/health
 
 # Check system resources
 top -p $(pgrep -f memory-mode-controller)
@@ -435,7 +435,7 @@ node memory-mode-controller.js cache analyze
 **Diagnosis**:
 ```bash
 # Test memory service responsiveness
-time curl -k https://localhost:8443/api/health
+time curl http://localhost:8000/api/health
 
 # Check service logs
 tail -f ~/Library/Logs/Claude/mcp-server-memory.log

--- a/docs/troubleshooting/general.md
+++ b/docs/troubleshooting/general.md
@@ -43,26 +43,16 @@ For detailed information, see the [First-Time Setup Guide](../first-time-setup.m
 
 **Solutions:**
 
-1. **Automatic Fallback (v6.13.2+)**
-   - The installer now automatically tries multiple installation methods
-   - It will attempt: uv pip, standard pip, source build, and GitHub installation
-   - If all fail, you'll be prompted to switch to ChromaDB
-
-2. **Use Python 3.12 (Recommended)**
+1. **Use Python 3.12 (Recommended)**
    ```bash
    # macOS
    brew install python@3.12
    python3.12 -m venv .venv
    source .venv/bin/activate
-   python install.py
+   pip install -e .
    ```
 
-3. **Switch to ChromaDB Backend**
-   ```bash
-   python install.py --storage-backend chromadb
-   ```
-
-4. **Manual Installation Attempts**
+2. **Manual Installation Attempts**
    ```bash
    # Force source build
    pip install --no-binary :all: sqlite-vec
@@ -74,7 +64,7 @@ For detailed information, see the [First-Time Setup Guide](../first-time-setup.m
    pip install pysqlite3-binary
    ```
 
-5. **Report Issue**
+3. **Report Issue**
    - Check for updates: https://github.com/asg017/sqlite-vec/issues
    - sqlite-vec may add Python 3.13 support in future releases
 
@@ -97,7 +87,7 @@ For detailed information, see the [First-Time Setup Guide](../first-time-setup.m
    python3 --version  # Verify Homebrew version
    
    # Reinstall MCP Memory Service
-   python3 install.py
+   pip install -e .
    ```
 
 2. **Use pyenv with Extension Support**
@@ -112,17 +102,10 @@ For detailed information, see the [First-Time Setup Guide](../first-time-setup.m
    pyenv install 3.12.0
    
    pyenv local 3.12.0
-   python install.py
+   pip install -e .
    ```
 
-3. **Switch to ChromaDB Backend**
-   ```bash
-   # ChromaDB doesn't require SQLite extensions
-   export MCP_MEMORY_STORAGE_BACKEND=chromadb
-   python install.py --storage-backend chromadb
-   ```
-
-4. **Verify Extension Support**
+3. **Verify Extension Support**
    ```bash
    python3 -c "
    import sqlite3

--- a/docs/tutorials/demo-session-walkthrough.md
+++ b/docs/tutorials/demo-session-walkthrough.md
@@ -26,7 +26,7 @@ Error storing memory: No module named 'aiohttp'
 **Solution Process**:
 1. **Identified the root cause**: Missing dependency not included in installer
 2. **Manual fix**: Added `aiohttp>=3.8.0` to `pyproject.toml`
-3. **Installer enhancement**: Updated `install.py` to handle aiohttp automatically
+3. **Installer enhancement**: Updated `scripts/installation/install.py` to handle aiohttp automatically
 4. **Documentation**: Added manual installation instructions
 
 **Commit**: `535c488 - fix: Add aiohttp dependency to resolve MCP server startup issues`
@@ -95,10 +95,12 @@ Error storing memory: No module named 'aiohttp'
 **Deployment Commands**:
 ```bash
 # Server setup
-python install.py --server-mode --enable-http-api
+pip install -e ".[full]"
+export MCP_HTTP_ENABLED=true
 export MCP_HTTP_HOST=0.0.0.0
+export MCP_HTTP_PORT=8000
 export MCP_API_KEY="your-secure-key"
-python scripts/run_http_server.py
+python scripts/server/run_http_server.py
 
 # Access points
 # API: http://server:8000/api/docs

--- a/scripts/ci/check_dead_refs.sh
+++ b/scripts/ci/check_dead_refs.sh
@@ -66,10 +66,8 @@ if [ $FOUND -eq 0 ]; then
   exit 0
 else
   echo ""
-  echo "⚠️  These are known docs debt — tracked in GitHub issue #662."
-  echo "    New dead references in newly added files will be caught here."
+  echo "⚠️  Dead references detected in active docs."
   echo "    Fix: remove or update the references listed above."
   echo "    Note: docs/archive/, docs/legacy/, docs/plans/ and migration guides are excluded."
-  # TODO: change to exit 1 once existing dead refs in active docs are cleaned up (issue #662)
-  exit 0
+  exit 1
 fi


### PR DESCRIPTION
## Summary

Closes #662 — removes all dead references flagged by `scripts/ci/check_dead_refs.sh` and flips the CI check from warning-only to blocking.

**Three classes of dead refs cleaned:**

- **ChromaDB backend** (removed) → replaced with `sqlite_vec`/`hybrid`, obsolete "Switch to ChromaDB" troubleshooting sections removed outright
- **Port 8443** → **8000** (current HTTP default per CLAUDE.md)
- **`python install.py`** → `pip install -e .` for dev docs, `pip install mcp-memory-service` for user docs, or qualified `scripts/installation/install.py` where the script still exists

**Multi-client + Homebrew integration docs** rewritten around current patterns (`MCP_HTTP_ENABLED=true` + `run_http_server.py`, `MCP_MEMORY_USE_HOMEBREW_PYTORCH=1`) — old installer flags (`--setup-multi-client`, `--use-homebrew-pytorch`, etc.) no longer exist.

**CI hardening:** `scripts/ci/check_dead_refs.sh` now `exit 1` on findings — prevents regressions.

## Files changed
15 docs files + 1 CI script (`docs/` tree + `scripts/ci/check_dead_refs.sh`).

## Test plan
- [x] `bash scripts/ci/check_dead_refs.sh` → ✅ No dead references found, exit 0
- [x] Manual review of rewritten sections (multi-client, homebrew) for coherence
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)