### PR TITLE
feat(mcp_server): add memory_graph tool to streamable-http mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **[#759] `memory_graph` tool for streamable-http MCP server**: Knowledge graph operations (find connected memories, shortest path, subgraph extraction) are now available in the FastMCP streamable-http server, matching the capabilities already present in stdio mode. Introduces a shared `GraphService` business-logic layer under `src/mcp_memory_service/services/graph_service.py` so both server variants reuse the same traversal + error-handling code paths. Graph operations require `sqlite_vec` or `hybrid` storage backends; `milvus` and `cloudflare` backends return a structured unavailability error instead of crashing. 14 unit tests for `GraphService`. Thanks to @henry201605 for the contribution. (PR #759)
+
+### Fixed
+
+- **[#759] Test isolation: `test_graph_service.py` no longer pollutes `sys.modules`**: The lightweight stub used to import `GraphService` without heavy dependencies previously replaced `mcp_memory_service.storage.graph` unconditionally at module-import time. This caused cascading `TypeError: _StubGraphStorage() takes no arguments` failures in `tests/test_graph_traversal.py` and `tests/web/api/test_analytics_graph.py` whenever `test_graph_service.py` was collected first. The stub is now only installed if the real module fails to import, preserving isolation in CI where dependencies are available.
+- **[#759] Removed unused `List` import in `graph_service.py`**: CodeQL alert #391 (unused import).
+
 ## [10.40.3] - 2026-04-24
 
 ### Fixed

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -71,6 +71,8 @@ from .config import (
 )
 from .storage.base import MemoryStorage
 from .services.memory_service import MemoryService
+from .services.graph_service import GraphService
+from .storage.graph import GraphStorage
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)  # Default to INFO level
@@ -168,6 +170,7 @@ class MCPServerContext:
     """Application context for the MCP server with all required components."""
     storage: MemoryStorage
     memory_service: MemoryService
+    graph_service: GraphService
 
 @asynccontextmanager
 async def mcp_server_lifespan(server: FastMCP) -> AsyncIterator[MCPServerContext]:
@@ -221,10 +224,21 @@ async def mcp_server_lifespan(server: FastMCP) -> AsyncIterator[MCPServerContext
         memory_service = _get_or_create_memory_service(storage)
         _log_cache_performance(start_time)
 
+    # Initialize graph service (only for SQLite-based backends)
+    graph_storage = None
+    if STORAGE_BACKEND in ('sqlite_vec', 'hybrid'):
+        try:
+            graph_storage = GraphStorage(SQLITE_VEC_PATH)
+            logger.info("GraphStorage initialized for %s backend", STORAGE_BACKEND)
+        except Exception as e:
+            logger.warning("GraphStorage initialization failed (graph tools disabled): %s", e)
+    graph_service = GraphService(graph_storage)
+
     try:
         yield MCPServerContext(
             storage=storage,
-            memory_service=memory_service
+            memory_service=memory_service,
+            graph_service=graph_service,
         )
     finally:
         # IMPORTANT: Do NOT close cached storage instances here!
@@ -678,6 +692,71 @@ Examples:
         tag=tag,
         memory_type=memory_type
     )
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Memory Graph",
+        readOnlyHint=True,
+    ),
+)
+async def memory_graph(
+    action: str,
+    ctx: Context,
+    hash: Optional[str] = None,
+    hash1: Optional[str] = None,
+    hash2: Optional[str] = None,
+    max_hops: int = 2,
+    max_depth: int = 5,
+    radius: int = 2,
+) -> Dict[str, Any]:
+    """Knowledge graph operations - explore connections between memories.
+
+USE THIS WHEN:
+- User asks "what's related to X", "how are these memories connected"
+- Investigating cause-and-effect chains between memories
+- Visualizing memory relationships for debugging or understanding
+- Finding the path between two related memories
+
+ACTIONS:
+- connected: Find memories connected to a given memory (BFS traversal up to max_hops)
+- path: Find shortest path between two memories
+- subgraph: Extract subgraph around a memory (nodes + edges for visualization)
+
+REQUIRES: SQLite-vec or Hybrid storage backend. Returns error for Milvus/Cloudflare.
+
+RETURNS:
+- connected: {success, connected: [{hash, distance}], count}
+- path: {success, path: [hash1, ..., hash2], length}
+- subgraph: {success, nodes: [...], edges: [{source, target, similarity, ...}], node_count, edge_count}
+
+Examples:
+{"action": "connected", "hash": "abc123def456...", "max_hops": 2}
+{"action": "path", "hash1": "abc123...", "hash2": "def456..."}
+{"action": "subgraph", "hash": "abc123...", "radius": 3}
+    """
+    graph_service = ctx.request_context.lifespan_context.graph_service
+
+    if action == "connected":
+        if not hash:
+            return {"success": False, "error": "hash is required for 'connected' action"}
+        return await graph_service.find_connected(hash, max_hops=max_hops)
+
+    elif action == "path":
+        if not hash1 or not hash2:
+            return {"success": False, "error": "hash1 and hash2 are required for 'path' action"}
+        return await graph_service.find_shortest_path(hash1, hash2, max_depth=max_depth)
+
+    elif action == "subgraph":
+        if not hash:
+            return {"success": False, "error": "hash is required for 'subgraph' action"}
+        return await graph_service.get_subgraph(hash, radius=radius)
+
+    else:
+        return {
+            "success": False,
+            "error": f"Invalid action '{action}'. Must be one of: connected, path, subgraph"
+        }
+
 
 @mcp.tool(
     annotations=ToolAnnotations(

--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -98,6 +98,8 @@ logger = logging.getLogger(__name__)
 
 _STORAGE_CACHE: Dict[str, MemoryStorage] = {}
 _MEMORY_SERVICE_CACHE: Dict[int, MemoryService] = {}
+_GRAPH_STORAGE_CACHE: Dict[str, GraphStorage] = {}
+_GRAPH_SERVICE_CACHE: Dict[int, GraphService] = {}
 _CACHE_LOCK: Optional[asyncio.Lock] = None  # Initialized on first use
 _CACHE_STATS = {
     "storage_hits": 0,
@@ -224,15 +226,37 @@ async def mcp_server_lifespan(server: FastMCP) -> AsyncIterator[MCPServerContext
         memory_service = _get_or_create_memory_service(storage)
         _log_cache_performance(start_time)
 
-    # Initialize graph service (only for SQLite-based backends)
-    graph_storage = None
+    # Initialize graph service with caching (only for SQLite-based backends)
+    graph_service = None
     if STORAGE_BACKEND in ('sqlite_vec', 'hybrid'):
-        try:
-            graph_storage = GraphStorage(SQLITE_VEC_PATH)
-            logger.info("GraphStorage initialized for %s backend", STORAGE_BACKEND)
-        except Exception as e:
-            logger.warning("GraphStorage initialization failed (graph tools disabled): %s", e)
-    graph_service = GraphService(graph_storage)
+        async with cache_lock:
+            if SQLITE_VEC_PATH in _GRAPH_STORAGE_CACHE:
+                graph_storage = _GRAPH_STORAGE_CACHE[SQLITE_VEC_PATH]
+                logger.info("✅ GraphStorage Cache HIT — reusing instance")
+            else:
+                try:
+                    # Offload blocking SQLite I/O to a separate thread
+                    graph_storage = await asyncio.to_thread(GraphStorage, SQLITE_VEC_PATH)
+                    _GRAPH_STORAGE_CACHE[SQLITE_VEC_PATH] = graph_storage
+                    logger.info("GraphStorage initialized and cached for %s backend", STORAGE_BACKEND)
+                except Exception as e:
+                    logger.warning("GraphStorage initialization failed (graph tools disabled): %s", e)
+                    graph_storage = None
+
+            if graph_storage is not None:
+                gs_id = id(graph_storage)
+                if gs_id in _GRAPH_SERVICE_CACHE:
+                    graph_service = _GRAPH_SERVICE_CACHE[gs_id]
+                    logger.info("✅ GraphService Cache HIT — reusing instance")
+                else:
+                    graph_service = GraphService(graph_storage)
+                    _GRAPH_SERVICE_CACHE[gs_id] = graph_service
+                    logger.info("💾 Cached GraphService instance")
+    else:
+        logger.info("Graph tools not available for %s backend (expected)", STORAGE_BACKEND)
+
+    if graph_service is None:
+        graph_service = GraphService(None)
 
     try:
         yield MCPServerContext(

--- a/src/mcp_memory_service/services/graph_service.py
+++ b/src/mcp_memory_service/services/graph_service.py
@@ -37,6 +37,12 @@ class GraphService:
     formatting. All methods return Dict with a ``success`` field
     and operation-specific data, matching the response format used
     by the stdio mode graph handlers.
+
+    Graph operations are only available for SQLite-based storage backends
+    (sqlite_vec and hybrid). For other backends (milvus, cloudflare),
+    ``graph_storage`` will be None and all operations return a structured
+    error. Callers should check :meth:`is_available` before assuming
+    graph features are present.
     """
 
     def __init__(self, graph_storage: Optional[GraphStorage] = None):

--- a/src/mcp_memory_service/services/graph_service.py
+++ b/src/mcp_memory_service/services/graph_service.py
@@ -22,7 +22,7 @@ MCP server (server_impl.py) and the streamable-http FastMCP server
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from ..storage.graph import GraphStorage
 

--- a/src/mcp_memory_service/services/graph_service.py
+++ b/src/mcp_memory_service/services/graph_service.py
@@ -1,0 +1,208 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Graph Service - Shared business logic for knowledge graph operations.
+
+Provides a unified interface for graph traversal operations (find connected,
+shortest path, subgraph extraction) that can be used by both the stdio
+MCP server (server_impl.py) and the streamable-http FastMCP server
+(mcp_server.py).
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from ..storage.graph import GraphStorage
+
+logger = logging.getLogger(__name__)
+
+
+class GraphService:
+    """
+    Shared service for knowledge graph operations.
+
+    Wraps GraphStorage with consistent error handling and response
+    formatting. All methods return Dict with a ``success`` field
+    and operation-specific data, matching the response format used
+    by the stdio mode graph handlers.
+    """
+
+    def __init__(self, graph_storage: Optional[GraphStorage] = None):
+        """
+        Initialize GraphService.
+
+        Args:
+            graph_storage: GraphStorage instance, or None if graph
+                operations are not available for the current backend.
+        """
+        self._graph = graph_storage
+
+    def is_available(self) -> bool:
+        """Check if graph operations are available."""
+        return self._graph is not None
+
+    async def find_connected(
+        self, content_hash: str, max_hops: int = 2
+    ) -> Dict[str, Any]:
+        """
+        Find memories connected to a given memory via associations.
+
+        Performs breadth-first traversal of the association graph up to
+        max_hops distance.
+
+        Args:
+            content_hash: Content hash of the starting memory.
+            max_hops: Maximum number of hops to traverse (default 2).
+
+        Returns:
+            Dict with success status, connected memories list, and count.
+        """
+        if not self.is_available():
+            return {
+                "success": False,
+                "error": "Graph operations not available for current storage backend",
+                "connected": [],
+                "count": 0,
+            }
+
+        try:
+            connected = await self._graph.find_connected(
+                content_hash, max_hops=max_hops
+            )
+            result = {
+                "success": True,
+                "connected": [
+                    {"hash": h, "distance": d} for h, d in connected
+                ],
+                "count": len(connected),
+            }
+            logger.info(
+                "Found %d connected memories within %d hops of %s",
+                len(connected), max_hops, content_hash[:12],
+            )
+            return result
+
+        except Exception as e:
+            logger.error("Error finding connected memories: %s", e)
+            return {
+                "success": False,
+                "error": str(e),
+                "connected": [],
+                "count": 0,
+            }
+
+    async def find_shortest_path(
+        self, hash1: str, hash2: str, max_depth: int = 5
+    ) -> Dict[str, Any]:
+        """
+        Find shortest path between two memories in the association graph.
+
+        Args:
+            hash1: Starting memory content hash.
+            hash2: Target memory content hash.
+            max_depth: Maximum path length (default 5).
+
+        Returns:
+            Dict with success status, path list, and path length.
+        """
+        if not self.is_available():
+            return {
+                "success": False,
+                "error": "Graph operations not available for current storage backend",
+                "path": None,
+                "length": 0,
+            }
+
+        try:
+            path = await self._graph.shortest_path(
+                hash1, hash2, max_depth=max_depth
+            )
+            if path is not None:
+                logger.info(
+                    "Found path of length %d between %s and %s",
+                    len(path), hash1[:12], hash2[:12],
+                )
+                return {"success": True, "path": path, "length": len(path)}
+
+            logger.info(
+                "No path found between %s and %s within depth %d",
+                hash1[:12], hash2[:12], max_depth,
+            )
+            return {
+                "success": True,
+                "path": None,
+                "length": 0,
+                "message": "No path found within depth limit",
+            }
+
+        except Exception as e:
+            logger.error("Error finding shortest path: %s", e)
+            return {
+                "success": False,
+                "error": str(e),
+                "path": None,
+                "length": 0,
+            }
+
+    async def get_subgraph(
+        self, content_hash: str, radius: int = 2
+    ) -> Dict[str, Any]:
+        """
+        Extract subgraph around a memory for visualization.
+
+        Args:
+            content_hash: Center memory content hash.
+            radius: Number of hops to include (default 2).
+
+        Returns:
+            Dict with success status, nodes, edges, and counts.
+        """
+        if not self.is_available():
+            return {
+                "success": False,
+                "error": "Graph operations not available for current storage backend",
+                "nodes": [],
+                "edges": [],
+                "node_count": 0,
+                "edge_count": 0,
+            }
+
+        try:
+            subgraph = await self._graph.get_subgraph(
+                content_hash, radius=radius
+            )
+            result = {
+                "success": True,
+                "nodes": subgraph["nodes"],
+                "edges": subgraph["edges"],
+                "node_count": len(subgraph["nodes"]),
+                "edge_count": len(subgraph["edges"]),
+            }
+            logger.info(
+                "Extracted subgraph: %d nodes, %d edges around %s",
+                result["node_count"], result["edge_count"], content_hash[:12],
+            )
+            return result
+
+        except Exception as e:
+            logger.error("Error extracting subgraph: %s", e)
+            return {
+                "success": False,
+                "error": str(e),
+                "nodes": [],
+                "edges": [],
+                "node_count": 0,
+                "edge_count": 0,
+            }

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -28,52 +28,50 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 # ---------------------------------------------------------------------------
-# Lightweight import of GraphService without triggering the full project
-# dependency chain (numpy, torch, sentence-transformers, etc.).
-#
-# Strategy: pre-populate sys.modules with a stub for the storage.graph
-# package so that graph_service.py's relative import resolves without
-# actually loading the real GraphStorage (which only needs sqlite3 but
-# the package __init__ chain pulls in heavy deps).
+# Import GraphService. Prefer the real module when project dependencies are
+# available (e.g., CI with full install). Fall back to an isolated stub setup
+# only when the heavy dependency chain (numpy, torch, sentence-transformers)
+# can't be loaded — this keeps the test file usable in lightweight dev envs
+# without polluting sys.modules for other test files that need the real
+# GraphStorage (e.g., tests/test_graph_traversal.py).
 # ---------------------------------------------------------------------------
 
-# Create stub parent packages so relative imports work
-for _pkg in [
-    'mcp_memory_service',
-    'mcp_memory_service.services',
-    'mcp_memory_service.storage',
-]:
-    if _pkg not in sys.modules:
-        _m = _types.ModuleType(_pkg)
-        _m.__path__ = []  # make it a package
-        sys.modules[_pkg] = _m
+try:
+    from mcp_memory_service.services.graph_service import GraphService
+except ImportError:
+    # Dependencies missing — build an isolated stub environment for this file.
+    for _pkg in [
+        'mcp_memory_service',
+        'mcp_memory_service.services',
+        'mcp_memory_service.storage',
+    ]:
+        if _pkg not in sys.modules:
+            _m = _types.ModuleType(_pkg)
+            _m.__path__ = []  # make it a package
+            sys.modules[_pkg] = _m
 
-# Create a stub GraphStorage class (tests only use mocks anyway)
-_graph_stub = _types.ModuleType('mcp_memory_service.storage.graph')
+    _graph_stub = _types.ModuleType('mcp_memory_service.storage.graph')
 
+    class _StubGraphStorage:
+        """Stub for import resolution — tests use MagicMock, never this class."""
+        pass
 
-class _StubGraphStorage:
-    """Stub for import resolution — tests use MagicMock, never this class."""
-    pass
+    _graph_stub.GraphStorage = _StubGraphStorage
+    sys.modules['mcp_memory_service.storage.graph'] = _graph_stub
 
+    _src = os.path.join(os.path.dirname(__file__), '..', 'src')
+    sys.path.insert(0, _src)
 
-_graph_stub.GraphStorage = _StubGraphStorage
-sys.modules['mcp_memory_service.storage.graph'] = _graph_stub
+    import importlib.util
+    _gs_spec = importlib.util.spec_from_file_location(
+        'mcp_memory_service.services.graph_service',
+        os.path.join(_src, 'mcp_memory_service', 'services', 'graph_service.py'),
+    )
+    _gs_mod = importlib.util.module_from_spec(_gs_spec)
+    sys.modules['mcp_memory_service.services.graph_service'] = _gs_mod
+    _gs_spec.loader.exec_module(_gs_mod)
 
-# Now we can safely import graph_service
-_src = os.path.join(os.path.dirname(__file__), '..', 'src')
-sys.path.insert(0, _src)
-
-import importlib
-_gs_spec = importlib.util.spec_from_file_location(
-    'mcp_memory_service.services.graph_service',
-    os.path.join(_src, 'mcp_memory_service', 'services', 'graph_service.py'),
-)
-_gs_mod = importlib.util.module_from_spec(_gs_spec)
-sys.modules['mcp_memory_service.services.graph_service'] = _gs_mod
-_gs_spec.loader.exec_module(_gs_mod)
-
-GraphService = _gs_mod.GraphService
+    GraphService = _gs_mod.GraphService
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -1,0 +1,272 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for GraphService used by the streamable-http MCP server.
+
+Covers:
+- Normal operation paths (find_connected, find_shortest_path, get_subgraph)
+- Unavailable graph storage (Milvus/Cloudflare backends)
+- Parameter validation
+"""
+
+import sys
+import os
+import types as _types
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+# ---------------------------------------------------------------------------
+# Lightweight import of GraphService without triggering the full project
+# dependency chain (numpy, torch, sentence-transformers, etc.).
+#
+# Strategy: pre-populate sys.modules with a stub for the storage.graph
+# package so that graph_service.py's relative import resolves without
+# actually loading the real GraphStorage (which only needs sqlite3 but
+# the package __init__ chain pulls in heavy deps).
+# ---------------------------------------------------------------------------
+
+# Create stub parent packages so relative imports work
+for _pkg in [
+    'mcp_memory_service',
+    'mcp_memory_service.services',
+    'mcp_memory_service.storage',
+]:
+    if _pkg not in sys.modules:
+        _m = _types.ModuleType(_pkg)
+        _m.__path__ = []  # make it a package
+        sys.modules[_pkg] = _m
+
+# Create a stub GraphStorage class (tests only use mocks anyway)
+_graph_stub = _types.ModuleType('mcp_memory_service.storage.graph')
+
+
+class _StubGraphStorage:
+    """Stub for import resolution — tests use MagicMock, never this class."""
+    pass
+
+
+_graph_stub.GraphStorage = _StubGraphStorage
+sys.modules['mcp_memory_service.storage.graph'] = _graph_stub
+
+# Now we can safely import graph_service
+_src = os.path.join(os.path.dirname(__file__), '..', 'src')
+sys.path.insert(0, _src)
+
+import importlib
+_gs_spec = importlib.util.spec_from_file_location(
+    'mcp_memory_service.services.graph_service',
+    os.path.join(_src, 'mcp_memory_service', 'services', 'graph_service.py'),
+)
+_gs_mod = importlib.util.module_from_spec(_gs_spec)
+sys.modules['mcp_memory_service.services.graph_service'] = _gs_mod
+_gs_spec.loader.exec_module(_gs_mod)
+
+GraphService = _gs_mod.GraphService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_graph_storage():
+    """Create a mock GraphStorage with async methods."""
+    storage = MagicMock()
+    storage.find_connected = AsyncMock(return_value=[
+        ("hash_a", 1),
+        ("hash_b", 2),
+    ])
+    storage.shortest_path = AsyncMock(return_value=["hash_1", "hash_mid", "hash_2"])
+    storage.get_subgraph = AsyncMock(return_value={
+        "nodes": ["hash_1", "hash_2", "hash_3"],
+        "edges": [
+            {
+                "source": "hash_1",
+                "target": "hash_2",
+                "similarity": 0.85,
+                "connection_types": ["semantic"],
+            }
+        ],
+    })
+    return storage
+
+
+@pytest.fixture
+def graph_service(mock_graph_storage):
+    """GraphService with a working mock storage."""
+    return GraphService(mock_graph_storage)
+
+
+@pytest.fixture
+def unavailable_graph_service():
+    """GraphService with no storage (simulates Milvus/Cloudflare backend)."""
+    return GraphService(None)
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+class TestIsAvailable:
+    def test_available_with_storage(self, graph_service):
+        assert graph_service.is_available() is True
+
+    def test_unavailable_without_storage(self, unavailable_graph_service):
+        assert unavailable_graph_service.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# find_connected — normal path
+# ---------------------------------------------------------------------------
+
+class TestFindConnected:
+    @pytest.mark.asyncio
+    async def test_returns_connected_memories(self, graph_service, mock_graph_storage):
+        result = await graph_service.find_connected("hash_center", max_hops=3)
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["connected"][0] == {"hash": "hash_a", "distance": 1}
+        assert result["connected"][1] == {"hash": "hash_b", "distance": 2}
+        mock_graph_storage.find_connected.assert_awaited_once_with("hash_center", max_hops=3)
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self, graph_service, mock_graph_storage):
+        mock_graph_storage.find_connected.return_value = []
+        result = await graph_service.find_connected("isolated_hash")
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["connected"] == []
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, graph_service, mock_graph_storage):
+        mock_graph_storage.find_connected.side_effect = RuntimeError("DB error")
+        result = await graph_service.find_connected("hash_x")
+
+        assert result["success"] is False
+        assert "DB error" in result["error"]
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# find_connected — unavailable
+# ---------------------------------------------------------------------------
+
+class TestFindConnectedUnavailable:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_unavailable(self, unavailable_graph_service):
+        result = await unavailable_graph_service.find_connected("any_hash")
+
+        assert result["success"] is False
+        assert "not available" in result["error"]
+        assert result["connected"] == []
+        assert result["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# find_shortest_path — normal path
+# ---------------------------------------------------------------------------
+
+class TestFindShortestPath:
+    @pytest.mark.asyncio
+    async def test_returns_path(self, graph_service, mock_graph_storage):
+        result = await graph_service.find_shortest_path("hash_1", "hash_2", max_depth=4)
+
+        assert result["success"] is True
+        assert result["path"] == ["hash_1", "hash_mid", "hash_2"]
+        assert result["length"] == 3
+        mock_graph_storage.shortest_path.assert_awaited_once_with("hash_1", "hash_2", max_depth=4)
+
+    @pytest.mark.asyncio
+    async def test_no_path_found(self, graph_service, mock_graph_storage):
+        mock_graph_storage.shortest_path.return_value = None
+        result = await graph_service.find_shortest_path("hash_a", "hash_z")
+
+        assert result["success"] is True
+        assert result["path"] is None
+        assert result["length"] == 0
+        assert "No path found" in result.get("message", "")
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, graph_service, mock_graph_storage):
+        mock_graph_storage.shortest_path.side_effect = RuntimeError("timeout")
+        result = await graph_service.find_shortest_path("h1", "h2")
+
+        assert result["success"] is False
+        assert "timeout" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# find_shortest_path — unavailable
+# ---------------------------------------------------------------------------
+
+class TestFindShortestPathUnavailable:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_unavailable(self, unavailable_graph_service):
+        result = await unavailable_graph_service.find_shortest_path("h1", "h2")
+
+        assert result["success"] is False
+        assert "not available" in result["error"]
+        assert result["path"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_subgraph — normal path
+# ---------------------------------------------------------------------------
+
+class TestGetSubgraph:
+    @pytest.mark.asyncio
+    async def test_returns_subgraph(self, graph_service, mock_graph_storage):
+        result = await graph_service.get_subgraph("hash_center", radius=3)
+
+        assert result["success"] is True
+        assert result["node_count"] == 3
+        assert result["edge_count"] == 1
+        assert "hash_1" in result["nodes"]
+        assert result["edges"][0]["source"] == "hash_1"
+        mock_graph_storage.get_subgraph.assert_awaited_once_with("hash_center", radius=3)
+
+    @pytest.mark.asyncio
+    async def test_empty_subgraph(self, graph_service, mock_graph_storage):
+        mock_graph_storage.get_subgraph.return_value = {"nodes": [], "edges": []}
+        result = await graph_service.get_subgraph("isolated")
+
+        assert result["success"] is True
+        assert result["node_count"] == 0
+        assert result["edge_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, graph_service, mock_graph_storage):
+        mock_graph_storage.get_subgraph.side_effect = RuntimeError("corrupt graph")
+        result = await graph_service.get_subgraph("hash_x")
+
+        assert result["success"] is False
+        assert "corrupt graph" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_subgraph — unavailable
+# ---------------------------------------------------------------------------
+
+class TestGetSubgraphUnavailable:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_unavailable(self, unavailable_graph_service):
+        result = await unavailable_graph_service.get_subgraph("any")
+
+        assert result["success"] is False
+        assert "not available" in result["error"]
+        assert result["nodes"] == []
+        assert result["edges"] == []


### PR DESCRIPTION
Add GraphService business logic layer and register memory_graph tool in FastMCP server, enabling graph traversal operations (connected, path, subgraph) for remote deployments using streamable-http transport.

Changes:
- New: services/graph_service.py — shared graph business logic
- Modified: mcp_server.py — GraphService init in lifespan + memory_graph tool
- New: tests/test_graph_service.py — 14 test cases (all passing)

Only available for sqlite_vec and hybrid backends. Returns clear error for milvus/cloudflare backends where graph storage is not supported.

# Pull Request

## Description

Add `memory_graph` tool to the streamable-http FastMCP server (`mcp_server.py`), enabling knowledge graph traversal operations for remote K8s deployments. Introduces a shared `GraphService` business logic layer under `services/graph_service.py` so both stdio and streamable-http server variants can reuse the same traversal and error-handling code paths.

## Motivation

Graph tools were previously only available in stdio mode (`server_impl.py`). Users deploying mcp-memory-service via streamable-http (e.g. K8s with `MCP_MODE=streamable-http`) had no access to knowledge graph operations (find connected memories, shortest path, subgraph extraction). This PR closes that gap.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## Changes

- New: `services/graph_service.py` — shared `GraphService` business logic layer with `find_connected`, `find_shortest_path`, `get_subgraph` methods and `is_available()` guard
- Modified: `mcp_server.py` — added `_GRAPH_STORAGE_CACHE` / `_GRAPH_SERVICE_CACHE` global caches, `GraphService` init in lifespan with `asyncio.to_thread`, registered `memory_graph` tool with action routing
- New: `tests/test_graph_service.py` — 14 unit test cases covering normal path, empty results, error handling, and unavailable backend scenarios

---

**Breaking Changes** (if any):
- None. Existing 6 tools are unchanged. `memory_graph` is a new addition.

## Testing

### How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version: 3.10
- OS: macOS (local), Linux (CI)
- Storage backend: sqlite_vec
- Installation method: pip install -e .

### Test Coverage

- [x] Added new tests (14 test cases for GraphService)
- [ ] Updated existing tests
- [x] Test coverage maintained/improved

## Related Issues

Fixes #
Closes #
Relates to #

## Screenshots

N/A

## Documentation

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [x] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [x] Updated code comments/docstrings
- [ ] Added API documentation
- [ ] No documentation needed

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] ✅ Any dependent changes have been merged and published
- [x] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [x] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

- Graph operations require `sqlite_vec` or `hybrid` storage backend. `milvus` and `cloudflare` backends return `{"success": false, "error": "Graph operations not available for current storage backend"}` without crashing.
- GraphStorage/GraphService instances are globally cached with `asyncio.to_thread` for non-blocking init, matching the existing `_STORAGE_CACHE` / `_MEMORY_SERVICE_CACHE` pattern.
- Integration test (end-to-end through FastMCP on real sqlite_vec DB) can be added in a follow-up PR if desired.

---

**For Reviewers**:
- Review checklist: See [Development Reference](https://github.com/doobidoo/mcp-memory-service/wiki/06-Development-Reference)
- Consider testing with Gemini Code Assist for comprehensive review
- Verify CHANGELOG.md entry is present and correctly formatted
- Check documentation accuracy and completeness
