### PR TITLE
feat(hooks): opt-in SessionEnd auto-harvest hook (#631)

### DIFF
--- a/claude-hooks/README-SESSION-HARVEST.md
+++ b/claude-hooks/README-SESSION-HARVEST.md
@@ -1,0 +1,146 @@
+# Session End Auto-Harvest Hook
+
+Lightweight Claude Code SessionEnd hook that calls `POST /api/harvest` on
+session end to extract learnings (decisions, bugs, conventions, learnings,
+context) from the session transcript.
+
+Implements issue #631. Requires the harvest endpoint from PR #710
+(mcp-memory-service v10.37.0+).
+
+## Why opt-in?
+
+The harvest endpoint can:
+
+- Store memories in your backend (when `dry_run=false`).
+- Call an LLM for classification (when `use_llm=true`), which costs money
+  (~$0.01–$0.02 per session via Groq/Gemini).
+
+Both behaviors are off by default. The first time the hook ever runs it
+additionally forces `dry_run=true` regardless of your config, so you can see
+what it would extract before it writes anything. A marker file at
+`~/.claude/mcp-memory-harvest-first-run.done` records that the first-run
+preview happened; delete it to replay the preview.
+
+## Enable
+
+1. Make sure `claude-hooks/config.json` exists (copy from `config.template.json`).
+2. Add or edit the `sessionHarvest` section:
+
+```json
+{
+  "sessionHarvest": {
+    "enabled": true,
+    "dryRun": true,
+    "dryRunOnFirstUse": true,
+    "minSessionMessages": 10,
+    "sessions": 1,
+    "useLlm": false,
+    "minConfidence": 0.6,
+    "types": ["decision", "bug", "convention", "learning", "context"],
+    "endpoint": "http://127.0.0.1:8000",
+    "apiKey": null,
+    "timeoutMs": 5000
+  },
+  "hooks": {
+    "sessionEndHarvest": { "enabled": true, "timeout": 7000, "priority": "low" }
+  }
+}
+```
+
+3. Register the hook in `~/.claude/settings.json` (you do this yourself;
+   the repo does not modify your user settings). Example snippet:
+
+```json
+{
+  "hooks": {
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "node /absolute/path/to/mcp-memory-service/claude-hooks/core/session-end-harvest.js" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See the [Claude Code hooks docs](https://docs.claude.com/en/docs/claude-code/hooks)
+for how to register multiple SessionEnd hooks alongside the existing
+`session-end.js` (consolidation) hook.
+
+## Config reference
+
+| Key                  | Default                                                   | Meaning                                                                       |
+|----------------------|-----------------------------------------------------------|-------------------------------------------------------------------------------|
+| `enabled`            | `false`                                                   | Master switch. Must be `true` for the hook to do anything.                    |
+| `dryRun`             | `true`                                                    | Sent as `dry_run` to `/api/harvest`. `true` = preview only, no writes.        |
+| `dryRunOnFirstUse`   | `true`                                                    | First run ever forces `dry_run=true` regardless of `dryRun`.                  |
+| `minSessionMessages` | `10`                                                      | Skip entirely if the transcript has fewer messages than this.                 |
+| `sessions`           | `1`                                                       | Number of recent sessions to harvest.                                         |
+| `useLlm`             | `false`                                                   | Enable LLM classification (incurs cost).                                      |
+| `minConfidence`      | `0.6`                                                     | Minimum candidate confidence.                                                 |
+| `types`              | `["decision","bug","convention","learning","context"]`    | Candidate types to extract.                                                   |
+| `endpoint`           | `http://127.0.0.1:8000`                                   | Memory service HTTP endpoint (port 8000).                                     |
+| `apiKey`             | `null`                                                    | Bearer token. Falls back to `MCP_API_KEY` env var.                            |
+| `timeoutMs`          | `5000`                                                    | Hard timeout. On timeout the hook logs a warning and exits cleanly.           |
+
+## API key precedence
+
+1. `context.apiKey` (provided by the Claude Code runner, if any)
+2. `sessionHarvest.apiKey` in `config.json`
+3. `memoryService.http.apiKey` / `memoryService.apiKey` in `config.json`
+4. `MCP_API_KEY` environment variable
+5. No `Authorization` header
+
+## Example output
+
+First run:
+
+```
+[Memory Hook] Harvest: first run detected, forcing dry_run=true
+[Memory Hook] Harvest: POST http://127.0.0.1:8000/api/harvest (project=-Users-hkr-Repositories-mcp-memory-service, dry_run=true)
+[Memory Hook] Session harvest: 7 candidates found, 0 stored (dry_run=true)
+```
+
+Subsequent run with `dryRun: false`:
+
+```
+[Memory Hook] Harvest: POST http://127.0.0.1:8000/api/harvest (project=-Users-hkr-Repositories-mcp-memory-service, dry_run=false)
+[Memory Hook] Session harvest: 7 candidates found, 5 stored (dry_run=false)
+```
+
+Any failure (timeout, non-2xx, network error) logs as a warning and does
+**not** block session end:
+
+```
+[Memory Hook] Harvest: request failed (non-fatal): timeout after 5000ms
+```
+
+## Costs
+
+With `useLlm: true`, each session harvest routes through the memory
+service's quality/classification pipeline, which typically uses Groq
+(Llama 3) or Gemini Flash. Expected cost: **~$0.01–$0.02 per session**.
+Keep `useLlm: false` (default) for the Phase-1 pattern-based harvester if
+you want zero cost.
+
+## Project path
+
+The hook derives `project_path` from `process.cwd()` by replacing path
+separators with `-`, mirroring the Python side
+(`str(Path.cwd()).replace(os.sep, "-")`). For example,
+`/Users/hkr/Repositories/mcp-memory-service` becomes
+`-Users-hkr-Repositories-mcp-memory-service`, which must match a
+directory under `~/.claude/projects/`. The endpoint rejects absolute paths
+and `..` components (CodeQL #383/#384).
+
+## Tests
+
+```bash
+node claude-hooks/tests/session-end-harvest.test.js
+```
+
+7 tests cover: disabled-by-default, short-session skip, first-run forced
+dry-run, subsequent-run honoring config, timeout resilience, HTTP 5xx
+resilience, and API key precedence.

--- a/claude-hooks/README-SESSION-HARVEST.md
+++ b/claude-hooks/README-SESSION-HARVEST.md
@@ -84,6 +84,7 @@ for how to register multiple SessionEnd hooks alongside the existing
 | `endpoint`           | `http://127.0.0.1:8000`                                   | Memory service HTTP endpoint (port 8000).                                     |
 | `apiKey`             | `null`                                                    | Bearer token. Falls back to `MCP_API_KEY` env var.                            |
 | `timeoutMs`          | `5000`                                                    | Hard timeout. On timeout the hook logs a warning and exits cleanly.           |
+| `allowSelfSignedCerts` | `false`                                                 | **HTTPS only.** When `true`, disables TLS certificate validation (vulnerable to MITM). Use **only** for local dev with self-signed certs. |
 
 ## API key precedence
 

--- a/claude-hooks/README-SESSION-HARVEST.md
+++ b/claude-hooks/README-SESSION-HARVEST.md
@@ -1,8 +1,8 @@
 # Session End Auto-Harvest Hook
 
 Lightweight Claude Code SessionEnd hook that calls `POST /api/harvest` on
-session end to extract learnings (decisions, bugs, conventions, learnings,
-context) from the session transcript.
+session end to extract key information (decisions, bugs, conventions,
+learnings, context) from the session transcript.
 
 Implements issue #631. Requires the harvest endpoint from PR #710
 (mcp-memory-service v10.37.0+).

--- a/claude-hooks/config.template.json
+++ b/claude-hooks/config.template.json
@@ -50,6 +50,11 @@
       "timeout": 15000,
       "priority": "normal"
     },
+    "sessionEndHarvest": {
+      "enabled": false,
+      "timeout": 7000,
+      "priority": "low"
+    },
     "topicChange": {
       "enabled": false,
       "timeout": 5000,
@@ -68,6 +73,19 @@
     "enableDebug": false,
     "logToFile": false,
     "logFilePath": "./claude-hooks.log"
+  },
+  "sessionHarvest": {
+    "enabled": false,
+    "dryRun": true,
+    "dryRunOnFirstUse": true,
+    "minSessionMessages": 10,
+    "sessions": 1,
+    "useLlm": false,
+    "minConfidence": 0.6,
+    "types": ["decision", "bug", "convention", "learning", "context"],
+    "endpoint": "http://127.0.0.1:8000",
+    "apiKey": null,
+    "timeoutMs": 5000
   },
   "permissionRequest": {
     "enabled": false,

--- a/claude-hooks/config.template.json
+++ b/claude-hooks/config.template.json
@@ -85,7 +85,8 @@
     "types": ["decision", "bug", "convention", "learning", "context"],
     "endpoint": "http://127.0.0.1:8000",
     "apiKey": null,
-    "timeoutMs": 5000
+    "timeoutMs": 5000,
+    "allowSelfSignedCerts": false
   },
   "permissionRequest": {
     "enabled": false,

--- a/claude-hooks/core/session-end-harvest.js
+++ b/claude-hooks/core/session-end-harvest.js
@@ -36,8 +36,9 @@ async function loadConfig() {
 /**
  * Build the Claude Code project directory name from a working directory.
  * Matches the Python side: str(Path.cwd()).replace(os.sep, '-')
- * Returns only the final segment (project name), which is what
- * /api/harvest expects as a *relative name* under ~/.claude/projects/.
+ * Returns the full path identifier (project directory name used by Claude
+ * Code under ~/.claude/projects/), with separators replaced by dashes —
+ * e.g. "/Users/hkr/foo" -> "-Users-hkr-foo". Not a basename.
  */
 function deriveProjectName(cwd) {
     if (!cwd) return null;
@@ -211,13 +212,13 @@ async function sessionEndHarvest(context) {
 
         // Resolve endpoint + api key.
         const endpoint = cfg.endpoint
-            || (config.memoryService && (config.memoryService.http && config.memoryService.http.endpoint))
-            || (config.memoryService && config.memoryService.endpoint)
+            || config.memoryService?.http?.endpoint
+            || config.memoryService?.endpoint
             || 'http://127.0.0.1:8000';
-        const apiKey = (context && context.apiKey)
+        const apiKey = context?.apiKey
             || cfg.apiKey
-            || (config.memoryService && (config.memoryService.http && config.memoryService.http.apiKey))
-            || (config.memoryService && config.memoryService.apiKey)
+            || config.memoryService?.http?.apiKey
+            || config.memoryService?.apiKey
             || process.env.MCP_API_KEY
             || null;
 

--- a/claude-hooks/core/session-end-harvest.js
+++ b/claude-hooks/core/session-end-harvest.js
@@ -1,0 +1,283 @@
+/**
+ * Claude Code Session End Auto-Harvest Hook
+ *
+ * Triggers POST /api/harvest on session end to extract learnings from the
+ * session transcript. Opt-in, fail-safe, never blocks session end.
+ *
+ * Issue #631. Depends on PR #710 (v10.37.0+) for the harvest endpoint.
+ */
+
+const fs = require('fs');
+const fsp = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const http = require('http');
+const https = require('https');
+
+const FIRST_RUN_FLAG_FILENAME = 'mcp-memory-harvest-first-run.done';
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_MIN_MESSAGES = 10;
+
+/**
+ * Load hook configuration (same pattern as session-end.js).
+ * Returns a safe default (disabled) when config is missing or unreadable.
+ */
+async function loadConfig() {
+    try {
+        const configPath = path.join(__dirname, '../config.json');
+        const data = await fsp.readFile(configPath, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        console.warn('[Memory Hook] Harvest: using default configuration:', error.message);
+        return {};
+    }
+}
+
+/**
+ * Build the Claude Code project directory name from a working directory.
+ * Matches the Python side: str(Path.cwd()).replace(os.sep, '-')
+ * Returns only the final segment (project name), which is what
+ * /api/harvest expects as a *relative name* under ~/.claude/projects/.
+ */
+function deriveProjectName(cwd) {
+    if (!cwd) return null;
+    // Python: str(Path.cwd()).replace(os.sep, "-")
+    // On POSIX cwd starts with "/", giving "-Users-hkr-..."
+    // On Windows cwd like "C:\\foo" becomes "C:-foo" — we mirror Python's behavior.
+    const sep = path.sep;
+    const joined = cwd.split(sep).join('-');
+    // When cwd is absolute on POSIX, split yields ["", "Users", ...] -> "-Users-..."
+    // which is already correct. On Windows there's no leading sep so prepend nothing.
+    return joined;
+}
+
+/**
+ * Get the first-run flag file path. Honors HOME env for testability.
+ */
+function firstRunFlagPath() {
+    const home = process.env.HOME || os.homedir();
+    return path.join(home, '.claude', FIRST_RUN_FLAG_FILENAME);
+}
+
+async function firstRunFlagExists() {
+    try {
+        await fsp.access(firstRunFlagPath(), fs.constants.F_OK);
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
+async function writeFirstRunFlag() {
+    const flagPath = firstRunFlagPath();
+    try {
+        await fsp.mkdir(path.dirname(flagPath), { recursive: true });
+        await fsp.writeFile(flagPath, new Date().toISOString() + '\n', 'utf8');
+    } catch (err) {
+        console.warn('[Memory Hook] Harvest: could not write first-run flag:', err.message);
+    }
+}
+
+/**
+ * POST to /api/harvest with a hard timeout. Never throws.
+ * Returns an object: { ok, status, body, error }.
+ */
+function postHarvest(endpoint, apiKey, payload, timeoutMs) {
+    return new Promise((resolve) => {
+        let url;
+        try {
+            url = new URL('/api/harvest', endpoint);
+        } catch (err) {
+            return resolve({ ok: false, error: `Invalid endpoint: ${err.message}` });
+        }
+
+        const isHttps = url.protocol === 'https:';
+        const requestModule = isHttps ? https : http;
+        const body = JSON.stringify(payload);
+
+        const headers = {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body)
+        };
+        if (apiKey) {
+            headers['Authorization'] = `Bearer ${apiKey}`;
+        }
+
+        const options = {
+            hostname: url.hostname,
+            port: url.port || (isHttps ? 443 : 80),
+            path: url.pathname,
+            method: 'POST',
+            headers,
+            timeout: timeoutMs
+        };
+        if (isHttps) {
+            options.rejectUnauthorized = false;
+        }
+
+        const req = requestModule.request(options, (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(data); } catch (_) { parsed = null; }
+                const ok = res.statusCode >= 200 && res.statusCode < 300;
+                resolve({ ok, status: res.statusCode, body: parsed, raw: data });
+            });
+        });
+
+        req.on('error', (err) => {
+            resolve({ ok: false, error: err.message });
+        });
+        req.on('timeout', () => {
+            req.destroy();
+            resolve({ ok: false, error: `timeout after ${timeoutMs}ms` });
+        });
+
+        req.write(body);
+        req.end();
+    });
+}
+
+/**
+ * Summarize a harvest response for logging.
+ */
+function summarizeResponse(resp) {
+    if (!resp || !resp.body || !Array.isArray(resp.body.results)) {
+        return { found: 0, stored: 0, dryRun: null };
+    }
+    let found = 0;
+    let stored = 0;
+    for (const r of resp.body.results) {
+        found += Number(r.found || 0);
+        stored += Number(r.stored || 0);
+    }
+    return { found, stored, dryRun: !!resp.body.dry_run };
+}
+
+/**
+ * Main hook entry point. Matches the Claude Code hook convention
+ * (same shape as session-end.js: async function taking `context`).
+ *
+ * Never throws; all failures are logged as warnings.
+ */
+async function sessionEndHarvest(context) {
+    try {
+        // Read via module.exports._internal so tests can monkeypatch loadConfig.
+        const config = await (module.exports._internal
+            ? module.exports._internal.loadConfig()
+            : loadConfig());
+        const cfg = config.sessionHarvest || {};
+
+        if (!cfg.enabled) {
+            // Opt-in: do nothing unless user turned it on.
+            return;
+        }
+
+        // Skip short sessions.
+        const minMessages = Number.isFinite(cfg.minSessionMessages)
+            ? cfg.minSessionMessages
+            : DEFAULT_MIN_MESSAGES;
+        const messages = (context && context.conversation && Array.isArray(context.conversation.messages))
+            ? context.conversation.messages
+            : [];
+        if (messages.length < minMessages) {
+            console.log(`[Memory Hook] Harvest: session has ${messages.length} messages (< ${minMessages}), skipping`);
+            return;
+        }
+
+        // Derive project_path.
+        const cwd = (context && context.workingDirectory) || process.cwd();
+        const projectName = deriveProjectName(cwd);
+        if (!projectName) {
+            console.warn('[Memory Hook] Harvest: could not derive project name, skipping');
+            return;
+        }
+
+        // First-run dry-run safety.
+        const dryRunOnFirstUse = cfg.dryRunOnFirstUse !== false; // default true
+        const isFirstRun = !(await firstRunFlagExists());
+        const forcedDryRun = dryRunOnFirstUse && isFirstRun;
+        const dryRun = forcedDryRun ? true : !!cfg.dryRun;
+
+        if (forcedDryRun) {
+            console.log('[Memory Hook] Harvest: first run detected, forcing dry_run=true');
+        }
+
+        // Resolve endpoint + api key.
+        const endpoint = cfg.endpoint
+            || (config.memoryService && (config.memoryService.http && config.memoryService.http.endpoint))
+            || (config.memoryService && config.memoryService.endpoint)
+            || 'http://127.0.0.1:8000';
+        const apiKey = (context && context.apiKey)
+            || cfg.apiKey
+            || (config.memoryService && (config.memoryService.http && config.memoryService.http.apiKey))
+            || (config.memoryService && config.memoryService.apiKey)
+            || process.env.MCP_API_KEY
+            || null;
+
+        const payload = {
+            sessions: Number.isFinite(cfg.sessions) ? cfg.sessions : 1,
+            use_llm: !!cfg.useLlm,
+            dry_run: dryRun,
+            min_confidence: Number.isFinite(cfg.minConfidence) ? cfg.minConfidence : 0.6,
+            types: Array.isArray(cfg.types) && cfg.types.length > 0
+                ? cfg.types
+                : ['decision', 'bug', 'convention', 'learning', 'context'],
+            project_path: projectName
+        };
+
+        const timeoutMs = Number.isFinite(cfg.timeoutMs) ? cfg.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+        console.log(`[Memory Hook] Harvest: POST ${endpoint}/api/harvest (project=${projectName}, dry_run=${dryRun})`);
+
+        const resp = await postHarvest(endpoint, apiKey, payload, timeoutMs);
+
+        if (!resp.ok) {
+            const detail = resp.error
+                || `HTTP ${resp.status}${resp.raw ? ' ' + String(resp.raw).slice(0, 200) : ''}`;
+            console.warn(`[Memory Hook] Harvest: request failed (non-fatal): ${detail}`);
+            return;
+        }
+
+        const { found, stored, dryRun: respDryRun } = summarizeResponse(resp);
+        console.log(`[Memory Hook] Session harvest: ${found} candidates found, ${stored} stored (dry_run=${respDryRun})`);
+
+        if (forcedDryRun) {
+            await writeFirstRunFlag();
+        }
+    } catch (error) {
+        // Absolute belt-and-braces: never let a harvest failure surface.
+        console.warn('[Memory Hook] Harvest: unexpected error (non-fatal):', error.message);
+    }
+}
+
+module.exports = sessionEndHarvest;
+
+// Also expose internals for testing.
+module.exports.sessionEndHarvest = sessionEndHarvest;
+module.exports._internal = {
+    loadConfig,
+    deriveProjectName,
+    firstRunFlagPath,
+    firstRunFlagExists,
+    writeFirstRunFlag,
+    postHarvest,
+    summarizeResponse,
+    DEFAULT_TIMEOUT_MS,
+    DEFAULT_MIN_MESSAGES
+};
+
+// Hook metadata (mirrors session-end.js shape for discovery tools).
+module.exports.metadata = {
+    name: 'memory-awareness-session-end-harvest',
+    version: '1.0.0',
+    description: 'Auto-harvest learnings from session transcript on session end (opt-in)',
+    trigger: 'session-end',
+    handler: sessionEndHarvest,
+    config: {
+        async: true,
+        timeout: DEFAULT_TIMEOUT_MS + 2000,
+        priority: 'low'
+    }
+};

--- a/claude-hooks/core/session-end-harvest.js
+++ b/claude-hooks/core/session-end-harvest.js
@@ -82,7 +82,7 @@ async function writeFirstRunFlag() {
  * POST to /api/harvest with a hard timeout. Never throws.
  * Returns an object: { ok, status, body, error }.
  */
-function postHarvest(endpoint, apiKey, payload, timeoutMs) {
+function postHarvest(endpoint, apiKey, payload, timeoutMs, options = {}) {
     return new Promise((resolve) => {
         let url;
         try {
@@ -103,7 +103,7 @@ function postHarvest(endpoint, apiKey, payload, timeoutMs) {
             headers['Authorization'] = `Bearer ${apiKey}`;
         }
 
-        const options = {
+        const requestOptions = {
             hostname: url.hostname,
             port: url.port || (isHttps ? 443 : 80),
             path: url.pathname,
@@ -111,11 +111,16 @@ function postHarvest(endpoint, apiKey, payload, timeoutMs) {
             headers,
             timeout: timeoutMs
         };
-        if (isHttps) {
-            options.rejectUnauthorized = false;
+        if (isHttps && options.allowSelfSignedCerts === true) {
+            requestOptions.rejectUnauthorized = false;
+            console.warn(
+                '[Memory Hook] Harvest: TLS certificate validation DISABLED ' +
+                '(allowSelfSignedCerts=true). This leaves the hook vulnerable to MITM — ' +
+                'use only for local development with self-signed certs.'
+            );
         }
 
-        const req = requestModule.request(options, (res) => {
+        const req = requestModule.request(requestOptions, (res) => {
             let data = '';
             res.on('data', (chunk) => { data += chunk; });
             res.on('end', () => {
@@ -231,7 +236,9 @@ async function sessionEndHarvest(context) {
 
         console.log(`[Memory Hook] Harvest: POST ${endpoint}/api/harvest (project=${projectName}, dry_run=${dryRun})`);
 
-        const resp = await postHarvest(endpoint, apiKey, payload, timeoutMs);
+        const resp = await postHarvest(endpoint, apiKey, payload, timeoutMs, {
+            allowSelfSignedCerts: cfg.allowSelfSignedCerts === true
+        });
 
         if (!resp.ok) {
             const detail = resp.error
@@ -268,6 +275,63 @@ module.exports._internal = {
     DEFAULT_MIN_MESSAGES
 };
 
+/**
+ * Read JSON context from stdin (Claude Code provides this to hook processes).
+ * Resolves to null if stdin is empty within 100ms (manual test / no pipe).
+ */
+function readStdinContext() {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        const timeout = setTimeout(() => resolve(null), 100);
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('readable', () => {
+            let chunk;
+            while ((chunk = process.stdin.read()) !== null) {
+                data += chunk;
+            }
+        });
+        process.stdin.on('end', () => {
+            clearTimeout(timeout);
+            if (!data.trim()) return resolve(null);
+            try {
+                resolve(JSON.parse(data));
+            } catch (error) {
+                console.error('[Memory Hook] Failed to parse stdin JSON:', error.message);
+                reject(error);
+            }
+        });
+        process.stdin.on('error', (error) => {
+            clearTimeout(timeout);
+            reject(error);
+        });
+    });
+}
+
+/**
+ * Count messages in a Claude Code transcript JSONL file.
+ * Errors are non-fatal — returns 0 so the hook gracefully degrades.
+ */
+async function countTranscriptMessages(transcriptPath) {
+    try {
+        const content = await fsp.readFile(transcriptPath, 'utf8');
+        return content.split('\n').filter((line) => {
+            if (!line.trim()) return false;
+            try {
+                const parsed = JSON.parse(line);
+                return parsed && parsed.type && parsed.message;
+            } catch (_) {
+                return false;
+            }
+        }).length;
+    } catch (error) {
+        console.warn('[Memory Hook] Harvest: could not read transcript (non-fatal):', error.message);
+        return 0;
+    }
+}
+
+module.exports._internal.readStdinContext = readStdinContext;
+module.exports._internal.countTranscriptMessages = countTranscriptMessages;
+
 // Hook metadata (mirrors session-end.js shape for discovery tools).
 module.exports.metadata = {
     name: 'memory-awareness-session-end-harvest',
@@ -281,3 +345,40 @@ module.exports.metadata = {
         priority: 'low'
     }
 };
+
+// Standalone CLI entry point. Claude Code invokes hooks as child processes and
+// passes session context via stdin (see docs/hooks). When run without stdin
+// this reduces to a no-op (useful for local troubleshooting).
+if (require.main === module) {
+    (async () => {
+        try {
+            const stdinContext = await readStdinContext();
+            let context;
+            if (stdinContext && stdinContext.transcript_path) {
+                const messageCount = await countTranscriptMessages(stdinContext.transcript_path);
+                console.log(`[Memory Hook] Harvest: read ${messageCount} messages from ${stdinContext.transcript_path}`);
+                context = {
+                    workingDirectory: stdinContext.cwd || process.cwd(),
+                    sessionId: stdinContext.session_id || 'unknown',
+                    reason: stdinContext.reason,
+                    conversation: {
+                        messages: Array.from({ length: messageCount }, () => ({}))
+                    }
+                };
+            } else {
+                console.log('[Memory Hook] Harvest: no stdin context (manual run) — using cwd only');
+                context = {
+                    workingDirectory: process.cwd(),
+                    sessionId: 'manual',
+                    conversation: { messages: [] }
+                };
+            }
+            await sessionEndHarvest(context);
+            console.log('[Memory Hook] Harvest: hook completed');
+        } catch (error) {
+            console.error('[Memory Hook] Harvest: hook failed:', error.message);
+            // Do not exit non-zero — a hook failure must not abort the session.
+            process.exit(0);
+        }
+    })();
+}

--- a/claude-hooks/tests/session-end-harvest.test.js
+++ b/claude-hooks/tests/session-end-harvest.test.js
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Tests for claude-hooks/core/session-end-harvest.js
+ *
+ * Uses Node's built-in assert and http modules (no external deps).
+ * Run: node claude-hooks/tests/session-end-harvest.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const fs = require('fs');
+const fsp = require('fs').promises;
+const path = require('path');
+const os = require('os');
+
+// Each test gets a fresh isolated HOME so the first-run flag is controlled.
+function makeTempHome() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harvest-hook-'));
+    return tmp;
+}
+
+function cleanupDir(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+}
+
+// Run a mock HTTP server that records requests. Returns {server, url, requests}.
+function startMockServer(handler) {
+    return new Promise((resolve) => {
+        const requests = [];
+        const server = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', (chunk) => { body += chunk; });
+            req.on('end', () => {
+                let parsed = null;
+                try { parsed = JSON.parse(body); } catch (_) { parsed = null; }
+                const rec = {
+                    method: req.method,
+                    url: req.url,
+                    headers: req.headers,
+                    body: parsed,
+                    raw: body
+                };
+                requests.push(rec);
+                handler(rec, res);
+            });
+        });
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({ server, url: `http://127.0.0.1:${port}`, requests });
+        });
+    });
+}
+
+function stopServer(server) {
+    return new Promise((resolve) => server.close(() => resolve()));
+}
+
+// Load the hook module fresh (important because config is read at call time,
+// but we also stub loadConfig per-test).
+function freshHook() {
+    const p = require.resolve('../core/session-end-harvest.js');
+    delete require.cache[p];
+    return require('../core/session-end-harvest.js');
+}
+
+function buildContext({ numMessages = 20, cwd = '/Users/test/project-foo' } = {}) {
+    const messages = [];
+    for (let i = 0; i < numMessages; i++) {
+        messages.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `msg ${i}` });
+    }
+    return { workingDirectory: cwd, conversation: { messages } };
+}
+
+// Override the loadConfig function on a freshly-required module.
+function withConfig(hookModule, configObj) {
+    hookModule._internal.loadConfig = async () => configObj;
+    return hookModule;
+}
+
+async function runTest(name, fn) {
+    const tmpHome = makeTempHome();
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    const origLog = console.log;
+    const origWarn = console.warn;
+    const logs = [];
+    console.log = (...a) => logs.push(['log', a.join(' ')]);
+    console.warn = (...a) => logs.push(['warn', a.join(' ')]);
+    try {
+        await fn({ tmpHome, logs });
+        console.log = origLog;
+        console.warn = origWarn;
+        console.log(`PASS: ${name}`);
+        return true;
+    } catch (err) {
+        console.log = origLog;
+        console.warn = origWarn;
+        console.error(`FAIL: ${name}`);
+        console.error(err && err.stack ? err.stack : err);
+        if (logs.length) {
+            console.error('--- captured logs ---');
+            for (const [lvl, msg] of logs) console.error(`[${lvl}] ${msg}`);
+        }
+        return false;
+    } finally {
+        process.env.HOME = origHome;
+        cleanupDir(tmpHome);
+    }
+}
+
+async function main() {
+    const results = [];
+
+    // 1. disabled_by_default
+    results.push(await runTest('disabled_by_default', async () => {
+        const { server, url, requests } = await startMockServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ dry_run: true, results: [] }));
+        });
+        try {
+            const hook = withConfig(freshHook(), { sessionHarvest: { enabled: false, endpoint: url } });
+            await hook(buildContext());
+            assert.strictEqual(requests.length, 0, 'no HTTP call when disabled');
+        } finally {
+            await stopServer(server);
+        }
+    }));
+
+    // 2. skips_short_sessions
+    results.push(await runTest('skips_short_sessions', async () => {
+        const { server, url, requests } = await startMockServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ dry_run: true, results: [] }));
+        });
+        try {
+            const hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 10, dryRunOnFirstUse: false }
+            });
+            await hook(buildContext({ numMessages: 3 }));
+            assert.strictEqual(requests.length, 0, 'no HTTP call for short sessions');
+        } finally {
+            await stopServer(server);
+        }
+    }));
+
+    // 3. first_run_forces_dry_run
+    results.push(await runTest('first_run_forces_dry_run', async ({ tmpHome }) => {
+        const { server, url, requests } = await startMockServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ dry_run: true, results: [{ session_id: 's', total_messages: 10, found: 2, stored: 0, by_type: {}, candidates: [] }] }));
+        });
+        try {
+            const hook = withConfig(freshHook(), {
+                sessionHarvest: {
+                    enabled: true,
+                    endpoint: url,
+                    dryRun: false,            // config says no dry-run
+                    dryRunOnFirstUse: true,   // but first-run forces it
+                    minSessionMessages: 5
+                }
+            });
+            await hook(buildContext({ numMessages: 12 }));
+            assert.strictEqual(requests.length, 1, 'HTTP call made');
+            assert.strictEqual(requests[0].body.dry_run, true, 'first run must force dry_run=true');
+            // Flag file should now exist
+            const flagPath = path.join(tmpHome, '.claude', 'mcp-memory-harvest-first-run.done');
+            assert.ok(fs.existsSync(flagPath), 'first-run flag file written');
+        } finally {
+            await stopServer(server);
+        }
+    }));
+
+    // 4. subsequent_run_honors_config
+    results.push(await runTest('subsequent_run_honors_config', async ({ tmpHome }) => {
+        // Pre-create flag file
+        const claudeDir = path.join(tmpHome, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        fs.writeFileSync(path.join(claudeDir, 'mcp-memory-harvest-first-run.done'), 'done\n');
+
+        const { server, url, requests } = await startMockServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ dry_run: false, results: [{ session_id: 's', total_messages: 10, found: 3, stored: 3, by_type: {}, candidates: [] }] }));
+        });
+        try {
+            const hook = withConfig(freshHook(), {
+                sessionHarvest: {
+                    enabled: true,
+                    endpoint: url,
+                    dryRun: false,
+                    dryRunOnFirstUse: true,
+                    minSessionMessages: 5
+                }
+            });
+            await hook(buildContext({ numMessages: 12 }));
+            assert.strictEqual(requests.length, 1);
+            assert.strictEqual(requests[0].body.dry_run, false, 'subsequent run honors dryRun=false');
+        } finally {
+            await stopServer(server);
+        }
+    }));
+
+    // 5. timeout_is_non_fatal
+    results.push(await runTest('timeout_is_non_fatal', async ({ tmpHome }) => {
+        // Server that never responds within timeout.
+        const server = http.createServer((_req, _res) => {
+            // intentionally hang
+        });
+        await new Promise((r) => server.listen(0, '127.0.0.1', r));
+        const { port } = server.address();
+        const url = `http://127.0.0.1:${port}`;
+        try {
+            // Pre-create flag to skip first-run dry-run path (irrelevant here).
+            fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true });
+            fs.writeFileSync(path.join(tmpHome, '.claude', 'mcp-memory-harvest-first-run.done'), 'x');
+
+            const hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 5, timeoutMs: 200 }
+            });
+            const start = Date.now();
+            await hook(buildContext({ numMessages: 12 }));
+            const elapsed = Date.now() - start;
+            assert.ok(elapsed < 3000, `must resolve quickly after timeout (elapsed=${elapsed}ms)`);
+        } finally {
+            await new Promise((r) => server.close(r));
+        }
+    }));
+
+    // 6. http_failure_is_non_fatal
+    results.push(await runTest('http_failure_is_non_fatal', async ({ tmpHome }) => {
+        const { server, url } = await startMockServer((_req, res) => {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ detail: 'boom' }));
+        });
+        try {
+            fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true });
+            fs.writeFileSync(path.join(tmpHome, '.claude', 'mcp-memory-harvest-first-run.done'), 'x');
+
+            const hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 5 }
+            });
+            // Should resolve without throwing.
+            await hook(buildContext({ numMessages: 12 }));
+        } finally {
+            await stopServer(server);
+        }
+    }));
+
+    // 7. api_key_precedence
+    results.push(await runTest('api_key_precedence', async ({ tmpHome }) => {
+        const { server, url, requests } = await startMockServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ dry_run: true, results: [] }));
+        });
+        try {
+            // Pre-flag to avoid first-run noise
+            fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true });
+            fs.writeFileSync(path.join(tmpHome, '.claude', 'mcp-memory-harvest-first-run.done'), 'x');
+
+            // Case A: context.apiKey wins
+            process.env.MCP_API_KEY = 'env-key';
+            let hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 5, apiKey: 'config-key' }
+            });
+            const ctxA = buildContext({ numMessages: 12 });
+            ctxA.apiKey = 'context-key';
+            await hook(ctxA);
+            assert.strictEqual(requests[0].headers['authorization'], 'Bearer context-key');
+
+            // Case B: config wins when no context.apiKey
+            hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 5, apiKey: 'config-key' }
+            });
+            await hook(buildContext({ numMessages: 12 }));
+            assert.strictEqual(requests[1].headers['authorization'], 'Bearer config-key');
+
+            // Case C: env wins when neither context nor config
+            hook = withConfig(freshHook(), {
+                sessionHarvest: { enabled: true, endpoint: url, minSessionMessages: 5 }
+            });
+            await hook(buildContext({ numMessages: 12 }));
+            assert.strictEqual(requests[2].headers['authorization'], 'Bearer env-key');
+
+            delete process.env.MCP_API_KEY;
+        } finally {
+            await stopServer(server);
+            delete process.env.MCP_API_KEY;
+        }
+    }));
+
+    const passed = results.filter(Boolean).length;
+    const total = results.length;
+    console.log(`\n${passed}/${total} tests passed`);
+    if (passed !== total) process.exit(1);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/claude-hooks/tests/session-end-harvest.test.js
+++ b/claude-hooks/tests/session-end-harvest.test.js
@@ -289,6 +289,75 @@ async function main() {
         }
     }));
 
+    results.push(await runTest('tls_validation_default_and_opt_in', async () => {
+        // The default for allowSelfSignedCerts must be undefined/false — we
+        // verify by calling postHarvest directly. https.request receives the
+        // options object; we intercept it by substituting a fake request fn.
+        const fresh = freshHook();
+        const { postHarvest } = fresh._internal;
+
+        const capturedByRun = [];
+        const originalHttps = require('https').request;
+
+        // Monkey-patch https.request to record the options it was handed.
+        require('https').request = function (opts, cb) {
+            capturedByRun.push(opts);
+            const fakeReq = {
+                on: () => fakeReq,
+                write: () => {},
+                end: () => {
+                    // Simulate an immediate non-network error so postHarvest resolves fast.
+                    setImmediate(() => fakeReq.listeners.error && fakeReq.listeners.error({ message: 'mocked' }));
+                }
+            };
+            fakeReq.listeners = {};
+            const on = fakeReq.on;
+            fakeReq.on = (event, handler) => { fakeReq.listeners[event] = handler; return fakeReq; };
+            return fakeReq;
+        };
+
+        try {
+            // Case A: allowSelfSignedCerts omitted → TLS validation stays enabled.
+            await postHarvest('https://example.invalid', null, { sessions: 1 }, 500, {});
+            const optA = capturedByRun[0];
+            assert.strictEqual(optA.rejectUnauthorized, undefined,
+                'TLS validation must stay enabled by default');
+
+            // Case B: explicit allowSelfSignedCerts=true → rejectUnauthorized=false.
+            await postHarvest('https://example.invalid', null, { sessions: 1 }, 500,
+                { allowSelfSignedCerts: true });
+            const optB = capturedByRun[1];
+            assert.strictEqual(optB.rejectUnauthorized, false,
+                'allowSelfSignedCerts=true must disable TLS validation');
+        } finally {
+            require('https').request = originalHttps;
+        }
+    }));
+
+    results.push(await runTest('count_transcript_messages', async () => {
+        const { countTranscriptMessages } = freshHook()._internal;
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harvest-test-'));
+        const transcript = path.join(tmp, 'session.jsonl');
+        fs.writeFileSync(transcript, [
+            JSON.stringify({ type: 'user', message: { content: 'hi' } }),
+            JSON.stringify({ type: 'assistant', message: { content: 'hello' } }),
+            '',  // empty line — must be skipped
+            'not json',  // malformed — must be skipped
+            JSON.stringify({ type: 'user', message: { content: 'third' } })
+        ].join('\n'));
+        const count = await countTranscriptMessages(transcript);
+        assert.strictEqual(count, 3, 'must count valid JSONL lines only');
+
+        // Missing file is non-fatal → returns 0.
+        const missing = await countTranscriptMessages(path.join(tmp, 'does-not-exist.jsonl'));
+        assert.strictEqual(missing, 0, 'missing file must return 0 (non-fatal)');
+
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }));
+
     const passed = results.filter(Boolean).length;
     const total = results.length;
     console.log(`\n${passed}/${total} tests passed`);


### PR DESCRIPTION
## Summary

Closes #631 — adds a Claude Code SessionEnd hook that automatically triggers \`POST /api/harvest\` (the HTTP endpoint from #630 / v10.37.0) at the end of each coding session.

**Opt-in and safe by default.**

## Behavior

- \`sessionHarvest.enabled: false\` in \`config.template.json\` — user must explicitly enable
- **First-run safety**: even if \`dryRun: false\` is configured, the first invocation forces \`dry_run: true\` and writes \`~/.claude/mcp-memory-harvest-first-run.done\`. This lets users preview candidates before live stores.
- **Minimum session threshold**: skips sessions with fewer than \`minSessionMessages\` (default 10) — avoids noise from short sessions.
- **5s timeout, graceful failure**: never blocks session end, never throws. Network errors / 5xx / timeouts log a warning and return.
- **API key precedence**: \`context.apiKey\` → \`config.memoryService.apiKey\` → \`MCP_API_KEY\` env → no header.

\`project_path\` is derived via \`process.cwd().replace(/\\//g, '-')\` to match the Python-side name under \`~/.claude/projects/\`.

## Files

**New:**
- \`claude-hooks/core/session-end-harvest.js\` — the hook (CommonJS, no npm deps)
- \`claude-hooks/tests/session-end-harvest.test.js\` — 7 tests with mock \`http.createServer\`
- \`claude-hooks/README-SESSION-HARVEST.md\` — user docs incl. enable snippet

**Modified:**
- \`claude-hooks/config.template.json\` — \`sessionHarvest\` + \`hooks.sessionEndHarvest\` sections with safe defaults

## Test plan

- [x] \`node claude-hooks/tests/session-end-harvest.test.js\` → 7/7 pass
  - disabled_by_default
  - skips_short_sessions
  - first_run_forces_dry_run
  - subsequent_run_honors_config
  - timeout_is_non_fatal
  - http_failure_is_non_fatal
  - api_key_precedence
- [x] Module loads cleanly via \`node -e \"require('./claude-hooks/core/session-end-harvest.js')\"\`

## Enable snippet (user's \`claude-hooks/config.json\`)

\`\`\`json
{
  \"sessionHarvest\": {
    \"enabled\": true,
    \"dryRun\": true,
    \"dryRunOnFirstUse\": true,
    \"minSessionMessages\": 10,
    \"useLlm\": false,
    \"endpoint\": \"http://127.0.0.1:8000\"
  },
  \"hooks\": {
    \"sessionEndHarvest\": { \"enabled\": true, \"timeout\": 7000, \"priority\": \"low\" }
  }
}
\`\`\`

## Related
- Depends on: #630 (PR #710, v10.37.0) — HTTP harvest endpoint
- Phase 1 (MCP tool): PR #615, Issue #596
- Phase 2: PR #628, Issue #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)