### PR TITLE
chore(milvus): remove unused Callable + _METADATA_MAX_LEN (CodeQL #386, #387)

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -44,7 +44,7 @@ import time
 import traceback
 from collections import OrderedDict
 from datetime import datetime, timezone, timedelta, date
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Disable wandb BEFORE importing sentence-transformers — same rationale as
 # sqlite_vec.py (Issue #311). Safe to set even when transformers is unused.
@@ -122,7 +122,6 @@ def _embedding_cache_size() -> int:
 # (metadata JSON keys etc.) don't push past the Milvus-side limit.
 _MILVUS_VARCHAR_MAX = 65535
 _CONTENT_MAX_LEN = _MILVUS_VARCHAR_MAX - 256
-_METADATA_MAX_LEN = _MILVUS_VARCHAR_MAX - 256
 _TAGS_MAX_LEN = 8192
 _ISO_MAX_LEN = 64
 _MEMORY_TYPE_MAX_LEN = 128


### PR DESCRIPTION
## Summary

Dead-code cleanup for the two CodeQL notes introduced with the Milvus backend (PR #721):

- **#387** `py/unused-import` — removes unused `Callable` from `typing` imports (line 47)
- **#386** `py/unused-global-variable` — removes unused `_METADATA_MAX_LEN` constant (line 125)

## Why minimal

The milvus backend does not enforce metadata length at the storage layer — content and tags have explicit bounds (`_CONTENT_MAX_LEN`, `_TAGS_MAX_LEN`) that are used. `_METADATA_MAX_LEN` was defined but never referenced anywhere in the file or the codebase. Same for `Callable`.

No behavior change. Tests still pass (`tests/storage/test_milvus.py` skipped when pymilvus not installed, as expected in local env).

## Test plan

- [x] Module still imports (`python -c "from src.mcp_memory_service.storage.milvus import MilvusMemoryStorage"`)
- [x] `pytest tests/storage/test_milvus.py` — 1 skipped (pymilvus not available), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)