### PR TITLE
feat(sync): dedupe force_sync against secondary to bypass embed rate limit (#750 phase 2)

### DIFF
--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -286,23 +286,27 @@ class BackgroundSyncService:
         (see issue #750). Without this check, every force_sync retries ~8000+ pushes
         that each fail at the embedding call, locking the system out of Workers AI
         until the rate window resets.
+
+        Uses id-based cursor pagination rather than LIMIT/OFFSET — see
+        `get_all_memories_cursor` at cloudflare.py:1938, which documents D1's OFFSET
+        limitations (400 Bad Request at large offsets) and uses the same pattern.
         """
-        secondary = getattr(self, 'secondary', None) or self
+        secondary = getattr(self, 'secondary', None)
         # Only CloudflareStorage has D1 access + a _retry_request method
-        if not hasattr(secondary, '_retry_request') or not hasattr(secondary, 'd1_database_id'):
+        if not secondary or not hasattr(secondary, '_retry_request') or not hasattr(secondary, 'd1_database_id'):
             return None
 
         hashes: set = set()
         limit = 1000
-        offset = 0
+        last_id = 0
         while True:
             try:
                 resp = await secondary._retry_request(
                     "POST",
                     f"{secondary.base_url}/d1/database/{secondary.d1_database_id}/query",
                     json={
-                        "sql": "SELECT content_hash FROM memories WHERE deleted_at IS NULL LIMIT ? OFFSET ?",
-                        "params": [limit, offset],
+                        "sql": "SELECT id, content_hash FROM memories WHERE deleted_at IS NULL AND id > ? ORDER BY id ASC LIMIT ?",
+                        "params": [last_id, limit],
                     },
                 )
                 data = resp.json()
@@ -310,10 +314,12 @@ class BackgroundSyncService:
                     logger.warning(f"Secondary hash fetch failed: {data.get('errors')}")
                     return None
                 batch = data["result"][0].get("results", [])
+                if not batch:
+                    break
                 hashes.update(r["content_hash"] for r in batch)
+                last_id = batch[-1]["id"]
                 if len(batch) < limit:
                     break
-                offset += limit
             except Exception as e:
                 logger.warning(f"Could not fetch secondary hashes for dedupe: {e}")
                 return None

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -272,6 +272,53 @@ class BackgroundSyncService:
             logger.warning("Sync queue full, processing operation immediately")
             await self._process_single_operation(operation)
 
+    async def _fetch_secondary_hashes(self) -> Optional[set]:
+        """
+        Fetch all content_hash values from secondary storage (Cloudflare D1).
+
+        Returns None if the secondary does not support efficient bulk hash fetch,
+        which signals the caller to fall back to per-item pushing (every item embeds,
+        previous behavior). Returns an empty set if the secondary is reachable but
+        has no memories.
+
+        Used by force_sync to skip pushing items that already exist on the secondary,
+        which prevents burning the Cloudflare Workers AI embedding quota on duplicates
+        (see issue #750). Without this check, every force_sync retries ~8000+ pushes
+        that each fail at the embedding call, locking the system out of Workers AI
+        until the rate window resets.
+        """
+        secondary = getattr(self, 'secondary', None) or self
+        # Only CloudflareStorage has D1 access + a _retry_request method
+        if not hasattr(secondary, '_retry_request') or not hasattr(secondary, 'd1_database_id'):
+            return None
+
+        hashes: set = set()
+        limit = 1000
+        offset = 0
+        while True:
+            try:
+                resp = await secondary._retry_request(
+                    "POST",
+                    f"{secondary.base_url}/d1/database/{secondary.d1_database_id}/query",
+                    json={
+                        "sql": "SELECT content_hash FROM memories WHERE deleted_at IS NULL LIMIT ? OFFSET ?",
+                        "params": [limit, offset],
+                    },
+                )
+                data = resp.json()
+                if not data.get("success"):
+                    logger.warning(f"Secondary hash fetch failed: {data.get('errors')}")
+                    return None
+                batch = data["result"][0].get("results", [])
+                hashes.update(r["content_hash"] for r in batch)
+                if len(batch) < limit:
+                    break
+                offset += limit
+            except Exception as e:
+                logger.warning(f"Could not fetch secondary hashes for dedupe: {e}")
+                return None
+        return hashes
+
     async def force_sync(self) -> Dict[str, Any]:
         """Force an immediate full synchronization between backends."""
         logger.info("Starting forced sync between primary and secondary storage")
@@ -296,6 +343,23 @@ class BackgroundSyncService:
                     'duration': time.time() - sync_start_time
                 }
 
+            # Dedupe: skip memories that already exist on the secondary. Without this,
+            # force_sync calls embed+upsert for every local memory and burns the CF
+            # Workers AI quota on duplicates — the root cause of `0 synced / N failed`
+            # reported in issue #750.
+            secondary_hashes = await self._fetch_secondary_hashes()
+            if secondary_hashes is not None:
+                new_memories = [m for m in primary_memories if m.content_hash not in secondary_hashes]
+                skipped_count = len(primary_memories) - len(new_memories)
+                logger.info(
+                    f"Dedupe: {skipped_count} of {len(primary_memories)} memories already on secondary, "
+                    f"pushing {len(new_memories)}"
+                )
+            else:
+                new_memories = primary_memories
+                skipped_count = 0
+                logger.debug("Secondary hash fetch unavailable — pushing all memories")
+
             # Sync from primary to secondary using concurrent operations
             async def sync_memory(memory):
                 try:
@@ -315,8 +379,8 @@ class BackgroundSyncService:
 
             # Process in batches to avoid overwhelming the system
             batch_size = self.batch_size  # Use configured batch size
-            for i in range(0, len(primary_memories), batch_size):
-                batch = primary_memories[i:i + batch_size]
+            for i in range(0, len(new_memories), batch_size):
+                batch = new_memories[i:i + batch_size]
                 results = await asyncio.gather(*[sync_memory(m) for m in batch], return_exceptions=True)
 
                 for result in results:
@@ -334,7 +398,10 @@ class BackgroundSyncService:
             self.sync_stats['last_sync_duration'] = sync_duration
             self.sync_stats['cloudflare_available'] = cloudflare_available
 
-            logger.info(f"Force sync completed: {synced_count} synced, {failed_count} failed in {sync_duration:.2f}s")
+            logger.info(
+                f"Force sync completed: {synced_count} synced, {failed_count} failed, "
+                f"{skipped_count} skipped (already on secondary) in {sync_duration:.2f}s"
+            )
 
             return {
                 'status': 'completed',
@@ -342,6 +409,7 @@ class BackgroundSyncService:
                 'primary_memories': len(primary_memories),
                 'synced_to_secondary': synced_count,
                 'failed_operations': failed_count,
+                'skipped_already_present': skipped_count,
                 'duration': sync_duration
             }
 

--- a/src/mcp_memory_service/web/api/sync.py
+++ b/src/mcp_memory_service/web/api/sync.py
@@ -170,11 +170,15 @@ async def force_sync(
 
         # Step 2: Push FROM local TO Cloudflare (existing behavior)
         push_result = await storage.force_sync()
-        operations_synced = push_result.get('operations_synced', 0)
+        # BackgroundSyncService.force_sync returns 'synced_to_secondary'; fall back to
+        # 'operations_synced' for compatibility with other implementations.
+        operations_synced = push_result.get('synced_to_secondary', push_result.get('operations_synced', 0))
+        skipped_already_present = push_result.get('skipped_already_present', 0)
 
-        # Check success flags from both operations
+        # Check success flags from both operations. `status == 'completed'` means push
+        # finished (may still have item-level failures, reported via failed_operations).
         pull_success = pull_result.get('success', True) if pull_result else True
-        push_success = push_result.get('success', False)
+        push_success = push_result.get('status') == 'completed' if 'status' in push_result else push_result.get('success', False)
         overall_success = pull_success and push_success
 
         time_taken = time.time() - start_time
@@ -186,6 +190,8 @@ async def force_sync(
             combined_message = f"Pulled {memories_pulled} from Cloudflare"
         elif operations_synced > 0:
             combined_message = f"Pushed {operations_synced} to Cloudflare"
+        elif skipped_already_present > 0:
+            combined_message = f"No changes to sync ({skipped_already_present} already synchronized)"
         else:
             combined_message = "No changes to sync (already synchronized)"
 

--- a/tests/test_hybrid_storage.py
+++ b/tests/test_hybrid_storage.py
@@ -475,13 +475,25 @@ class TestBackgroundSyncService:
                 self.existing_hashes = set()
 
             async def _retry_request(self, method, url, **kwargs):
+                # Single-page response: return all hashes once, empty thereafter to
+                # satisfy the cursor-based pagination loop (id > last_id; break when
+                # batch size < limit).
+                params = kwargs.get("json", {}).get("params", [])
+                last_id = params[0] if params else 0
                 resp = Mock()
-                resp.json = Mock(return_value={
-                    "success": True,
-                    "result": [{"results": [
-                        {"content_hash": h} for h in self.existing_hashes
-                    ]}]
-                })
+                if last_id == 0:
+                    resp.json = Mock(return_value={
+                        "success": True,
+                        "result": [{"results": [
+                            {"id": i, "content_hash": h}
+                            for i, h in enumerate(self.existing_hashes, start=1)
+                        ]}]
+                    })
+                else:
+                    resp.json = Mock(return_value={
+                        "success": True,
+                        "result": [{"results": []}]
+                    })
                 return resp
 
             async def store(self, memory):

--- a/tests/test_hybrid_storage.py
+++ b/tests/test_hybrid_storage.py
@@ -18,7 +18,7 @@ import os
 import sys
 import logging
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from typing import Dict, Any
 
 # Add src to path for imports
@@ -455,6 +455,90 @@ class TestBackgroundSyncService:
         assert 'cloudflare_available' in status
 
         await sync_service.stop()
+
+    @pytest.mark.asyncio
+    async def test_force_sync_dedupes_against_secondary(self, temp_sqlite_db):
+        """force_sync skips items already on the secondary to avoid burning the
+        Cloudflare Workers AI embedding quota on duplicates (regression guard for
+        issue #750 Phase 2)."""
+        primary = SqliteVecMemoryStorage(temp_sqlite_db)
+        await primary.initialize()
+
+        # Secondary that mimics CloudflareStorage enough to expose bulk hash fetch.
+        class DedupeMockCloudflareStorage(MockCloudflareStorage):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.base_url = "https://mock"
+                self.d1_database_id = "mock-db"
+                self.store_call_count = 0
+                # Pretend these hashes are already on secondary
+                self.existing_hashes = set()
+
+            async def _retry_request(self, method, url, **kwargs):
+                resp = Mock()
+                resp.json = Mock(return_value={
+                    "success": True,
+                    "result": [{"results": [
+                        {"content_hash": h} for h in self.existing_hashes
+                    ]}]
+                })
+                return resp
+
+            async def store(self, memory):
+                self.store_call_count += 1
+                return await super().store(memory)
+
+        secondary = DedupeMockCloudflareStorage()
+        await secondary.initialize()
+
+        # Seed primary with 3 memories; secondary already has 2 of them
+        memories = []
+        for i, content in enumerate(["alpha", "beta", "gamma"]):
+            m = Memory(
+                content=content,
+                content_hash=generate_content_hash(content),
+                tags=["test"],
+                memory_type="test",
+            )
+            memories.append(m)
+            await primary.store(m)
+
+        secondary.existing_hashes = {memories[0].content_hash, memories[1].content_hash}
+
+        sync_service = BackgroundSyncService(primary, secondary, sync_interval=1, batch_size=5)
+        result = await sync_service.force_sync()
+
+        assert result['status'] == 'completed'
+        assert result['primary_memories'] == 3
+        # Only the non-duplicate 'gamma' should be pushed → 1 store call
+        assert secondary.store_call_count == 1, (
+            f"Expected 1 store call (only new memories), got {secondary.store_call_count}. "
+            f"Dedupe regression — see issue #750."
+        )
+        assert result.get('skipped_already_present') == 2
+
+    @pytest.mark.asyncio
+    async def test_force_sync_falls_back_when_dedupe_unavailable(self, sync_service_components):
+        """If the secondary doesn't expose a bulk hash fetch (no _retry_request /
+        d1_database_id attrs), force_sync must still work — pushing all items (old
+        behavior, preserved for non-Cloudflare secondaries)."""
+        primary, secondary, sync_service = sync_service_components
+
+        # Seed primary
+        for content in ("one", "two"):
+            m = Memory(
+                content=content,
+                content_hash=generate_content_hash(content),
+                tags=["test"],
+                memory_type="test",
+            )
+            await primary.store(m)
+
+        # MockCloudflareStorage intentionally lacks _retry_request
+        result = await sync_service.force_sync()
+        assert result['status'] == 'completed'
+        # Fallback path doesn't populate skipped_already_present
+        assert result.get('skipped_already_present', 0) == 0
 
 
 class TestPerformanceCharacteristics:


### PR DESCRIPTION
## Summary

Phase 2 of #750. Fixes the root cause behind the `Force sync completed: 0 synced, N failed` log pattern: `force_sync` pushed every local memory unconditionally, burning the Cloudflare Workers AI embedding quota on items that already existed on the secondary.

## Changes

- **`BackgroundSyncService._fetch_secondary_hashes()`** — new helper. Paginated `SELECT content_hash FROM memories WHERE deleted_at IS NULL` against D1. Returns `None` when the secondary doesn't expose D1 access (test mocks, non-Cloudflare backends) → caller falls back to the old push-all path.
- **`BackgroundSyncService.force_sync()`** — compute `new_memories = primary_memories - secondary_hashes` before the push loop. Report `skipped_already_present` in the return dict. Old `primary_memories` total is preserved for back-compat.
- **`/api/sync/force`** — read the correct `synced_to_secondary` key (was reading `operations_synced`, which never existed, so the API always reported `0 synced`). Adds `skipped_already_present` to the user-facing message.

## Why this matters

With 8000+ memories and a Cloudflare Workers AI rate window of ~30s, the previous behavior spent each force_sync cycle trying to re-embed the entire DB, failed immediately at rate-limit, and produced the misleading "sync broken" signal that kicked off the whole #750 investigation. After this change: subsequent force_syncs push zero items when caught up, push only net-new items otherwise.

Combined with the existing `force_pull_sync`, `POST /api/sync/force` is now a true bidirectional reconciliation: pull missing, push missing, skip matching.

## Test plan

- [x] New `test_force_sync_dedupes_against_secondary` — seeds 3 primary memories, marks 2 as already on secondary, asserts `secondary.store` called exactly once (not 3×) and `skipped_already_present == 2`.
- [x] New `test_force_sync_falls_back_when_dedupe_unavailable` — verifies non-Cloudflare secondaries (mocks without `_retry_request`) still work via the fallback path.
- [x] `pytest tests/test_hybrid_storage.py tests/unit/test_cloudflare_storage.py tests/storage/` → 179 passed, 1 skipped, 5 xfailed, 1 xpassed.
- [x] `bash scripts/pr/pre_pr_check.sh` — test suite, handler coverage, import validation, debug code, docstrings all PASS.

## Known pre-existing issues flagged by pre-PR check (not introduced)

Same list as #751:
- Quality gate fails: Gemini CLI not installed locally.
- Coverage 58.57% < 80% threshold (repo-wide baseline).
- Inline imports in `hybrid.py` and `test_hybrid_storage.py` (pre-existing; scope creep to clean up).

## Follow-up (not in this PR)

#750 still tracks these, scheduled for later phases:
- Periodic full-reconcile pass in the background drift reconciler (current reconciler is incremental only).
- Rate-limit strategy overhaul and/or external embedding API support (#669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
