### PR TITLE
fix(mcp): return 202 for JSON-RPC notifications on /mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **[#733] MCP: return HTTP 202 for JSON-RPC notifications on `/mcp`**: JSON-RPC 2.0 §4.1 forbids servers from replying to notifications (messages without `id`), and MCP Streamable HTTP requires HTTP 202 Accepted with an empty body in that case. The `/mcp` handler previously fell through to method dispatch and returned a `-32601 Method not found` error for `notifications/initialized`. Tolerant clients (Claude Code) ignored it; strict clients (Codex's `rmcp`) treated the response as a handshake failure and refused to start the MCP server. Fixed by short-circuiting to `Response(status_code=202)` at the top of `mcp_endpoint` whenever `request.id is None`. Added regression tests for the 202/empty-body path and the `initialize` happy path. (PR #733)
+
 ## [10.38.3] - 2026-04-17
 
 ### Fixed

--- a/src/mcp_memory_service/web/api/mcp.py
+++ b/src/mcp_memory_service/web/api/mcp.py
@@ -8,7 +8,7 @@ to directly access memory operations using the MCP standard.
 import json
 import logging
 from typing import Dict, Any, Optional, Union
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict
 
@@ -151,6 +151,13 @@ async def mcp_endpoint(
 ):
     """Main MCP protocol endpoint for processing MCP requests."""
     try:
+        # JSON-RPC 2.0: a message without `id` is a Notification; the server
+        # MUST NOT reply. MCP Streamable HTTP requires HTTP 202 Accepted with
+        # no body in that case. Returning an error here breaks strict clients
+        # (e.g. Codex's rmcp) during the `notifications/initialized` handshake.
+        if request.id is None:
+            return Response(status_code=202)
+
         storage = get_storage()
 
         if request.method == "initialize":

--- a/tests/web/api/test_jsonrpc_endpoint.py
+++ b/tests/web/api/test_jsonrpc_endpoint.py
@@ -35,15 +35,14 @@ async def initialized_storage(temp_db, monkeypatch):
 
 @pytest.fixture
 def test_app(initialized_storage, monkeypatch):
-    monkeypatch.setenv("MCP_API_KEY", "")
-    monkeypatch.setenv("MCP_OAUTH_ENABLED", "false")
-    monkeypatch.setenv("MCP_ALLOW_ANONYMOUS_ACCESS", "true")
-
-    import sys
-    import importlib
-    for mod in ("mcp_memory_service.config", "mcp_memory_service.web.oauth.middleware"):
-        if mod in sys.modules:
-            importlib.reload(sys.modules[mod])
+    # Patch module-level auth config directly instead of reloading modules.
+    # Reloading (importlib.reload) creates new function objects, which
+    # desynchronizes FastAPI dependency_overrides keys from the references
+    # the app was initialized with, and causes cross-test state pollution.
+    from mcp_memory_service.web.oauth import middleware
+    monkeypatch.setattr(middleware, "API_KEY", None)
+    monkeypatch.setattr(middleware, "OAUTH_ENABLED", False)
+    monkeypatch.setattr(middleware, "ALLOW_ANONYMOUS_ACCESS", True)
 
     from mcp_memory_service.web.app import app
     from mcp_memory_service.web.oauth.middleware import (

--- a/tests/web/api/test_jsonrpc_endpoint.py
+++ b/tests/web/api/test_jsonrpc_endpoint.py
@@ -1,0 +1,113 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for JSON-RPC handling on the /mcp endpoint."""
+
+import pytest
+import pytest_asyncio
+import tempfile
+import os
+from fastapi.testclient import TestClient
+
+from mcp_memory_service.web.dependencies import set_storage
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield os.path.join(tmpdir, "test.db")
+
+
+@pytest_asyncio.fixture
+async def initialized_storage(temp_db, monkeypatch):
+    monkeypatch.setenv("MCP_SEMANTIC_DEDUP_ENABLED", "false")
+    storage = SqliteVecMemoryStorage(temp_db)
+    await storage.initialize()
+    yield storage
+    await storage.close()
+
+
+@pytest.fixture
+def test_app(initialized_storage, monkeypatch):
+    monkeypatch.setenv("MCP_API_KEY", "")
+    monkeypatch.setenv("MCP_OAUTH_ENABLED", "false")
+    monkeypatch.setenv("MCP_ALLOW_ANONYMOUS_ACCESS", "true")
+
+    import sys
+    import importlib
+    for mod in ("mcp_memory_service.config", "mcp_memory_service.web.oauth.middleware"):
+        if mod in sys.modules:
+            importlib.reload(sys.modules[mod])
+
+    from mcp_memory_service.web.app import app
+    from mcp_memory_service.web.oauth.middleware import (
+        get_current_user, require_read_access, AuthenticationResult,
+    )
+
+    set_storage(initialized_storage)
+
+    async def mock_user():
+        return AuthenticationResult(
+            authenticated=True, client_id="test", scope="read write admin", auth_method="test",
+        )
+
+    app.dependency_overrides[get_current_user] = mock_user
+    app.dependency_overrides[require_read_access] = mock_user
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_initialized_notification_returns_202_with_empty_body(test_app):
+    """
+    JSON-RPC 2.0 requires servers never respond to notifications (messages
+    without `id`). MCP Streamable HTTP further requires HTTP 202 Accepted
+    with no body in this case. Regression for:
+    clients like Codex's rmcp that treat a JSON-RPC error response to
+    `notifications/initialized` as a handshake failure.
+    """
+    response = test_app.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+
+    assert response.status_code == 202, (
+        f"Notifications must get 202 Accepted, got {response.status_code} "
+        f"with body: {response.text!r}"
+    )
+    assert response.content == b"", (
+        f"Notifications must get empty body, got: {response.text!r}"
+    )
+
+
+@pytest.mark.integration
+def test_initialize_request_still_returns_200_with_result(test_app):
+    """Sanity check: regular requests (with `id`) continue to work."""
+    response = test_app.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 1
+    assert "result" in body
+    assert "protocolVersion" in body["result"]


### PR DESCRIPTION
## Description

JSON-RPC 2.0 forbids servers from replying to notifications (messages with no `id`), and MCP Streamable HTTP requires HTTP 202 Accepted with no body for that case. The /mcp handler previously fell through to the method-dispatch else-branch and returned a JSON-RPC error `-32601 Method not found` for `notifications/initialized`.

Tolerant clients (Claude Code) ignore the response; strict clients (Codex's rmcp) treat the resulting transport behavior as a handshake failure and fail to start the MCP server.

## Motivation

Using the mcp-memory-service with strict clients like Codex

## Type of Change

<!-- Check all that apply -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## Changes

<!-- List the specific changes made in this PR -->

Fix: short-circuit to `Response(status_code=202)` at the top of `mcp_endpoint` whenever `request.id is None`. This covers `notifications/initialized` and any other future notification methods uniformly.

**Breaking Changes** (if any):

N/A

## Testing

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version:
- OS:
- Storage backend:
- Installation method:

### Test Coverage

<!-- Describe the test coverage added or modified -->

- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Test coverage maintained/improved

## Related Issues

<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

Fixes #
Closes #
Relates to #

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Documentation

<!-- Check all that apply -->

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [ ] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [x] Updated code comments/docstrings
- [ ] Added API documentation
- [ ] No documentation needed

## Pre-submission Checklist

<!-- Check all boxes before submitting -->

- [ ] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [ ] ✅ I have performed a self-review of my code
- [ ] ✅ I have commented my code, particularly in hard-to-understand areas
- [ ] ✅ I have made corresponding changes to the documentation
- [ ] ✅ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works
- [ ] ✅ New and existing unit tests pass locally with my changes
- [ ] ✅ Any dependent changes have been merged and published
- [ ] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [ ] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

<!-- Any additional information, context, or notes for reviewers -->

---

**For Reviewers**:
- Review checklist: See [Development Reference](https://github.com/doobidoo/mcp-memory-service/wiki/06-Development-Reference)
- Consider testing with Gemini Code Assist for comprehensive review
- Verify CHANGELOG.md entry is present and correctly formatted
- Check documentation accuracy and completeness
