### PR TITLE
fix(server): make --sse-host / --sse-port CLI flags actually take effect

### DIFF
--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -267,11 +267,16 @@ class ServerRunManager:
                 response = Response("Not Found", status_code=404)
                 await response(scope, receive, send)
 
-        self.logger.info(f"Starting SSE transport on {MCP_SSE_HOST}:{MCP_SSE_PORT}")
+        # Re-read env at runtime so late-set values (e.g. from CLI flags in
+        # cli/main.py after package __init__ has already frozen config.py
+        # module constants) still take effect.
+        sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
+        sse_port = int(os.environ.get('MCP_SSE_PORT', MCP_SSE_PORT))
+        self.logger.info(f"Starting SSE transport on {sse_host}:{sse_port}")
         config = uvicorn.Config(
             app,
-            host=MCP_SSE_HOST,
-            port=MCP_SSE_PORT,
+            host=sse_host,
+            port=sse_port,
             log_level="info",
             timeout_keep_alive=MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE,
             timeout_graceful_shutdown=MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN,
@@ -411,11 +416,14 @@ class ServerRunManager:
             await response(scope, receive, send)
             return False
 
-        self.logger.info(f"Starting Streamable HTTP transport on {MCP_SSE_HOST}:{MCP_SSE_PORT}")
+        # Re-read env at runtime; see run_sse() for rationale.
+        sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
+        sse_port = int(os.environ.get('MCP_SSE_PORT', MCP_SSE_PORT))
+        self.logger.info(f"Starting Streamable HTTP transport on {sse_host}:{sse_port}")
         config = uvicorn.Config(
             app,
-            host=MCP_SSE_HOST,
-            port=MCP_SSE_PORT,
+            host=sse_host,
+            port=sse_port,
             log_level="info",
             timeout_keep_alive=MCP_TRANSPORT_TIMEOUT_KEEP_ALIVE,
             timeout_graceful_shutdown=MCP_TRANSPORT_TIMEOUT_GRACEFUL_SHUTDOWN,

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -270,8 +270,9 @@ class ServerRunManager:
         # Re-read env at runtime so late-set values (e.g. from CLI flags in
         # cli/main.py after package __init__ has already frozen config.py
         # module constants) still take effect.
+        from ..config import safe_get_int_env
         sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
-        sse_port = int(os.environ.get('MCP_SSE_PORT', MCP_SSE_PORT))
+        sse_port = safe_get_int_env('MCP_SSE_PORT', MCP_SSE_PORT, min_value=1024, max_value=65535)
         self.logger.info(f"Starting SSE transport on {sse_host}:{sse_port}")
         config = uvicorn.Config(
             app,

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -418,8 +418,9 @@ class ServerRunManager:
             return False
 
         # Re-read env at runtime; see run_sse() for rationale.
+        from ..config import safe_get_int_env
         sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
-        sse_port = int(os.environ.get('MCP_SSE_PORT', MCP_SSE_PORT))
+        sse_port = safe_get_int_env('MCP_SSE_PORT', MCP_SSE_PORT, min_value=1024, max_value=65535)
         self.logger.info(f"Starting Streamable HTTP transport on {sse_host}:{sse_port}")
         config = uvicorn.Config(
             app,


### PR DESCRIPTION
## Problem

\`memory server --streamable-http --sse-host 0.0.0.0 --sse-port 9000\` silently binds to \`127.0.0.1:8765\` (the defaults). Same for \`--sse\` transport. The only way to change the bind address is to set \`MCP_SSE_HOST\` / \`MCP_SSE_PORT\` in the environment *before* invoking the CLI — which defeats the point of having CLI flags.

## Root cause

\`config.py:545\` reads env vars at import time and stores them in module constants:

\`\`\`python
MCP_SSE_HOST = os.getenv('MCP_SSE_HOST', '127.0.0.1')
MCP_SSE_PORT = safe_get_int_env('MCP_SSE_PORT', 8765, ...)
\`\`\`

Import chain from \`memory\` entry point:
1. Python imports package \`mcp_memory_service\` → runs \`__init__.py\`
2. \`__init__.py:29\`: \`from .storage import MemoryStorage\` → chain loads \`config.py\` → \`MCP_SSE_HOST\` / \`MCP_SSE_PORT\` frozen to env-at-that-moment.
3. Click dispatches to \`cli/main.py:server()\`, which **then** calls \`os.environ['MCP_SSE_HOST'] = sse_host\` (lines 87, 95) — too late; the constant is already set.
4. \`startup_orchestrator.py:34\` \`from ..config import MCP_SSE_HOST, MCP_SSE_PORT\` imports the already-frozen values.
5. \`uvicorn.Config(host=MCP_SSE_HOST, ...)\` uses the stale default.

## Reproduction

\`\`\`
$ MCP_SSE_HOST=  memory server --streamable-http --sse-host 0.0.0.0 --sse-port 9000 &
$ ss -tlnp | grep -E '8765|9000'
LISTEN  0  2048  127.0.0.1:8765  0.0.0.0:*  users:(("memory",...))
# Bound to the default 127.0.0.1:8765, ignoring both --sse-host and --sse-port.
\`\`\`

## Fix

Re-read \`MCP_SSE_HOST\` and \`MCP_SSE_PORT\` from the environment at transport-start time inside \`run_sse()\` and \`run_streamable_http()\`, falling back to the imported module constants when env is unset. This preserves existing behavior for users who set env vars externally, while making the CLI flags work as their \`--help\` text documents.

Minimal blast radius — only two functions touched, no public API change.

## Test plan

- [x] Without patch: \`memory server --streamable-http --sse-host 0.0.0.0 --sse-port 9000\` → binds \`127.0.0.1:8765\`
- [x] With patch: same command → binds \`0.0.0.0:9000\`
- [x] With patch + only env var set (\`MCP_SSE_HOST=1.2.3.4 memory server --sse\`, no CLI flag) → still binds \`1.2.3.4\` (backward compatible)
- [x] With patch + neither env nor flag → binds \`127.0.0.1:8765\` (default unchanged)