### PR TITLE
fix(cli): import missing generate_content_hash in ingestion

### DIFF
--- a/src/mcp_memory_service/cli/ingestion.py
+++ b/src/mcp_memory_service/cli/ingestion.py
@@ -26,6 +26,7 @@ import click
 from ..ingestion import get_loader_for_file, is_supported_file, SUPPORTED_FORMATS
 from ..models.memory import Memory
 from ..utils import _process_and_store_chunk
+from ..utils.hashing import generate_content_hash
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/cli/ingestion.py
+++ b/src/mcp_memory_service/cli/ingestion.py
@@ -25,8 +25,7 @@ import click
 
 from ..ingestion import get_loader_for_file, is_supported_file, SUPPORTED_FORMATS
 from ..models.memory import Memory
-from ..utils import _process_and_store_chunk
-from ..utils.hashing import generate_content_hash
+from ..utils import _process_and_store_chunk, generate_content_hash
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

\`memory ingest-document\` and \`memory ingest-directory\` silently fail to store any chunks because \`generate_content_hash\` is used at \`src/mcp_memory_service/cli/ingestion.py:113\` but never imported. The exception is swallowed by the outer try/except (line 128) and surfaces only in \`--verbose\` mode:

\`\`\`
⚠️  Exception in chunk 0: name 'generate_content_hash' is not defined
\`\`\`

Without \`--verbose\`, users just see a confusing \`Chunks stored: 0\` / \`Success rate: 0.0%\`.

## Reproduction

\`\`\`
$ memory ingest-document /path/to/any.md --verbose
...
⚠️  Exception in chunk 0: name 'generate_content_hash' is not defined
✅ Document ingestion completed: any.md
📄 Chunks processed: 1
💾 Chunks stored: 0
⚡ Success rate: 0.0%
\`\`\`

## Fix

Add the missing import from \`..utils.hashing\`, matching the existing pattern in \`server/handlers/documents.py\` (line 119) and \`services/memory_service.py\` (line 35).

## Test plan

- [x] Verified without patch: \`memory ingest-document\` reports 0/1 stored with \`NameError\` in verbose output
- [x] Verified with patch: same command reports 1/1 stored, record persists in \`sqlite_vec.db\`