### PR TITLE
chore(ci): ignore glama.ai in markdown link-check

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -44,6 +44,9 @@
     },
     {
       "pattern": "^https://docs\\.zilliz\\.com"
+    },
+    {
+      "pattern": "^https://glama\\.ai"
     }
   ],
   "aliveStatusCodes": [200, 206, 429]


### PR DESCRIPTION
## Summary

Add `glama.ai` to the `.mlc-config.json` ignore list. The host consistently times out (Status 0) in CI runs, causing flaky link-check failures unrelated to PR content.

Recent example: PR #786 link-check failed on `https://glama.ai/mcp/servers/bzvl3lz34o` even though no docs files in that PR were touched.

## Pattern

Same mitigation as [PR #741](https://github.com/doobidoo/mcp-memory-service/pull/741) for other flaky external hosts (freedesktop.org, sbert.net, milvus.io, etc.).

## Test plan

- [x] CI link-check passes after change
- [x] No legitimate broken links masked (glama.ai is only used as a directory listing reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)