### PR TITLE
fix(web): auto-check updates on Server tab open + accurate initial label

### DIFF
--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -4394,6 +4394,16 @@ class MemoryDashboard {
         if (tabName === 'credentials') {
             this.loadCredentials();
         }
+
+        // Load server status + auto-check for updates when switching to server tab
+        // (runs once per modal open to avoid repeated git fetches)
+        if (tabName === 'server') {
+            this.loadServerStatus();
+            if (!this._serverUpdateChecked) {
+                this._serverUpdateChecked = true;
+                this.checkForUpdates();
+            }
+        }
     }
 
     /**

--- a/src/mcp_memory_service/web/static/index.html
+++ b/src/mcp_memory_service/web/static/index.html
@@ -1519,7 +1519,7 @@
                             </div>
                             <div class="info-row">
                                 <span class="info-label">Update Available:</span>
-                                <span class="info-value" id="settingsUpdateAvailable">Checking...</span>
+                                <span class="info-value" id="settingsUpdateAvailable">Not checked yet</span>
                             </div>
                             <div class="server-actions">
                                 <button type="button" id="checkUpdatesBtn" class="btn btn-sm btn-secondary">Check for Updates</button>


### PR DESCRIPTION
## Summary
- Settings > Server tab showed `Update Available: Checking...` as a static label that never resolved — users had no signal that the check wasn't actually running.
- Initial label changed to `Not checked yet` so the UI reflects reality.
- `switchSettingsTab('server')` now auto-invokes `loadServerStatus()` + `checkForUpdates()` once per page load (flag-guarded to avoid repeated `git fetch` on tab flipping).

## Why
Observed in production: opening Settings > Server consistently displayed stale "Checking..." text until the user manually clicked **Check for Updates**. That's a UX dead-end — either auto-check or don't mislead.

## Scope
- `src/mcp_memory_service/web/static/index.html` — 1 line (initial label)
- `src/mcp_memory_service/web/static/app.js` — adds 9 lines to `switchSettingsTab()`

No backend / API changes. No new endpoints. Pure dashboard UX.

## Test plan
- [ ] Hard-reload dashboard (Cmd+Shift+R), open **Settings**, switch to **Server** tab
- [ ] Verify "Update Available" transitions from `Not checked yet` → `Up to date` (or `Yes - N commit(s)`) without clicking
- [ ] Switch to another settings tab and back — confirm `git fetch` doesn't re-fire (single check per page load)
- [ ] Click **Check for Updates** manually — still works on demand

## Related
Follow-up issue for the `/server/update` silent-failure behavior (where clicking "Update & Restart" didn't actually restart) will be opened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)