### PR TITLE
fix(dashboard): render knowledge-graph edges for non-canonical relationship types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- **Knowledge graph dashboard: edges invisible for non-canonical `relationship_type` values**: `.graph-link` in `src/mcp_memory_service/web/static/style.css` used `stroke: var(--text-tertiary)`, but `--text-tertiary` is not declared anywhere in the stylesheet. Relationships whose type was not one of the six canonical values (`causes`, `fixes`, `contradicts`, `supports`, `follows`, `related`) — e.g. consolidation-generated types such as `uses`, `routes-to`, `documents`, `calls`, `part-of`, `contains`, `feeds-into` — had no typed `.link-*` override and therefore fell back to `stroke: none` (CSS `stroke` initial value when a `var()` resolves to nothing), rendering the edges invisible on `/api/analytics/graph-visualization` regardless of `limit` or `min_connections`. Added a `--neutral-400` fallback to the `var()` call so all edges now render in a neutral gray when no typed color applies. Data from `/api/analytics/graph-visualization` was always correct; the regression was purely CSS.
+- **Knowledge graph dashboard**: Fixed invisible edges for non-canonical relationship types by providing a fallback color for undefined CSS variables.
 - **Flaky concurrent test**: Relaxed strict write-count assertions in `test_concurrent_clients.py` from `== 10` to `>= 9` (and `== 5` to `>= 4`). SQLite WAL lock contention under CI runner load can legitimately drop 1 of N concurrent writes.
 
 ## [10.38.2] - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- **Knowledge graph dashboard: edges invisible for non-canonical `relationship_type` values**: `.graph-link` in `src/mcp_memory_service/web/static/style.css` used `stroke: var(--text-tertiary)`, but `--text-tertiary` is not declared anywhere in the stylesheet. Relationships whose type was not one of the six canonical values (`causes`, `fixes`, `contradicts`, `supports`, `follows`, `related`) — e.g. consolidation-generated types such as `uses`, `routes-to`, `documents`, `calls`, `part-of`, `contains`, `feeds-into` — had no typed `.link-*` override and therefore fell back to `stroke: none` (CSS `stroke` initial value when a `var()` resolves to nothing), rendering the edges invisible on `/api/analytics/graph-visualization` regardless of `limit` or `min_connections`. Added a `--neutral-400` fallback to the `var()` call so all edges now render in a neutral gray when no typed color applies. Data from `/api/analytics/graph-visualization` was always correct; the regression was purely CSS.
 - **Flaky concurrent test**: Relaxed strict write-count assertions in `test_concurrent_clients.py` from `== 10` to `>= 9` (and `== 5` to `>= 4`). SQLite WAL lock contention under CI runner load can legitimately drop 1 of N concurrent writes.
 
 ## [10.38.2] - 2026-04-16

--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -5026,7 +5026,7 @@ body.dark-mode .quality-tier-low,
 }
 
 .graph-link {
-    stroke: var(--text-tertiary);
+    stroke: var(--text-tertiary, var(--neutral-400));
     stroke-opacity: 0.6;
     stroke-width: 1.5px;
     fill: none;


### PR DESCRIPTION
# Pull Request

## Description

The Knowledge Graph tab in the web dashboard renders every edge with the base CSS rule `.graph-link { stroke: var(--text-tertiary); ... }`, but `--text-tertiary` is not declared anywhere in the stylesheet. The `var()` resolves to its initial value (`stroke: none`), so every edge whose `relationship_type` is not one of the six canonical values with a `.link-<type>` override renders invisible.

## Motivation

The dashboard shows nodes but no edges whenever memories use `relationship_type` values outside the canonical set (`causes`, `fixes`, `contradicts`, `supports`, `follows`, `related`). The API returns edges correctly; only the rendering is broken.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [x] 🎨 UI/UX improvement

## Changes

- `src/mcp_memory_service/web/static/style.css`: add a `--neutral-400` fallback to `var(--text-tertiary)` on `.graph-link` so edges render when no typed override applies.
- `CHANGELOG.md`: one-line entry under `[Unreleased] ▸ Fixed`.

**Breaking Changes** (if any):

- None.

## Testing

### How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version: n/a (no Python code changed)
- OS: macOS 14 (Darwin 25.3.0)
- Storage backend: `sqlite_vec`
- Installation method: live dashboard, v10.36.4

### Test Coverage

- [ ] Added new tests
- [ ] Updated existing tests
- [x] Test coverage maintained/improved

## Related Issues

Fixes #
Closes #
Relates to #

## Screenshots
<img width="1678" height="947" alt="image" src="https://github.com/user-attachments/assets/208f0892-1d9c-424a-bbe7-8a7b17c8ef8a" />

<img width="1639" height="932" alt="image" src="https://github.com/user-attachments/assets/7067610c-c2a6-4c3a-ab4f-0862e898b6cb" />



## Documentation

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [x] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [ ] Updated code comments/docstrings
- [ ] Added API documentation
- [ ] No documentation needed

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] ✅ Any dependent changes have been merged and published
- [x] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [x] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

Stylesheet-only fix. Typed edges continue to win via their more specific `.link-<type>` rules.