### PR TITLE
ci(docs-link-check): ignore milvus.io and docs.zilliz.com

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -35,6 +35,12 @@
     },
     {
       "pattern": "^https://www\\.remotion\\.dev"
+    },
+    {
+      "pattern": "^https://milvus\\.io"
+    },
+    {
+      "pattern": "^https://docs\\.zilliz\\.com"
     }
   ],
   "aliveStatusCodes": [200, 206]


### PR DESCRIPTION
## Summary

- Add `^https://milvus\.io` and `^https://docs\.zilliz\.com` to `.mlc-config.json` ignore patterns.
- GitHub Actions runners intermittently return Status 0 (connection failure) on both hosts. Both sites are live in normal browsing — this is a runner-side network flake, not a dead-link problem.
- Same treatment already applied to `dash.cloudflare.com`, `www.npmjs.com`, `www.freedesktop.org`, `www.remotion.dev`.

## Context

The Docs Link Check job on #721 (Milvus storage backend) failed with:

```
[✖] https://milvus.io → Status: 0
[✖] https://milvus.io/docs/milvus_lite.md → Status: 0
ERROR: 2 dead links found!
```

Unblocks #721 once Cheney rebases / pushes his next commit.

## Test plan

- [ ] Docs Link Check passes on this PR
- [ ] After merge + rebase, Docs Link Check passes on #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)