### PR TITLE
fix: change author field to object format for Claude Code plugin spec compliance

### DIFF
--- a/claude-hooks/.claude-plugin/plugin.json
+++ b/claude-hooks/.claude-plugin/plugin.json
@@ -2,7 +2,9 @@
   "name": "mcp-memory-service",
   "version": "1.0.0",
   "description": "Automatic memory capture and injection for Claude Code via MCP Memory Service",
-  "author": "doobidoo",
+  "author": {
+    "name": "doobidoo"
+  },
   "homepage": "https://github.com/doobidoo/mcp-memory-service",
   "mcpServers": "./.mcp.json",
   "hooks": "./.claude-plugin/hooks.json"


### PR DESCRIPTION
## Description

Fixes #738

The `plugin.json` manifest file had an invalid `author` field format. The Claude Code plugin validator expects `author` to be an object, but the current implementation uses a string.

## Changes

Changed `author` field from string to object format:

```diff
- "author": "doobidoo",
+ "author": {
+   "name": "doobidoo"
+ },
```

## Testing

Verified the fix allows successful plugin installation after this change.