### PR TITLE
ci: skip full test suite on docs-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,21 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '.claude/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   # First, try to create a release


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to `main.yml` for `docs/**`, `*.md`, `.claude/**`, `LICENSE`, `.gitignore`
- Docs-only PRs no longer trigger the full 1587-test pytest suite + Docker build + CodeQL scan
- Saves ~5 min CI time and runner resources per docs PR

## Context
Every push to main — including README/CHANGELOG edits — triggered the full CI pipeline. With ~40% of recent PRs being docs-only, this wastes significant CI budget for zero test value.

## Test plan
- [ ] Push a docs-only commit to this branch and verify main.yml workflow does NOT trigger
- [ ] Push a code change and verify main.yml workflow DOES trigger normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)