### PR TITLE
fix(sync): correct misleading drift signals in status + stats reporting (#750)

### DIFF
--- a/src/mcp_memory_service/models/memory.py
+++ b/src/mcp_memory_service/models/memory.py
@@ -147,7 +147,10 @@ class Memory:
                 time_diff = abs(created_at - iso_ts)
                 # Allow up to 1 second difference for rounding, but reject obvious timezone mismatches
                 if time_diff > 1.0 and time_diff < 86400:  # Between 1 second and 24 hours suggests timezone issue
-                    logger.info(f"Timezone mismatch detected (diff: {time_diff}s), preferring float timestamp")
+                    # DEBUG rather than INFO: rows stored with local-TZ ISO strings
+                    # (pre-UTC-normalization) trigger this on every read — was flooding
+                    # the log and masking real errors. See issue #750.
+                    logger.debug(f"Timezone mismatch detected (diff: {time_diff}s), preferring float timestamp")
                     # Use the float timestamp as authoritative and regenerate ISO
                     self.created_at = created_at
                     self.created_at_iso = float_to_iso(created_at)
@@ -186,7 +189,7 @@ class Memory:
                 time_diff = abs(updated_at - iso_ts)
                 # Allow up to 1 second difference for rounding, but reject obvious timezone mismatches
                 if time_diff > 1.0 and time_diff < 86400:  # Between 1 second and 24 hours suggests timezone issue
-                    logger.info(f"Timezone mismatch detected in updated_at (diff: {time_diff}s), preferring float timestamp")
+                    logger.debug(f"Timezone mismatch detected in updated_at (diff: {time_diff}s), preferring float timestamp")
                     # Use the float timestamp as authoritative and regenerate ISO
                     self.updated_at = updated_at
                     self.updated_at_iso = float_to_iso(updated_at)

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -568,9 +568,9 @@ class CloudflareStorage(MemoryStorage):
                 "content_hash": memory.content_hash,
                 "memory_type": memory.memory_type or "standard",
                 "tags": ",".join(memory.tags) if memory.tags else "",
-                "created_at": memory.created_at_iso or datetime.now().isoformat()
+                "created_at": memory.created_at_iso or datetime.now(timezone.utc).isoformat()
             }
-            
+
             await self._store_vectorize_vector(vector_id, embedding, vector_metadata)
             
             # Store metadata in D1
@@ -650,7 +650,10 @@ class CloudflareStorage(MemoryStorage):
         """
 
         now = time.time()
-        now_iso = datetime.now().isoformat()
+        # Use UTC ISO to keep `updated_at_iso` aligned with the float `updated_at`
+        # (which is already UTC epoch). Local-TZ ISO strings cause a 1h/2h offset
+        # on read that floods logs with "Timezone mismatch detected" warnings.
+        now_iso = datetime.now(timezone.utc).isoformat()
 
         params = [
             memory.content_hash,
@@ -1355,7 +1358,7 @@ class CloudflareStorage(MemoryStorage):
 
             # Handle timestamp updates based on preserve_timestamps flag
             now = time.time()
-            now_iso = datetime.now().isoformat()
+            now_iso = datetime.now(timezone.utc).isoformat()  # match float UTC epoch
 
             if not preserve_timestamps:
                 # When preserve_timestamps=False, use timestamps from updates dict if provided
@@ -1439,7 +1442,10 @@ class CloudflareStorage(MemoryStorage):
             # Calculate timestamp for memories from last 7 days
             week_ago = time.time() - (7 * 24 * 60 * 60)
 
-            # Get memory count and size from D1
+            # Filter tombstones (deleted_at IS NOT NULL) so `total_memories` is
+            # consistent with SqliteVecMemoryStorage — otherwise hybrid health reports
+            # show CF counts inflated by soft-deleted rows, which looks like sync drift
+            # but is just an unfiltered stats query (see issue #750 follow-up).
             sql = f"""
             SELECT
                 COUNT(*) as total_memories,
@@ -1447,8 +1453,10 @@ class CloudflareStorage(MemoryStorage):
                 COUNT(DISTINCT vector_id) as total_vectors,
                 COUNT(r2_key) as r2_stored_count,
                 (SELECT COUNT(*) FROM tags) as unique_tags,
-                (SELECT COUNT(*) FROM memories WHERE created_at >= {week_ago}) as memories_this_week
+                (SELECT COUNT(*) FROM memories WHERE created_at >= {week_ago} AND deleted_at IS NULL) as memories_this_week,
+                (SELECT COUNT(*) FROM memories WHERE deleted_at IS NOT NULL) as tombstone_count
             FROM memories
+            WHERE deleted_at IS NULL
             """
 
             payload = {"sql": sql}
@@ -1464,6 +1472,7 @@ class CloudflareStorage(MemoryStorage):
                     "memories_this_week": stats.get("memories_this_week", 0),
                     "total_content_size_bytes": stats.get("total_content_size", 0),
                     "total_vectors": stats.get("total_vectors", 0),
+                    "tombstone_count": stats.get("tombstone_count", 0),
                     "r2_stored_count": stats.get("r2_stored_count", 0),
                     "storage_backend": "cloudflare",
                     "vectorize_index": self.vectorize_index,

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -1446,20 +1446,21 @@ class CloudflareStorage(MemoryStorage):
             # consistent with SqliteVecMemoryStorage — otherwise hybrid health reports
             # show CF counts inflated by soft-deleted rows, which looks like sync drift
             # but is just an unfiltered stats query (see issue #750 follow-up).
-            sql = f"""
+            # COALESCE guards against NULL when the filtered set is empty.
+            sql = """
             SELECT
                 COUNT(*) as total_memories,
-                SUM(content_size) as total_content_size,
+                COALESCE(SUM(content_size), 0) as total_content_size,
                 COUNT(DISTINCT vector_id) as total_vectors,
                 COUNT(r2_key) as r2_stored_count,
                 (SELECT COUNT(*) FROM tags) as unique_tags,
-                (SELECT COUNT(*) FROM memories WHERE created_at >= {week_ago} AND deleted_at IS NULL) as memories_this_week,
+                (SELECT COUNT(*) FROM memories WHERE created_at >= ? AND deleted_at IS NULL) as memories_this_week,
                 (SELECT COUNT(*) FROM memories WHERE deleted_at IS NOT NULL) as tombstone_count
             FROM memories
             WHERE deleted_at IS NULL
             """
 
-            payload = {"sql": sql}
+            payload = {"sql": sql, "params": [week_ago]}
             response = await self._retry_request("POST", f"{self.d1_url}/query", json=payload)
             result = response.json()
 

--- a/src/mcp_memory_service/web/api/sync.py
+++ b/src/mcp_memory_service/web/api/sync.py
@@ -18,6 +18,7 @@ Sync management endpoints for hybrid backend.
 Provides status monitoring and manual sync triggering for hybrid storage mode.
 """
 
+import time
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Depends
@@ -40,12 +41,13 @@ class SyncStatusResponse(BaseModel):
     is_paused: bool
     last_sync_time: float
     operations_pending: int
-    operations_processed: int
-    operations_failed: int
+    operations_processed: int  # lifetime success count
+    operations_failed: int  # lifetime failure count (does not indicate current health)
+    consecutive_failures: int = 0  # resets on any success — use this for current health
     sync_interval_seconds: int
     time_since_last_sync_seconds: float
     next_sync_eta_seconds: float
-    status: str  # 'synced', 'syncing', 'pending', 'error'
+    status: str  # 'synced', 'syncing', 'pending', 'error' — reflects current health only
 
 
 class SyncForceResponse(BaseModel):
@@ -90,7 +92,6 @@ async def get_sync_status(
         sync_status = await storage.get_sync_status()
 
         # Calculate time since last sync
-        import time
         current_time = time.time()
         last_sync = sync_status.get('last_sync_time', 0)
         time_since_sync = current_time - last_sync if last_sync > 0 else 0
@@ -99,16 +100,19 @@ async def get_sync_status(
         sync_interval = sync_status.get('sync_interval', 300)
         next_sync_eta = max(0, sync_interval - time_since_sync)
 
-        # Determine status
+        # Determine status — reflects CURRENT health only. Lifetime `operations_failed`
+        # is not used here because a single historical failure would then pin `status`
+        # to 'error' forever, masking real-time sync health (see issue #750).
         is_running = sync_status.get('is_running', False)
         pending_ops = sync_status.get('pending_operations', 0)
         actively_syncing = sync_status.get('actively_syncing', False)  # True only during active sync
+        consecutive_failures = sync_status.get('consecutive_failures', 0)
 
         if actively_syncing:
             status = 'syncing'
         elif pending_ops > 0:
             status = 'pending'
-        elif sync_status.get('operations_failed', 0) > 0:
+        elif consecutive_failures > 0:
             status = 'error'
         else:
             status = 'synced'
@@ -121,6 +125,7 @@ async def get_sync_status(
             operations_pending=pending_ops,
             operations_processed=sync_status.get('operations_processed', 0),
             operations_failed=sync_status.get('operations_failed', 0),
+            consecutive_failures=consecutive_failures,
             sync_interval_seconds=sync_interval,
             time_since_last_sync_seconds=time_since_sync,
             next_sync_eta_seconds=next_sync_eta,
@@ -154,7 +159,6 @@ async def force_sync(
         )
 
     try:
-        import time
         start_time = time.time()
 
         # Step 1: Pull FROM Cloudflare TO local (if method exists)

--- a/tests/unit/test_cloudflare_storage.py
+++ b/tests/unit/test_cloudflare_storage.py
@@ -14,10 +14,13 @@
 
 """Tests for Cloudflare storage backend."""
 
-import pytest
 import asyncio
-from unittest.mock import Mock, AsyncMock, patch
+from datetime import date
 from typing import List
+from unittest.mock import Mock, AsyncMock, patch
+
+import httpx
+import pytest
 
 from src.mcp_memory_service.storage.cloudflare import CloudflareStorage
 from src.mcp_memory_service.models.memory import Memory
@@ -117,7 +120,6 @@ class TestCloudflareStorage:
     @pytest.mark.asyncio
     async def test_retry_logic(self, cloudflare_storage):
         """Test retry logic with rate limiting."""
-        import httpx
         
         # Mock rate limited response followed by success
         responses = [
@@ -486,20 +488,54 @@ class TestCloudflareStorage:
                     "total_memories": 10,
                     "total_content_size": 1024,
                     "total_vectors": 10,
-                    "r2_stored_count": 2
+                    "r2_stored_count": 2,
+                    "tombstone_count": 0
                 }]
             }]
         }
-        
+
         with patch.object(cloudflare_storage, '_retry_request', return_value=mock_response):
             stats = await cloudflare_storage.get_stats()
-            
+
             assert stats["total_memories"] == 10
             assert stats["total_content_size_bytes"] == 1024
             assert stats["storage_backend"] == "cloudflare"
             assert stats["vectorize_index"] == "test-index"
             assert stats["status"] == "operational"
-    
+
+    @pytest.mark.asyncio
+    async def test_get_stats_filters_tombstones(self, cloudflare_storage):
+        """Stats query must filter tombstones (deleted_at IS NULL) so total_memories
+        aligns with SqliteVecMemoryStorage. Regression guard for issue #750."""
+        captured_sql = {}
+
+        async def capture(method, url, **kwargs):
+            captured_sql["sql"] = kwargs.get("json", {}).get("sql", "")
+            resp = Mock()
+            resp.json.return_value = {
+                "success": True,
+                "result": [{"results": [{
+                    "total_memories": 8265,   # active count (what callers expect)
+                    "total_content_size": 100,
+                    "total_vectors": 8265,
+                    "r2_stored_count": 0,
+                    "unique_tags": 42,
+                    "memories_this_week": 5,
+                    "tombstone_count": 602,   # soft-deleted, excluded from total
+                }]}]
+            }
+            return resp
+
+        with patch.object(cloudflare_storage, '_retry_request', side_effect=capture):
+            stats = await cloudflare_storage.get_stats()
+
+        assert "deleted_at IS NULL" in captured_sql["sql"], (
+            "get_stats SQL must filter tombstones (see issue #750)"
+        )
+        assert stats["total_memories"] == 8265
+        assert stats["tombstone_count"] == 602
+
+
     @pytest.mark.asyncio
     async def test_cleanup_duplicates(self, cloudflare_storage):
         """Test cleaning up duplicate memories."""
@@ -571,7 +607,6 @@ class TestCloudflareTimeBasedDeletion:
     @pytest.mark.asyncio
     async def test_delete_by_timeframe_d1_query(self, cloudflare_storage):
         """Test delete_by_timeframe constructs correct D1 SQL query."""
-        from datetime import date
 
         # Mock response with content hashes to delete
         mock_find_response = Mock()
@@ -615,7 +650,6 @@ class TestCloudflareTimeBasedDeletion:
     @pytest.mark.asyncio
     async def test_delete_by_timeframe_with_tag(self, cloudflare_storage):
         """Test delete_by_timeframe includes tag filter in SQL."""
-        from datetime import date
 
         mock_find_response = Mock()
         mock_find_response.json.return_value = {
@@ -650,7 +684,6 @@ class TestCloudflareTimeBasedDeletion:
     @pytest.mark.asyncio
     async def test_delete_by_timeframe_api_error(self, cloudflare_storage):
         """Test delete_by_timeframe handles API errors gracefully."""
-        from datetime import date
 
         start = date(2025, 1, 1)
         end = date(2025, 1, 31)
@@ -667,7 +700,6 @@ class TestCloudflareTimeBasedDeletion:
     @pytest.mark.asyncio
     async def test_delete_before_date_d1_query(self, cloudflare_storage):
         """Test delete_before_date constructs correct D1 SQL query."""
-        from datetime import date
 
         mock_find_response = Mock()
         mock_find_response.json.return_value = {
@@ -701,7 +733,6 @@ class TestCloudflareTimeBasedDeletion:
     @pytest.mark.asyncio
     async def test_delete_before_date_with_tag(self, cloudflare_storage):
         """Test delete_before_date includes tag filter in SQL."""
-        from datetime import date
 
         mock_find_response = Mock()
         mock_find_response.json.return_value = {


### PR DESCRIPTION
## Summary

Three narrow fixes addressing misleading sync health signals documented in #750:

- **#5 CF stats tombstone filter** — `CloudflareStorage.get_stats()` now filters `WHERE deleted_at IS NULL` so `total_memories` aligns with local SQLite counts. Exposes `tombstone_count` separately.
- **#3 Sync status semantic fix** — `/api/sync/status` uses `consecutive_failures` (current) instead of lifetime `operations_failed` so the `status` flag reflects current health, not every historical failure. New response field `consecutive_failures` for client-side diagnosis.
- **#7 UTC-normalized D1 writes** — three `datetime.now().isoformat()` write sites in cloudflare.py now emit UTC strings, aligning `updated_at_iso` with the float `updated_at`. Read-time `Timezone mismatch detected` log demoted from INFO to DEBUG (fires on every pre-existing row, floods logs).

All three are pure reporting/accuracy fixes — no behavioral change to sync mechanics, no schema migration.

## Context

Diagnosing "sync appears broken" on a production hybrid deployment revealed that the symptoms were mostly reporting bugs, not real sync failures:

| Observed | Actual |
|---|---|
| `status: "error"` after 2-day uptime | 13 lifetime failures (all historical); `consecutive_failures: 0` |
| Local 8265, CF 8867 → 602 "missing" | 602 tombstones present on both sides; CF stats just didn't filter |
| Thousands of "Timezone mismatch" INFO logs | 1h TZ offset in stored ISO vs float; prefer-float fallback already handled correctly |

See #750 for the full diagnostic trail and #750 comment for follow-up findings.

## Test plan

- [x] `pytest tests/unit/test_cloudflare_storage.py` — 29 passed, 1 xfailed
- [x] `pytest tests/unit/` — 322 passed, 5 skipped, 1 xfailed
- [x] New regression test `test_get_stats_filters_tombstones` asserts `WHERE deleted_at IS NULL` in SQL and `tombstone_count` field presence
- [x] `bash scripts/pr/pre_pr_check.sh` — passes import ordering, test suite, handler coverage, import validation, debug code, docstrings
- [ ] Verified manually against live CF/local stores during investigation (see #750)

## Known pre-existing issues flagged by pre-PR check (not introduced by this PR)

- **Coverage 58.57% < 80% threshold** — repo-wide baseline, not regression. New test raises per-file coverage for `cloudflare.py:get_stats`.
- **Quality gate fails: Gemini CLI not installed** — local env issue, unrelated to code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
