### PR TITLE
fix(docker): correct invalid Python one-liner in ONNX pre-download (#756)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -70,13 +70,8 @@ RUN if [ "$FORCE_CPU_PYTORCH" = "true" ] || [ "$INSTALL_EXTRA" = "[sqlite]" ]; t
 # Conditionally pre-download ONNX models for lightweight embedding
 RUN if [ "$SKIP_MODEL_DOWNLOAD" != "true" ]; then \
         echo "Pre-downloading ONNX embedding models..." && \
-        python -c "try:\
-            import onnxruntime as ort; \
-            print('ONNX runtime available for lightweight embeddings'); \
-            print('ONNX models will be downloaded at runtime as needed')\
-        except Exception as e:\
-            print(f'Warning: ONNX runtime not available: {e}'); \
-            print('Embedding functionality may be limited')" || echo "ONNX check failed, continuing..."; \
+        python -c "import onnxruntime as ort; print('ONNX runtime available for lightweight embeddings'); print('ONNX models will be downloaded at runtime as needed')" \
+            || echo "ONNX check failed, continuing..."; \
     else \
         echo "Skipping model download (SKIP_MODEL_DOWNLOAD=true)"; \
     fi

--- a/tools/docker/Dockerfile.slim
+++ b/tools/docker/Dockerfile.slim
@@ -72,14 +72,8 @@ RUN python -m uv pip install \
 # Conditionally pre-download ONNX embedding models
 RUN if [ "$SKIP_MODEL_DOWNLOAD" != "true" ]; then \
         echo "Pre-downloading ONNX embedding models..." && \
-        python -c "try:\
-            from mcp_memory_service.embeddings.onnx_embeddings import ONNXEmbeddingModel; \
-            print('Initializing ONNX embedding model...'); \
-            model = ONNXEmbeddingModel(); \
-            print('ONNX models cached successfully')\
-        except Exception as e:\
-            print(f'Warning: Could not pre-download ONNX models: {e}'); \
-            print('Models will be downloaded at runtime')" || echo "ONNX model download failed, continuing..."; \
+        python -c "from mcp_memory_service.embeddings.onnx_embeddings import ONNXEmbeddingModel; print('Initializing ONNX embedding model...'); ONNXEmbeddingModel(); print('ONNX models cached successfully')" \
+            || echo "ONNX model download failed, will retry at runtime"; \
     else \
         echo "Skipping ONNX model download (SKIP_MODEL_DOWNLOAD=true)"; \
     fi


### PR DESCRIPTION
## Summary

Fixes #756. Both `tools/docker/Dockerfile` and `tools/docker/Dockerfile.slim` used a `try/except` compound statement inside `python -c "..."` with backslash line continuations. The continuations collapse to a single line, and Python rejects compound statements in `-c` one-liners with `SyntaxError`. The shell `|| echo ...` fallback then masked the failure on every build.

## Impact (per reporter @netizen1119)

- **Dockerfile.slim**: ONNX model cache was never populated at build time, so containers had to download the model on first start (~25s). This can exceed Fly.io's 40s health check grace period and cause intermittent deployment failures. After fix: cold start dropped from ~30s to ~3s; Fly.io health check passes in ~19s.
- **Dockerfile** (non-slim): the `onnxruntime` availability check silently skipped (less impactful but same root cause).

## Fix

Replace the broken `try/except` with a simple expression chain (`import; call; print`). Python's `-c` form accepts simple expressions chained with `;`. The shell `||` fallback continues to catch genuine runtime errors.

```diff
-        python -c "try:\
-            from mcp_memory_service.embeddings.onnx_embeddings import ONNXEmbeddingModel; \
-            print('Initializing ONNX embedding model...'); \
-            model = ONNXEmbeddingModel(); \
-            print('ONNX models cached successfully')\
-        except Exception as e:\
-            print(f'Warning: Could not pre-download ONNX models: {e}'); \
-            print('Models will be downloaded at runtime')" || echo "ONNX model download failed, continuing..."; \
+        python -c "from mcp_memory_service.embeddings.onnx_embeddings import ONNXEmbeddingModel; print('Initializing ONNX embedding model...'); ONNXEmbeddingModel(); print('ONNX models cached successfully')" \
+            || echo "ONNX model download failed, will retry at runtime"; \
```

Note: reporter only flagged `Dockerfile.slim`; identical anti-pattern was discovered in `Dockerfile` and fixed in the same PR.

## Credit

Diagnosis, root cause analysis, reproduction, and verified fix by @netizen1119. Their fork commit: [`netizen1119/mcp-memory-service@e83d6d0d`](https://github.com/netizen1119/mcp-memory-service/commit/e83d6d0d).

## Test plan

- [ ] `docker build -f tools/docker/Dockerfile.slim -t mcp-memory-slim .` — confirm STEP 19 shows `ONNX models cached successfully` (not `SyntaxError`)
- [ ] Inspect built image for populated `~/.cache/huggingface` (or equivalent ONNX cache)
- [ ] Run resulting image; confirm cold start does not re-download the model
- [ ] `docker build -f tools/docker/Dockerfile -t mcp-memory .` — confirm `ONNX runtime available for lightweight embeddings` prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)