### PR TITLE
chore: release v10.40.2 — fix(docker): correct invalid Python one-liner in ONNX pre-download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.40.2] - 2026-04-23
+
+### Fixed
+
+- **[#756] Docker: ONNX model pre-download now actually executes at build time**: The `python -c "..."` one-liner in `tools/docker/Dockerfile.slim` used `try/except` compound statements with backslash continuations — a construct Python rejects with `SyntaxError`. The shell `|| echo` fallback was silently swallowing the error, so the model cache was never populated. Replaced with a simple expression chain (`import; call; print`) and let the shell `||` fallback handle genuine download failures as originally intended. Cold-start time on `Dockerfile.slim` drops from ~30s to ~3s; prevents Fly.io 40s health-check grace-period timeouts. `Dockerfile` (non-slim) gets the same fix for its `onnxruntime` availability check. Thanks to @netizen1119 for the report, root-cause analysis, and verified fix. (PR #757)
+
 ## [10.40.1] - 2026-04-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.40.1 - fix(sync): CF hybrid sync reliability + reporting accuracy — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.40.2 - fix(docker): correct invalid Python one-liner in ONNX pre-download — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -437,20 +437,21 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.40.1** (April 21, 2026)
+## Latest Release: **v10.40.2** (April 23, 2026)
 
-**fix(sync): CF hybrid sync reliability + reporting accuracy**
+**fix(docker): correct invalid Python one-liner in ONNX pre-download**
 
 **What's New:**
-- **`POST /api/sync/force` reliably completes**: Deduplication now skips already-synced memories before embedding, eliminating "0 synced / N failed" from CF Workers AI rate-limit exhaustion. (PR #753)
-- **Sync status flag reflects current health**: `sync_ok` no longer latches `False` from historical errors — it tracks the most-recent sync attempt. (PR #751)
-- **CF stats exclude tombstones**: Remote memory totals no longer inflate with soft-deleted records. (PR #751)
-- **Reduced timezone-mismatch log noise**: Spurious drift warnings from UTC vs naive-datetime comparisons are suppressed. (PR #751)
+- **Docker cold-start drops from ~30s to ~3s** (`Dockerfile.slim`): ONNX model cache is now actually populated at build time — the previous `try/except` one-liner was rejected by Python with `SyntaxError` and silently swallowed by the shell fallback.
+- **Fly.io health-check timeouts resolved**: Prevents deployments from failing the 40s grace-period timeout caused by the missing model cache.
+- **`Dockerfile` (non-slim) fix**: `onnxruntime` availability check now runs correctly (was previously silently skipped).
+- Thanks to @netizen1119 for the report, root-cause analysis, and verified fix. (PR #757)
 - **1,675 Python tests** passing.
 
 ---
 
 **Previous Releases**:
+- **v10.40.1** - fix(sync): CF hybrid sync reliability + reporting accuracy (PRs #751, #753)
 - **v10.40.0** - feat: Milvus storage backend (Lite / self-hosted / Zilliz Cloud), OAuth XSS hardening, plugin shape validation (PRs #721, #745, #740)
 - **v10.39.1** - hotfix: plugin.json author field object format — unblocks `/plugin install mcp-memory-service` (#738, #739)
 - **v10.39.0** - feat: Claude Code plugin install (`/plugin marketplace add doobidoo/mcp-memory-service`) + MemoryClient.storeMemory() protocol-native writes (PRs #736, #735)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.40.1"
+version = "10.40.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.40.1"
+__version__ = "10.40.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.40.1"
+version = "10.40.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version 10.40.1 → 10.40.2 (PATCH release)
- Updates `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `pyproject.toml`, `_version.py`, `uv.lock`
- No test changes (Docker build-time fix only)

## Fix

The `python -c "..."` one-liner in `tools/docker/Dockerfile.slim` used `try/except` compound statements with backslash continuations — a construct Python rejects with `SyntaxError`. The shell `|| echo` fallback silently swallowed the error, so the ONNX model cache was never populated at build time.

**Impact:**
- `Dockerfile.slim`: cold-start time drops from ~30s to ~3s; prevents Fly.io 40s health-check grace-period timeouts
- `Dockerfile` (non-slim): `onnxruntime` availability check now runs correctly

**Fix:** Replaced `try/except` with a simple expression chain (`import; call; print`), letting the shell `||` handle genuine download failures as originally intended.

Credit: @netizen1119 for the report, root-cause analysis, and verified fix. (Issue #756, PR #757)

## Test plan

- [ ] CI passes on this branch
- [ ] No code or test changes — Docker build-time fix only
- [ ] Version correctly shows 10.40.2 in `pyproject.toml` and `_version.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)