### PR TITLE
feat(ci): weekly discussion triage workflow

### DIFF
--- a/.github/workflows/discussion-triage.yml
+++ b/.github/workflows/discussion-triage.yml
@@ -1,0 +1,38 @@
+name: Discussion Triage
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Print to logs only, do not update issue"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  discussions: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/maintenance/triage_discussions.py
+
+      - name: Run triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          ARGS=("--repo" "$REPO" "--issue")
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            ARGS+=("--dry-run")
+          fi
+          python3 scripts/maintenance/triage_discussions.py "${ARGS[@]}"

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -138,7 +138,10 @@ def upsert_triage_issue(repo: str, body: str, dry_run: bool) -> None:
 
     if existing:
         subprocess.run(
-            ["gh", "issue", "edit", str(existing), "--repo", repo, "--body", body],
+        subprocess.run(
+            ["gh", "issue", "edit", str(existing), "--repo", repo, "--body-file", "-"],
+            input=body,
+            text=True,
             check=True,
         )
         print(f"updated triage issue #{existing}")

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -95,17 +95,17 @@ def needs_response(d: dict, now: dt.datetime) -> tuple[bool, str]:
     return False, "recently active"
 
 
-def render_markdown(items: list[dict]) -> str:
+def render_markdown(items: list[tuple[dict, str]], now: dt.datetime) -> str:
     if not items:
         return (
             "_No discussions currently need a response._ Last triage: "
-            f"{dt.datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}\n"
+            f"{now.strftime('%Y-%m-%d %H:%M UTC')}\n"
         )
 
     lines = [
         f"# Discussions needing a response ({len(items)})",
         "",
-        f"_Last triage: {dt.datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}_",
+        f"_Last triage: {now.strftime('%Y-%m-%d %H:%M UTC')}_",
         "",
         "| # | Title | Category | Status |",
         "|---|-------|----------|--------|",

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -138,18 +138,15 @@ def upsert_triage_issue(repo: str, body: str, dry_run: bool) -> None:
 
     if existing:
         subprocess.run(
-        subprocess.run(
             ["gh", "issue", "edit", str(existing), "--repo", repo, "--body-file", "-"],
-            input=body,
-            text=True,
-            check=True,
+            input=body, text=True, check=True,
         )
         print(f"updated triage issue #{existing}")
     else:
         subprocess.run(
             ["gh", "issue", "create", "--repo", repo, "--title", TRIAGE_ISSUE_TITLE,
-             "--body", body, "--label", "triage,automated"],
-            check=True,
+             "--body-file", "-", "--label", "triage,automated"],
+            input=body, text=True, check=True,
         )
         print("created new triage issue")
 

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 from typing import Any
 
-REPO = "doobidoo/mcp-memory-service"
+REPO = os.getenv("GITHUB_REPOSITORY", "doobidoo/mcp-memory-service")
 MAINTAINERS = {"doobidoo", "henkr", "github-actions", "github-actions[bot]"}
 SKIP_CATEGORIES = {"Announcements"}
 STALE_DAYS = 7

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Triage GitHub Discussions needing maintainer responses.
+
+Filters discussions by:
+- Open + not locked + not in Announcements category
+- No accepted answer
+- Either zero comments OR last comment >= STALE_DAYS old AND last commenter not in MAINTAINERS
+
+Outputs Markdown for posting to a triage issue (--issue) or stdout (default).
+Designed to run from a GitHub Action with a GITHUB_TOKEN.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+REPO = "doobidoo/mcp-memory-service"
+MAINTAINERS = {"doobidoo", "henkr", "github-actions", "github-actions[bot]"}
+SKIP_CATEGORIES = {"Announcements"}
+STALE_DAYS = 7
+TRIAGE_ISSUE_TITLE = "[automated] Discussion triage — items needing a response"
+
+
+def gh_graphql(query: str, **variables: Any) -> dict:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for k, v in variables.items():
+        cmd += ["-F", f"{k}={v}"]
+    out = subprocess.run(cmd, check=True, capture_output=True, text=True).stdout
+    return json.loads(out)
+
+
+DISCUSSIONS_QUERY = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    discussions(first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number title url locked
+        category { name }
+        author { login }
+        answer { id }
+        createdAt updatedAt
+        comments(last: 1) {
+          totalCount
+          nodes { author { login } createdAt }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_all_discussions(owner: str, name: str) -> list[dict]:
+    discussions = []
+    cursor = None
+    while True:
+        data = gh_graphql(DISCUSSIONS_QUERY, owner=owner, name=name, cursor=cursor or "")
+        repo = data["data"]["repository"]["discussions"]
+        discussions.extend(repo["nodes"])
+        if not repo["pageInfo"]["hasNextPage"]:
+            return discussions
+        cursor = repo["pageInfo"]["endCursor"]
+
+
+def needs_response(d: dict, now: dt.datetime) -> tuple[bool, str]:
+    if d["locked"]:
+        return False, "locked"
+    if d["category"]["name"] in SKIP_CATEGORIES:
+        return False, "announcement"
+    if d.get("answer"):
+        return False, "answered"
+
+    comments = d["comments"]
+    total = comments["totalCount"]
+    if total == 0:
+        age_days = (now - dt.datetime.fromisoformat(d["createdAt"].replace("Z", "+00:00"))).days
+        if age_days >= STALE_DAYS:
+            return True, f"unanswered ({age_days}d old)"
+        return False, "fresh"
+
+    last = comments["nodes"][0]
+    last_author = (last["author"] or {}).get("login", "")
+    if last_author in MAINTAINERS:
+        return False, f"last reply from maintainer ({last_author})"
+
+    last_age = (now - dt.datetime.fromisoformat(last["createdAt"].replace("Z", "+00:00"))).days
+    if last_age >= STALE_DAYS:
+        return True, f"stale {last_age}d (last: @{last_author})"
+    return False, "recently active"
+
+
+def render_markdown(items: list[dict]) -> str:
+    if not items:
+        return (
+            "_No discussions currently need a response._ Last triage: "
+            f"{dt.datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}\n"
+        )
+
+    lines = [
+        f"# Discussions needing a response ({len(items)})",
+        "",
+        f"_Last triage: {dt.datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}_",
+        "",
+        "| # | Title | Category | Status |",
+        "|---|-------|----------|--------|",
+    ]
+    for d, reason in items:
+        title = d["title"].replace("|", r"\|")
+        lines.append(f"| [#{d['number']}]({d['url']}) | {title} | {d['category']['name']} | {reason} |")
+    lines += ["", "<!-- triage-bot:end -->"]
+    return "\n".join(lines)
+
+
+def find_triage_issue(repo: str) -> int | None:
+    out = subprocess.run(
+        ["gh", "issue", "list", "--repo", repo, "--search", TRIAGE_ISSUE_TITLE,
+         "--state", "open", "--json", "number,title", "--limit", "5"],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    for issue in json.loads(out):
+        if issue["title"] == TRIAGE_ISSUE_TITLE:
+            return issue["number"]
+    return None
+
+
+def upsert_triage_issue(repo: str, body: str, dry_run: bool) -> None:
+    existing = find_triage_issue(repo)
+    if dry_run:
+        print(f"[dry-run] would {'update' if existing else 'create'} triage issue", file=sys.stderr)
+        print(body)
+        return
+
+    if existing:
+        subprocess.run(
+            ["gh", "issue", "edit", str(existing), "--repo", repo, "--body", body],
+            check=True,
+        )
+        print(f"updated triage issue #{existing}")
+    else:
+        subprocess.run(
+            ["gh", "issue", "create", "--repo", repo, "--title", TRIAGE_ISSUE_TITLE,
+             "--body", body, "--label", "triage,automated"],
+            check=True,
+        )
+        print("created new triage issue")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=REPO)
+    ap.add_argument("--issue", action="store_true", help="Update/create triage issue")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    owner, name = args.repo.split("/", 1)
+    now = dt.datetime.now(dt.timezone.utc)
+    discussions = fetch_all_discussions(owner, name)
+
+    needing = []
+    for d in discussions:
+        ok, reason = needs_response(d, now)
+        if ok:
+            needing.append((d, reason))
+
+    body = render_markdown(needing)
+
+    if args.issue:
+        upsert_triage_issue(args.repo, body, args.dry_run)
+    else:
+        print(body)
+
+    print(f"\n[summary] {len(needing)} of {len(discussions)} discussions need attention", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maintenance/triage_discussions.py
+++ b/scripts/maintenance/triage_discussions.py
@@ -171,7 +171,7 @@ def main() -> int:
         if ok:
             needing.append((d, reason))
 
-    body = render_markdown(needing)
+    body = render_markdown(needing, now)
 
     if args.issue:
         upsert_triage_issue(args.repo, body, args.dry_run)


### PR DESCRIPTION
## Summary

Adds an automated GitHub Action that runs every Monday at 09:00 UTC and maintains a single triage issue listing GitHub Discussions needing a maintainer response.

**Filter heuristic:**
- Open + not locked + not in Announcements category
- No accepted answer
- Either zero comments AND ≥7d old, OR last comment ≥7d old AND last commenter is not a known maintainer

**Why an issue, not notifications:** the workflow upserts a single living issue so it doesn't spam — just a dashboard the maintainer can glance at.

## Local dry-run

```bash
python3 scripts/maintenance/triage_discussions.py --dry-run
```

Today's run flagged 7 of 25 discussions. Sample output:

| # | Title | Category | Status |
|---|-------|----------|--------|
| #652 | Knwler concentric ring graph | Ideas | unanswered (25d old) |
| #377 | ChatGPT + Cloudflare connector | Q&A | stale 30d (last: @omni-front) |
| #611 | File-based markdown memory | Show and tell | stale 34d |
| #330 | Memory hooks with Gemini CLI? | Q&A | stale 109d |
| #272 | Multiple memory DB instances | Ideas | unanswered (138d old) |
| #235 | Claude Code HTTP transport | Q&A | stale 158d |
| #105 | HTTP transport connection issues | Q&A | stale 207d |

## Configuration knobs

In `triage_discussions.py`:
- `STALE_DAYS = 7` — how old "last activity" needs to be
- `MAINTAINERS = {"doobidoo", "henkr", ...}` — extend with co-maintainers
- `SKIP_CATEGORIES = {"Announcements"}` — ignored categories

## Permissions

Workflow uses the default `GITHUB_TOKEN` with `issues: write` + `discussions: read` — no PAT needed.

## Test plan

- [x] Local dry-run succeeds and produces sensible output
- [ ] Trigger via `workflow_dispatch` with `dry-run=true` after merge to verify CI environment
- [ ] First scheduled run on Monday 09:00 UTC creates the triage issue
- [ ] Subsequent runs update the same issue (no duplicate creation)

## Follow-up

A separate scheduled drafting agent will read this triage issue and propose comment drafts for the maintainer to review — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)