### PR TITLE
fix(windows): PS7+ cert bypass + chicken-egg lib sourcing

### DIFF
--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -139,16 +139,17 @@ function Enable-McpSelfSignedCertBypass {
         Bypasses self-signed certificate validation for the current PowerShell
         session, so Invoke-WebRequest can talk to the HTTPS health endpoint.
         No-op on HTTP-only setups. Safe to call multiple times.
+
+    .DESCRIPTION
+        PowerShell 5.1 (.NET Framework) and PowerShell 7+ (.NET Core/5+)
+        differ in cert-validation APIs:
+          - .NET Framework has System.Net.ICertificatePolicy (now obsolete).
+          - .NET Core/5+ REMOVED ICertificatePolicy entirely — Add-Type with
+            that interface fails with "Cannot add type. Compilation errors".
+
+        ServerCertificateValidationCallback is supported on both runtimes,
+        so we use it exclusively. No Add-Type / C# compile step needed.
     #>
-    if (-not ('TrustAllCertsPolicy' -as [type])) {
-        Add-Type -TypeDefinition @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(ServicePoint sp, X509Certificate cert, WebRequest req, int problem) { return true; }
-}
-"@ -ErrorAction SilentlyContinue
-    }
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 }

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -49,12 +49,16 @@ $StartTime = Get-Date
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
 $ManageServiceScript = Join-Path $PSScriptRoot "manage_service.ps1"
 
-# Load shared server-config helper (reads host/port/https from .env)
-. "$PSScriptRoot\lib\server-config.ps1"
-$ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
-Enable-McpSelfSignedCertBypass
-$HealthUrl = $ServerConfig.HealthUrl
-$DashboardUrl = $ServerConfig.DashboardUrl
+# NOTE: Do NOT dot-source lib/server-config.ps1 here!
+#
+# Chicken-egg problem: if the currently checked-out lib has a bug
+# (e.g., ICertificatePolicy incompatible with PowerShell 7+), sourcing
+# it at script start would fail *before* `git pull` can deliver the fix.
+# We defer sourcing to AFTER the pull+install steps, so the freshly
+# pulled lib version is loaded. Steps 1-4 (status/pull/install) don't
+# need any lib functions.
+$HealthUrl = $null
+$DashboardUrl = $null
 
 # Color helpers
 function Write-InfoLog { param($Message) Write-Host "[i] $Message" -ForegroundColor Cyan }
@@ -269,6 +273,15 @@ try {
 } catch {
     Write-WarningLog "Could not verify installation version"
 }
+
+# Source shared server-config lib AFTER pull+install so we get the freshly
+# pulled version (see note at top). Needed for URL resolution and HTTPS
+# cert bypass during restart + health check.
+. "$PSScriptRoot\lib\server-config.ps1"
+$ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
+Enable-McpSelfSignedCertBypass
+$HealthUrl = $ServerConfig.HealthUrl
+$DashboardUrl = $ServerConfig.DashboardUrl
 
 # Step 6: Restart server (if requested)
 if ($NoRestart) {


### PR DESCRIPTION
## Summary
- Fix `Enable-McpSelfSignedCertBypass` failing on PowerShell 7+ (removed `ICertificatePolicy` interface)
- Fix chicken-egg problem where `update_and_restart.ps1` sourced buggy lib *before* `git pull` could deliver the fix

## Root cause

### Issue 1 — `Add-Type` compile error on pwsh
`lib/server-config.ps1` used `Add-Type` with `ICertificatePolicy`. That interface exists only in .NET Framework (Windows PowerShell 5.1). PowerShell 7+ runs on .NET Core/5+, which removed it — `Add-Type` fails with:

```
Add-Type: Cannot add type. Compilation errors occurred.
```

Fix: replace with `ServerCertificateValidationCallback = { $true }` which is supported on both runtimes. No C# compile step needed.

### Issue 2 — Self-update chicken-egg
`update_and_restart.ps1:53-55` dot-sourced the lib and called `Enable-McpSelfSignedCertBypass` *before* `git pull`. If the checked-out lib had a bug (e.g., issue 1), sourcing failed and the script couldn't self-heal via pull.

Fix: defer lib sourcing until after pull + install. Steps 1–4 (status/pull/install) need no lib functions.

## Test plan
- [x] Parse both files with `[System.Management.Automation.Language.Parser]::ParseFile` — OK
- [x] Runtime test `Enable-McpSelfSignedCertBypass` on Windows PowerShell 5.1 — OK
- [x] Runtime test `Enable-McpSelfSignedCertBypass` on PowerShell 7+ (pwsh) — OK
- [ ] End-to-end: run `.\scripts\service\windows\update_and_restart.ps1` on PS7+ and confirm no `Add-Type` error, dashboard restarts

## Platform
Windows-only change. No Linux/macOS impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)