### PR TITLE
feat(plugin): Claude Code plugin packaging for mcp-memory-service hooks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcp-memory-service",
+  "owner": { "name": "doobidoo", "url": "https://github.com/doobidoo" },
+  "plugins": [
+    {
+      "name": "mcp-memory-service",
+      "source": "./claude-hooks",
+      "description": "Semantic memory for Claude Code sessions"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,9 @@ claude_config/claude_desktop_config.json
 
 # Personalized setup guides (generated locally)
 YOUR_PERSONALIZED_SETUP_GUIDE.md
-.mcp.json
+# Only ignore the root-level .mcp.json (local dev config).
+# Plugin-level claude-hooks/.mcp.json is tracked.
+/.mcp.json
 
 # Local memory service configuration (contains private endpoints/keys)
 CLAUDE_MEMORY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **plugin**: Claude Code plugin packaging for the claude-hooks suite. Install via `/plugin marketplace add doobidoo/mcp-memory-service` + `/plugin install mcp-memory-service`. Ships with `.mcp.json`, hook wiring, and self-healing `ensure-server.js`. Coexists with the legacy `install_hooks.py` installer — see [claude-hooks/PLUGIN.md](claude-hooks/PLUGIN.md). Closes #530 (plugin packaging track).
+
 ### Changed
 - **hooks**: Route memory writes through `MemoryClient.storeMemory()` — enables MCP protocol fallback for `session-end` and `auto-capture` hooks. Closes silent write-failure path documented in #530 (Option B).
 

--- a/claude-hooks/.claude-plugin/hooks.json
+++ b/claude-hooks/.claude-plugin/hooks.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure-server.js\"" },
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/core/session-start.js\"" }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/core/session-end.js\"" }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/core/mid-conversation.js\"" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/core/auto-capture-hook.js\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-hooks/.claude-plugin/plugin.json
+++ b/claude-hooks/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "mcp-memory-service",
+  "version": "1.0.0",
+  "description": "Automatic memory capture and injection for Claude Code via MCP Memory Service",
+  "author": "doobidoo",
+  "homepage": "https://github.com/doobidoo/mcp-memory-service",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./.claude-plugin/hooks.json"
+}

--- a/claude-hooks/.mcp.json
+++ b/claude-hooks/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "python",
+      "args": ["-m", "mcp_memory_service.server"],
+      "env": {
+        "MCP_MEMORY_STORAGE_BACKEND": "hybrid",
+        "MCP_HYBRID_SYNC_OWNER": "http"
+      }
+    }
+  }
+}

--- a/claude-hooks/PLUGIN.md
+++ b/claude-hooks/PLUGIN.md
@@ -1,0 +1,83 @@
+# Claude Code Plugin Installation
+
+This directory can be installed as a Claude Code plugin via the GitHub
+marketplace. Two setup paths exist: the plugin (recommended for new users)
+and the legacy Python installer (`install_hooks.py`). Both work; they should
+not be active simultaneously.
+
+## Install via plugin marketplace
+
+```
+/plugin marketplace add doobidoo/mcp-memory-service
+/plugin install mcp-memory-service
+```
+
+Claude Code registers the MCP server (`.mcp.json`) and the hook wiring
+(`.claude-plugin/hooks.json`) automatically. Updates come via `git pull`
+on the marketplace entry.
+
+## Configuration
+
+The plugin reads `~/.claude/hooks/config.json`. If that file does not
+exist, copy `config.template.json` from this directory:
+
+```
+mkdir -p ~/.claude/hooks
+cp ~/.claude/plugins/marketplaces/doobidoo/mcp-memory-service/claude-hooks/config.template.json \
+   ~/.claude/hooks/config.json
+```
+
+Then edit `~/.claude/hooks/config.json` — at minimum set
+`memoryService.http.endpoint` and `memoryService.http.apiKey`.
+
+## Server lifecycle
+
+On SessionStart the plugin runs `scripts/ensure-server.js`, which:
+
+1. Probes `GET /api/health` on the configured endpoint
+2. If unreachable, tries (in order):
+   - `memory server --http` (CLI entry point, works from any directory if `mcp-memory-service` is pip-installed)
+   - `python -m mcp_memory_service.cli.main server --http` (module form)
+   - `python scripts/server/run_http_server.py` (dev-mode fallback, requires repo checkout as cwd)
+3. Polls for health for up to 10 seconds
+
+The script never blocks session start — all failure paths exit 0 with a
+warning on stderr. Logs go to `~/.mcp-memory-service/http.log` (fallback:
+`/tmp/mcp-memory-service-http.log` if the preferred location is unwritable).
+
+Set `ENSURE_SERVER_NO_SPAWN=1` to disable the spawn path (probe-only mode).
+
+## Migrating from `install_hooks.py`
+
+If you already installed via the Python installer, remove its hook entries
+from `~/.claude/settings.json` before installing the plugin — otherwise
+every hook runs twice.
+
+```
+grep -n "claude-hooks" ~/.claude/settings.json
+```
+
+Remove the matching entries from the `hooks` object and save.
+
+## Uninstall
+
+```
+/plugin uninstall mcp-memory-service
+```
+
+This removes hooks and MCP server registration. It does not delete
+`~/.claude/hooks/config.json` or `~/.mcp-memory-service/` logs.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Hooks run twice | Both installer and plugin active | Remove installer hook entries from `~/.claude/settings.json` |
+| `ensure-server.js` warns "could not spawn" | `mcp-memory-service` not pip-installed, no `memory` on PATH, no Python available | `pip install mcp-memory-service`, or set `MCP_MEMORY_PYTHON` to a Python with the package installed |
+| Writes silently fail | API key missing | Set `memoryService.http.apiKey` in `~/.claude/hooks/config.json` |
+| Server starts but never becomes healthy | Port collision | Check `~/.mcp-memory-service/http.log`, change port in `.env` |
+
+## Status
+
+v1.0.0 is **experimental**. Please file issues at
+https://github.com/doobidoo/mcp-memory-service/issues with the `plugin` label.

--- a/claude-hooks/README.md
+++ b/claude-hooks/README.md
@@ -2,6 +2,14 @@
 
 Automatic memory awareness and intelligent context injection for Claude Code using the MCP Memory Service.
 
+## Installation (quick start)
+
+**Recommended (experimental):** Install as a Claude Code plugin — see [PLUGIN.md](./PLUGIN.md).
+
+**Legacy:** The Python installer (`install_hooks.py`) continues to work and is documented in the sections below. Both setups are mutually exclusive.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/claude-hooks/scripts/ensure-server.js
+++ b/claude-hooks/scripts/ensure-server.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * ensure-server.js — SessionStart hook that ensures the HTTP memory server
+ * is reachable, starting it in the background if necessary.
+ *
+ * Contract: NEVER block session start. All failure paths exit 0 with stderr.
+ */
+'use strict';
+
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+const HEALTH_TIMEOUT_MS = 500;
+const POLL_INTERVAL_MS = 500;
+const POLL_TIMEOUT_MS = 10_000;
+const NO_SPAWN = process.env.ENSURE_SERVER_NO_SPAWN === '1';
+
+function log(msg) {
+    process.stderr.write(`[ensure-server] ${msg}\n`);
+}
+
+function resolveEndpoint() {
+    if (process.env.MCP_MEMORY_ENDPOINT) {
+        return process.env.MCP_MEMORY_ENDPOINT;
+    }
+    const configPath = path.join(os.homedir(), '.claude', 'hooks', 'config.json');
+    try {
+        const cfg = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        const endpoint =
+            cfg.memoryService?.http?.endpoint ||
+            cfg.memoryService?.endpoint ||
+            cfg.sessionHarvest?.endpoint;
+        if (endpoint) return endpoint;
+    } catch (_) {
+        // fall through to default
+    }
+    return 'http://127.0.0.1:8000';
+}
+
+function checkHealth(endpoint) {
+    return new Promise((resolve) => {
+        let url;
+        try {
+            url = new URL('/api/health', endpoint);
+        } catch (_) {
+            return resolve(false);
+        }
+        const lib = url.protocol === 'https:' ? https : http;
+        const req = lib.get(url, { timeout: HEALTH_TIMEOUT_MS }, (res) => {
+            res.resume();
+            resolve(res.statusCode === 200);
+        });
+        req.on('error', () => resolve(false));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve(false);
+        });
+    });
+}
+
+function resolveLogPath() {
+    const preferred = path.join(os.homedir(), '.mcp-memory-service', 'http.log');
+    try {
+        fs.mkdirSync(path.dirname(preferred), { recursive: true });
+        fs.accessSync(path.dirname(preferred), fs.constants.W_OK);
+        return preferred;
+    } catch (_) {
+        return path.join(os.tmpdir(), 'mcp-memory-service-http.log');
+    }
+}
+
+function spawnServer() {
+    const pythonCandidates = [
+        process.env.MCP_MEMORY_PYTHON,
+        path.join(process.cwd(), '.venv', 'bin', 'python'),
+        'python3',
+        'python',
+    ].filter(Boolean);
+
+    const scriptPath = path.join('scripts', 'server', 'run_http_server.py');
+    const logPath = resolveLogPath();
+    const logFd = fs.openSync(logPath, 'a');
+
+    for (const python of pythonCandidates) {
+        try {
+            const child = spawn(python, [scriptPath], {
+                detached: true,
+                stdio: ['ignore', logFd, logFd],
+                env: process.env,
+            });
+            child.unref();
+            log(`spawned HTTP server via ${python} (log: ${logPath})`);
+            return true;
+        } catch (err) {
+            log(`spawn with ${python} failed: ${err.message}`);
+        }
+    }
+    log('could not spawn python — install python3 or set MCP_MEMORY_PYTHON');
+    return false;
+}
+
+async function pollUntilHealthy(endpoint, deadlineMs) {
+    while (Date.now() < deadlineMs) {
+        if (await checkHealth(endpoint)) return true;
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    return false;
+}
+
+async function main() {
+    const endpoint = resolveEndpoint();
+    if (await checkHealth(endpoint)) return;
+
+    log(`HTTP server unreachable at ${endpoint}`);
+    if (NO_SPAWN) {
+        log('ENSURE_SERVER_NO_SPAWN=1 — skipping spawn (test mode)');
+        return;
+    }
+
+    if (!spawnServer()) return;
+
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    const ok = await pollUntilHealthy(endpoint, deadline);
+    if (!ok) {
+        log(`server did not become healthy within ${POLL_TIMEOUT_MS}ms`);
+    } else {
+        log('server is healthy');
+    }
+}
+
+main()
+    .catch((err) => {
+        log(`unexpected error: ${err.message}`);
+    })
+    .finally(() => {
+        process.exit(0); // never block
+    });

--- a/claude-hooks/scripts/ensure-server.js
+++ b/claude-hooks/scripts/ensure-server.js
@@ -74,33 +74,65 @@ function resolveLogPath() {
 }
 
 function spawnServer() {
-    const pythonCandidates = [
-        process.env.MCP_MEMORY_PYTHON,
-        path.join(process.cwd(), '.venv', 'bin', 'python'),
-        'python3',
-        'python',
-    ].filter(Boolean);
-
-    const scriptPath = path.join('scripts', 'server', 'run_http_server.py');
     const logPath = resolveLogPath();
-    const logFd = fs.openSync(logPath, 'a');
+    let logFd;
+    try {
+        logFd = fs.openSync(logPath, 'a');
+    } catch (err) {
+        log(`could not open log file at ${logPath}: ${err.message}`);
+        return false;
+    }
 
-    for (const python of pythonCandidates) {
+    try {
+        // Strategy 1: memory CLI entry point (installed by pip install mcp-memory-service)
         try {
-            const child = spawn(python, [scriptPath], {
+            const child = spawn('memory', ['server', '--http'], {
                 detached: true,
                 stdio: ['ignore', logFd, logFd],
                 env: process.env,
             });
             child.unref();
-            log(`spawned HTTP server via ${python} (log: ${logPath})`);
+            log(`spawned HTTP server via 'memory server --http' (log: ${logPath})`);
             return true;
         } catch (err) {
-            log(`spawn with ${python} failed: ${err.message}`);
+            log(`'memory' CLI unavailable: ${err.message}`);
         }
+
+        // Strategy 2 & 3: python-based fallbacks
+        const pythonCandidates = [
+            process.env.MCP_MEMORY_PYTHON,
+            path.join(process.cwd(), '.venv', 'bin', 'python'),
+            'python3',
+            'python',
+        ].filter(Boolean);
+
+        const pythonInvocations = [
+            ['-m', 'mcp_memory_service.cli.main', 'server', '--http'],
+            [path.join('scripts', 'server', 'run_http_server.py')],
+        ];
+
+        for (const python of pythonCandidates) {
+            for (const args of pythonInvocations) {
+                try {
+                    const child = spawn(python, args, {
+                        detached: true,
+                        stdio: ['ignore', logFd, logFd],
+                        env: process.env,
+                    });
+                    child.unref();
+                    log(`spawned HTTP server via ${python} ${args.join(' ')} (log: ${logPath})`);
+                    return true;
+                } catch (err) {
+                    log(`spawn with ${python} ${args.join(' ')} failed: ${err.message}`);
+                }
+            }
+        }
+
+        log('could not spawn HTTP server — install mcp-memory-service or set MCP_MEMORY_PYTHON');
+        return false;
+    } finally {
+        try { fs.closeSync(logFd); } catch (_) {}
     }
-    log('could not spawn python — install python3 or set MCP_MEMORY_PYTHON');
-    return false;
 }
 
 async function pollUntilHealthy(endpoint, deadlineMs) {

--- a/claude-hooks/scripts/ensure-server.js
+++ b/claude-hooks/scripts/ensure-server.js
@@ -101,14 +101,14 @@ function spawnServer() {
         // Strategy 2 & 3: python-based fallbacks
         const pythonCandidates = [
             process.env.MCP_MEMORY_PYTHON,
-            path.join(process.cwd(), '.venv', 'bin', 'python'),
+            path.join(__dirname, '..', '..', '.venv', 'bin', 'python'),
             'python3',
             'python',
         ].filter(Boolean);
 
         const pythonInvocations = [
             ['-m', 'mcp_memory_service.cli.main', 'server', '--http'],
-            [path.join('scripts', 'server', 'run_http_server.py')],
+            [path.join(__dirname, '..', '..', 'scripts', 'server', 'run_http_server.py')],
         ];
 
         for (const python of pythonCandidates) {
@@ -131,7 +131,7 @@ function spawnServer() {
         log('could not spawn HTTP server — install mcp-memory-service or set MCP_MEMORY_PYTHON');
         return false;
     } finally {
-        try { fs.closeSync(logFd); } catch (_) {}
+        if (typeof logFd === 'number') { try { fs.closeSync(logFd); } catch (_) {} }
     }
 }
 
@@ -164,10 +164,12 @@ async function main() {
     }
 }
 
-main()
-    .catch((err) => {
-        log(`unexpected error: ${err.message}`);
-    })
-    .finally(() => {
-        process.exit(0); // never block
-    });
+if (require.main === module) {
+    main()
+        .catch((err) => {
+            log(`unexpected error: ${err.message}`);
+        })
+        .finally(() => {
+            process.exit(0); // never block
+        });
+}

--- a/claude-hooks/scripts/test-plugin-install.sh
+++ b/claude-hooks/scripts/test-plugin-install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# test-plugin-install.sh — Validate plugin structure without installing.
+# Run: bash claude-hooks/scripts/test-plugin-install.sh
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok() { echo "OK: $1"; }
+
+# 1. plugin.json must parse
+node -e "JSON.parse(require('fs').readFileSync('$PLUGIN_ROOT/.claude-plugin/plugin.json'))" \
+  || fail "plugin.json invalid"
+ok "plugin.json parseable"
+
+# 2. hooks.json must parse
+node -e "JSON.parse(require('fs').readFileSync('$PLUGIN_ROOT/.claude-plugin/hooks.json'))" \
+  || fail "hooks.json invalid"
+ok "hooks.json parseable"
+
+# 3. .mcp.json must parse
+node -e "JSON.parse(require('fs').readFileSync('$PLUGIN_ROOT/.mcp.json'))" \
+  || fail ".mcp.json invalid"
+ok ".mcp.json parseable"
+
+# 4. marketplace.json (repo root) must parse
+node -e "JSON.parse(require('fs').readFileSync('$REPO_ROOT/.claude-plugin/marketplace.json'))" \
+  || fail "marketplace.json invalid"
+ok "marketplace.json parseable"
+
+# 5. Every script referenced in hooks.json must exist
+node -e "
+const hooks = JSON.parse(require('fs').readFileSync('$PLUGIN_ROOT/.claude-plugin/hooks.json'));
+const fs = require('fs');
+const path = require('path');
+for (const [event, entries] of Object.entries(hooks.hooks)) {
+  for (const entry of entries) {
+    for (const hook of entry.hooks) {
+      const m = hook.command.match(/\\\$\{CLAUDE_PLUGIN_ROOT\}\/([^\"]+)/);
+      if (!m) { console.error('Unparseable command:', hook.command); process.exit(1); }
+      const file = path.join('$PLUGIN_ROOT', m[1]);
+      if (!fs.existsSync(file)) { console.error('Missing:', file); process.exit(1); }
+    }
+  }
+}
+"
+ok "all referenced hook scripts exist"
+
+# 6. Every referenced script must parse as Node
+for f in \
+  "$PLUGIN_ROOT/scripts/ensure-server.js" \
+  "$PLUGIN_ROOT/core/session-start.js" \
+  "$PLUGIN_ROOT/core/session-end.js" \
+  "$PLUGIN_ROOT/core/mid-conversation.js" \
+  "$PLUGIN_ROOT/core/auto-capture-hook.js"; do
+  node -e "require('$f')" 2>/dev/null || fail "$f fails to load"
+  ok "$(basename "$f") loads"
+done
+
+echo
+echo "All plugin structural checks passed."

--- a/claude-hooks/tests/ensure-server.test.js
+++ b/claude-hooks/tests/ensure-server.test.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/ensure-server.js
+ * Run: node claude-hooks/tests/ensure-server.test.js
+ */
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'ensure-server.js');
+
+function runScript(env = {}) {
+    return new Promise((resolve) => {
+        const proc = spawn('node', [SCRIPT], {
+            env: { ...process.env, ...env },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', (d) => (stdout += d));
+        proc.stderr.on('data', (d) => (stderr += d));
+        proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+}
+
+function startMockHealthServer(statusCode = 200) {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            if (req.url === '/api/health') {
+                res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ status: 'ok' }));
+            } else {
+                res.writeHead(404);
+                res.end();
+            }
+        });
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({ server, port });
+        });
+    });
+}
+
+function stopServer(server) {
+    return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function runTest(name, fn) {
+    try {
+        await fn();
+        console.log(`PASS: ${name}`);
+        return true;
+    } catch (err) {
+        console.error(`FAIL: ${name}`);
+        console.error(err);
+        return false;
+    }
+}
+
+async function testHealthyServerExitsZero() {
+    const { server, port } = await startMockHealthServer(200);
+    try {
+        const { code, stderr } = await runScript({
+            MCP_MEMORY_ENDPOINT: `http://127.0.0.1:${port}`,
+            ENSURE_SERVER_NO_SPAWN: '1',
+        });
+        assert.strictEqual(code, 0, `expected exit 0, got ${code}. stderr: ${stderr}`);
+    } finally {
+        await stopServer(server);
+    }
+}
+
+async function testUnreachableServerExitsZeroWithWarning() {
+    const { code, stderr } = await runScript({
+        MCP_MEMORY_ENDPOINT: 'http://127.0.0.1:1',
+        ENSURE_SERVER_NO_SPAWN: '1',
+    });
+    assert.strictEqual(code, 0, 'must never block session start');
+    assert.ok(
+        /unreach|could not|failed/i.test(stderr),
+        `expected warning in stderr, got: ${stderr}`,
+    );
+}
+
+async function run() {
+    const results = [];
+    results.push(await runTest('testHealthyServerExitsZero', testHealthyServerExitsZero));
+    results.push(await runTest('testUnreachableServerExitsZeroWithWarning', testUnreachableServerExitsZeroWithWarning));
+    const passed = results.filter(Boolean).length;
+    console.log(`${passed}/${results.length} tests passed`);
+    if (passed !== results.length) process.exit(1);
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

Ships `claude-hooks/` as a Claude Code plugin installable via the GitHub marketplace. Two commands replace the `install_hooks.py` + API-key-generation + MCP-config-editing ceremony.

```
/plugin marketplace add doobidoo/mcp-memory-service
/plugin install mcp-memory-service
```

**Scope: Phase 2 of 2.** Builds on [#735](https://github.com/doobidoo/mcp-memory-service/pull/735) (Phase 1, merged). This PR implements Phase 2 from the plan in [docs/superpowers/plans/2026-04-19-claude-code-plugin-packaging.md](docs/superpowers/plans/2026-04-19-claude-code-plugin-packaging.md). Closes [#530](https://github.com/doobidoo/mcp-memory-service/issues/530) (plugin packaging track).

## Why

Issue #530 documented the burden of the existing setup: users had to run `install_hooks.py`, generate an API key, edit `~/.claude.json` manually, and keep two server processes alive with a bash wrapper. The plugin removes every one of those steps.

## Design

- **Coexistence, no breaking change.** Legacy `install_hooks.py` still works. Users opt into the plugin; users with the installer can migrate by removing their existing hook entries from `~/.claude/settings.json` (documented in `PLUGIN.md`).
- **Four core hooks** in v1: `session-start`, `session-end`, `mid-conversation`, `auto-capture-hook`. Extended set (`session-end-harvest`, `topic-change`, `permission-request`, `memory-retrieval`) deferred to v2.
- **Self-healing server start** via `ensure-server.js` at SessionStart. Tries `memory server --http` CLI entry first (location-independent), falls back to Python module invocation, then to a cwd-relative dev script. Contract: never blocks session start — all failure paths exit 0 with stderr warning.
- **Config is shared** with the installer — plugin reads `~/.claude/hooks/config.json` so existing users migrate with zero config changes.

## Files

**New plugin manifest & wiring:**
- [`claude-hooks/.claude-plugin/plugin.json`](claude-hooks/.claude-plugin/plugin.json)
- [`claude-hooks/.claude-plugin/hooks.json`](claude-hooks/.claude-plugin/hooks.json) (4 events)
- [`claude-hooks/.mcp.json`](claude-hooks/.mcp.json) (stdio MCP registration)
- [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) (repo root — makes repo installable as marketplace)

**New scripts:**
- [`claude-hooks/scripts/ensure-server.js`](claude-hooks/scripts/ensure-server.js) (141 lines, self-healing HTTP starter)
- [`claude-hooks/scripts/test-plugin-install.sh`](claude-hooks/scripts/test-plugin-install.sh) (structural smoke test)

**New tests:**
- [`claude-hooks/tests/ensure-server.test.js`](claude-hooks/tests/ensure-server.test.js) (2 tests: healthy + unreachable)

**New docs:**
- [`claude-hooks/PLUGIN.md`](claude-hooks/PLUGIN.md) (install, config, lifecycle, migration, troubleshooting)

**Modifications:**
- [`claude-hooks/README.md`](claude-hooks/README.md) — new "Installation (quick start)" section at top, pointing to PLUGIN.md; legacy installer docs preserved below
- `.gitignore` — scoped `.mcp.json` pattern to root only (was matching everywhere, blocking plugin manifest)

## Tests

All three validation suites green:

```bash
node claude-hooks/tests/memory-client-store.test.js   # 4/4 (unchanged, Phase 1)
node claude-hooks/tests/ensure-server.test.js          # 2/2 (new, Phase 2)
bash claude-hooks/scripts/test-plugin-install.sh       # structural — all OK
```

## Test plan

- [x] Unit tests: `ensure-server.test.js` 2/2 pass (`ENSURE_SERVER_NO_SPAWN=1` test-mode)
- [x] Structural smoke test validates all 4 JSON manifests + 5 hook scripts load
- [x] Phase 1 regression: `memory-client-store.test.js` still 4/4
- [ ] Manual: fresh Claude Code install, `/plugin marketplace add doobidoo/mcp-memory-service` + `/plugin install mcp-memory-service`, verify session-start hook runs and memories store via MCP
- [ ] Manual: verify installer + plugin coexist does NOT cause double-hook execution after installer entries are removed per `PLUGIN.md`
- [ ] Manual: verify `ensure-server.js` actually starts the HTTP server when `memory server --http` is in PATH

## Known limitations (documented)

- **dev-mode fallback is cwd-relative.** If `memory` CLI is not on PATH and `MCP_MEMORY_PYTHON` is unset, the last-resort spawn strategy uses `scripts/server/run_http_server.py` relative to `process.cwd()`. Works when Claude Code is invoked from a repo checkout; fails silently otherwise. Primary CLI-first strategy sidesteps this in the normal case.
- **HTTP helper extraction** in `MemoryClient` deferred to a follow-up PR (flagged by TODO in `memory-client.js` after Gemini review on #735).

## Follow-ups

After merge:
1. Address HTTP helper duplication in `memory-client.js` (follow-up to Gemini review on #735)
2. Beta feedback on plugin (4-week window per rollout plan in the spec)
3. v2 additions: harvest, topic-change, permission-request, memory-retrieval hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)