### PR TITLE
feat(web): add POST /api/harvest HTTP endpoint (#630)

### DIFF
--- a/src/mcp_memory_service/harvest/harvester.py
+++ b/src/mcp_memory_service/harvest/harvester.py
@@ -1,5 +1,6 @@
 """Orchestrator for session harvest operations."""
 
+import asyncio
 import logging
 from collections import Counter
 from datetime import datetime, timezone
@@ -55,7 +56,9 @@ class SessionHarvester:
 
         results = []
         for filepath in session_files:
-            result = self._harvest_file(filepath, config)
+            # _harvest_file does synchronous file I/O — offload so the event
+            # loop stays responsive when harvest_and_store is called from HTTP.
+            result = await asyncio.to_thread(self._harvest_file, filepath, config)
 
             if not config.dry_run and self.memory_service and result.candidates:
                 stored = 0

--- a/src/mcp_memory_service/web/api/harvest.py
+++ b/src/mcp_memory_service/web/api/harvest.py
@@ -1,0 +1,171 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Session Harvest API endpoint.
+
+Extracts learnings (decisions, bugs, conventions, learnings, context) from
+Claude Code session transcripts. Wraps :class:`SessionHarvester` to mirror
+the ``memory_harvest`` MCP tool over HTTP.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ...harvest.harvester import SessionHarvester
+from ...harvest.models import HARVEST_TYPES, HarvestConfig, MAX_CANDIDATE_PREVIEW_LENGTH
+from ..oauth.middleware import AuthenticationResult, require_write_access
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/harvest", tags=["harvest"])
+
+
+class HarvestRequest(BaseModel):
+    """Request model for session harvest."""
+    sessions: int = Field(default=1, ge=1, description="Number of recent sessions to harvest")
+    session_ids: Optional[List[str]] = Field(default=None, description="Specific session IDs to harvest")
+    use_llm: bool = Field(default=False, description="Enable LLM-based classification (Phase 2)")
+    dry_run: bool = Field(default=True, description="Preview candidates without storing")
+    min_confidence: float = Field(default=0.6, ge=0.0, le=1.0, description="Minimum confidence threshold")
+    types: List[str] = Field(
+        default_factory=lambda: list(HARVEST_TYPES),
+        description="Candidate memory types to include",
+    )
+    project_path: Optional[str] = Field(default=None, description="Override project directory")
+
+
+class HarvestCandidateModel(BaseModel):
+    """A single extracted candidate in the response."""
+    type: str
+    content: str
+    confidence: float
+    tags: List[str]
+
+
+class HarvestSessionResult(BaseModel):
+    """Per-session harvest result."""
+    session_id: str
+    total_messages: int
+    found: int
+    stored: int
+    by_type: Dict[str, int]
+    candidates: List[HarvestCandidateModel]
+
+
+class HarvestResponse(BaseModel):
+    """Response model mirroring the ``memory_harvest`` MCP tool output."""
+    dry_run: bool
+    results: List[HarvestSessionResult]
+
+
+def _resolve_project_path(override: Optional[str]) -> Path:
+    """Resolve the Claude project directory, mirroring the MCP handler."""
+    if override:
+        return Path(override)
+    cwd = Path.cwd()
+    claude_projects = Path.home() / ".claude" / "projects"
+    project_dir_name = str(cwd).replace(os.sep, "-")
+    return claude_projects / project_dir_name
+
+
+@router.post("", response_model=HarvestResponse)
+async def harvest_sessions(
+    request: HarvestRequest,
+    user: AuthenticationResult = Depends(require_write_access),
+) -> Dict[str, Any]:
+    """
+    Extract learnings from Claude Code session transcripts.
+
+    When ``dry_run`` is true (default), returns candidates without storing.
+    When false, stores high-confidence candidates as memories (evolves existing
+    similar memories where possible).
+
+    Raises:
+        HTTPException: 400 for invalid input, 404 if project directory missing,
+            500 for harvest failures.
+    """
+    invalid_types = [t for t in request.types if t not in HARVEST_TYPES]
+    if invalid_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid types: {invalid_types}. Must be subset of {HARVEST_TYPES}",
+        )
+
+    project_path = _resolve_project_path(request.project_path)
+    if not project_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"Project directory not found: {project_path}",
+        )
+
+    config = HarvestConfig(
+        sessions=request.sessions,
+        session_ids=request.session_ids,
+        types=request.types,
+        min_confidence=request.min_confidence,
+        dry_run=request.dry_run,
+        project_path=str(project_path),
+        use_llm=request.use_llm,
+    )
+
+    memory_service = None
+    if not config.dry_run:
+        try:
+            from ...services.memory_service import MemoryService
+            from ..dependencies import get_storage
+            storage = get_storage()
+            memory_service = MemoryService(storage)
+        except Exception:
+            logger.error("Failed to initialize memory service for harvest", exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to initialize storage for harvest")
+
+    harvester = SessionHarvester(project_dir=project_path, memory_service=memory_service)
+
+    try:
+        if config.dry_run:
+            results = harvester.harvest(config)
+        else:
+            results = await harvester.harvest_and_store(config)
+    except Exception:
+        logger.error("Session harvest failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Harvest failed")
+
+    return {
+        "dry_run": config.dry_run,
+        "results": [
+            {
+                "session_id": r.session_id,
+                "total_messages": r.total_messages,
+                "found": r.found,
+                "stored": r.stored,
+                "by_type": r.by_type,
+                "candidates": [
+                    {
+                        "type": c.memory_type,
+                        "content": c.content[:MAX_CANDIDATE_PREVIEW_LENGTH],
+                        "confidence": round(c.confidence, 2),
+                        "tags": c.tags,
+                    }
+                    for c in r.candidates
+                ],
+            }
+            for r in results
+        ],
+    }

--- a/src/mcp_memory_service/web/api/harvest.py
+++ b/src/mcp_memory_service/web/api/harvest.py
@@ -76,11 +76,23 @@ class HarvestResponse(BaseModel):
 
 
 def _resolve_project_path(override: Optional[str]) -> Path:
-    """Resolve the Claude project directory, mirroring the MCP handler."""
+    """Resolve the Claude project directory, mirroring the MCP handler.
+
+    When ``override`` is provided, the resolved path is constrained to the
+    ``~/.claude/projects/`` tree to prevent path-traversal via the HTTP API.
+    """
+    claude_projects = (Path.home() / ".claude" / "projects").resolve()
     if override:
-        return Path(override)
+        candidate = Path(override).resolve()
+        try:
+            candidate.relative_to(claude_projects)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="project_path must be within ~/.claude/projects/",
+            ) from exc
+        return candidate
     cwd = Path.cwd()
-    claude_projects = Path.home() / ".claude" / "projects"
     project_dir_name = str(cwd).replace(os.sep, "-")
     return claude_projects / project_dir_name
 

--- a/src/mcp_memory_service/web/api/harvest.py
+++ b/src/mcp_memory_service/web/api/harvest.py
@@ -20,9 +20,10 @@ Claude Code session transcripts. Wraps :class:`SessionHarvester` to mirror
 the ``memory_harvest`` MCP tool over HTTP.
 """
 
+import asyncio
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -75,22 +76,29 @@ class HarvestResponse(BaseModel):
     results: List[HarvestSessionResult]
 
 
+_INVALID_PROJECT_PATH = (
+    "project_path must be a directory name under ~/.claude/projects/ "
+    "(no '..', no absolute paths, no path separators beyond nested project dirs)"
+)
+
+
 def _resolve_project_path(override: Optional[str]) -> Path:
     """Resolve the Claude project directory, mirroring the MCP handler.
 
-    When ``override`` is provided, the resolved path is constrained to the
-    ``~/.claude/projects/`` tree to prevent path-traversal via the HTTP API.
+    When ``override`` is provided it is treated as a *relative name* under
+    ``~/.claude/projects/``. Absolute paths, parent-directory traversal
+    (``..``), and escape via symlinks are rejected with HTTP 400
+    (CodeQL #383/#384).
     """
     claude_projects = (Path.home() / ".claude" / "projects").resolve()
     if override:
-        candidate = Path(override).resolve()
-        try:
-            candidate.relative_to(claude_projects)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail="project_path must be within ~/.claude/projects/",
-            ) from exc
+        relative = override.strip()
+        pure = PurePosixPath(relative.replace(os.sep, "/"))
+        if pure.is_absolute() or ".." in pure.parts or not pure.parts:
+            raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
+        candidate = (claude_projects / Path(*pure.parts)).resolve()
+        if not candidate.is_relative_to(claude_projects):
+            raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
         return candidate
     cwd = Path.cwd()
     project_dir_name = str(cwd).replace(os.sep, "-")
@@ -152,7 +160,8 @@ async def harvest_sessions(
 
     try:
         if config.dry_run:
-            results = harvester.harvest(config)
+            # harvest() does synchronous file I/O — offload to avoid blocking the event loop.
+            results = await asyncio.to_thread(harvester.harvest, config)
         else:
             results = await harvester.harvest_and_store(config)
     except Exception:

--- a/src/mcp_memory_service/web/api/harvest.py
+++ b/src/mcp_memory_service/web/api/harvest.py
@@ -83,26 +83,32 @@ _INVALID_PROJECT_PATH = (
 
 
 def _resolve_project_path(override: Optional[str]) -> Path:
-    """Resolve the Claude project directory, mirroring the MCP handler.
+    """Resolve the Claude project directory.
 
-    When ``override`` is provided it is treated as a *relative name* under
-    ``~/.claude/projects/``. Absolute paths, parent-directory traversal
-    (``..``), and escape via symlinks are rejected with HTTP 400
-    (CodeQL #383/#384).
+    Unlike the MCP tool (which can infer the project from CWD because it
+    runs inside the Claude Code process), the HTTP endpoint runs in a
+    long-lived web server whose CWD is typically the repo root or ``/``.
+    CWD-based inference there would silently point at the wrong directory,
+    so ``project_path`` is required.
+
+    ``project_path`` is treated as a *relative name* under
+    ``~/.claude/projects/``. Absolute paths, ``..`` components, and
+    escape via symlinks are rejected with HTTP 400 (CodeQL #383/#384).
     """
+    if not override:
+        raise HTTPException(
+            status_code=400,
+            detail="project_path is required for HTTP harvest (CWD inference only works in MCP context)",
+        )
     claude_projects = (Path.home() / ".claude" / "projects").resolve()
-    if override:
-        relative = override.strip()
-        pure = PurePosixPath(relative.replace(os.sep, "/"))
-        if pure.is_absolute() or ".." in pure.parts or not pure.parts:
-            raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
-        candidate = (claude_projects / Path(*pure.parts)).resolve()
-        if not candidate.is_relative_to(claude_projects):
-            raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
-        return candidate
-    cwd = Path.cwd()
-    project_dir_name = str(cwd).replace(os.sep, "-")
-    return claude_projects / project_dir_name
+    relative = override.strip()
+    pure = PurePosixPath(relative.replace(os.sep, "/"))
+    if pure.is_absolute() or ".." in pure.parts or not pure.parts:
+        raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
+    candidate = (claude_projects / Path(*pure.parts)).resolve()
+    if not candidate.is_relative_to(claude_projects):
+        raise HTTPException(status_code=400, detail=_INVALID_PROJECT_PATH)
+    return candidate
 
 
 @router.post("", response_model=HarvestResponse)

--- a/src/mcp_memory_service/web/app.py
+++ b/src/mcp_memory_service/web/app.py
@@ -62,6 +62,7 @@ from .api.server import router as server_router
 from .api.configuration import router as configuration_router
 from .api.oauth_status import router as oauth_status_router
 from .api.conflicts import router as conflicts_router
+from .api.harvest import router as harvest_router
 from .sse import sse_manager
 
 logger = logging.getLogger(__name__)
@@ -333,6 +334,10 @@ def create_app() -> FastAPI:
     # Include conflicts router (P3 conflict detection)
     app.include_router(conflicts_router, prefix="/api", tags=["conflicts"])
     logger.info(f"✓ Included conflicts router with {len(conflicts_router.routes)} routes")
+
+    # Include session harvest router (Issue #630)
+    app.include_router(harvest_router, tags=["harvest"])
+    logger.info(f"✓ Included harvest router with {len(harvest_router.routes)} routes")
 
     # Include MCP protocol router
     app.include_router(mcp_router, tags=["mcp-protocol"])

--- a/tests/web/api/test_harvest_api.py
+++ b/tests/web/api/test_harvest_api.py
@@ -21,15 +21,22 @@ from mcp_memory_service.harvest.models import HarvestCandidate, HarvestResult
 
 
 @pytest.fixture
-def project_dir():
-    """Create a temporary Claude-projects-style session directory with one jsonl."""
-    with tempfile.TemporaryDirectory() as tmp:
-        p = Path(tmp)
-        session = p / "session-abc123.jsonl"
-        session.write_text(
-            json.dumps({"type": "user", "message": {"content": "hello world"}}) + "\n"
-        )
-        yield p
+def project_dir(tmp_path, monkeypatch):
+    """Create a Claude-projects-style session directory under a redirected HOME.
+
+    The endpoint constrains project_path to ``~/.claude/projects/`` to prevent
+    path traversal (CodeQL #383). Tests therefore redirect ``Path.home()`` to
+    ``tmp_path`` so the fake project dir lives inside the allowed tree.
+    """
+    projects_root = tmp_path / ".claude" / "projects"
+    project = projects_root / "test-project"
+    project.mkdir(parents=True)
+    session = project / "session-abc123.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "message": {"content": "hello world"}}) + "\n"
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield project
 
 
 @pytest.fixture
@@ -168,14 +175,28 @@ def test_harvest_rejects_negative_sessions(authed_client, project_dir):
     assert response.status_code == 422
 
 
-def test_harvest_missing_project_dir_returns_404(authed_client, tmp_path):
-    """Non-existent project path returns 404."""
-    missing = tmp_path / "does-not-exist"
+def test_harvest_missing_project_dir_returns_404(authed_client, tmp_path, monkeypatch):
+    """Non-existent project path (inside the allowed tree) returns 404."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude" / "projects").mkdir(parents=True)
+    missing = tmp_path / ".claude" / "projects" / "does-not-exist"
     response = authed_client.post(
         "/api/harvest",
         json={"dry_run": True, "project_path": str(missing)},
     )
     assert response.status_code == 404
+
+
+def test_harvest_rejects_path_outside_allowed_tree(authed_client, tmp_path):
+    """project_path outside ~/.claude/projects/ is rejected with 400 (CodeQL #383)."""
+    outside = tmp_path / "evil"
+    outside.mkdir()
+    response = authed_client.post(
+        "/api/harvest",
+        json={"dry_run": True, "project_path": str(outside)},
+    )
+    assert response.status_code == 400
+    assert ".claude/projects" in response.json()["detail"]
 
 
 @pytest.mark.integration

--- a/tests/web/api/test_harvest_api.py
+++ b/tests/web/api/test_harvest_api.py
@@ -186,6 +186,13 @@ def test_harvest_missing_project_dir_returns_404(authed_client, tmp_path, monkey
     assert response.status_code == 404
 
 
+def test_harvest_requires_project_path(authed_client):
+    """HTTP endpoint requires explicit project_path (no CWD fallback)."""
+    response = authed_client.post("/api/harvest", json={"dry_run": True})
+    assert response.status_code == 400
+    assert "project_path is required" in response.json()["detail"]
+
+
 @pytest.mark.parametrize("bad_path", ["../evil", "/abs/path", "../../etc", "foo/../../bar"])
 def test_harvest_rejects_traversal_attempts(authed_client, tmp_path, monkeypatch, bad_path):
     """Absolute paths and parent-dir traversal are rejected with 400 (CodeQL #383/#384)."""

--- a/tests/web/api/test_harvest_api.py
+++ b/tests/web/api/test_harvest_api.py
@@ -123,7 +123,7 @@ def test_harvest_dry_run_happy_path(authed_client, project_dir):
                 "use_llm": False,
                 "dry_run": True,
                 "min_confidence": 0.6,
-                "project_path": str(project_dir),
+                "project_path": project_dir.name,
             },
         )
 
@@ -145,7 +145,7 @@ def test_harvest_requires_auth(unauth_client, project_dir):
     """Without credentials the endpoint returns 401."""
     response = unauth_client.post(
         "/api/harvest",
-        json={"dry_run": True, "project_path": str(project_dir)},
+        json={"dry_run": True, "project_path": project_dir.name},
     )
     assert response.status_code == 401
 
@@ -157,7 +157,7 @@ def test_harvest_rejects_invalid_types(authed_client, project_dir):
         "/api/harvest",
         json={
             "dry_run": True,
-            "project_path": str(project_dir),
+            "project_path": project_dir.name,
             "types": ["decision", "not-a-real-type"],
         },
     )
@@ -170,33 +170,33 @@ def test_harvest_rejects_negative_sessions(authed_client, project_dir):
     """Pydantic validation rejects sessions < 1."""
     response = authed_client.post(
         "/api/harvest",
-        json={"sessions": -1, "dry_run": True, "project_path": str(project_dir)},
+        json={"sessions": -1, "dry_run": True, "project_path": project_dir.name},
     )
     assert response.status_code == 422
 
 
 def test_harvest_missing_project_dir_returns_404(authed_client, tmp_path, monkeypatch):
-    """Non-existent project path (inside the allowed tree) returns 404."""
+    """Non-existent project name under the allowed tree returns 404."""
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / ".claude" / "projects").mkdir(parents=True)
-    missing = tmp_path / ".claude" / "projects" / "does-not-exist"
     response = authed_client.post(
         "/api/harvest",
-        json={"dry_run": True, "project_path": str(missing)},
+        json={"dry_run": True, "project_path": "does-not-exist"},
     )
     assert response.status_code == 404
 
 
-def test_harvest_rejects_path_outside_allowed_tree(authed_client, tmp_path):
-    """project_path outside ~/.claude/projects/ is rejected with 400 (CodeQL #383)."""
-    outside = tmp_path / "evil"
-    outside.mkdir()
+@pytest.mark.parametrize("bad_path", ["../evil", "/abs/path", "../../etc", "foo/../../bar"])
+def test_harvest_rejects_traversal_attempts(authed_client, tmp_path, monkeypatch, bad_path):
+    """Absolute paths and parent-dir traversal are rejected with 400 (CodeQL #383/#384)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude" / "projects").mkdir(parents=True)
     response = authed_client.post(
         "/api/harvest",
-        json={"dry_run": True, "project_path": str(outside)},
+        json={"dry_run": True, "project_path": bad_path},
     )
     assert response.status_code == 400
-    assert ".claude/projects" in response.json()["detail"]
+    assert "claude/projects" in response.json()["detail"]
 
 
 @pytest.mark.integration
@@ -208,7 +208,7 @@ def test_harvest_propagates_harvester_failure_as_500(authed_client, project_dir)
         mock_cls.return_value.harvest.side_effect = RuntimeError("boom")
         response = authed_client.post(
             "/api/harvest",
-            json={"dry_run": True, "project_path": str(project_dir)},
+            json={"dry_run": True, "project_path": project_dir.name},
         )
     assert response.status_code == 500
     assert response.json()["detail"] == "Harvest failed"

--- a/tests/web/api/test_harvest_api.py
+++ b/tests/web/api/test_harvest_api.py
@@ -1,0 +1,193 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for POST /api/harvest endpoint (Issue #630)."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_memory_service.harvest.models import HarvestCandidate, HarvestResult
+
+
+@pytest.fixture
+def project_dir():
+    """Create a temporary Claude-projects-style session directory with one jsonl."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp)
+        session = p / "session-abc123.jsonl"
+        session.write_text(
+            json.dumps({"type": "user", "message": {"content": "hello world"}}) + "\n"
+        )
+        yield p
+
+
+@pytest.fixture
+def authed_client(monkeypatch):
+    """FastAPI TestClient with auth mocked to allow write access."""
+    monkeypatch.setenv("MCP_API_KEY", "")
+    monkeypatch.setenv("MCP_OAUTH_ENABLED", "false")
+    monkeypatch.setenv("MCP_ALLOW_ANONYMOUS_ACCESS", "true")
+
+    from mcp_memory_service.web.app import app
+    from mcp_memory_service.web.oauth.middleware import (
+        AuthenticationResult,
+        get_current_user,
+        require_read_access,
+        require_write_access,
+    )
+
+    async def _user():
+        return AuthenticationResult(
+            authenticated=True, client_id="test", scope="read write", auth_method="test"
+        )
+
+    app.dependency_overrides[get_current_user] = _user
+    app.dependency_overrides[require_read_access] = _user
+    app.dependency_overrides[require_write_access] = _user
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def unauth_client():
+    """TestClient with auth dependencies overridden to reject requests (401)."""
+    from fastapi import HTTPException, status
+    from mcp_memory_service.web.app import app
+    from mcp_memory_service.web.oauth.middleware import (
+        get_current_user,
+        require_read_access,
+        require_write_access,
+    )
+
+    async def _reject():
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="auth required")
+
+    app.dependency_overrides[get_current_user] = _reject
+    app.dependency_overrides[require_read_access] = _reject
+    app.dependency_overrides[require_write_access] = _reject
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_harvest_dry_run_happy_path(authed_client, project_dir):
+    """Dry-run harvest returns candidates wrapped from SessionHarvester."""
+    fake_result = HarvestResult(
+        candidates=[
+            HarvestCandidate(
+                content="Decided to use SQLite-Vec for local storage",
+                memory_type="decision",
+                tags=["decision"],
+                confidence=0.9,
+                source_line="",
+            )
+        ],
+        session_id="session-abc123",
+        total_messages=42,
+        found=1,
+        by_type={"decision": 1},
+    )
+
+    with patch(
+        "mcp_memory_service.web.api.harvest.SessionHarvester"
+    ) as mock_cls:
+        instance = mock_cls.return_value
+        instance.harvest.return_value = [fake_result]
+
+        response = authed_client.post(
+            "/api/harvest",
+            json={
+                "sessions": 1,
+                "use_llm": False,
+                "dry_run": True,
+                "min_confidence": 0.6,
+                "project_path": str(project_dir),
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is True
+    assert len(data["results"]) == 1
+    r0 = data["results"][0]
+    assert r0["session_id"] == "session-abc123"
+    assert r0["total_messages"] == 42
+    assert r0["found"] == 1
+    assert r0["by_type"] == {"decision": 1}
+    assert r0["candidates"][0]["type"] == "decision"
+    assert r0["candidates"][0]["confidence"] == 0.9
+
+
+@pytest.mark.integration
+def test_harvest_requires_auth(unauth_client, project_dir):
+    """Without credentials the endpoint returns 401."""
+    response = unauth_client.post(
+        "/api/harvest",
+        json={"dry_run": True, "project_path": str(project_dir)},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+def test_harvest_rejects_invalid_types(authed_client, project_dir):
+    """Types not in HARVEST_TYPES are rejected with 400."""
+    response = authed_client.post(
+        "/api/harvest",
+        json={
+            "dry_run": True,
+            "project_path": str(project_dir),
+            "types": ["decision", "not-a-real-type"],
+        },
+    )
+    assert response.status_code == 400
+    assert "Invalid types" in response.json()["detail"]
+
+
+@pytest.mark.integration
+def test_harvest_rejects_negative_sessions(authed_client, project_dir):
+    """Pydantic validation rejects sessions < 1."""
+    response = authed_client.post(
+        "/api/harvest",
+        json={"sessions": -1, "dry_run": True, "project_path": str(project_dir)},
+    )
+    assert response.status_code == 422
+
+
+def test_harvest_missing_project_dir_returns_404(authed_client, tmp_path):
+    """Non-existent project path returns 404."""
+    missing = tmp_path / "does-not-exist"
+    response = authed_client.post(
+        "/api/harvest",
+        json={"dry_run": True, "project_path": str(missing)},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.integration
+def test_harvest_propagates_harvester_failure_as_500(authed_client, project_dir):
+    """Unexpected harvester exceptions surface as 500."""
+    with patch(
+        "mcp_memory_service.web.api.harvest.SessionHarvester"
+    ) as mock_cls:
+        mock_cls.return_value.harvest.side_effect = RuntimeError("boom")
+        response = authed_client.post(
+            "/api/harvest",
+            json={"dry_run": True, "project_path": str(project_dir)},
+        )
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Harvest failed"


### PR DESCRIPTION
## Summary

Closes #630 — adds a REST HTTP endpoint for Session Harvest so it can be triggered from scripts, cron jobs, or the dashboard (not only via MCP tools).

Wraps the existing \`SessionHarvester\` — no duplication of harvest logic.

## Endpoint

\`\`\`
POST /api/harvest
Authorization: Bearer \$MCP_API_KEY
Content-Type: application/json

{
  \"sessions\": 1,
  \"use_llm\": true,
  \"dry_run\": true,
  \"min_confidence\": 0.6,
  \"types\": [\"decision\", \"bug\", \"convention\", \"learning\", \"context\"],
  \"session_ids\": null,
  \"project_path\": null
}
\`\`\`

Response shape mirrors the \`memory_harvest\` MCP tool byte-for-byte (same keys, same preview truncation, same confidence rounding).

## Changes
- \`src/mcp_memory_service/web/api/harvest.py\` (new) — router, Pydantic models, auth
- \`src/mcp_memory_service/web/app.py\` — register router
- \`tests/web/api/test_harvest_api.py\` (new) — 6 tests

## Test plan
- [x] \`pytest tests/web/api/test_harvest_api.py -v\` — 6/6 passed
  - dry-run happy path
  - auth required (401 without API key)
  - invalid types (400)
  - negative sessions (422 Pydantic validation)
  - missing project dir (404)
  - harvester failure propagation (500)
- [x] Route registered in OpenAPI at \`/api/harvest\`

## Related
- Phase 1 (MCP tool): PR #615, Issue #596
- Phase 2 (enhancements): PR #628, Issue #618
- Follow-up: #631 (SessionEnd hook using this endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)