### PR TITLE
chore: release v10.38.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.38.4] - 2026-04-19
+
 ### Fixed
 
 - **[#733] MCP: return HTTP 202 for JSON-RPC notifications on `/mcp`**: JSON-RPC 2.0 §4.1 forbids servers from replying to notifications (messages without `id`), and MCP Streamable HTTP requires HTTP 202 Accepted with an empty body in that case. The `/mcp` handler previously fell through to method dispatch and returned a `-32601 Method not found` error for `notifications/initialized`. Tolerant clients (Claude Code) ignored it; strict clients (Codex's `rmcp`) treated the response as a handshake failure and refused to start the MCP server. Fixed by short-circuiting to `Response(status_code=202)` at the top of `mcp_endpoint` whenever `request.id is None`. Added regression tests for the 202/empty-body path and the `initialize` happy path. (PR #733)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.38.3 - fix: Server tab auto-check, list_memories total_pages, knowledge graph edge rendering (PRs #728, #731, #730) — 1,547 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.38.4 - fix(mcp): return HTTP 202 for JSON-RPC notifications on /mcp — fixes Codex/strict-client handshake (PR #733) — 1,547 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -434,19 +434,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.38.3** (April 17, 2026)
+## Latest Release: **v10.38.4** (April 19, 2026)
 
-**fix: Server tab auto-check, list_memories total_pages, knowledge graph edge rendering**
+**fix(mcp): return HTTP 202 for JSON-RPC notifications — fixes Codex / strict-client handshake**
 
 **What's New:**
-- **Server tab auto-check**: Dashboard now auto-checks for updates on Server tab open and shows an accurate initial label before the first check completes. (PR #728)
-- **`list_memories` total_pages**: REST API `list_memories` response now includes `total_pages` field for correct pagination. (PR #731)
-- **Knowledge graph edge rendering**: Fixed invisible edges for non-canonical relationship types by providing fallback colors for undefined CSS variables. (PR #730)
+- **Strict-client compatibility**: The `/mcp` endpoint now returns HTTP 202 Accepted with an empty body for JSON-RPC notifications (messages without `id`), per JSON-RPC 2.0 §4.1 and MCP Streamable HTTP spec. Previously returned `-32601 Method not found` for `notifications/initialized`. (PR #733)
+- **Codex / rmcp fix**: Strict MCP clients like Codex's `rmcp` library treated the old error response as a handshake failure and refused to start. This release fixes that.
 - **1,547 Python tests** passing.
 
 ---
 
 **Previous Releases**:
+- **v10.38.3** - fix: Server tab auto-check, list_memories total_pages, knowledge graph edge rendering (PRs #728, #731, #730)
 - **v10.38.2** - fix(windows): PS 7+ cert bypass, per-call SkipCertificateCheck, chicken-egg lib sourcing (PR #723)
 - **v10.38.1** - fix: OAuth loopback ports (RFC 8252), CLI ingestion NameError, SSE CLI flags, Docker CI bumps (PRs #697, #704, #705, #707-709)
 - **v10.38.0** - feat: opt-in Claude Code SessionEnd auto-harvest hook — safe-by-default, zero npm deps, 5s timeout, TLS opt-in (PR #711, 1,547 tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.38.3"
+version = "10.38.4"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.38.3"
+__version__ = "10.38.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.38.3"
+version = "10.38.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to 10.38.4 in `pyproject.toml`, `src/mcp_memory_service/_version.py`
- Move [Unreleased] CHANGELOG entry into `## [10.38.4] - 2026-04-19`
- Update README "Latest Release" section and Previous Releases list
- Update CLAUDE.md version callout
- Run `uv lock` to update lockfile

## Fix included (PR #733)

`/mcp` endpoint now returns HTTP 202 Accepted with empty body for JSON-RPC notifications (messages without `id`), per JSON-RPC 2.0 §4.1 and MCP Streamable HTTP spec. Previously returned `-32601 Method not found` for `notifications/initialized`, causing strict MCP clients (Codex's `rmcp`) to fail during the MCP handshake.

## Test plan

- [x] CI green on release branch
- [x] Version consistent across `pyproject.toml`, `_version.py`, CHANGELOG, README, CLAUDE.md
- [x] CHANGELOG [Unreleased] is empty after move