### PR TITLE
feat(oauth): implement refresh_token grant with rotation (SEP-2207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 - Use Cloudflare ZeroTrust with subnet-based access control (e.g., allow Anthropic subnets + your own IPs)
 - Add **Client IP Address Filtering** to all Cloudflare API tokens (Dashboard → My Profile → API Tokens → Edit → Client IP Address Filtering) to limit abuse if a token leaks
 - If using IPv6, include your IPv6 /64 network in the allowlist (Python prefers IPv6 by default)
-- Set `MCP_OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES=1440` to extend OAuth tokens to 24 hours (refresh tokens not yet supported)
+- For long-running browser sessions, request the `offline_access` scope during authorization to receive a rotating `refresh_token` (lifetime via `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS`, default 30 days). Without this scope, access tokens are the only credential — extend `MCP_OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` up to `1440` (24h) if you need longer single-shot sessions.
 - Consider an auth proxy like [AuthMCP](https://github.com/loglux/authmcp-gateway) or [mcp-auth-proxy](https://github.com/sigbit/mcp-auth-proxy) for robust session management
 
 ## Comparison with Alternatives

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -52,6 +52,7 @@ python tests/integration/test_oauth_flow.py http://localhost:8000
 | `MCP_OAUTH_ISSUER` | Auto-detected | OAuth issuer URL |
 | `MCP_OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | `60` | Access token lifetime |
 | `MCP_OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES` | `10` | Authorization code lifetime |
+| `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS` | `30` | Refresh token lifetime (issued only when `offline_access` scope is requested) |
 
 ### Example Configuration
 
@@ -132,11 +133,54 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" \
 
 ### Scope-Based Authorization
 
-The OAuth system supports three scopes:
+The OAuth system supports four scopes:
 
 - **`read`**: Access to read-only endpoints
 - **`write`**: Access to create/update endpoints
 - **`admin`**: Access to administrative endpoints
+- **`offline_access`**: Opt-in signal that the client wants a `refresh_token` alongside the access token (see below). Does not grant additional permissions on its own.
+
+### Refresh Tokens
+
+The token endpoint supports the `refresh_token` grant so long-lived sessions can renew an access token without re-driving the authorization flow.
+
+**To receive a `refresh_token`, include `offline_access` in the `scope` parameter of the authorization request.** Clients that don't request it keep the existing single-token response — this behavior is opt-in to stay compatible with existing integrations.
+
+```bash
+# Authorization request — note offline_access in scope
+GET /oauth/authorize?response_type=code
+    &client_id=...
+    &redirect_uri=...
+    &scope=read%20write%20offline_access
+    &code_challenge=...&code_challenge_method=S256
+```
+
+The token response then includes `refresh_token`:
+
+```json
+{
+  "access_token": "eyJhbGc...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "q8Oj...48-byte-opaque...",
+  "scope": "read write offline_access"
+}
+```
+
+**Renewing an access token:**
+
+```bash
+curl -X POST http://localhost:8000/oauth/token \
+     -u "<client_id>:<client_secret>" \
+     -d "grant_type=refresh_token" \
+     -d "refresh_token=q8Oj..."
+```
+
+Public clients (registered with `token_endpoint_auth_method=none`) omit the `-u` credentials; the refresh token itself is the binding.
+
+**Rotation (OAuth 2.1 §4.3.1):** every successful refresh issues a new `refresh_token` AND revokes the one that was presented. A stolen refresh token is therefore single-use — if both the legitimate client and an attacker try to use it, one succeeds and the other gets `invalid_grant`. Always store the latest `refresh_token` from each response.
+
+**Scope on refresh:** the `scope` parameter is optional and may only be a subset of the originally granted scope; requesting a broader scope returns `invalid_scope`.
 
 ### API Key Authentication (OAuth-Free)
 

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -914,6 +914,11 @@ def validate_oauth_configuration() -> None:
     elif OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES > 60:  # 1 hour
         warnings.append(f"OAuth authorization code expiry is longer than recommended: {OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES} minutes")
 
+    if OAUTH_REFRESH_TOKEN_EXPIRE_DAYS <= 0:
+        errors.append(f"OAuth refresh token expiry must be positive: {OAUTH_REFRESH_TOKEN_EXPIRE_DAYS}")
+    elif OAUTH_REFRESH_TOKEN_EXPIRE_DAYS > 365:
+        warnings.append(f"OAuth refresh token expiry is very long: {OAUTH_REFRESH_TOKEN_EXPIRE_DAYS} days")
+
     # Validate security settings
     if "localhost" in OAUTH_ISSUER or "127.0.0.1" in OAUTH_ISSUER:
         if not os.getenv('MCP_OAUTH_ISSUER'):
@@ -970,6 +975,7 @@ OAUTH_ISSUER = os.getenv('MCP_OAUTH_ISSUER') or get_oauth_issuer()
 # OAuth token configuration
 OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES = safe_get_int_env('MCP_OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES', 60, min_value=1, max_value=1440)  # 1 minute to 24 hours
 OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES = safe_get_int_env('MCP_OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES', 10, min_value=1, max_value=60)  # 1 minute to 1 hour
+OAUTH_REFRESH_TOKEN_EXPIRE_DAYS = safe_get_int_env('MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS', 30, min_value=1, max_value=365)  # 1 day to 1 year
 
 # OAuth security configuration
 ALLOW_ANONYMOUS_ACCESS = safe_get_bool_env('MCP_ALLOW_ANONYMOUS_ACCESS', False)

--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -648,7 +648,22 @@ async def _handle_refresh_token_grant(
 
     token_data = await get_oauth_storage().get_refresh_token(refresh_token_value)
     if not token_data:
-        # Unknown, expired, or already-rotated token — do not disclose which.
+        # Unknown, expired, or already-rotated token. If it was previously
+        # rotated (revoked), this looks like a replay — the legitimate client
+        # would not present a stale token. We cannot distinguish replay from
+        # the attacker case, so per OAuth 2.1 §4.3.1 we also revoke every
+        # other live token in the same rotation chain (compromise mitigation).
+        # `revoke_refresh_token_chain` is a no-op (returns 0) for genuinely
+        # unknown tokens, so this is safe to call unconditionally here.
+        chain_revoked = await get_oauth_storage().revoke_refresh_token_chain(
+            refresh_token_value
+        )
+        if chain_revoked:
+            logger.warning(
+                "Refresh token replay detected; revoked %d additional "
+                "token(s) in the rotation chain",
+                chain_revoked,
+            )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
@@ -678,6 +693,17 @@ async def _handle_refresh_token_grant(
             detail={
                 "error": "invalid_grant",
                 "error_description": "Client no longer registered",
+            },
+        )
+
+    # Public clients still MUST send client_id (RFC 6749 §6) — the token's
+    # internal binding is not a substitute for the explicit parameter.
+    if client.token_endpoint_auth_method == "none" and not final_client_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_request",
+                "error_description": "Missing required parameter: client_id",
             },
         )
 
@@ -718,8 +744,8 @@ async def _handle_refresh_token_grant(
     granted_scope = requested_scope if requested_scope else original_scope
 
     # Rotation: atomically revoke the presented refresh token. If we lose the
-    # race (another refresh already consumed it), fail the grant — this is the
-    # replay detection guarantee from OAuth 2.1 §4.3.1.
+    # race (another refresh already consumed it), fail the grant — defense in
+    # depth on top of the unknown-token check above.
     if not await get_oauth_storage().revoke_refresh_token(refresh_token_value):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -33,12 +33,15 @@ from ...config import (
     OAUTH_ISSUER,
     OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
     OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES,
+    OAUTH_REFRESH_TOKEN_EXPIRE_DAYS,
     API_KEY,
     get_jwt_algorithm,
     get_jwt_signing_key,
 )
 from .models import TokenResponse
 from .storage import get_oauth_storage
+
+OFFLINE_ACCESS_SCOPE = "offline_access"
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +189,66 @@ def create_access_token(client_id: str, scope: Optional[str] = None) -> tuple[st
 
     logger.debug("Creating JWT token")
     token = jwt.encode(payload, signing_key, algorithm=algorithm)
+    return token, expires_in
+
+
+def _scope_has_offline_access(scope: Optional[str]) -> bool:
+    """Return True if the scope string explicitly requests offline_access.
+
+    Per OIDC convention (also adopted by MCP SEP-2207), refresh tokens are
+    only issued when the client asks for them via the ``offline_access``
+    scope. Clients that don't opt in keep their existing single-token flow.
+    """
+    if not scope:
+        return False
+    return OFFLINE_ACCESS_SCOPE in scope.split()
+
+
+def _is_scope_subset(requested: Optional[str], original: Optional[str]) -> bool:
+    """Return True if every token in ``requested`` appears in ``original``.
+
+    Used by the refresh grant to enforce RFC 6749 §6: clients may narrow
+    the granted scope on refresh but must not broaden it.
+    """
+    if not requested:
+        return True
+    if not original:
+        return False
+    original_set = set(original.split())
+    return set(requested.split()).issubset(original_set)
+
+
+async def create_refresh_token(
+    client_id: str,
+    scope: Optional[str] = None,
+    parent_token: Optional[str] = None,
+) -> tuple[str, int]:
+    """
+    Create and persist an opaque refresh token for the given client.
+
+    Refresh tokens are DB-backed (not JWT) so they can be revoked on
+    rotation or logout — a property JWTs cannot provide without an
+    additional blocklist.
+
+    Args:
+        client_id: Authenticated client the token is bound to.
+        scope: Space-separated granted scope (preserved from the original
+            authorization for rotation parity).
+        parent_token: The refresh token this one supersedes, recorded
+            on the row for rotation-chain audit.
+
+    Returns:
+        Tuple of (token, expires_in_seconds).
+    """
+    expires_in = OAUTH_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
+    token = get_oauth_storage().generate_refresh_token()
+    await get_oauth_storage().store_refresh_token(
+        token=token,
+        client_id=client_id,
+        scope=scope,
+        expires_in=expires_in,
+        parent_token=parent_token,
+    )
     return token, expires_in
 
 
@@ -538,12 +601,155 @@ async def _handle_authorization_code_grant(
         expires_in=expires_in,
     )
 
-    logger.info("Access token issued")
+    # Issue a refresh token only when the client explicitly requested it
+    # via the "offline_access" scope (OIDC convention / MCP SEP-2207).
+    # Clients that don't opt in keep their current single-token behavior,
+    # so this change is non-breaking.
+    refresh_token: Optional[str] = None
+    if _scope_has_offline_access(code_data["scope"]):
+        refresh_token, _ = await create_refresh_token(
+            client_id=final_client_id,
+            scope=code_data["scope"],
+        )
+        logger.info("Access + refresh tokens issued (offline_access requested)")
+    else:
+        logger.info("Access token issued")
+
     return TokenResponse(
         access_token=access_token,
         token_type="Bearer",
         expires_in=expires_in,
+        refresh_token=refresh_token,
         scope=code_data["scope"],
+    )
+
+
+async def _handle_refresh_token_grant(
+    final_client_id: Optional[str],
+    final_client_secret: Optional[str],
+    refresh_token_value: Optional[str],
+    requested_scope: Optional[str],
+) -> TokenResponse:
+    """
+    Handle the OAuth 2.1 refresh_token grant (RFC 6749 §6).
+
+    Implements the OAuth 2.1 rotation requirement (§4.3.1): every successful
+    refresh issues a new refresh token AND revokes the one that was presented,
+    so a stolen refresh token is single-use.
+    """
+    if not refresh_token_value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_request",
+                "error_description": "Missing required parameter: refresh_token",
+            },
+        )
+
+    token_data = await get_oauth_storage().get_refresh_token(refresh_token_value)
+    if not token_data:
+        # Unknown, expired, or already-rotated token — do not disclose which.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_grant",
+                "error_description": "Refresh token is invalid, expired, or revoked",
+            },
+        )
+
+    bound_client_id = token_data["client_id"]
+
+    # If the client authenticated, it must match the refresh token binding.
+    # Public clients may omit client_id in the request body (the token itself
+    # is the binding), but any supplied client_id must match.
+    if final_client_id and final_client_id != bound_client_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_grant",
+                "error_description": "Refresh token was issued to a different client",
+            },
+        )
+
+    client = await get_oauth_storage().get_client(bound_client_id)
+    if not client:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_grant",
+                "error_description": "Client no longer registered",
+            },
+        )
+
+    # Confidential clients must authenticate on refresh (RFC 6749 §6).
+    # Public clients (token_endpoint_auth_method=none) do not present a secret;
+    # the rotated refresh token itself is the binding.
+    if client.token_endpoint_auth_method != "none":
+        if not final_client_secret:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "error": "invalid_client",
+                    "error_description": "Client authentication required",
+                },
+            )
+        if not await get_oauth_storage().authenticate_client(
+            bound_client_id, final_client_secret
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "error": "invalid_client",
+                    "error_description": "Client authentication failed",
+                },
+            )
+
+    original_scope = token_data["scope"]
+
+    # RFC 6749 §6: scope may be narrowed on refresh but not broadened.
+    if requested_scope is not None and not _is_scope_subset(requested_scope, original_scope):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_scope",
+                "error_description": "Requested scope exceeds originally granted scope",
+            },
+        )
+    granted_scope = requested_scope if requested_scope else original_scope
+
+    # Rotation: atomically revoke the presented refresh token. If we lose the
+    # race (another refresh already consumed it), fail the grant — this is the
+    # replay detection guarantee from OAuth 2.1 §4.3.1.
+    if not await get_oauth_storage().revoke_refresh_token(refresh_token_value):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "invalid_grant",
+                "error_description": "Refresh token is invalid, expired, or revoked",
+            },
+        )
+
+    access_token, expires_in = create_access_token(bound_client_id, granted_scope)
+    await get_oauth_storage().store_access_token(
+        token=access_token,
+        client_id=bound_client_id,
+        scope=granted_scope,
+        expires_in=expires_in,
+    )
+
+    new_refresh_token, _ = await create_refresh_token(
+        client_id=bound_client_id,
+        scope=granted_scope,
+        parent_token=refresh_token_value,
+    )
+
+    logger.info("Access + refresh tokens issued via refresh_token grant (rotated)")
+    return TokenResponse(
+        access_token=access_token,
+        token_type="Bearer",
+        expires_in=expires_in,
+        refresh_token=new_refresh_token,
+        scope=granted_scope,
     )
 
 
@@ -601,13 +807,16 @@ async def token(
     client_id: Optional[str] = Form(None, description="OAuth client identifier"),
     client_secret: Optional[str] = Form(None, description="OAuth client secret"),
     code_verifier: Optional[str] = Form(None, description="PKCE code verifier"),
+    refresh_token: Optional[str] = Form(None, description="Refresh token (refresh_token grant)"),
+    scope: Optional[str] = Form(None, description="Requested scope on refresh"),
 ):
     """
     OAuth 2.1 Token endpoint.
 
-    Exchanges authorization codes for access tokens.
-    Supports both authorization_code and client_credentials grant types.
-    Supports both client_secret_post (form data) and client_secret_basic (HTTP Basic auth).
+    Exchanges authorization codes for access tokens and rotates refresh
+    tokens. Supports authorization_code, client_credentials, and
+    refresh_token grant types. Accepts both client_secret_post (form data)
+    and client_secret_basic (HTTP Basic auth).
     """
     # Extract client credentials from either HTTP Basic auth or form data
     auth_header = request.headers.get("authorization")
@@ -627,6 +836,10 @@ async def token(
         elif grant_type == "client_credentials":
             return await _handle_client_credentials_grant(
                 final_client_id, final_client_secret
+            )
+        elif grant_type == "refresh_token":
+            return await _handle_refresh_token_grant(
+                final_client_id, final_client_secret, refresh_token, scope
             )
 
         else:

--- a/src/mcp_memory_service/web/oauth/discovery.py
+++ b/src/mcp_memory_service/web/oauth/discovery.py
@@ -42,7 +42,7 @@ async def oauth_protected_resource_metadata() -> OAuthProtectedResourceMetadata:
     return OAuthProtectedResourceMetadata(
         resource=OAUTH_ISSUER,
         authorization_servers=[OAUTH_ISSUER],
-        scopes_supported=["read", "write", "admin"],
+        scopes_supported=["read", "write", "admin", "offline_access"],
         bearer_methods_supported=["header"],
         resource_documentation=f"{OAUTH_ISSUER}/docs",
     )
@@ -66,10 +66,10 @@ async def oauth_authorization_server_metadata() -> OAuthServerMetadata:
         authorization_endpoint=f"{OAUTH_ISSUER}/oauth/authorize",
         token_endpoint=f"{OAUTH_ISSUER}/oauth/token",
         registration_endpoint=f"{OAUTH_ISSUER}/oauth/register",
-        grant_types_supported=["authorization_code", "client_credentials"],
+        grant_types_supported=["authorization_code", "client_credentials", "refresh_token"],
         response_types_supported=["code"],
         token_endpoint_auth_methods_supported=["client_secret_basic", "client_secret_post", "none"],
-        scopes_supported=["read", "write", "admin"],
+        scopes_supported=["read", "write", "admin", "offline_access"],
         id_token_signing_alg_values_supported=[algorithm],
         code_challenge_methods_supported=["S256"]
     )

--- a/src/mcp_memory_service/web/oauth/models.py
+++ b/src/mcp_memory_service/web/oauth/models.py
@@ -29,7 +29,7 @@ class OAuthServerMetadata(BaseModel):
     registration_endpoint: str = Field(..., description="Dynamic registration endpoint URL")
 
     grant_types_supported: List[str] = Field(
-        default=["authorization_code", "client_credentials"],
+        default=["authorization_code", "client_credentials", "refresh_token"],
         description="Supported OAuth 2.1 grant types"
     )
     response_types_supported: List[str] = Field(
@@ -162,12 +162,32 @@ class TokenRequest(BaseModel):
     client_secret: Optional[str] = Field(default=None, description="OAuth client secret")
 
 
+class RefreshTokenRequest(BaseModel):
+    """OAuth 2.1 Refresh Token Request parameters (RFC 6749 §6)."""
+
+    grant_type: str = Field(default="refresh_token", description="Must be 'refresh_token'")
+    refresh_token: str = Field(..., description="The refresh token issued to the client")
+    scope: Optional[str] = Field(
+        default=None,
+        description="Optional subset of the originally granted scope to downscope the access token",
+    )
+    client_id: Optional[str] = Field(default=None, description="OAuth client identifier")
+    client_secret: Optional[str] = Field(default=None, description="OAuth client secret")
+
+
 class TokenResponse(BaseModel):
     """OAuth 2.1 Token Response."""
 
     access_token: str = Field(..., description="OAuth 2.0 access token")
     token_type: str = Field(default="Bearer", description="Token type")
     expires_in: Optional[int] = Field(default=3600, description="Access token lifetime in seconds")
+    refresh_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "Refresh token for obtaining new access tokens. Only issued when the "
+            "client requested the 'offline_access' scope on authorization."
+        ),
+    )
     scope: Optional[str] = Field(default=None, description="Granted scope")
 
 

--- a/src/mcp_memory_service/web/oauth/storage/base.py
+++ b/src/mcp_memory_service/web/oauth/storage/base.py
@@ -258,6 +258,26 @@ class OAuthStorage(ABC):
         pass
 
     @abstractmethod
+    async def revoke_refresh_token_chain(self, token: str) -> int:
+        """
+        Revoke every refresh token in the same rotation chain.
+
+        Compromise mitigation per OAuth 2.1 §4.3.1: when a replay of an
+        already-revoked refresh token is detected, the authorization
+        server cannot tell whether the legitimate client or an attacker
+        presented the stale token, so it revokes the entire family rooted
+        at the same initial issuance.
+
+        Args:
+            token: Any refresh token in the chain (typically the replayed one)
+
+        Returns:
+            Number of previously-live tokens revoked by this call.
+            Already-revoked or unknown tokens do not count.
+        """
+        pass
+
+    @abstractmethod
     async def cleanup_expired(self) -> Dict[str, int]:
         """
         Clean up expired authorization codes, access tokens, and refresh tokens.

--- a/src/mcp_memory_service/web/oauth/storage/base.py
+++ b/src/mcp_memory_service/web/oauth/storage/base.py
@@ -184,14 +184,89 @@ class OAuthStorage(ABC):
         pass
 
     @abstractmethod
+    async def store_refresh_token(
+        self,
+        token: str,
+        client_id: str,
+        scope: Optional[str] = None,
+        expires_in: Optional[int] = None,
+        parent_token: Optional[str] = None,
+    ) -> None:
+        """
+        Store a refresh token.
+
+        Args:
+            token: Refresh token value
+            client_id: OAuth client identifier
+            scope: Space-separated list of granted scopes
+            expires_in: Expiration time in seconds (None uses default)
+            parent_token: Previous refresh token this one replaces (rotation chain)
+
+        Raises:
+            Exception: If storage operation fails
+        """
+        pass
+
+    @abstractmethod
+    async def get_refresh_token(self, token: str) -> Optional[Dict]:
+        """
+        Retrieve refresh token information if valid.
+
+        Returns None when the token is unknown, expired, or revoked. Does NOT
+        consume the token; rotation is performed by the caller via
+        :meth:`revoke_refresh_token` once a replacement has been issued.
+
+        Args:
+            token: Refresh token value
+
+        Returns:
+            Dict with keys: client_id, scope, expires_at, parent_token
+            None if token not found, expired, or revoked
+        """
+        pass
+
+    @abstractmethod
+    async def revoke_refresh_token(self, token: str) -> bool:
+        """
+        Revoke a refresh token (mark as unusable, keep record for audit).
+
+        Used for OAuth 2.1 §4.3.1 rotation: the caller invalidates the
+        previously-presented refresh token after issuing its replacement.
+
+        Args:
+            token: Refresh token value to revoke
+
+        Returns:
+            True if a live token was revoked, False if unknown/already revoked
+        """
+        pass
+
+    @abstractmethod
+    async def delete_refresh_token(self, token: str) -> bool:
+        """
+        Delete a refresh token record outright.
+
+        Intended for explicit logout / client deregistration flows where
+        audit history is not required.
+
+        Args:
+            token: Refresh token value
+
+        Returns:
+            True if a record was removed, False otherwise
+        """
+        pass
+
+    @abstractmethod
     async def cleanup_expired(self) -> Dict[str, int]:
         """
-        Clean up expired authorization codes and access tokens.
+        Clean up expired authorization codes, access tokens, and refresh tokens.
 
         This method should be called periodically to prevent storage bloat.
 
         Returns:
-            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned
+            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned,
+            expired_refresh_tokens_cleaned
 
         Raises:
             Exception: If cleanup operation fails
@@ -250,6 +325,19 @@ class OAuthStorage(ABC):
         """
         import secrets
         return secrets.token_urlsafe(32)
+
+    def generate_refresh_token(self) -> str:
+        """
+        Generate a secure refresh token.
+
+        Refresh tokens use more entropy than access tokens because they are
+        long-lived (days/weeks), DB-backed, and a key target for replay.
+
+        Returns:
+            Secure random refresh token string
+        """
+        import secrets
+        return secrets.token_urlsafe(48)
 
     # Optional statistics method
     async def get_stats(self) -> Dict:

--- a/src/mcp_memory_service/web/oauth/storage/memory.py
+++ b/src/mcp_memory_service/web/oauth/storage/memory.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Copyright 2024 Heinrich Krupp
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -262,6 +266,50 @@ class MemoryOAuthStorage(OAuthStorage):
                 return False
             data["revoked"] = True
             return True
+
+    async def revoke_refresh_token_chain(self, token: str) -> int:
+        """Revoke the entire rotation chain (in-memory equivalent)."""
+        async with self._lock:
+            # Walk up to find the chain root.
+            current = token
+            seen: set[str] = set()
+            root = current
+            while current and current not in seen:
+                seen.add(current)
+                data = self._refresh_tokens.get(current)
+                if not data:
+                    root = current
+                    break
+                parent = data.get("parent_token")
+                if not parent:
+                    root = current
+                    break
+                root = parent
+                current = parent
+
+            # BFS descendants.
+            members: set[str] = {root}
+            frontier = [root]
+            while frontier:
+                children = [
+                    t for t, d in self._refresh_tokens.items()
+                    if d.get("parent_token") in frontier and t not in members
+                ]
+                members.update(children)
+                frontier = children
+
+            count = 0
+            for t in members:
+                d = self._refresh_tokens.get(t)
+                if d and not d["revoked"]:
+                    d["revoked"] = True
+                    count += 1
+            if count:
+                logger.warning(
+                    "Revoked %d refresh token(s) in chain (replay mitigation)",
+                    count,
+                )
+            return count
 
     async def delete_refresh_token(self, token: str) -> bool:
         """Remove refresh token record entirely."""

--- a/src/mcp_memory_service/web/oauth/storage/memory.py
+++ b/src/mcp_memory_service/web/oauth/storage/memory.py
@@ -26,7 +26,11 @@ import asyncio
 from typing import Dict, Optional
 from .base import OAuthStorage
 from ..models import RegisteredClient
-from ....config import OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES, OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES
+from ....config import (
+    OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
+    OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES,
+    OAUTH_REFRESH_TOKEN_EXPIRE_DAYS,
+)
 
 
 class MemoryOAuthStorage(OAuthStorage):
@@ -53,6 +57,9 @@ class MemoryOAuthStorage(OAuthStorage):
 
         # Active access tokens (token -> {client_id, expires_at, scope})
         self._access_tokens: Dict[str, Dict] = {}
+
+        # Refresh tokens (token -> {client_id, scope, expires_at, revoked, parent_token})
+        self._refresh_tokens: Dict[str, Dict] = {}
 
         # Thread safety lock for concurrent access
         self._lock = asyncio.Lock()
@@ -214,12 +221,60 @@ class MemoryOAuthStorage(OAuthStorage):
                 return True
             return False
 
+    async def store_refresh_token(
+        self,
+        token: str,
+        client_id: str,
+        scope: Optional[str] = None,
+        expires_in: Optional[int] = None,
+        parent_token: Optional[str] = None,
+    ) -> None:
+        """Store a refresh token."""
+        if expires_in is None:
+            expires_in = OAUTH_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
+        async with self._lock:
+            self._refresh_tokens[token] = {
+                "client_id": client_id,
+                "scope": scope,
+                "expires_at": time.time() + expires_in,
+                "revoked": False,
+                "parent_token": parent_token,
+            }
+
+    async def get_refresh_token(self, token: str) -> Optional[Dict]:
+        """Return refresh token data if live (not expired, not revoked)."""
+        async with self._lock:
+            data = self._refresh_tokens.get(token)
+            if not data:
+                return None
+            if data["revoked"]:
+                return None
+            if data["expires_at"] <= time.time():
+                return None
+            # Return a copy to prevent external mutation
+            return dict(data)
+
+    async def revoke_refresh_token(self, token: str) -> bool:
+        """Mark refresh token as revoked (keep record for rotation audit)."""
+        async with self._lock:
+            data = self._refresh_tokens.get(token)
+            if not data or data["revoked"]:
+                return False
+            data["revoked"] = True
+            return True
+
+    async def delete_refresh_token(self, token: str) -> bool:
+        """Remove refresh token record entirely."""
+        async with self._lock:
+            return self._refresh_tokens.pop(token, None) is not None
+
     async def cleanup_expired(self) -> Dict[str, int]:
         """
-        Clean up expired authorization codes and access tokens.
+        Clean up expired authorization codes, access tokens, and refresh tokens.
 
         Returns:
-            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned
+            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned,
+            expired_refresh_tokens_cleaned
         """
         async with self._lock:
             current_time = time.time()
@@ -240,9 +295,19 @@ class MemoryOAuthStorage(OAuthStorage):
             for token in expired_tokens:
                 self._access_tokens.pop(token, None)
 
+            # Clean up expired refresh tokens (revoked tokens are kept until expiry
+            # so rotated values cannot be re-used during the lifetime of the chain)
+            expired_refresh = [
+                token for token, data in self._refresh_tokens.items()
+                if data["expires_at"] <= current_time
+            ]
+            for token in expired_refresh:
+                self._refresh_tokens.pop(token, None)
+
             return {
                 "expired_codes_cleaned": len(expired_codes),
-                "expired_tokens_cleaned": len(expired_tokens)
+                "expired_tokens_cleaned": len(expired_tokens),
+                "expired_refresh_tokens_cleaned": len(expired_refresh),
             }
 
     async def close(self) -> None:
@@ -262,8 +327,14 @@ class MemoryOAuthStorage(OAuthStorage):
             Dict with counts of registered clients, active codes, and active tokens
         """
         async with self._lock:
+            now = time.time()
+            active_refresh = sum(
+                1 for data in self._refresh_tokens.values()
+                if not data["revoked"] and data["expires_at"] > now
+            )
             return {
                 "registered_clients": len(self._clients),
                 "active_authorization_codes": len(self._authorization_codes),
-                "active_access_tokens": len(self._access_tokens)
+                "active_access_tokens": len(self._access_tokens),
+                "active_refresh_tokens": active_refresh,
             }

--- a/src/mcp_memory_service/web/oauth/storage/sqlite.py
+++ b/src/mcp_memory_service/web/oauth/storage/sqlite.py
@@ -39,7 +39,11 @@ import aiosqlite
 
 from .base import OAuthStorage
 from ..models import RegisteredClient
-from ....config import OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES, OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES
+from ....config import (
+    OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES,
+    OAUTH_AUTHORIZATION_CODE_EXPIRE_MINUTES,
+    OAUTH_REFRESH_TOKEN_EXPIRE_DAYS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +218,33 @@ class SQLiteOAuthStorage(OAuthStorage):
         )
         await self._execute(
             "CREATE INDEX IF NOT EXISTS idx_access_tokens_client ON oauth_access_tokens(client_id)"
+        )
+
+        # Create oauth_refresh_tokens table.
+        # Additive schema change: CREATE IF NOT EXISTS only — existing deployments
+        # pick the table up on next startup without ALTER migrations.
+        await self._execute("""
+            CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
+                token TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                scope TEXT,
+                expires_at REAL NOT NULL,
+                revoked INTEGER NOT NULL DEFAULT 0,
+                parent_token TEXT,
+                created_at REAL NOT NULL,
+                FOREIGN KEY (client_id) REFERENCES oauth_clients(client_id) ON DELETE CASCADE
+            )
+        """)
+
+        # Create indexes for refresh tokens
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires ON oauth_refresh_tokens(expires_at)"
+        )
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_refresh_tokens_client ON oauth_refresh_tokens(client_id)"
+        )
+        await self._execute(
+            "CREATE INDEX IF NOT EXISTS idx_refresh_tokens_parent ON oauth_refresh_tokens(parent_token)"
         )
 
         await self._commit()
@@ -524,14 +555,90 @@ class SQLiteOAuthStorage(OAuthStorage):
                 logger.debug(f"Revoked access token")
             return revoked
 
+    async def store_refresh_token(
+        self,
+        token: str,
+        client_id: str,
+        scope: Optional[str] = None,
+        expires_in: Optional[int] = None,
+        parent_token: Optional[str] = None,
+    ) -> None:
+        """Store a refresh token."""
+        if expires_in is None:
+            expires_in = OAUTH_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60
+
+        async with self._lock:
+            now = time.time()
+            await self._execute(
+                """
+                INSERT INTO oauth_refresh_tokens
+                (token, client_id, scope, expires_at, revoked, parent_token, created_at)
+                VALUES (?, ?, ?, ?, 0, ?, ?)
+                """,
+                (token, client_id, scope, now + expires_in, parent_token, now),
+            )
+            await self._commit()
+            logger.debug(f"Stored refresh token for client: {_sanitize_log_value(client_id)}")
+
+    async def get_refresh_token(self, token: str) -> Optional[Dict]:
+        """Return refresh token data if live (not revoked, not expired)."""
+        async with self._lock:
+            now = time.time()
+            cursor = await self._execute(
+                """
+                SELECT * FROM oauth_refresh_tokens
+                WHERE token = ? AND revoked = 0 AND expires_at > ?
+                """,
+                (token, now),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            return {
+                "client_id": row["client_id"],
+                "scope": row["scope"],
+                "expires_at": row["expires_at"],
+                "parent_token": row["parent_token"],
+            }
+
+    async def revoke_refresh_token(self, token: str) -> bool:
+        """
+        Atomically mark a refresh token as revoked.
+
+        Uses UPDATE...WHERE revoked=0 + rowcount check to serialize rotation
+        under concurrent refresh requests (same pattern as authorization code
+        consumption).
+        """
+        async with self._lock:
+            cursor = await self._execute(
+                "UPDATE oauth_refresh_tokens SET revoked = 1 WHERE token = ? AND revoked = 0",
+                (token,),
+            )
+            await self._commit()
+            revoked = cursor.rowcount > 0
+            if revoked:
+                logger.debug("Revoked refresh token")
+            return revoked
+
+    async def delete_refresh_token(self, token: str) -> bool:
+        """Remove refresh token record outright."""
+        async with self._lock:
+            cursor = await self._execute(
+                "DELETE FROM oauth_refresh_tokens WHERE token = ?",
+                (token,),
+            )
+            await self._commit()
+            return cursor.rowcount > 0
+
     async def cleanup_expired(self) -> Dict[str, int]:
         """
-        Clean up expired authorization codes and access tokens.
+        Clean up expired authorization codes, access tokens, and refresh tokens.
 
         This method should be called periodically to prevent storage bloat.
 
         Returns:
-            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned
+            Dict with keys: expired_codes_cleaned, expired_tokens_cleaned,
+            expired_refresh_tokens_cleaned
 
         Raises:
             Exception: If cleanup operation fails
@@ -553,17 +660,26 @@ class SQLiteOAuthStorage(OAuthStorage):
             )
             tokens_cleaned = cursor2.rowcount
 
+            # Clean up expired refresh tokens
+            cursor3 = await self._execute(
+                "DELETE FROM oauth_refresh_tokens WHERE expires_at < ?",
+                (now,)
+            )
+            refresh_cleaned = cursor3.rowcount
+
             await self._commit()
 
-            if codes_cleaned > 0 or tokens_cleaned > 0:
+            if codes_cleaned > 0 or tokens_cleaned > 0 or refresh_cleaned > 0:
                 logger.info(
-                    f"Cleaned up {codes_cleaned} expired authorization codes "
-                    f"and {tokens_cleaned} expired access tokens"
+                    f"Cleaned up {codes_cleaned} expired authorization codes, "
+                    f"{tokens_cleaned} expired access tokens, and "
+                    f"{refresh_cleaned} expired refresh tokens"
                 )
 
             return {
                 "expired_codes_cleaned": codes_cleaned,
-                "expired_tokens_cleaned": tokens_cleaned
+                "expired_tokens_cleaned": tokens_cleaned,
+                "expired_refresh_tokens_cleaned": refresh_cleaned,
             }
 
     async def close(self) -> None:
@@ -610,10 +726,19 @@ class SQLiteOAuthStorage(OAuthStorage):
             row3 = await cursor3.fetchone()
             token_count = row3[0] if row3 else 0
 
+            # Count active (non-revoked, non-expired) refresh tokens
+            cursor4 = await self._execute(
+                "SELECT COUNT(*) FROM oauth_refresh_tokens WHERE revoked = 0 AND expires_at > ?",
+                (time.time(),)
+            )
+            row4 = await cursor4.fetchone()
+            refresh_count = row4[0] if row4 else 0
+
             return {
                 "backend": "sqlite",
                 "db_path": self.db_path,
                 "registered_clients": client_count,
                 "active_authorization_codes": code_count,
-                "active_access_tokens": token_count
+                "active_access_tokens": token_count,
+                "active_refresh_tokens": refresh_count,
             }

--- a/src/mcp_memory_service/web/oauth/storage/sqlite.py
+++ b/src/mcp_memory_service/web/oauth/storage/sqlite.py
@@ -620,6 +620,71 @@ class SQLiteOAuthStorage(OAuthStorage):
                 logger.debug("Revoked refresh token")
             return revoked
 
+    async def revoke_refresh_token_chain(self, token: str) -> int:
+        """
+        Revoke the entire rotation chain that ``token`` belongs to.
+
+        Walks parent_token pointers up to the chain root, then BFS-walks
+        descendants, then issues a single bulk UPDATE under the storage
+        lock so the operation is atomic with respect to concurrent
+        rotations.
+        """
+        async with self._lock:
+            # Walk up to find the chain root.
+            current = token
+            seen: set[str] = set()
+            root = current
+            while current and current not in seen:
+                seen.add(current)
+                cur = await self._execute(
+                    "SELECT parent_token FROM oauth_refresh_tokens WHERE token = ?",
+                    (current,),
+                )
+                row = await cur.fetchone()
+                if not row:
+                    # token unknown to us — treat the supplied value as the root
+                    root = current
+                    break
+                parent = row["parent_token"]
+                if not parent:
+                    root = current
+                    break
+                root = parent
+                current = parent
+
+            # BFS descendants from the root.
+            members: set[str] = {root}
+            frontier = [root]
+            while frontier:
+                placeholders = ",".join("?" * len(frontier))
+                cur = await self._execute(
+                    f"SELECT token FROM oauth_refresh_tokens "
+                    f"WHERE parent_token IN ({placeholders})",
+                    frontier,
+                )
+                rows = await cur.fetchall()
+                children = [r["token"] for r in rows if r["token"] not in members]
+                members.update(children)
+                frontier = children
+
+            if not members:
+                return 0
+
+            placeholders = ",".join("?" * len(members))
+            cur = await self._execute(
+                f"UPDATE oauth_refresh_tokens SET revoked = 1 "
+                f"WHERE token IN ({placeholders}) AND revoked = 0",
+                list(members),
+            )
+            await self._commit()
+            count = cur.rowcount or 0
+            if count:
+                logger.warning(
+                    "Revoked %d refresh token(s) in chain (replay mitigation)",
+                    count,
+                )
+            return count
+
     async def delete_refresh_token(self, token: str) -> bool:
         """Remove refresh token record outright."""
         async with self._lock:

--- a/tests/unit/test_oauth_refresh.py
+++ b/tests/unit/test_oauth_refresh.py
@@ -1,0 +1,449 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the OAuth 2.1 refresh_token grant (RFC 6749 §6, OAuth 2.1 §4.3.1).
+
+Covers issuance (only when offline_access is requested), rotation
+(old refresh token rejected after use), expiry, scope narrowing, client
+binding, and the public-client path. Also includes a regression check
+that the existing authorization_code flow without offline_access keeps
+its single-token response shape.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from mcp_memory_service.web.oauth.authorization import (
+    _handle_authorization_code_grant,
+    _handle_refresh_token_grant,
+    create_refresh_token,
+)
+from mcp_memory_service.web.oauth.discovery import router as discovery_router
+from mcp_memory_service.web.oauth.models import RegisteredClient
+from mcp_memory_service.web.oauth.storage.memory import MemoryOAuthStorage
+
+
+CONFIDENTIAL_CLIENT_ID = "conf-client"
+CONFIDENTIAL_CLIENT_SECRET = "conf-secret"
+PUBLIC_CLIENT_ID = "pub-client"
+
+
+async def _register_confidential_client(storage: MemoryOAuthStorage) -> None:
+    await storage.store_client(
+        RegisteredClient(
+            client_id=CONFIDENTIAL_CLIENT_ID,
+            client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            redirect_uris=["https://example.com/cb"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_basic",
+            client_name="Confidential Client",
+            created_at=time.time(),
+        )
+    )
+
+
+async def _register_public_client(storage: MemoryOAuthStorage) -> None:
+    await storage.store_client(
+        RegisteredClient(
+            client_id=PUBLIC_CLIENT_ID,
+            client_secret="unused",
+            redirect_uris=["http://127.0.0.1/cb"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            client_name="Public PKCE Client",
+            created_at=time.time(),
+        )
+    )
+
+
+async def _issue_via_auth_code(
+    storage: MemoryOAuthStorage,
+    scope: str,
+    client_id: str = CONFIDENTIAL_CLIENT_ID,
+    client_secret: str | None = CONFIDENTIAL_CLIENT_SECRET,
+    code_verifier: str | None = None,
+):
+    """Drive authorization_code grant to issuance so we have a real refresh token."""
+    code = "auth-code-" + str(time.time_ns())
+    await storage.store_authorization_code(
+        code=code,
+        client_id=client_id,
+        redirect_uri="https://example.com/cb",
+        scope=scope,
+        expires_in=300,
+    )
+    return await _handle_authorization_code_grant(
+        final_client_id=client_id,
+        final_client_secret=client_secret,
+        code=code,
+        redirect_uri="https://example.com/cb",
+        code_verifier=code_verifier,
+    )
+
+
+# ===========================================================================
+# Issuance — refresh token only when offline_access was requested
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_issued_when_offline_access_requested():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        resp = await _issue_via_auth_code(storage, scope="read write offline_access")
+
+    assert resp.access_token
+    assert resp.refresh_token is not None
+    assert resp.refresh_token != resp.access_token
+    assert "offline_access" in (resp.scope or "")
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_not_issued_without_offline_access():
+    """Regression: clients that don't opt in keep the single-token response shape."""
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        resp = await _issue_via_auth_code(storage, scope="read write")
+
+    assert resp.access_token
+    assert resp.refresh_token is None
+    assert resp.scope == "read write"
+
+
+# ===========================================================================
+# Refresh grant — happy path and rotation
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_refresh_grant_returns_new_access_token():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="read write offline_access")
+        refreshed = await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=issued.refresh_token,
+            requested_scope=None,
+        )
+
+    assert refreshed.access_token
+    assert refreshed.access_token != issued.access_token
+    assert refreshed.scope == issued.scope
+
+
+@pytest.mark.asyncio
+async def test_refresh_grant_rotates_refresh_token():
+    """Each refresh must issue a new, distinct refresh token (OAuth 2.1 §4.3.1)."""
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="offline_access read")
+        refreshed = await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=issued.refresh_token,
+            requested_scope=None,
+        )
+
+    assert refreshed.refresh_token is not None
+    assert refreshed.refresh_token != issued.refresh_token
+
+    # The new token's parent_token points to the original for audit.
+    new_record = await storage.get_refresh_token(refreshed.refresh_token)
+    assert new_record is not None
+    assert new_record["parent_token"] == issued.refresh_token
+
+
+@pytest.mark.asyncio
+async def test_old_refresh_token_rejected_after_rotation():
+    """After a successful refresh, the presented token must be unusable."""
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="offline_access read")
+        await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=issued.refresh_token,
+            requested_scope=None,
+        )
+
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+                refresh_token_value=issued.refresh_token,
+                requested_scope=None,
+            )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"] == "invalid_grant"
+
+
+# ===========================================================================
+# Rejection paths
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_expired_refresh_token_rejected():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    # Insert a refresh token with negative TTL so it's already expired on read.
+    await storage.store_refresh_token(
+        token="rt-expired",
+        client_id=CONFIDENTIAL_CLIENT_ID,
+        scope="offline_access",
+        expires_in=-1,
+    )
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+                refresh_token_value="rt-expired",
+                requested_scope=None,
+            )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_invalid_refresh_token_rejected():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+                refresh_token_value="never-issued",
+                requested_scope=None,
+            )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_client_mismatch_rejected():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+    # Second client registered under a different id — refresh must not cross.
+    other_id = "other-client"
+    await storage.store_client(
+        RegisteredClient(
+            client_id=other_id,
+            client_secret="other-secret",
+            redirect_uris=["https://example.com/cb"],
+            grant_types=["refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_basic",
+            client_name="Other",
+            created_at=time.time(),
+        )
+    )
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="offline_access")
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=other_id,
+                final_client_secret="other-secret",
+                refresh_token_value=issued.refresh_token,
+                requested_scope=None,
+            )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_refresh_scope_narrowing_allowed():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="read write offline_access")
+        refreshed = await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=issued.refresh_token,
+            requested_scope="read",
+        )
+
+    assert refreshed.scope == "read"
+
+
+@pytest.mark.asyncio
+async def test_refresh_scope_broadening_rejected():
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="read offline_access")
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+                refresh_token_value=issued.refresh_token,
+                requested_scope="read write admin",
+            )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail["error"] == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_confidential_client_without_secret_rejected():
+    """Refresh from a confidential client with no client authentication fails."""
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        issued = await _issue_via_auth_code(storage, scope="offline_access")
+        with pytest.raises(HTTPException) as excinfo:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=None,
+                refresh_token_value=issued.refresh_token,
+                requested_scope=None,
+            )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail["error"] == "invalid_client"
+
+
+# ===========================================================================
+# Public client (PKCE) path — no client secret required on refresh
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_public_client_refresh_without_secret():
+    """Public clients authenticate via the rotating refresh token itself."""
+    storage = MemoryOAuthStorage()
+    await _register_public_client(storage)
+
+    # For this unit test we bypass PKCE on the issuance side by pre-seeding
+    # a refresh token directly — the surface under test is the refresh grant.
+    rt, _ = None, None
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        rt, _ = await create_refresh_token(
+            client_id=PUBLIC_CLIENT_ID,
+            scope="read offline_access",
+        )
+        refreshed = await _handle_refresh_token_grant(
+            final_client_id=None,
+            final_client_secret=None,
+            refresh_token_value=rt,
+            requested_scope=None,
+        )
+
+    assert refreshed.access_token
+    assert refreshed.refresh_token is not None
+    assert refreshed.refresh_token != rt
+
+
+# ===========================================================================
+# Discovery advertises refresh_token and offline_access
+# ===========================================================================
+
+
+def _discovery_client() -> TestClient:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(discovery_router)
+    return TestClient(app)
+
+
+def test_discovery_advertises_refresh_token_grant():
+    client = _discovery_client()
+    response = client.get("/.well-known/oauth-authorization-server/mcp")
+    assert response.status_code == 200
+    body = response.json()
+    assert "refresh_token" in body["grant_types_supported"]
+
+
+def test_discovery_advertises_offline_access_scope():
+    client = _discovery_client()
+    response = client.get("/.well-known/oauth-authorization-server/mcp")
+    assert response.status_code == 200
+    body = response.json()
+    assert "offline_access" in body["scopes_supported"]
+
+
+def test_protected_resource_metadata_advertises_offline_access():
+    client = _discovery_client()
+    response = client.get("/.well-known/oauth-protected-resource")
+    assert response.status_code == 200
+    body = response.json()
+    assert "offline_access" in body["scopes_supported"]

--- a/tests/unit/test_oauth_refresh.py
+++ b/tests/unit/test_oauth_refresh.py
@@ -401,7 +401,7 @@ async def test_public_client_refresh_without_secret():
             scope="read offline_access",
         )
         refreshed = await _handle_refresh_token_grant(
-            final_client_id=None,
+            final_client_id=PUBLIC_CLIENT_ID,
             final_client_secret=None,
             refresh_token_value=rt,
             requested_scope=None,
@@ -447,3 +447,103 @@ def test_protected_resource_metadata_advertises_offline_access():
     assert response.status_code == 200
     body = response.json()
     assert "offline_access" in body["scopes_supported"]
+
+
+# ===========================================================================
+# Review feedback regression — chain revoke + public client client_id
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_replay_revokes_chain():
+    """
+    OAuth 2.1 §4.3.1: replay of an already-revoked refresh token signals
+    possible compromise. The server cannot tell the legitimate client from
+    an attacker, so it MUST revoke every other live token in the rotation
+    chain (compromise mitigation).
+    """
+    storage = MemoryOAuthStorage()
+    await _register_confidential_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        # Issue an initial refresh token (R0).
+        first = await _issue_via_auth_code(storage, scope="read offline_access")
+        r0 = first.refresh_token
+        assert r0 is not None
+
+        # Rotate once (R0 -> R1).
+        second = await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=r0,
+            requested_scope=None,
+        )
+        r1 = second.refresh_token
+        assert r1 is not None and r1 != r0
+
+        # Rotate again (R1 -> R2). R2 is the only live token at this point.
+        third = await _handle_refresh_token_grant(
+            final_client_id=CONFIDENTIAL_CLIENT_ID,
+            final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+            refresh_token_value=r1,
+            requested_scope=None,
+        )
+        r2 = third.refresh_token
+        assert r2 is not None
+
+        # Sanity: R2 should still be live before the replay.
+        assert await storage.get_refresh_token(r2) is not None
+
+        # Replay R0 (already revoked by the first rotation).
+        with pytest.raises(HTTPException) as exc_info:
+            await _handle_refresh_token_grant(
+                final_client_id=CONFIDENTIAL_CLIENT_ID,
+                final_client_secret=CONFIDENTIAL_CLIENT_SECRET,
+                refresh_token_value=r0,
+                requested_scope=None,
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "invalid_grant"
+
+        # The live descendant R2 must now also be revoked
+        # (chain-wide revocation triggered by the replay).
+        assert await storage.get_refresh_token(r2) is None
+
+
+@pytest.mark.asyncio
+async def test_public_client_must_send_client_id():
+    """
+    RFC 6749 §6: refresh requests MUST include client_id when the client
+    is not authenticating (public clients). The token's internal binding
+    is not a substitute for the explicit parameter.
+    """
+    storage = MemoryOAuthStorage()
+    await _register_public_client(storage)
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ):
+        # Bypass PKCE on issuance — we are testing the refresh grant surface.
+        refresh_token, _ = await create_refresh_token(
+            client_id=PUBLIC_CLIENT_ID,
+            scope="read offline_access",
+        )
+        assert refresh_token is not None
+
+        # Public client omitting client_id — should be rejected with
+        # invalid_request / 400.
+        with pytest.raises(HTTPException) as exc_info:
+            await _handle_refresh_token_grant(
+                final_client_id=None,
+                final_client_secret=None,
+                refresh_token_value=refresh_token,
+                requested_scope=None,
+            )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "invalid_request"
+        assert "client_id" in exc_info.value.detail["error_description"]
+

--- a/tests/unit/test_oauth_storage_backends.py
+++ b/tests/unit/test_oauth_storage_backends.py
@@ -256,6 +256,9 @@ class TestOAuthStorageBackends:
         await storage.store_access_token(
             token="valid_token", client_id="client_1", expires_in=3600
         )
+        await storage.store_refresh_token(
+            token="valid_refresh", client_id="client_1", expires_in=3600
+        )
 
         # Store expired code and token
         await storage.store_authorization_code(
@@ -263,6 +266,9 @@ class TestOAuthStorageBackends:
         )
         await storage.store_access_token(
             token="expired_token", client_id="client_1", expires_in=1
+        )
+        await storage.store_refresh_token(
+            token="expired_refresh", client_id="client_1", expires_in=1
         )
 
         # Wait for expiration
@@ -274,8 +280,10 @@ class TestOAuthStorageBackends:
         # Verify cleanup results
         assert "expired_codes_cleaned" in result
         assert "expired_tokens_cleaned" in result
+        assert "expired_refresh_tokens_cleaned" in result
         assert result["expired_codes_cleaned"] >= 1
         assert result["expired_tokens_cleaned"] >= 1
+        assert result["expired_refresh_tokens_cleaned"] >= 1
 
         # Verify valid items still exist
         valid_code = await storage.get_authorization_code("valid_code")
@@ -284,12 +292,18 @@ class TestOAuthStorageBackends:
         valid_token = await storage.get_access_token("valid_token")
         assert valid_token is not None
 
+        valid_refresh = await storage.get_refresh_token("valid_refresh")
+        assert valid_refresh is not None
+
         # Verify expired items were cleaned
         expired_code = await storage.get_authorization_code("expired_code")
         assert expired_code is None
 
         expired_token = await storage.get_access_token("expired_token")
         assert expired_token is None
+
+        expired_refresh = await storage.get_refresh_token("expired_refresh")
+        assert expired_refresh is None
 
     @pytest.mark.asyncio
     async def test_get_client_not_found(self, storage):
@@ -364,6 +378,99 @@ class TestOAuthStorageBackends:
         assert len(failed) == 9, f"Expected 9 failures, got {len(failed)}"
         assert successful[0]["client_id"] == "client_1"
 
+    # -------------------- refresh token storage --------------------
+
+    @pytest.mark.asyncio
+    async def test_store_and_get_refresh_token(self, storage):
+        """Refresh tokens round-trip through storage with all fields preserved."""
+        await storage.store_refresh_token(
+            token="rt_basic",
+            client_id="client_1",
+            scope="read write offline_access",
+            expires_in=3600,
+        )
+
+        data = await storage.get_refresh_token("rt_basic")
+        assert data is not None
+        assert data["client_id"] == "client_1"
+        assert data["scope"] == "read write offline_access"
+        assert data["expires_at"] > time.time()
+        assert data["parent_token"] is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_expiration(self, storage):
+        """Expired refresh tokens must not be returned."""
+        await storage.store_refresh_token(
+            token="rt_expired", client_id="client_1", expires_in=1
+        )
+        await asyncio.sleep(1.1)
+        assert await storage.get_refresh_token("rt_expired") is None
+
+    @pytest.mark.asyncio
+    async def test_revoke_refresh_token(self, storage):
+        """Revocation must block subsequent lookups and idempotently return False."""
+        await storage.store_refresh_token(
+            token="rt_rev", client_id="client_1", expires_in=3600
+        )
+        assert await storage.get_refresh_token("rt_rev") is not None
+
+        assert await storage.revoke_refresh_token("rt_rev") is True
+        assert await storage.get_refresh_token("rt_rev") is None
+
+        # Re-revocation: already revoked, so returns False (not a live token)
+        assert await storage.revoke_refresh_token("rt_rev") is False
+
+        # Unknown token
+        assert await storage.revoke_refresh_token("rt_unknown") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_refresh_token(self, storage):
+        """Delete removes the record outright (no audit trail retained)."""
+        await storage.store_refresh_token(
+            token="rt_del", client_id="client_1", expires_in=3600
+        )
+        assert await storage.delete_refresh_token("rt_del") is True
+        assert await storage.delete_refresh_token("rt_del") is False
+        assert await storage.get_refresh_token("rt_del") is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_rotation_chain(self, storage):
+        """parent_token records the rotation predecessor."""
+        await storage.store_refresh_token(
+            token="rt_v1", client_id="client_1", expires_in=3600
+        )
+        await storage.store_refresh_token(
+            token="rt_v2",
+            client_id="client_1",
+            expires_in=3600,
+            parent_token="rt_v1",
+        )
+
+        data = await storage.get_refresh_token("rt_v2")
+        assert data is not None
+        assert data["parent_token"] == "rt_v1"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_refresh_token_revocation(self, storage):
+        """
+        Concurrent revocations of the same refresh token yield exactly one winner.
+
+        Mirrors the authorization-code replay guard: rotation must be serialized
+        so that two refresh requests cannot both succeed against the same token.
+        """
+        if isinstance(storage, MemoryOAuthStorage):
+            pytest.skip("Memory backend has a single-asyncio-lock; no race exposure")
+
+        await storage.store_refresh_token(
+            token="rt_race", client_id="client_1", expires_in=3600
+        )
+
+        tasks = [storage.revoke_refresh_token("rt_race") for _ in range(10)]
+        results = await asyncio.gather(*tasks)
+
+        assert sum(1 for r in results if r is True) == 1
+        assert sum(1 for r in results if r is False) == 9
+
 
 class TestSQLiteSpecific:
     """SQLite-specific tests (persistence, multi-process)."""
@@ -412,8 +519,23 @@ class TestSQLiteSpecific:
             assert retrieved_token is not None
             assert retrieved_token["client_id"] == "persist_test"
 
-            # Cleanup
+            # Store a refresh token, reopen, verify persistence
+            await storage2.store_refresh_token(
+                token="persist_refresh",
+                client_id="persist_test",
+                scope="offline_access",
+                expires_in=3600,
+            )
             await storage2.close()
+
+            storage3 = create_oauth_storage("sqlite", db_path=db_path)
+            retrieved_refresh = await storage3.get_refresh_token("persist_refresh")
+            assert retrieved_refresh is not None
+            assert retrieved_refresh["client_id"] == "persist_test"
+            assert retrieved_refresh["scope"] == "offline_access"
+
+            # Cleanup
+            await storage3.close()
 
         finally:
             if os.path.exists(db_path):


### PR DESCRIPTION
# Pull Request

## Description

Implements `refresh_token` grant per OAuth 2.1 §6 and MCP SEP-2207, gated
by the `offline_access` scope.

## Motivation

`refresh_token` is currently advertised in `supported_grant_types`
(`registration.py:175`) but the actual issuance / storage / validation
logic is missing. As a result, clients are forced through full
re-authentication every time the access token expires (default 1h).

This PR closes that gap as an opt-in feature: clients that don't request
`offline_access` get exactly the same response shape as today, so
existing integrations are unaffected.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] 🧪 Test improvement

## Changes

- **Storage layer** (`config.py`, `oauth/storage/{base,memory,sqlite}.py`):
  4 abstract methods (`store/get/revoke/delete_refresh_token`), with
  parity between memory and sqlite backends. SQLite uses additive schema
  (`CREATE TABLE IF NOT EXISTS`), no `ALTER` required.
- **Grant flow** (`oauth/authorization.py`, `oauth/discovery.py`,
  `oauth/models.py`): new `_handle_refresh_token_grant`, atomic rotation
  on every refresh, scope narrowing allowed / broadening rejected.
  Discovery now advertises `refresh_token` grant + `offline_access` scope.
- **Tests**: `tests/unit/test_oauth_refresh.py` (15 tests covering
  issuance, rotation, replay detection, scope rules, public/confidential
  client paths). `test_oauth_storage_backends.py` extended with refresh
  storage parity + concurrent revocation race test.
- **Docs**: `docs/oauth-setup.md` env var table + new "Refresh Tokens"
  section + rotation contract. `README.md` updated to remove the
  "refresh tokens not yet supported" note.

**Breaking Changes** (if any): None. `TokenResponse.refresh_token` is
`Optional[str] = None`; clients that don't request `offline_access` get
the same response shape as before.

## Testing

### How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

72 OAuth unit tests pass locally (storage 46 + refresh 15 + native
clients + DCR 11).

End-to-end verified on a production deployment (Fly.io, sqlite backend):
- Discovery endpoint advertises `refresh_token` + `offline_access`
- Real client (Claude.ai) requested `offline_access` → refresh_token
  issued and persisted (DB row counts after one tool call:
  refresh=1, clients=1, access=1)
- Rotation behavior verified at the access-token TTL boundary: tool
  call past the 1h mark succeeded via refresh, with no browser
  re-authentication

**Test Configuration**:
- Python version: 3.10 (production runtime), 3.14 (local dev)
- OS: Debian (production container), Fedora 43 (local)
- Storage backend: sqlite_vec (memory), sqlite (oauth)
- Installation method: source / Fly.io Docker deployment

### Test Coverage

- [x] Added new tests
- [x] Updated existing tests
- [x] Test coverage maintained/improved

## Related Issues

Relates to MCP SEP-2207 (`offline_access` scope, refresh token rotation).

No existing issue tracking this gap — happy to open one if preferred.

## Documentation

- [x] Updated README.md
- [x] Updated CHANGELOG.md (under [Unreleased])
- [x] Updated code comments/docstrings
- [x] Added API documentation (oauth-setup.md)

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [x] ✅ I have commented my code, particularly in hard-to-understand areas
- [x] ✅ I have made corresponding changes to the documentation
- [x] ✅ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [x] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

Configuration knobs added:

| Env var | Default | Notes |
|---|---|---|
| `MCP_OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` | 60 | Existing var, behavior unchanged |
| `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS` | 30 | New, range 1-365 |
| `MCP_OAUTH_STORAGE_BACKEND` | `memory` | `sqlite` recommended for production |
| `MCP_OAUTH_SQLITE_PATH` | — | Path to oauth.db when using sqlite backend |

Refresh tokens are opaque (DB-backed), not JWT — revocation is required
for rotation, which JWTs can't do statelessly. Access tokens remain JWT.

AI tooling (Claude Code) was used to draft and review this change,
consistent with how the project's recent releases are tagged.

Happy to split this into smaller PRs (storage / grant / tests / docs) if
that's preferred for review.