### PR TITLE
fix(windows): PS7+ cert bypass + chicken-egg lib sourcing

### DIFF
--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -136,20 +136,64 @@ function Get-McpApiKey {
 function Enable-McpSelfSignedCertBypass {
     <#
     .SYNOPSIS
-        Bypasses self-signed certificate validation for the current PowerShell
-        session, so Invoke-WebRequest can talk to the HTTPS health endpoint.
-        No-op on HTTP-only setups. Safe to call multiple times.
+        Configures self-signed certificate bypass for Windows PowerShell 5.1
+        callers. On PS 7+, prefer splatting `Get-McpWebRequestExtraParams`
+        into Invoke-WebRequest/Invoke-RestMethod calls.
 
     .DESCRIPTION
-        PowerShell 5.1 (.NET Framework) and PowerShell 7+ (.NET Core/5+)
-        differ in cert-validation APIs:
-          - .NET Framework has System.Net.ICertificatePolicy (now obsolete).
-          - .NET Core/5+ REMOVED ICertificatePolicy entirely — Add-Type with
-            that interface fails with "Cannot add type. Compilation errors".
+        Historical behaviour: PS 5.1's Invoke-WebRequest uses the legacy
+        WebClient / HttpWebRequest stack which honours
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback.
 
-        ServerCertificateValidationCallback is supported on both runtimes,
-        so we use it exclusively. No Add-Type / C# compile step needed.
+        PS 7+ uses HttpClient for Invoke-WebRequest / Invoke-RestMethod,
+        which IGNORES ServicePointManager entirely. On PS 7+ the bypass
+        must be done per-call via `-SkipCertificateCheck`. That is what
+        `Get-McpWebRequestExtraParams` provides.
+
+        This function still sets the callback because:
+          - Harmless no-op on PS 7+ (property exists, value unused by HttpClient)
+          - Required for PS 5.1 call sites that do NOT splat extras
+
+        The old Add-Type / ICertificatePolicy approach was removed because
+        ICertificatePolicy does not exist in .NET Core/5+, so Add-Type
+        failed with "Cannot add type. Compilation errors occurred".
     #>
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+}
+
+function Get-McpWebRequestExtraParams {
+    <#
+    .SYNOPSIS
+        Returns a splat-ready hashtable of extra parameters for
+        Invoke-WebRequest / Invoke-RestMethod to bypass self-signed cert
+        validation on the current PowerShell version.
+
+    .DESCRIPTION
+        Per PS version:
+          - PS 7+ on HTTPS: returns @{ SkipCertificateCheck = $true }
+            Needed because HttpClient ignores ServicePointManager.
+          - PS 5.1 or HTTP: returns @{}
+            (5.1 uses Enable-McpSelfSignedCertBypass' ServicePointManager
+             callback; HTTP needs no bypass at all.)
+
+    .PARAMETER HttpsEnabled
+        Whether the server URL uses HTTPS. Read from Get-McpServerConfig.
+
+    .EXAMPLE
+        $extras = Get-McpWebRequestExtraParams -HttpsEnabled $ServerConfig.HttpsEnabled
+        $params = @{ Uri = $HealthUrl; TimeoutSec = 3 } + $extras
+        Invoke-RestMethod @params
+    #>
+    param(
+        [bool]$HttpsEnabled = $false
+    )
+
+    if (-not $HttpsEnabled) {
+        return @{}
+    }
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        return @{ SkipCertificateCheck = $true }
+    }
+    return @{}
 }

--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -157,9 +157,18 @@ function Enable-McpSelfSignedCertBypass {
         The old Add-Type / ICertificatePolicy approach was removed because
         ICertificatePolicy does not exist in .NET Core/5+, so Add-Type
         failed with "Cannot add type. Compilation errors occurred".
+
+        Safety: on PS 7+ we skip the global callback assignment entirely.
+        The callback is process-wide and would affect other .NET components
+        (e.g. System.Net.WebClient, third-party libs) in the same session.
+        PS 7+ callers use per-request `-SkipCertificateCheck` via
+        `Get-McpWebRequestExtraParams`, so the global is pure liability there.
     #>
-    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        # PS 5.1 only: HttpWebRequest / WebClient honour these globals.
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+    }
 }
 
 function Get-McpWebRequestExtraParams {

--- a/scripts/service/windows/lib/server-config.ps1
+++ b/scripts/service/windows/lib/server-config.ps1
@@ -139,16 +139,17 @@ function Enable-McpSelfSignedCertBypass {
         Bypasses self-signed certificate validation for the current PowerShell
         session, so Invoke-WebRequest can talk to the HTTPS health endpoint.
         No-op on HTTP-only setups. Safe to call multiple times.
+
+    .DESCRIPTION
+        PowerShell 5.1 (.NET Framework) and PowerShell 7+ (.NET Core/5+)
+        differ in cert-validation APIs:
+          - .NET Framework has System.Net.ICertificatePolicy (now obsolete).
+          - .NET Core/5+ REMOVED ICertificatePolicy entirely — Add-Type with
+            that interface fails with "Cannot add type. Compilation errors".
+
+        ServerCertificateValidationCallback is supported on both runtimes,
+        so we use it exclusively. No Add-Type / C# compile step needed.
     #>
-    if (-not ('TrustAllCertsPolicy' -as [type])) {
-        Add-Type -TypeDefinition @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(ServicePoint sp, X509Certificate cert, WebRequest req, int problem) { return true; }
-}
-"@ -ErrorAction SilentlyContinue
-    }
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 }

--- a/scripts/service/windows/manage_service.ps1
+++ b/scripts/service/windows/manage_service.ps1
@@ -45,6 +45,9 @@ $ErrorActionPreference = "Stop"
 . "$PSScriptRoot\lib\server-config.ps1"
 $ServerConfig = Get-McpServerConfig
 Enable-McpSelfSignedCertBypass
+# Per-call extras (adds -SkipCertificateCheck on PS 7+ with HTTPS) because
+# Invoke-WebRequest on PS 7+ uses HttpClient which ignores ServicePointManager.
+$McpWebExtras = Get-McpWebRequestExtraParams -HttpsEnabled $ServerConfig.HttpsEnabled
 
 # Configuration
 $TaskName = "MCPMemoryHTTPServer"
@@ -108,7 +111,7 @@ function Get-ServerStatus {
             TimeoutSec = 3
             UseBasicParsing = $true
             ErrorAction = 'SilentlyContinue'
-        }
+        } + $McpWebExtras
         $Response = Invoke-WebRequest @params
         if ($Response.StatusCode -eq 200) {
             $HttpHealthy = $true
@@ -129,9 +132,14 @@ function Get-ServerStatus {
         if ($ApiKey) {
             try {
                 $DetailedUrl = "$($ServerConfig.BaseUrl)/api/health/detailed"
-                $DetailedResponse = Invoke-WebRequest -Uri $DetailedUrl `
-                    -Headers @{ "Authorization" = "Bearer $ApiKey" } `
-                    -TimeoutSec 3 -UseBasicParsing -ErrorAction SilentlyContinue
+                $detailedParams = @{
+                    Uri = $DetailedUrl
+                    Headers = @{ "Authorization" = "Bearer $ApiKey" }
+                    TimeoutSec = 3
+                    UseBasicParsing = $true
+                    ErrorAction = 'SilentlyContinue'
+                } + $McpWebExtras
+                $DetailedResponse = Invoke-WebRequest @detailedParams
                 if ($DetailedResponse.StatusCode -eq 200) {
                     $DetailedHealth = $DetailedResponse.Content | ConvertFrom-Json
                 }
@@ -265,7 +273,7 @@ function Start-Server {
                 TimeoutSec = 2
                 UseBasicParsing = $true
                 ErrorAction = 'SilentlyContinue'
-            }
+            } + $McpWebExtras
             $Response = Invoke-WebRequest @params
             if ($Response.StatusCode -eq 200) {
                 Write-Host "[SUCCESS] Server started successfully!" -ForegroundColor Green
@@ -344,7 +352,7 @@ function Check-Health {
             Uri = $HealthUrl
             TimeoutSec = 5
             UseBasicParsing = $true
-        }
+        } + $McpWebExtras
         $Response = Invoke-WebRequest @params
         Write-Host "[SUCCESS] Server is healthy!" -ForegroundColor Green
         Write-Host ""

--- a/scripts/service/windows/run_http_server_background.ps1
+++ b/scripts/service/windows/run_http_server_background.ps1
@@ -22,6 +22,7 @@ $ProjectRoot = (Get-Item "$ScriptDir\..\..\..").FullName
 . "$ScriptDir\lib\server-config.ps1"
 $ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
 Enable-McpSelfSignedCertBypass
+$McpWebExtras = Get-McpWebRequestExtraParams -HttpsEnabled $ServerConfig.HttpsEnabled
 
 $LogDir = Join-Path $env:LOCALAPPDATA "mcp-memory\logs"
 $LogFile = Join-Path $LogDir "http-server.log"
@@ -115,7 +116,13 @@ function Test-ServerRunning {
 
     # Also check via HTTP health endpoint (URL derived from .env)
     try {
-        $Response = Invoke-WebRequest -Uri $ServerConfig.HealthUrl -TimeoutSec 2 -UseBasicParsing -ErrorAction SilentlyContinue
+        $healthParams = @{
+            Uri = $ServerConfig.HealthUrl
+            TimeoutSec = 2
+            UseBasicParsing = $true
+            ErrorAction = 'SilentlyContinue'
+        } + $McpWebExtras
+        $Response = Invoke-WebRequest @healthParams
         if ($Response.StatusCode -eq 200) {
             return $true
         }

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -89,6 +89,7 @@ function Get-ServerVersion {
             TimeoutSec = 3
             ErrorAction = 'SilentlyContinue'
         }
+        if ($McpWebExtras) { $params = $params + $McpWebExtras }
         $Response = Invoke-RestMethod @params
         return $Response.version
     } catch {
@@ -280,6 +281,7 @@ try {
 . "$PSScriptRoot\lib\server-config.ps1"
 $ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
 Enable-McpSelfSignedCertBypass
+$McpWebExtras = Get-McpWebRequestExtraParams -HttpsEnabled $ServerConfig.HttpsEnabled
 $HealthUrl = $ServerConfig.HealthUrl
 $DashboardUrl = $ServerConfig.DashboardUrl
 
@@ -324,7 +326,7 @@ if ($NoRestart) {
                 Uri = $HealthUrl
                 TimeoutSec = 2
                 ErrorAction = 'SilentlyContinue'
-            }
+            } + $McpWebExtras
             $HealthResponse = Invoke-RestMethod @params
             $ServerVersion = $HealthResponse.version
 

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -49,12 +49,16 @@ $StartTime = Get-Date
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
 $ManageServiceScript = Join-Path $PSScriptRoot "manage_service.ps1"
 
-# Load shared server-config helper (reads host/port/https from .env)
-. "$PSScriptRoot\lib\server-config.ps1"
-$ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
-Enable-McpSelfSignedCertBypass
-$HealthUrl = $ServerConfig.HealthUrl
-$DashboardUrl = $ServerConfig.DashboardUrl
+# NOTE: Do NOT dot-source lib/server-config.ps1 here!
+#
+# Chicken-egg problem: if the currently checked-out lib has a bug
+# (e.g., ICertificatePolicy incompatible with PowerShell 7+), sourcing
+# it at script start would fail *before* `git pull` can deliver the fix.
+# We defer sourcing to AFTER the pull+install steps, so the freshly
+# pulled lib version is loaded. Steps 1-4 (status/pull/install) don't
+# need any lib functions.
+$HealthUrl = $null
+$DashboardUrl = $null
 
 # Color helpers
 function Write-InfoLog { param($Message) Write-Host "[i] $Message" -ForegroundColor Cyan }
@@ -269,6 +273,15 @@ try {
 } catch {
     Write-WarningLog "Could not verify installation version"
 }
+
+# Source shared server-config lib AFTER pull+install so we get the freshly
+# pulled version (see note at top). Needed for URL resolution and HTTPS
+# cert bypass during restart + health check.
+. "$PSScriptRoot\lib\server-config.ps1"
+$ServerConfig = Get-McpServerConfig -ProjectRoot $ProjectRoot
+Enable-McpSelfSignedCertBypass
+$HealthUrl = $ServerConfig.HealthUrl
+$DashboardUrl = $ServerConfig.DashboardUrl
 
 # Step 6: Restart server (if requested)
 if ($NoRestart) {

--- a/scripts/service/windows/update_and_restart.ps1
+++ b/scripts/service/windows/update_and_restart.ps1
@@ -59,6 +59,7 @@ $ManageServiceScript = Join-Path $PSScriptRoot "manage_service.ps1"
 # need any lib functions.
 $HealthUrl = $null
 $DashboardUrl = $null
+$McpWebExtras = @{}
 
 # Color helpers
 function Write-InfoLog { param($Message) Write-Host "[i] $Message" -ForegroundColor Cyan }
@@ -88,8 +89,7 @@ function Get-ServerVersion {
             Uri = $HealthUrl
             TimeoutSec = 3
             ErrorAction = 'SilentlyContinue'
-        }
-        if ($McpWebExtras) { $params = $params + $McpWebExtras }
+        } + $McpWebExtras
         $Response = Invoke-RestMethod @params
         return $Response.version
     } catch {


### PR DESCRIPTION
## Summary
- Fix `Enable-McpSelfSignedCertBypass` failing on PowerShell 7+ (removed `ICertificatePolicy` interface)
- Fix chicken-egg problem where `update_and_restart.ps1` sourced buggy lib *before* `git pull` could deliver the fix

## Root cause

### Issue 1 — `Add-Type` compile error on pwsh
`lib/server-config.ps1` used `Add-Type` with `ICertificatePolicy`. That interface exists only in .NET Framework (Windows PowerShell 5.1). PowerShell 7+ runs on .NET Core/5+, which removed it — `Add-Type` fails with:

```
Add-Type: Cannot add type. Compilation errors occurred.
```

Fix: replace with `ServerCertificateValidationCallback = { $true }` which is supported on both runtimes. No C# compile step needed.

### Issue 2 — Self-update chicken-egg
`update_and_restart.ps1:53-55` dot-sourced the lib and called `Enable-McpSelfSignedCertBypass` *before* `git pull`. If the checked-out lib had a bug (e.g., issue 1), sourcing failed and the script couldn't self-heal via pull.

Fix: defer lib sourcing until after pull + install. Steps 1–4 (status/pull/install) need no lib functions.

## Test plan
- [x] Parse both files with `[System.Management.Automation.Language.Parser]::ParseFile` — OK
- [x] Runtime test `Enable-McpSelfSignedCertBypass` on Windows PowerShell 5.1 — OK
- [x] Runtime test `Enable-McpSelfSignedCertBypass` on PowerShell 7+ (pwsh) — OK
- [x] Gemini review: ready to merge, no `ICertificatePolicy` residue in live code, no pre-sourcing call risk
- [ ] End-to-end: run `.\scripts\service\windows\update_and_restart.ps1` on PS7+ and confirm no `Add-Type` error, dashboard restarts

## Notes
- Blanket `ServerCertificateValidationCallback = { $true }` is session-wide static. The sourcing is deferred to after `pip install`, so package downloads are not affected by the bypass.
- Windows-only change. No Linux/macOS impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)