### PR TITLE
fix(api): add total_pages to list_memories return

### DIFF
--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -650,6 +650,7 @@ RETURNS:
 - page: Current page number
 - page_size: Results per page
 - total_pages: Total pages available
+- has_more: True if additional pages follow the current one
 
 Examples:
 {

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -8,6 +8,7 @@ all memory operations, eliminating the DRY violation and ensuring consistent beh
 
 import json
 import logging
+import math
 import sys
 from typing import Dict, List, Optional, Any, Union
 
@@ -313,11 +314,14 @@ class MemoryService:
             for memory in memories:
                 results.append(self._format_memory_response(memory))
 
+            total_pages = math.ceil(total / page_size) if page_size > 0 else 0
+
             return {
                 "memories": results,
                 "page": page,
                 "page_size": page_size,
                 "total": total,
+                "total_pages": total_pages,
                 "has_more": offset + page_size < total
             }
 
@@ -328,7 +332,10 @@ class MemoryService:
                 "error": f"Failed to list memories: {str(e)}",
                 "memories": [],
                 "page": page,
-                "page_size": page_size
+                "page_size": page_size,
+                "total": 0,
+                "total_pages": 0,
+                "has_more": False
             }
 
     async def store_memory(

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -155,6 +155,27 @@ async def test_list_memories_has_more_false(memory_service, mock_storage, sample
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("total,page_size,expected_pages", [
+    (0, 10, 0),     # empty dataset
+    (5, 2, 3),      # partial last page (ceil)
+    (10, 10, 1),    # exact fit
+    (11, 10, 2),    # one extra item rolls to next page
+    (100, 25, 4),   # clean division
+])
+async def test_list_memories_total_pages_calculation(
+    memory_service, mock_storage, sample_memories, total, page_size, expected_pages
+):
+    """Test total_pages is computed correctly for various total/page_size combinations."""
+    mock_storage.get_all_memories.return_value = sample_memories[:min(total, page_size)]
+    mock_storage.count_all_memories.return_value = total
+
+    result = await memory_service.list_memories(page=1, page_size=page_size)
+
+    assert result["total"] == total
+    assert result["total_pages"] == expected_pages
+
+
+@pytest.mark.asyncio
 async def test_list_memories_error_handling(memory_service, mock_storage):
     """Test error handling in list_memories."""
     mock_storage.get_all_memories.side_effect = Exception("Database error")
@@ -165,6 +186,10 @@ async def test_list_memories_error_handling(memory_service, mock_storage):
     assert "error" in result
     assert "Database error" in result["error"]
     assert result["memories"] == []
+    # Error path must still expose pagination fields per documented contract
+    assert result["total"] == 0
+    assert result["total_pages"] == 0
+    assert result["has_more"] is False
 
 
 # Test store_memory method


### PR DESCRIPTION
## Summary
- The `list_memories` MCP tool docstring advertised a `total_pages` field in the return shape, but the implementation only returned `has_more`. Clients treating the docstring as contract received a missing field.
- Adds `total_pages = ceil(total / page_size)` to both the success and error return paths in `MemoryService.list_memories`.
- Documents the existing `has_more` field in the MCP tool docstring so the contract matches reality in both directions.

## Why
Discovered while writing a Rust port spec against the documented tool surface — the docstring said one thing, the wire response said another. LLM-authored clients (which are the primary caller class for an MCP server) parse the docstring literally and will silently break on `result["total_pages"]`.

Picking the add-the-field path over the shrink-the-docstring path because:
- `total_pages` is strictly more useful than `has_more` for pagination UIs (you can render a page picker, not just a "next" button).
- `has_more` stays available for callers that already depend on it — no breaking change.
- The error branch previously only returned `{success, error, memories, page, page_size}`; it now also returns `total`, `total_pages`, `has_more` so a caller can treat success and error paths uniformly for pagination fields.

## Files
- `src/mcp_memory_service/services/memory_service.py` — compute and include `total_pages`; normalize error return.
- `src/mcp_memory_service/mcp_server.py` — document `has_more` in the tool docstring.
- `tests/unit/test_memory_service.py` — parametrized test for `total_pages` across edge cases (0, ceil-rounding, exact-fit, overflow) + error-path pagination fields.

## Test plan
- [x] `pytest tests/unit/test_memory_service.py -k list_memories` — 12 passed locally.
- [ ] CI green on this branch.
- [ ] Manual: call `list_memories` via MCP stdio, confirm `total_pages` in response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)