### PR TITLE
fix(scripts): rotate missed boundary footers in changelog housekeeping (#717)

### DIFF
--- a/scripts/maintenance/changelog_housekeeping.py
+++ b/scripts/maintenance/changelog_housekeeping.py
@@ -135,12 +135,18 @@ def update_archive_header_boundary(archive_header: str, newest_archived: str) ->
     this helper covers the prose variant in the archive file (#717).
     """
     # Boundary suffix is optional so the helper can also insert it when missing
-    # (e.g. a recreated fallback header without the version range).
+    # (e.g. a recreated fallback header without the version range). The trailing
+    # period acts as a required anchor — without it, matching the prefix without
+    # the optional version group would sit *before* an existing boundary and
+    # produce a duplicate "(vX and earlier) (vY and earlier)." chain.
+    # [\w.-]+ in the version group accepts pre-release/metadata identifiers
+    # like 1.0.0-beta, 1.0.0-rc.1, or 1.0.0+build.5.
     pattern = re.compile(
-        r"(Older changelog entries for MCP Memory Service)(?:\s*\(v[\d.]+ and earlier\))?"
+        r"(Older changelog entries for MCP Memory Service)"
+        r"(?:\s*\(v[\w.+-]+ and earlier\))?(\.)"
     )
     return pattern.sub(
-        rf"\1 (v{newest_archived} and earlier)",
+        rf"\1 (v{newest_archived} and earlier)\2",
         archive_header,
     )
 
@@ -157,9 +163,13 @@ def update_readme_footer_boundary(text: str, newest_archived: str) -> str:
     """
     # Boundary suffix is optional so the helper can also insert it into the
     # fallback footer that trim_readme_previous_releases recreates when the
-    # "Previous Releases" section ends up bare.
+    # "Previous Releases" section ends up bare. The trailing `\]\([^)]+\)`
+    # anchor (the markdown link URL part) prevents the prefix from matching
+    # *before* an existing boundary and producing a duplicate.
+    # [\w.-]+ in the version group accepts pre-release/metadata identifiers
+    # like 1.0.0-beta, 1.0.0-rc.1, or 1.0.0+build.5.
     pattern = re.compile(
-        r"(\[Older versions)(?:\s*\(v[\d.]+ and earlier\))?(\]\([^)]+\))"
+        r"(\[Older versions)(?:\s*\(v[\w.+-]+ and earlier\))?(\]\([^)]+\))"
     )
     return pattern.sub(
         rf"\1 (v{newest_archived} and earlier)\2",

--- a/scripts/maintenance/changelog_housekeeping.py
+++ b/scripts/maintenance/changelog_housekeeping.py
@@ -125,6 +125,43 @@ def update_header_range(header: str, oldest_kept: str, newest_archived: str) -> 
     return new_header
 
 
+def update_archive_header_boundary(archive_header: str, newest_archived: str) -> str:
+    """Patch the plain-prose boundary in docs/archive/CHANGELOG-HISTORIC.md.
+
+    Matches lines like:
+        Older changelog entries for MCP Memory Service (v10.24.0 and earlier).
+
+    The `update_header_range()` family matches bolded CHANGELOG headers;
+    this helper covers the prose variant in the archive file (#717).
+    """
+    pattern = re.compile(
+        r"(Older changelog entries for MCP Memory Service )\(v[\d.]+ and earlier\)"
+    )
+    return pattern.sub(
+        rf"\1(v{newest_archived} and earlier)",
+        archive_header,
+    )
+
+
+def update_readme_footer_boundary(text: str, newest_archived: str) -> str:
+    """Patch the \"Older versions\" link text in README.md.
+
+    Matches the markdown-link text in:
+        **Full version history**: [CHANGELOG.md](...) | [Older versions (v10.22.0 and earlier)](docs/archive/CHANGELOG-HISTORIC.md) | [All Releases](...)
+
+    The boundary is the oldest version NOT kept in CHANGELOG.md (i.e. the
+    newest version that just got archived), so readers following the link
+    land at a file whose first entry matches what the footer promises (#717).
+    """
+    pattern = re.compile(
+        r"(\[Older versions )\(v[\d.]+ and earlier\)(\]\([^)]+\))"
+    )
+    return pattern.sub(
+        rf"\1(v{newest_archived} and earlier)\2",
+        text,
+    )
+
+
 def _is_previous_releases_start(line: str) -> bool:
     """Detect 'Previous Releases' section start in various formats.
 
@@ -327,6 +364,10 @@ def run(dry_run: bool = False) -> int:
             f"For current versions (v{oldest_kept}+)",
             archive_header_text,
         )
+        # Update "Older changelog entries ... (vX.Y.Z and earlier)" prose boundary (#717)
+        archive_header_text = update_archive_header_boundary(
+            archive_header_text, newest_archived
+        )
 
         new_blocks_text = "\n\n".join(
             block_text.rstrip() for _, block_text in new_archive_blocks
@@ -349,6 +390,9 @@ def run(dry_run: bool = False) -> int:
     new_readme, readme_removed = trim_readme_previous_releases(
         readme_text, MAX_README_ENTRIES
     )
+    # Also patch the "Older versions (vX.Y.Z and earlier)" link text so the
+    # boundary tracks the newest-archived version (#717).
+    new_readme = update_readme_footer_boundary(new_readme, newest_archived)
 
     # --- Validate ---
     _, _, new_version_blocks = parse_changelog_blocks(new_changelog)

--- a/scripts/maintenance/changelog_housekeeping.py
+++ b/scripts/maintenance/changelog_housekeeping.py
@@ -134,11 +134,13 @@ def update_archive_header_boundary(archive_header: str, newest_archived: str) ->
     The `update_header_range()` family matches bolded CHANGELOG headers;
     this helper covers the prose variant in the archive file (#717).
     """
+    # Boundary suffix is optional so the helper can also insert it when missing
+    # (e.g. a recreated fallback header without the version range).
     pattern = re.compile(
-        r"(Older changelog entries for MCP Memory Service )\(v[\d.]+ and earlier\)"
+        r"(Older changelog entries for MCP Memory Service)(?:\s*\(v[\d.]+ and earlier\))?"
     )
     return pattern.sub(
-        rf"\1(v{newest_archived} and earlier)",
+        rf"\1 (v{newest_archived} and earlier)",
         archive_header,
     )
 
@@ -153,11 +155,14 @@ def update_readme_footer_boundary(text: str, newest_archived: str) -> str:
     newest version that just got archived), so readers following the link
     land at a file whose first entry matches what the footer promises (#717).
     """
+    # Boundary suffix is optional so the helper can also insert it into the
+    # fallback footer that trim_readme_previous_releases recreates when the
+    # "Previous Releases" section ends up bare.
     pattern = re.compile(
-        r"(\[Older versions )\(v[\d.]+ and earlier\)(\]\([^)]+\))"
+        r"(\[Older versions)(?:\s*\(v[\d.]+ and earlier\))?(\]\([^)]+\))"
     )
     return pattern.sub(
-        rf"\1(v{newest_archived} and earlier)\2",
+        rf"\1 (v{newest_archived} and earlier)\2",
         text,
     )
 

--- a/tests/maintenance/test_changelog_housekeeping.py
+++ b/tests/maintenance/test_changelog_housekeeping.py
@@ -83,6 +83,33 @@ def test_update_readme_footer_boundary_inserts_when_missing(housekeeping):
     assert "[Older versions (v10.36.3 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)" in updated
 
 
+def test_update_archive_header_boundary_handles_prerelease(housekeeping):
+    """Pre-release versions like 1.0.0-beta must be matched and replaced cleanly."""
+    original = "Older changelog entries for MCP Memory Service (v1.0.0-beta and earlier).\n"
+    updated = housekeeping.update_archive_header_boundary(original, "10.36.3")
+    assert "(v10.36.3 and earlier)" in updated
+    assert "v1.0.0-beta" not in updated
+    # No double-version
+    assert updated.count("and earlier") == 1
+
+
+def test_update_readme_footer_boundary_handles_prerelease(housekeeping):
+    original = (
+        "[Older versions (v1.0.0-rc.1 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)"
+    )
+    updated = housekeeping.update_readme_footer_boundary(original, "10.36.3")
+    assert "[Older versions (v10.36.3 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)" in updated
+    assert "v1.0.0-rc.1" not in updated
+
+
+def test_update_archive_header_boundary_no_double_version_when_unknown_format(housekeeping):
+    """If the existing boundary has an unparseable version, the period-anchored
+    regex still requires a period — so no match means no-op (not duplicate)."""
+    # Hypothetical corrupted boundary without period at end → no match, no-op
+    weird = "Older changelog entries for MCP Memory Service (v???) somewhere in the middle\n"
+    assert housekeeping.update_archive_header_boundary(weird, "10.36.3") == weird
+
+
 def test_update_header_range_still_works_after_refactor(housekeeping):
     """Regression: the two new helpers must not shadow the bolded-header pattern."""
     header = (

--- a/tests/maintenance/test_changelog_housekeeping.py
+++ b/tests/maintenance/test_changelog_housekeeping.py
@@ -64,6 +64,25 @@ def test_update_archive_header_boundary_no_match_is_noop(housekeeping):
     assert housekeeping.update_archive_header_boundary(prose, "10.36.3") == prose
 
 
+def test_update_archive_header_boundary_inserts_when_missing(housekeeping):
+    """When the boundary suffix is absent (e.g. recreated fallback), insert it."""
+    bare = "Older changelog entries for MCP Memory Service.\n"
+    updated = housekeeping.update_archive_header_boundary(bare, "10.36.3")
+    assert "(v10.36.3 and earlier)" in updated
+
+
+def test_update_readme_footer_boundary_inserts_when_missing(housekeeping):
+    """Fallback footer from trim_readme_previous_releases omits the boundary;
+    helper must still inject the correct one (#717 Gemini feedback)."""
+    fallback = (
+        "**Full version history**: [CHANGELOG.md](CHANGELOG.md) "
+        "| [Older versions](docs/archive/CHANGELOG-HISTORIC.md) "
+        "| [All Releases](https://github.com/doobidoo/mcp-memory-service/releases)\n"
+    )
+    updated = housekeeping.update_readme_footer_boundary(fallback, "10.36.3")
+    assert "[Older versions (v10.36.3 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)" in updated
+
+
 def test_update_header_range_still_works_after_refactor(housekeeping):
     """Regression: the two new helpers must not shadow the bolded-header pattern."""
     header = (

--- a/tests/maintenance/test_changelog_housekeeping.py
+++ b/tests/maintenance/test_changelog_housekeeping.py
@@ -1,0 +1,75 @@
+"""Unit tests for scripts/maintenance/changelog_housekeeping.py boundary helpers (#717)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "maintenance" / "changelog_housekeeping.py"
+
+
+@pytest.fixture(scope="module")
+def housekeeping():
+    spec = importlib.util.spec_from_file_location("changelog_housekeeping", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_update_archive_header_boundary_rewrites_prose_version(housekeeping):
+    original = "Older changelog entries for MCP Memory Service (v10.24.0 and earlier).\n"
+    updated = housekeeping.update_archive_header_boundary(original, "10.36.3")
+    assert "v10.36.3 and earlier" in updated
+    assert "v10.24.0" not in updated
+
+
+def test_update_archive_header_boundary_leaves_unrelated_text(housekeeping):
+    original = (
+        "# Historic Changelog Archive\n\n"
+        "Older changelog entries for MCP Memory Service (v10.24.0 and earlier).\n\n"
+        "For current versions (v10.25.0+), see [CHANGELOG.md](../../CHANGELOG.md).\n"
+    )
+    updated = housekeeping.update_archive_header_boundary(original, "10.36.3")
+    assert "# Historic Changelog Archive" in updated
+    assert "For current versions (v10.25.0+)" in updated
+
+
+def test_update_readme_footer_boundary_rewrites_link_text(housekeeping):
+    original = (
+        "**Full version history**: [CHANGELOG.md](CHANGELOG.md) | "
+        "[Older versions (v10.22.0 and earlier)](docs/archive/CHANGELOG-HISTORIC.md) | "
+        "[All Releases](https://github.com/doobidoo/mcp-memory-service/releases)\n"
+    )
+    updated = housekeeping.update_readme_footer_boundary(original, "10.36.3")
+    assert "[Older versions (v10.36.3 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)" in updated
+    assert "v10.22.0" not in updated
+
+
+def test_update_readme_footer_boundary_idempotent(housekeeping):
+    current = "[Older versions (v10.36.3 and earlier)](docs/archive/CHANGELOG-HISTORIC.md)"
+    assert housekeeping.update_readme_footer_boundary(current, "10.36.3") == current
+
+
+def test_update_readme_footer_boundary_no_link_match_is_noop(housekeeping):
+    """Prose that mentions `Older versions` without a markdown link must not match."""
+    prose = "Older versions (v9.0.0 and earlier) are deprecated.\n"
+    assert housekeeping.update_readme_footer_boundary(prose, "10.36.3") == prose
+
+
+def test_update_archive_header_boundary_no_match_is_noop(housekeeping):
+    prose = "Random text mentioning (v10.0.0 and earlier) without the phrase.\n"
+    assert housekeeping.update_archive_header_boundary(prose, "10.36.3") == prose
+
+
+def test_update_header_range_still_works_after_refactor(housekeeping):
+    """Regression: the two new helpers must not shadow the bolded-header pattern."""
+    header = (
+        "**Recent releases for MCP Memory Service (v10.25.0 and later)**\n\n"
+        "**Versions v10.24.0 and earlier** – See [HISTORIC](./docs/archive/CHANGELOG-HISTORIC.md).\n"
+    )
+    updated = housekeeping.update_header_range(header, "10.36.4", "10.36.3")
+    assert "**Recent releases for MCP Memory Service (v10.36.4 and later)**" in updated
+    assert "**Versions v10.36.3 and earlier**" in updated


### PR DESCRIPTION
## Summary

Closes #717. PR #716 had to patch two version-boundary strings by hand because \`scripts/maintenance/changelog_housekeeping.py\` only matched bolded-header patterns. This PR teaches the script to update both remaining formats automatically.

## Fixes

Two new helpers alongside the existing \`update_header_range()\`:

- **\`update_archive_header_boundary()\`** — matches the plain-prose line in \`docs/archive/CHANGELOG-HISTORIC.md\`:
  \`\`\`
  Older changelog entries for MCP Memory Service (vX.Y.Z and earlier).
  \`\`\`
- **\`update_readme_footer_boundary()\`** — matches the markdown-link text in the README \"Full version history\" footer:
  \`\`\`markdown
  ... | [Older versions (vX.Y.Z and earlier)](docs/archive/CHANGELOG-HISTORIC.md) | ...
  \`\`\`

Both wired into \`run()\` at the points where the archive header and README are already being rewritten. Both use \`newest_archived\` (the oldest version *not* kept in CHANGELOG.md) — that's the correct boundary for someone following the \"Older versions\" link.

## Tests

\`tests/maintenance/test_changelog_housekeeping.py\` — **7/7 passing**:
- Each helper rewrites its target format correctly
- Idempotent (re-running with the current boundary is a no-op)
- No-op on unrelated prose that happens to contain \"and earlier\"
- Regression: existing \`update_header_range()\` still matches bolded headers after the refactor

## Verification

\`python scripts/maintenance/changelog_housekeeping.py --dry-run\` against current main: correctly reports \"No housekeeping needed\" (90 lines / 7 entries, below thresholds). Next rotation won't need manual Gemini follow-up for these footers.

## Changes
- \`scripts/maintenance/changelog_housekeeping.py\`: +43 lines (two helpers + two call sites)
- \`tests/maintenance/test_changelog_housekeeping.py\`: +76 lines (new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)