### PR TITLE
chore: release v10.40.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **[#759] Test isolation: `test_graph_service.py` no longer pollutes `sys.modules`**: The lightweight stub used to import `GraphService` without heavy dependencies previously replaced `mcp_memory_service.storage.graph` unconditionally at module-import time. This caused cascading `TypeError: _StubGraphStorage() takes no arguments` failures in `tests/test_graph_traversal.py` and `tests/web/api/test_analytics_graph.py` whenever `test_graph_service.py` was collected first. The stub is now only installed if the real module fails to import, preserving isolation in CI where dependencies are available.
 - **[#759] Removed unused `List` import in `graph_service.py`**: CodeQL alert #391 (unused import).
 
+## [10.40.4] - 2026-04-28
+
+### Fixed
+
+- **[#764] quality: ONNX cross-encoder scalar logits no longer silently return 0.5 placeholder score**: The cross-encoder scoring path in `ONNXRankerModel.rerank()` assumed logits always had shape `(N,)`, but the ONNX model can output shape `(1, 1)` for a single-pair input, causing a `TypeError` when indexing with `[i]`. The outer `except Exception` handler swallowed the error and fell back to a neutral 0.5, making quality-boosted search silently rank all results equal. The fix squeezes the logit tensor to 1-D before indexing, making the scorer shape-agnostic. Thanks to @thewusman2025 for the root-cause analysis and patch. (PR #765)
+
 ## [10.40.3] - 2026-04-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.40.3 - fix(claude-hooks): eliminate socket hang-up and raise hook timeout — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.40.4 - fix(quality): handle shape (1, 1) cross-encoder logits in ONNX ranker — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -437,19 +437,19 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.40.3** (April 24, 2026)
+## Latest Release: **v10.40.4** (April 28, 2026)
 
-**fix(claude-hooks): eliminate socket hang-up and raise hook timeout**
+**fix(quality): handle shape (1, 1) cross-encoder logits in ONNX ranker**
 
 **What's New:**
-- **Socket hang-up eliminated**: Node.js HTTPS agent `keepAlive` caused dead-socket reuse across multi-phase retrieval — hook silently dropped memories. Fixed with `agent: false` + `Connection: close` on all HTTP paths.
-- **Hook timeout raised 9.5 s → 28 s**: Multi-phase retrieval (git + recent + tagged) takes 12–15 s cold; old budget expired before the injection block was written. Claude Code VSCode extension now reliably shows the memory-context block.
-- **Installer outer timeout raised 10 s → 30 s**: `~/.claude/settings.json` kill limit now matches the new internal budget.
+- **Quality scorer shape-agnostic**: ONNX cross-encoder outputs `(1, 1)` logits for single-pair inputs, causing a `TypeError` silently caught by the outer handler — every result returned 0.5 quality score, breaking quality-boosted search ranking. Fixed by squeezing logit tensor to 1-D before indexing.
 - **1,675 Python tests** passing.
+- Thanks to @thewusman2025 for root-cause analysis and the patch.
 
 ---
 
 **Previous Releases**:
+- **v10.40.3** - fix(claude-hooks): eliminate socket hang-up and raise hook timeout (PR #761)
 - **v10.40.2** - fix(docker): correct invalid Python one-liner in ONNX pre-download (PR #757)
 - **v10.40.1** - fix(sync): CF hybrid sync reliability + reporting accuracy (PRs #751, #753)
 - **v10.40.0** - feat: Milvus storage backend (Lite / self-hosted / Zilliz Cloud), OAuth XSS hardening, plugin shape validation (PRs #721, #745, #740)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.40.3"
+version = "10.40.4"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.40.3"
+__version__ = "10.40.4"

--- a/src/mcp_memory_service/quality/onnx_ranker.py
+++ b/src/mcp_memory_service/quality/onnx_ranker.py
@@ -404,8 +404,11 @@ class ONNXRankerModel:
                 score = float(np.dot(probs, class_values))
 
             elif self.model_config['type'] == 'cross-encoder':
-                # MS-MARCO: Binary classification with sigmoid
-                logit = float(logits[0] if len(logits.shape) > 0 and logits.shape[0] > 1 else logits)
+                # MS-MARCO: Binary classification with sigmoid.
+                # ORT may return shape (1,), (1, 1), or scalar — flatten to be shape-agnostic
+                # (issue #764: shape (1, 1) previously raised TypeError, swallowed to 0.5 placeholder).
+                logits_arr = np.asarray(logits)
+                logit = float(logits_arr.reshape(-1)[0])
                 score = 1.0 / (1.0 + np.exp(-logit))
 
             return np.clip(score, 0.0, 1.0)

--- a/tests/test_lightweight_onnx.py
+++ b/tests/test_lightweight_onnx.py
@@ -263,6 +263,58 @@ class TestLightweightONNXSetup:
                 call_args = mock_tokenizer.encode.call_args
                 assert call_args is not None, "Tokenizer should have been called"
 
+    @pytest.mark.parametrize("logits_output,expected_logit", [
+        (np.array([[1.5]]), 1.5),       # Shape (1, 1) — the bug from issue #764
+        (np.array([1.5]), 1.5),         # Shape (1,) — historical path
+        (np.array([[-0.7]]), -0.7),     # Shape (1, 1), negative logit
+        (np.array([[[2.0]]]), 2.0),     # Shape (1, 1, 1), defensive
+    ])
+    def test_cross_encoder_scalar_extraction_shape_agnostic(self, logits_output, expected_logit):
+        """Regression test for issue #764: cross-encoder must handle (1, 1) logits.
+
+        Previously, ``float(logits)`` on a non-zero-dim ndarray raised TypeError, which
+        was swallowed by the outer handler and pinned every score to 0.5. This test
+        exercises the scalar extraction path directly with multiple shapes.
+        """
+        from mcp_memory_service.quality.onnx_ranker import ONNXRankerModel
+
+        # Bypass heavy __init__; we only need to drive score_quality()
+        ranker = ONNXRankerModel.__new__(ONNXRankerModel)
+        ranker.model_name = 'ms-marco-cross-encoder'
+        ranker.model_config = {
+            'name': 'ms-marco-cross-encoder',
+            'type': 'cross-encoder',
+            'repo': 'cross-encoder/ms-marco-MiniLM-L-6-v2',
+            'onnx_file': 'model.onnx',
+        }
+        ranker._use_fast_tokenizer = True
+
+        # Tokenizer mock for cross-encoder pair encoding
+        mock_encoded = Mock()
+        mock_encoded.ids = [0] * 8
+        mock_encoded.attention_mask = [1] * 8
+        mock_encoded.type_ids = [0] * 8
+        mock_tokenizer = Mock()
+        mock_tokenizer.encode.return_value = mock_encoded
+        mock_tokenizer.enable_truncation = Mock()
+        mock_tokenizer.enable_padding = Mock()
+        ranker._tokenizer = mock_tokenizer
+
+        # ORT session returns the parametrized shape
+        mock_model = Mock()
+        mock_model.run.return_value = [logits_output]
+        ranker._model = mock_model
+
+        score = ranker.score_quality(query="q", memory_content="doc")
+
+        # Score must be the sigmoid of the embedded logit, NOT the 0.5 placeholder
+        expected_score = 1.0 / (1.0 + np.exp(-expected_logit))
+        assert 0.0 <= score <= 1.0
+        assert abs(score - expected_score) < 1e-6, (
+            f"Expected sigmoid({expected_logit})={expected_score:.4f}, got {score:.4f}. "
+            "If this is 0.5, the (1,1) shape regression has returned."
+        )
+
     @pytest.mark.xfail(reason="Needs refactoring: mock storage doesn't properly simulate real storage behavior. Rewrite to use actual test storage.")
     @pytest.mark.asyncio
     async def test_auto_quality_scoring_after_store(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.40.3"
+version = "10.40.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to 10.40.4 in `pyproject.toml`, `_version.py`, `uv.lock`
- Add CHANGELOG entry for [10.40.4] - 2026-04-28
- Update README Latest Release section; add v10.40.3 to Previous Releases
- Update CLAUDE.md version callout

## Fix included (cherry-picked from PR branch)

**fix(quality): ONNX cross-encoder scalar logits no longer silently return 0.5 placeholder** — resolves #764

The cross-encoder in `ONNXRankerModel.rerank()` assumed logit shape `(N,)`, but ONNX outputs `(1, 1)` for single-pair inputs. The `TypeError` was swallowed by the outer `except`, returning a neutral 0.5 for every result and breaking quality-boosted search ranking. Fix squeezes tensor to 1-D before indexing.

Special thanks to @thewusman2025 for root-cause analysis and the patch. (PR #765)

## Test plan

- [ ] CI green on this branch
- [ ] No landing-page update needed (PATCH release)