### PR TITLE
chore: release v10.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.40.1] - 2026-04-21
+
+### Fixed
+
+- **[#750] CF hybrid sync: `POST /api/sync/force` now reliably completes**: Deduplication logic in the force-sync path now compares against secondary-store hashes before embedding, so already-synced memories are skipped cheaply rather than consuming Cloudflare Workers AI quota. This eliminates the "0 synced / N failed" result that was caused by exhausting the embed rate limit on redundant re-submissions. (PR #753)
+- **[#750] CF hybrid sync: sync status flag reflects current health, not lifetime-cumulative failures**: `status.sync_ok` was latching `False` on any historical error and never recovering. It now reflects whether the most-recent sync attempt succeeded, so dashboards and health probes show accurate state after a transient failure is resolved. (PR #751)
+- **[#750] CF stats: totals no longer inflated by soft-deleted tombstones**: The Cloudflare statistics endpoint was counting soft-deleted (tombstoned) records in memory totals, making the remote count appear larger than the live dataset. Tombstones are now excluded from count queries. (PR #751)
+- **[#750] Reduced timezone-mismatch log noise**: Spurious drift warnings caused by comparing UTC timestamps from Cloudflare against local naive datetimes have been suppressed. (PR #751)
+
+### Changed
+
+- **Dependency bumps (Dependabot)**: `python-semantic-release/python-semantic-release` (PR #748), `actions/setup-python` 5 → 6 (PR #749), `actions/setup-node` 4 → 6 (PR #747).
+
 ## [10.40.0] - 2026-04-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.40.0 - feat: Milvus storage backend (Lite / self-hosted / Zilliz Cloud) — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.40.1 - fix(sync): CF hybrid sync reliability + reporting accuracy — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -437,19 +437,21 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.40.0** (April 22, 2026)
+## Latest Release: **v10.40.1** (April 21, 2026)
 
-**feat: Milvus storage backend — Lite / self-hosted / Zilliz Cloud**
+**fix(sync): CF hybrid sync reliability + reporting accuracy**
 
 **What's New:**
-- **New Milvus storage backend** (`MCP_MEMORY_STORAGE_BACKEND=milvus`): Three deployment modes from one code path — Milvus Lite (zero-dep local file), self-hosted Docker, and Zilliz Cloud. ~1,750 lines, 39 tests, `@zc277584121` committed to 6-month SLA on `backend:milvus` issues. See `docs/milvus-backend.md`. (PR #721)
-- **OAuth security hardening**: Defense-in-depth guards against CodeQL `py/reflective-xss` and `py/url-redirection` in the authorization-code redirect flow. (PR #745)
-- **Plugin manifest shape validation**: CI now validates `plugin.json` structure against the Claude Code plugin spec. (PR #740)
+- **`POST /api/sync/force` reliably completes**: Deduplication now skips already-synced memories before embedding, eliminating "0 synced / N failed" from CF Workers AI rate-limit exhaustion. (PR #753)
+- **Sync status flag reflects current health**: `sync_ok` no longer latches `False` from historical errors — it tracks the most-recent sync attempt. (PR #751)
+- **CF stats exclude tombstones**: Remote memory totals no longer inflate with soft-deleted records. (PR #751)
+- **Reduced timezone-mismatch log noise**: Spurious drift warnings from UTC vs naive-datetime comparisons are suppressed. (PR #751)
 - **1,675 Python tests** passing.
 
 ---
 
 **Previous Releases**:
+- **v10.40.0** - feat: Milvus storage backend (Lite / self-hosted / Zilliz Cloud), OAuth XSS hardening, plugin shape validation (PRs #721, #745, #740)
 - **v10.39.1** - hotfix: plugin.json author field object format — unblocks `/plugin install mcp-memory-service` (#738, #739)
 - **v10.39.0** - feat: Claude Code plugin install (`/plugin marketplace add doobidoo/mcp-memory-service`) + MemoryClient.storeMemory() protocol-native writes (PRs #736, #735)
 - **v10.38.4** - fix(mcp): return HTTP 202 for JSON-RPC notifications — fixes Codex/strict-client handshake (PR #733)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.40.0"
+version = "10.40.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.40.0"
+__version__ = "10.40.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.40.0"
+version = "10.40.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to `10.40.1` in `pyproject.toml`, `_version.py`, `uv.lock`
- Add `[10.40.1]` CHANGELOG entry covering CF hybrid sync reliability and reporting fixes (PRs #751, #753) plus Dependabot CI bumps (#747–#749)
- Update README "Latest Release" section; v10.40.0 moved to Previous Releases
- Update CLAUDE.md version callout

## Changes included (commits since v10.40.0)

- `6936765` feat(sync): dedupe force_sync against secondary to bypass embed rate limit (#753)
- `bbb20e4` fix(sync): correct misleading drift signals in status + stats reporting (#751)
- `46901f0` chore(deps): bump python-semantic-release (#748)
- `1d301ec` chore(deps): bump actions/setup-python 5→6 (#749)
- `1c6da55` chore(deps): bump actions/setup-node 4→6 (#747)

## Test plan

- [x] Main CI/CD Pipeline green on main (run 24789988679)
- [x] `uv lock` updated cleanly
- [x] CHANGELOG has no duplicate version entries
- [x] docs/index.html NOT touched (PATCH release — MINOR/MAJOR only per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)