### PR TITLE
chore: release v10.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.41.0] - 2026-04-28
+
 ### Added
 
+- **[#766] OAuth 2.1 `refresh_token` grant with rotation (MCP SEP-2207)**: Clients that include the `offline_access` scope in their authorization request now receive a refresh token alongside the access token (RFC 6749 §6, OAuth 2.1 §4.3.1). Every successful refresh issues a new access token AND a rotated refresh token while atomically revoking the presented one, preventing replay attacks. Replay detection walks the full `parent_token` chain to the root and bulk-revokes all descendant tokens in a single `UPDATE`, ensuring a stolen token cannot be reused even after the legitimate client has already rotated past it. Discovery (`/.well-known/oauth-authorization-server`) now advertises `refresh_token` in `grant_types_supported` and `offline_access` in `scopes_supported`. Both the Memory and SQLite OAuth storage backends implement the new contract; the SQLite backend uses additive schema changes only (no destructive `ALTER TABLE`). New env vars: `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS` (default 30, range 1–365). Clients that do not request `offline_access` receive the same response shape as before — zero breaking changes. 17 new unit tests in `tests/unit/test_oauth_refresh.py`; storage parity tests extended in `tests/unit/test_oauth_storage_backends.py`. Documentation updated: `docs/oauth-setup.md`, `README.md`. Thanks to @netizen1119 for the contribution. (PR #766)
 - **[#759] `memory_graph` tool for streamable-http MCP server**: Knowledge graph operations (find connected memories, shortest path, subgraph extraction) are now available in the FastMCP streamable-http server, matching the capabilities already present in stdio mode. Introduces a shared `GraphService` business-logic layer under `src/mcp_memory_service/services/graph_service.py` so both server variants reuse the same traversal + error-handling code paths. Graph operations require `sqlite_vec` or `hybrid` storage backends; `milvus` and `cloudflare` backends return a structured unavailability error instead of crashing. 14 unit tests for `GraphService`. Thanks to @henry201605 for the contribution. (PR #759)
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.40.4 - fix(quality): handle shape (1, 1) cross-encoder logits in ONNX ranker — 1,675 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.41.0 - feat(oauth): refresh_token grant with rotation (SEP-2207, PR #766, @netizen1119) — 1,692 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -437,18 +437,21 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 ---
 
 
-## Latest Release: **v10.40.4** (April 28, 2026)
+## Latest Release: **v10.41.0** (April 28, 2026)
 
-**fix(quality): handle shape (1, 1) cross-encoder logits in ONNX ranker**
+**feat(oauth): OAuth 2.1 refresh_token grant with rotation (MCP SEP-2207)**
 
 **What's New:**
-- **Quality scorer shape-agnostic**: ONNX cross-encoder outputs `(1, 1)` logits for single-pair inputs, causing a `TypeError` silently caught by the outer handler — every result returned 0.5 quality score, breaking quality-boosted search ranking. Fixed by squeezing logit tensor to 1-D before indexing.
-- **1,675 Python tests** passing.
-- Thanks to @thewusman2025 for root-cause analysis and the patch.
+- **OAuth refresh tokens**: Clients requesting `offline_access` scope receive a refresh token with atomic rotation — every refresh issues a new token and revokes the old one, with full chain revocation on replay detection. (PR #766, @netizen1119)
+- **`memory_graph` tool on streamable-http server**: Knowledge graph queries (connected memories, shortest path, subgraph) now work in the FastMCP streamable-http transport, matching stdio parity. (PR #759, @henry201605)
+- **New env var**: `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS` (default 30, range 1–365). Zero breaking changes.
+- **1,692 Python tests** passing.
+- Special thanks to @netizen1119 for the OAuth refresh token implementation.
 
 ---
 
 **Previous Releases**:
+- **v10.40.4** - fix(quality): handle shape (1, 1) cross-encoder logits in ONNX ranker (PR #765)
 - **v10.40.3** - fix(claude-hooks): eliminate socket hang-up and raise hook timeout (PR #761)
 - **v10.40.2** - fix(docker): correct invalid Python one-liner in ONNX pre-download (PR #757)
 - **v10.40.1** - fix(sync): CF hybrid sync reliability + reporting accuracy (PRs #751, #753)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.40 — Semantic Memory Layer for AI Applications</title>
+<title>MCP Memory Service v10.41 — Semantic Memory Layer for AI Applications</title>
 <meta name="description" content="Semantic memory layer for AI applications. REST API + MCP transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, self-hosted, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.40">
-<meta property="og:description" content="New Milvus backend: Lite, self-hosted, and Zilliz Cloud — three deployment modes from one code path. Streamable HTTP + OAuth 2.1 + PKCE. Verified with LongMemEval benchmark: R@5 80.4%, R@10 90.4% on 500 questions, zero LLM API calls.">
+<meta property="og:title" content="MCP Memory Service v10.41">
+<meta property="og:description" content="OAuth 2.1 refresh_token grant with rotation (MCP SEP-2207): offline_access scope, atomic token rotation, replay detection with chain revocation. Streamable HTTP + OAuth 2.1 + PKCE. Verified with LongMemEval benchmark: R@5 80.4%, R@10 90.4% on 500 questions, zero LLM API calls.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.40 &mdash; Now Available</span>
+  <span class="hero-badge">v10.41 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,18 +136,18 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.40</h2>
-    <p class="section-subtitle">New Milvus storage backend — three deployment modes from one code path: Milvus Lite, self-hosted Docker, and Zilliz Cloud. Plus OAuth security hardening and 1,675 tests.</p>
+    <h2 class="section-title">What's New in v10.41</h2>
+    <p class="section-subtitle">OAuth 2.1 refresh_token grant with atomic rotation (MCP SEP-2207) — plus knowledge graph on streamable-http. 1,692 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon http">&#128268;</div>
-        <h3>Milvus Backend — Lite Mode</h3>
-        <p>Zero-dependency local <code>.db</code> file via Milvus Lite. Ideal for scripts, CI, and single-user deployments. Set <code>MCP_MEMORY_STORAGE_BACKEND=milvus</code> and go. (PR #721, @zc277584121)</p>
+        <div class="feature-icon oauth">&#128260;</div>
+        <h3>OAuth Refresh Tokens (SEP-2207)</h3>
+        <p>Clients requesting <code>offline_access</code> scope receive a refresh token with atomic rotation. Every refresh issues a new token and revokes the old one. Replay detection walks the full token chain and bulk-revokes descendants. (PR #766, @netizen1119)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon oauth">&#128736;</div>
-        <h3>Milvus Backend — Self-Hosted &amp; Zilliz Cloud</h3>
-        <p>Same code path scales to self-hosted Docker (recommended for MCP servers) and Zilliz Cloud (managed, team/production). @zc277584121 committed to 6-month SLA on <code>backend:milvus</code> issues. (PR #721)</p>
+        <div class="feature-icon http">&#128268;</div>
+        <h3>Knowledge Graph on Streamable-HTTP</h3>
+        <p>The <code>memory_graph</code> tool (connected memories, shortest path, subgraph extraction) now works in the FastMCP streamable-http transport, matching stdio parity. Shared <code>GraphService</code> layer for both server variants. (PR #759, @henry201605)</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon privacy">&#128274;</div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1675">0</div>
+        <div class="stat-number" data-target="1692">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.40.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.41.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.40.4"
+version = "10.41.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.40.4"
+__version__ = "10.41.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.40.4"
+version = "10.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version to **v10.41.0** (MINOR — new OAuth 2.1 refresh_token feature)
- Updates `pyproject.toml`, `src/mcp_memory_service/_version.py`, `CLAUDE.md`, `CHANGELOG.md`, `README.md`, `docs/index.html`, `uv.lock`

## What's in this release

### Special Thanks
Huge thanks to @netizen1119 for the OAuth 2.1 refresh token implementation (PR #766) — a high-quality contribution covering both Memory and SQLite backends, 17 new tests, replay detection with chain revocation, and zero breaking changes.

### New Features (PR #766 — @netizen1119)
- OAuth 2.1 `refresh_token` grant gated by `offline_access` scope (RFC 6749 §6, OAuth 2.1 §4.3.1, MCP SEP-2207)
- Atomic rotation: every refresh issues new access + refresh tokens, revokes presented token
- Replay detection with full chain revocation (BFS descendants, single bulk UPDATE)
- Discovery advertises `refresh_token` in `grant_types_supported`, `offline_access` in `scopes_supported`
- Memory + SQLite backends both implement new contract; SQLite uses additive schema only
- New env var: `MCP_OAUTH_REFRESH_TOKEN_EXPIRE_DAYS` (default 30, range 1–365)
- 17 new unit tests; zero breaking changes

### New Features (PR #759 — @henry201605)
- `memory_graph` tool now available in FastMCP streamable-http transport
- Shared `GraphService` layer for stdio + streamable-http parity

## Test plan
- [ ] CI passes on this PR
- [ ] PyPI publish workflow triggers on tag push
- [ ] Landing page badge shows v10.41

🤖 Generated with [Claude Code](https://claude.com/claude-code)