### PR TITLE
feat(quality): add openai-compatible provider for LiteLLM/Ollama/MLX

### DIFF
--- a/.claude/directives/quality-system-details.md
+++ b/.claude/directives/quality-system-details.md
@@ -7,9 +7,15 @@
 ```bash
 # Quality System (Local-First Defaults)
 MCP_QUALITY_SYSTEM_ENABLED=true         # Default: enabled
-MCP_QUALITY_AI_PROVIDER=local           # local|groq|gemini|auto|none
+MCP_QUALITY_AI_PROVIDER=local           # local|openai-compatible|groq|gemini|auto|none
 MCP_QUALITY_LOCAL_MODEL=nvidia-quality-classifier-deberta  # Default v8.49.0+
 MCP_QUALITY_LOCAL_DEVICE=auto           # auto|cpu|cuda|mps|directml
+
+# OpenAI-compatible provider (homelab / self-hosted LLM — no cloud key required)
+# MCP_QUALITY_AI_PROVIDER=openai-compatible
+# MCP_QUALITY_AI_BASE_URL=http://localhost:11434/v1   # required
+# MCP_QUALITY_AI_MODEL=qwen2.5:7b-instruct            # required
+# MCP_QUALITY_AI_API_KEY=ollama                       # optional
 
 # Legacy model (backward compatible, not recommended)
 # MCP_QUALITY_LOCAL_MODEL=ms-marco-MiniLM-L-6-v2

--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,27 @@ MCP_SEMANTIC_DEDUP_THRESHOLD=0.85            # Similarity threshold 0.0-1.0 (def
 # MCP_QUALITY_MIN_GPU_BATCH=16          # Min batch size for GPU batched inference (default: 16)
 #                                       # Below this threshold, uses sequential GPU calls (faster for small batches)
 
+# Quality System - OpenAI-Compatible Provider (homelab / self-hosted LLM)
+# Point scoring at any OpenAI-compatible /v1/chat/completions endpoint:
+# LiteLLM proxy, Ollama, vLLM, MLX-LM server, or any OpenAI-shim.
+# Required when MCP_QUALITY_AI_PROVIDER=openai-compatible
+#
+# MCP_QUALITY_AI_PROVIDER=openai-compatible
+# MCP_QUALITY_AI_BASE_URL=http://localhost:11434/v1   # Ollama default
+# MCP_QUALITY_AI_MODEL=qwen2.5:7b-instruct            # Recommended: Ollama
+# MCP_QUALITY_AI_API_KEY=ollama                       # Optional; use "ollama" for Ollama, omit for local stacks
+#
+# Recommended models by runtime:
+#   Apple Silicon / MLX:  mlx-community/Qwen2.5-7B-Instruct-4bit
+#   Ollama:               qwen2.5:7b-instruct  |  llama3.1:8b  |  mistral-small:24b
+#   LiteLLM proxy:        set MCP_QUALITY_AI_BASE_URL=http://litellm:4000/v1, model=your-alias
+#   vLLM:                 set MCP_QUALITY_AI_BASE_URL=http://vllm:8000/v1, model=<served-model-id>
+#
+# Notes:
+#   - Avoid base (non-instruct) models, sub-3B models, and reasoning models (QwQ, etc.)
+#   - Scoring uses max_tokens=50, temperature=0.1; the model must return a bare float
+#   - On endpoint failure the tier falls back to implicit_signals automatically
+
 # HTTP Interface (Web Dashboard)
 # NOTE: The HTTP dashboard is a SEPARATE server from the MCP server.
 # To start the dashboard: uv run python scripts/server/run_http_server.py

--- a/README.md
+++ b/README.md
@@ -423,6 +423,18 @@ Export memories from mcp-memory-service → Import to shodh-cloudflare → Sync 
 🔒 **Privacy-First** – Local-first, you control your data
 📊 **Web Dashboard** – Visualize and manage memories at `http://localhost:8000`
 🧬 **Knowledge Graph** – Interactive D3.js visualization of memory relationships 🆕
+🏠 **Homelab Quality Scoring** – Point scoring at any OpenAI-compatible endpoint (Ollama, LiteLLM, vLLM) 🆕
+
+**Homelab / self-hosted quality scoring** (v10.45.0+): set `MCP_QUALITY_AI_PROVIDER=openai-compatible` to score memories with your local LLM instead of ONNX or a cloud API:
+
+```bash
+MCP_QUALITY_AI_PROVIDER=openai-compatible
+MCP_QUALITY_AI_BASE_URL=http://localhost:11434/v1   # Ollama
+MCP_QUALITY_AI_MODEL=qwen2.5:7b-instruct
+# MCP_QUALITY_AI_API_KEY=ollama                     # optional
+```
+
+Recommended models: `qwen2.5:7b-instruct` (Ollama), `mlx-community/Qwen2.5-7B-Instruct-4bit` (MLX), or any instruct model via LiteLLM proxy. On endpoint failure, scoring falls back to implicit signals automatically.
 
 ### 🖥️ Dashboard Preview (v9.3.0)
 

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -6,6 +6,7 @@ Coordinates between local SLM, Groq, Gemini, and implicit signals.
 import asyncio
 import logging
 from typing import List, Optional
+import httpx
 from .config import QualityConfig
 from .onnx_ranker import get_onnx_ranker_model, ONNXRankerModel
 from .implicit_signals import ImplicitSignalsEvaluator
@@ -17,7 +18,7 @@ logger = logging.getLogger(__name__)
 class QualityEvaluator:
     """
     Multi-tier AI quality evaluator with fallback chain.
-    Tries: Local ONNX → Groq → Gemini → Implicit Signals
+    Tries: Local ONNX → OpenAI-compatible → Groq → Gemini → Implicit Signals
     """
 
     def __init__(self, config: Optional[QualityConfig] = None):
@@ -161,7 +162,17 @@ class QualityEvaluator:
             else:
                 score = None
 
-        # Tier 2: Groq API (if available and ONNX failed or in auto mode)
+        # Tier 2: OpenAI-compatible endpoint (if configured)
+        if score is None and self.config.can_use_openai_compatible:
+            try:
+                score = await self._score_with_openai_compatible(query, memory)
+                provider_used = 'openai_compatible'
+                logger.debug(f"OpenAI-compatible score: {score:.3f}")
+            except Exception as e:
+                logger.warning(f"OpenAI-compatible scoring failed: {e}")
+                score = None
+
+        # Tier 3: Groq API (if available and ONNX failed or in auto mode)
         if score is None and self.config.can_use_groq and self._groq_bridge:
             try:
                 score = await self._score_with_groq(query, memory)
@@ -171,7 +182,7 @@ class QualityEvaluator:
                 logger.warning(f"Groq scoring failed: {e}")
                 score = None
 
-        # Tier 3: Gemini API (if available and previous tiers failed)
+        # Tier 4: Gemini API (if available and previous tiers failed)
         if score is None and self.config.can_use_gemini:
             try:
                 score = await self._score_with_gemini(query, memory)
@@ -181,7 +192,7 @@ class QualityEvaluator:
                 logger.warning(f"Gemini scoring failed: {e}")
                 score = None
 
-        # Tier 4: Implicit signals (always available as fallback)
+        # Tier 5: Implicit signals (always available as fallback)
         if score is None:
             score = self._implicit_evaluator.evaluate_quality(memory, query)
             provider_used = 'implicit_signals'
@@ -288,6 +299,77 @@ class QualityEvaluator:
             memory.metadata['quality_provider'] = 'fallback_deberta-msmarco'
 
         return final_scores
+
+    async def _score_with_openai_compatible(self, query: str, memory: Memory) -> float:
+        """
+        Score quality using any OpenAI-compatible /v1/chat/completions endpoint.
+
+        Works with LiteLLM proxy, Ollama, vLLM, MLX-LM server, or any server
+        that implements the OpenAI chat completions API shape.
+
+        Args:
+            query: Search query
+            memory: Memory to score
+
+        Returns:
+            Quality score between 0.0 and 1.0
+
+        Raises:
+            RuntimeError: On HTTP errors or unparseable responses (caller falls through to next tier)
+        """
+        base_url = (self.config.openai_compat_base_url or "").rstrip("/")
+        model = self.config.openai_compat_model
+        api_key = self.config.openai_compat_api_key or "none"
+
+        prompt = self._create_scoring_prompt(query, memory.content)
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a quality scorer. Respond only with a number between 0.0 and 1.0.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": 50,
+            "temperature": 0.1,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    f"{base_url}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(
+                f"OpenAI-compatible endpoint returned HTTP {exc.response.status_code}: {exc.response.text[:200]}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"OpenAI-compatible endpoint request failed: {exc}") from exc
+
+        # Extract text from standard OpenAI response shape
+        try:
+            response_text = data["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(f"Unexpected response shape from endpoint: {data}") from exc
+
+        # Parse float and clamp to [0, 1]
+        try:
+            score = float(response_text)
+            return max(0.0, min(1.0, score))
+        except ValueError:
+            raise RuntimeError(
+                f"Could not parse score from openai-compatible response: {response_text!r}"
+            )
 
     async def _score_with_groq(self, query: str, memory: Memory) -> float:
         """

--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -36,6 +36,7 @@ class QualityEvaluator:
         self._onnx_models: dict = {}  # For fallback mode (multiple models)
         self._implicit_evaluator = ImplicitSignalsEvaluator()
         self._groq_bridge = None
+        self._httpx_client: Optional[httpx.AsyncClient] = None
         self._initialized = False
 
     def _ensure_initialized(self):
@@ -300,6 +301,22 @@ class QualityEvaluator:
 
         return final_scores
 
+    def _get_httpx_client(self) -> httpx.AsyncClient:
+        """Lazy-init a shared httpx.AsyncClient with a connection pool.
+
+        Reused across scoring calls so batches don't pay TCP/TLS handshake cost
+        per request. Closed via `aclose()`.
+        """
+        if self._httpx_client is None:
+            self._httpx_client = httpx.AsyncClient(timeout=30.0)
+        return self._httpx_client
+
+    async def aclose(self) -> None:
+        """Close the shared httpx client. Safe to call multiple times."""
+        if self._httpx_client is not None:
+            await self._httpx_client.aclose()
+            self._httpx_client = None
+
     async def _score_with_openai_compatible(self, query: str, memory: Memory) -> float:
         """
         Score quality using any OpenAI-compatible /v1/chat/completions endpoint.
@@ -340,15 +357,15 @@ class QualityEvaluator:
             "temperature": 0.1,
         }
 
+        client = self._get_httpx_client()
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.post(
-                    f"{base_url}/chat/completions",
-                    headers=headers,
-                    json=payload,
-                )
-                response.raise_for_status()
-                data = response.json()
+            response = await client.post(
+                f"{base_url}/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
         except httpx.HTTPStatusError as exc:
             raise RuntimeError(
                 f"OpenAI-compatible endpoint returned HTTP {exc.response.status_code}: {exc.response.text[:200]}"

--- a/src/mcp_memory_service/quality/config.py
+++ b/src/mcp_memory_service/quality/config.py
@@ -12,7 +12,8 @@ class QualityConfig:
     enabled: bool = True
 
     # AI provider selection
-    # Options: 'local' (ONNX only), 'groq', 'gemini', 'auto' (try all), 'none' (implicit only)
+    # Options: 'local' (ONNX only), 'openai-compatible', 'groq', 'gemini',
+    #          'auto' (try all), 'none' (implicit only)
     ai_provider: str = 'local'
 
     # Local ONNX model settings
@@ -22,6 +23,11 @@ class QualityConfig:
     # Cloud API settings (optional, user opt-in)
     groq_api_key: Optional[str] = None
     gemini_api_key: Optional[str] = None
+
+    # OpenAI-compatible endpoint settings (LiteLLM proxy, Ollama, vLLM, MLX-LM, etc.)
+    openai_compat_base_url: Optional[str] = None   # e.g. http://localhost:11434/v1
+    openai_compat_model: Optional[str] = None      # e.g. qwen2.5:7b-instruct
+    openai_compat_api_key: Optional[str] = None    # optional; use "ollama" for Ollama
 
     # Quality boost (AI + implicit signals combination)
     boost_enabled: bool = False
@@ -43,6 +49,9 @@ class QualityConfig:
             local_device=os.getenv('MCP_QUALITY_LOCAL_DEVICE', 'auto'),
             groq_api_key=os.getenv('GROQ_API_KEY'),
             gemini_api_key=os.getenv('GEMINI_API_KEY'),
+            openai_compat_base_url=os.getenv('MCP_QUALITY_AI_BASE_URL'),
+            openai_compat_model=os.getenv('MCP_QUALITY_AI_MODEL'),
+            openai_compat_api_key=os.getenv('MCP_QUALITY_AI_API_KEY'),
             boost_enabled=os.getenv('MCP_QUALITY_BOOST_ENABLED', 'false').lower() == 'true',
             boost_weight=float(os.getenv('MCP_QUALITY_BOOST_WEIGHT', '0.3')),
             fallback_enabled=os.getenv('MCP_QUALITY_FALLBACK_ENABLED', 'false').lower() == 'true',
@@ -52,7 +61,8 @@ class QualityConfig:
 
     def validate(self) -> bool:
         """Validate configuration settings."""
-        if self.ai_provider not in ['local', 'groq', 'gemini', 'auto', 'none']:
+        valid_providers = ['local', 'openai-compatible', 'groq', 'gemini', 'auto', 'none']
+        if self.ai_provider not in valid_providers:
             raise ValueError(f"Invalid ai_provider: {self.ai_provider}")
 
         if self.local_device not in ['auto', 'cpu', 'cuda', 'mps', 'directml']:
@@ -91,12 +101,32 @@ class QualityConfig:
         if self.ai_provider == 'gemini' and not self.gemini_api_key:
             raise ValueError("Gemini provider selected but GEMINI_API_KEY not set")
 
+        # openai-compatible requires base_url and model
+        if self.ai_provider == 'openai-compatible':
+            if not self.openai_compat_base_url:
+                raise ValueError(
+                    "openai-compatible provider selected but MCP_QUALITY_AI_BASE_URL is not set"
+                )
+            if not self.openai_compat_model:
+                raise ValueError(
+                    "openai-compatible provider selected but MCP_QUALITY_AI_MODEL is not set"
+                )
+
         return True
 
     @property
     def use_local_only(self) -> bool:
         """Check if using local-only scoring."""
         return self.ai_provider in ['local', 'none']
+
+    @property
+    def can_use_openai_compatible(self) -> bool:
+        """Check if an OpenAI-compatible endpoint is configured."""
+        return (
+            self.ai_provider == 'openai-compatible'
+            and bool(self.openai_compat_base_url)
+            and bool(self.openai_compat_model)
+        )
 
     @property
     def can_use_groq(self) -> bool:

--- a/tests/test_openai_compat_quality.py
+++ b/tests/test_openai_compat_quality.py
@@ -1,0 +1,315 @@
+"""
+Tests for the openai-compatible quality scoring provider.
+
+Covers:
+- Config validation (missing base_url / model raises ValueError)
+- Successful score parse and clamp to [0, 1]
+- Graceful fallback to implicit_signals on endpoint failure
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import httpx
+
+from src.mcp_memory_service.quality.config import QualityConfig
+from src.mcp_memory_service.quality.ai_evaluator import QualityEvaluator
+from src.mcp_memory_service.models.memory import Memory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_memory(content: str = "Test memory content about Python decorators.") -> Memory:
+    return Memory(
+        content=content,
+        content_hash="abc123",
+        tags=["test"],
+    )
+
+
+def _compat_config(**kwargs) -> QualityConfig:
+    defaults = dict(
+        ai_provider="openai-compatible",
+        openai_compat_base_url="http://localhost:11434/v1",
+        openai_compat_model="qwen2.5:7b-instruct",
+    )
+    defaults.update(kwargs)
+    return QualityConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestOpenAICompatConfig:
+    def test_valid_config_passes(self):
+        cfg = _compat_config()
+        assert cfg.validate() is True
+
+    def test_missing_base_url_raises(self):
+        cfg = QualityConfig(
+            ai_provider="openai-compatible",
+            openai_compat_model="qwen2.5:7b-instruct",
+        )
+        with pytest.raises(ValueError, match="MCP_QUALITY_AI_BASE_URL"):
+            cfg.validate()
+
+    def test_missing_model_raises(self):
+        cfg = QualityConfig(
+            ai_provider="openai-compatible",
+            openai_compat_base_url="http://localhost:11434/v1",
+        )
+        with pytest.raises(ValueError, match="MCP_QUALITY_AI_MODEL"):
+            cfg.validate()
+
+    def test_can_use_openai_compatible_true(self):
+        cfg = _compat_config()
+        assert cfg.can_use_openai_compatible is True
+
+    def test_can_use_openai_compatible_false_when_other_provider(self):
+        cfg = QualityConfig(ai_provider="local")
+        assert cfg.can_use_openai_compatible is False
+
+    def test_can_use_openai_compatible_false_when_base_url_missing(self):
+        cfg = QualityConfig(
+            ai_provider="openai-compatible",
+            openai_compat_model="qwen2.5:7b-instruct",
+        )
+        assert cfg.can_use_openai_compatible is False
+
+    def test_from_env_loads_compat_vars(self, monkeypatch):
+        monkeypatch.setenv("MCP_QUALITY_AI_PROVIDER", "openai-compatible")
+        monkeypatch.setenv("MCP_QUALITY_AI_BASE_URL", "http://litellm:4000/v1")
+        monkeypatch.setenv("MCP_QUALITY_AI_MODEL", "llama3.1:8b")
+        monkeypatch.setenv("MCP_QUALITY_AI_API_KEY", "sk-test")
+        cfg = QualityConfig.from_env()
+        assert cfg.ai_provider == "openai-compatible"
+        assert cfg.openai_compat_base_url == "http://litellm:4000/v1"
+        assert cfg.openai_compat_model == "llama3.1:8b"
+        assert cfg.openai_compat_api_key == "sk-test"
+
+    def test_invalid_provider_still_raises(self):
+        cfg = QualityConfig(ai_provider="unknown-provider")
+        with pytest.raises(ValueError, match="Invalid ai_provider"):
+            cfg.validate()
+
+
+# ---------------------------------------------------------------------------
+# _score_with_openai_compatible — unit tests via mock
+# ---------------------------------------------------------------------------
+
+def _mock_httpx_response(score_text: str, status_code: int = 200):
+    """Return a fake httpx.Response-like object for mocking."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = {
+        "choices": [{"message": {"content": score_text}}]
+    }
+    response.raise_for_status = MagicMock()
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=response,
+        )
+        response.text = f"Error {status_code}"
+    return response
+
+
+class TestScoreWithOpenAICompatible:
+    def _make_evaluator(self, **cfg_kwargs) -> QualityEvaluator:
+        cfg = _compat_config(**cfg_kwargs)
+        ev = QualityEvaluator.__new__(QualityEvaluator)
+        ev.config = cfg
+        ev._onnx_ranker = None
+        ev._onnx_models = {}
+        ev._groq_bridge = None
+        ev._initialized = True
+        from src.mcp_memory_service.quality.implicit_signals import ImplicitSignalsEvaluator
+        ev._implicit_evaluator = ImplicitSignalsEvaluator()
+        return ev
+
+    @pytest.mark.asyncio
+    async def test_successful_score_parse(self):
+        ev = self._make_evaluator()
+        mock_resp = _mock_httpx_response("0.85")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            score = await ev._score_with_openai_compatible("python", _make_memory())
+        assert score == pytest.approx(0.85)
+
+    @pytest.mark.asyncio
+    async def test_score_clamped_above_1(self):
+        ev = self._make_evaluator()
+        mock_resp = _mock_httpx_response("1.5")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            score = await ev._score_with_openai_compatible("python", _make_memory())
+        assert score == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_score_clamped_below_0(self):
+        ev = self._make_evaluator()
+        mock_resp = _mock_httpx_response("-0.3")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            score = await ev._score_with_openai_compatible("python", _make_memory())
+        assert score == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_unparseable_response_raises_runtime_error(self):
+        ev = self._make_evaluator()
+        mock_resp = _mock_httpx_response("I cannot score this.")
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="Could not parse score"):
+                await ev._score_with_openai_compatible("python", _make_memory())
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises_runtime_error(self):
+        ev = self._make_evaluator()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_resp = _mock_httpx_response("", status_code=500)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="HTTP 500"):
+                await ev._score_with_openai_compatible("python", _make_memory())
+
+    @pytest.mark.asyncio
+    async def test_request_error_raises_runtime_error(self):
+        ev = self._make_evaluator()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="request failed"):
+                await ev._score_with_openai_compatible("python", _make_memory())
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_stripped_from_base_url(self):
+        """Endpoint URL must not double-slash when base_url has trailing slash."""
+        ev = self._make_evaluator(openai_compat_base_url="http://localhost:11434/v1/")
+        mock_resp = _mock_httpx_response("0.7")
+        posted_urls = []
+
+        async def capture_post(url, **kwargs):
+            posted_urls.append(url)
+            return mock_resp
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=capture_post)
+            mock_client_cls.return_value = mock_client
+
+            score = await ev._score_with_openai_compatible("python", _make_memory())
+
+        assert score == pytest.approx(0.7)
+        assert posted_urls[0] == "http://localhost:11434/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_optional_api_key_uses_none_placeholder(self):
+        """When no api_key is set the Authorization header uses 'none'."""
+        ev = self._make_evaluator(openai_compat_api_key=None)
+        mock_resp = _mock_httpx_response("0.6")
+        captured_headers = {}
+
+        async def capture_post(url, headers=None, **kwargs):
+            captured_headers.update(headers or {})
+            return mock_resp
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=capture_post)
+            mock_client_cls.return_value = mock_client
+
+            await ev._score_with_openai_compatible("python", _make_memory())
+
+        assert captured_headers.get("Authorization") == "Bearer none"
+
+
+# ---------------------------------------------------------------------------
+# Fallback integration — endpoint failure → implicit_signals
+# ---------------------------------------------------------------------------
+
+class TestOpenAICompatFallback:
+    @pytest.mark.asyncio
+    async def test_endpoint_failure_falls_back_to_implicit(self):
+        """If the openai-compatible endpoint fails, evaluate_quality must not raise."""
+        cfg = _compat_config()
+        ev = QualityEvaluator.__new__(QualityEvaluator)
+        ev.config = cfg
+        ev._onnx_ranker = None
+        ev._onnx_models = {}
+        ev._groq_bridge = None
+        ev._initialized = True
+        from src.mcp_memory_service.quality.implicit_signals import ImplicitSignalsEvaluator
+        ev._implicit_evaluator = ImplicitSignalsEvaluator()
+
+        with patch.object(
+            ev,
+            "_score_with_openai_compatible",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            score = await ev.evaluate_quality("python decorators", _make_memory())
+
+        # Must be a valid float in [0, 1] from implicit_signals
+        assert 0.0 <= score <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_provider_tag_set_on_memory(self):
+        """quality_provider metadata tag is set to 'openai_compatible' on success."""
+        cfg = _compat_config()
+        ev = QualityEvaluator.__new__(QualityEvaluator)
+        ev.config = cfg
+        ev._onnx_ranker = None
+        ev._onnx_models = {}
+        ev._groq_bridge = None
+        ev._initialized = True
+        from src.mcp_memory_service.quality.implicit_signals import ImplicitSignalsEvaluator
+        ev._implicit_evaluator = ImplicitSignalsEvaluator()
+
+        memory = _make_memory()
+        with patch.object(
+            ev,
+            "_score_with_openai_compatible",
+            new_callable=AsyncMock,
+            return_value=0.75,
+        ):
+            score = await ev.evaluate_quality("python", memory)
+
+        assert score == pytest.approx(0.75)
+        assert memory.metadata.get("quality_provider") == "openai_compatible"

--- a/tests/test_openai_compat_quality.py
+++ b/tests/test_openai_compat_quality.py
@@ -130,90 +130,57 @@ class TestScoreWithOpenAICompatible:
         ev._implicit_evaluator = ImplicitSignalsEvaluator()
         return ev
 
+    def _install_mock_post(self, ev, *, return_value=None, side_effect=None):
+        """Install a mock httpx client on the evaluator and return it."""
+        mock_client = AsyncMock()
+        if side_effect is not None:
+            mock_client.post = AsyncMock(side_effect=side_effect)
+        else:
+            mock_client.post = AsyncMock(return_value=return_value)
+        ev._httpx_client = mock_client
+        return mock_client
+
     @pytest.mark.asyncio
     async def test_successful_score_parse(self):
         ev = self._make_evaluator()
-        mock_resp = _mock_httpx_response("0.85")
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
-            score = await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, return_value=_mock_httpx_response("0.85"))
+        score = await ev._score_with_openai_compatible("python", _make_memory())
         assert score == pytest.approx(0.85)
 
     @pytest.mark.asyncio
     async def test_score_clamped_above_1(self):
         ev = self._make_evaluator()
-        mock_resp = _mock_httpx_response("1.5")
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
-            score = await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, return_value=_mock_httpx_response("1.5"))
+        score = await ev._score_with_openai_compatible("python", _make_memory())
         assert score == pytest.approx(1.0)
 
     @pytest.mark.asyncio
     async def test_score_clamped_below_0(self):
         ev = self._make_evaluator()
-        mock_resp = _mock_httpx_response("-0.3")
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
-            score = await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, return_value=_mock_httpx_response("-0.3"))
+        score = await ev._score_with_openai_compatible("python", _make_memory())
         assert score == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_unparseable_response_raises_runtime_error(self):
         ev = self._make_evaluator()
-        mock_resp = _mock_httpx_response("I cannot score this.")
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
-            with pytest.raises(RuntimeError, match="Could not parse score"):
-                await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, return_value=_mock_httpx_response("I cannot score this."))
+        with pytest.raises(RuntimeError, match="Could not parse score"):
+            await ev._score_with_openai_compatible("python", _make_memory())
 
     @pytest.mark.asyncio
     async def test_http_error_raises_runtime_error(self):
         ev = self._make_evaluator()
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_resp = _mock_httpx_response("", status_code=500)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client_cls.return_value = mock_client
-
-            with pytest.raises(RuntimeError, match="HTTP 500"):
-                await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, return_value=_mock_httpx_response("", status_code=500))
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            await ev._score_with_openai_compatible("python", _make_memory())
 
     @pytest.mark.asyncio
     async def test_request_error_raises_runtime_error(self):
         ev = self._make_evaluator()
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(
-                side_effect=httpx.ConnectError("Connection refused")
-            )
-            mock_client_cls.return_value = mock_client
-
-            with pytest.raises(RuntimeError, match="request failed"):
-                await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, side_effect=httpx.ConnectError("Connection refused"))
+        with pytest.raises(RuntimeError, match="request failed"):
+            await ev._score_with_openai_compatible("python", _make_memory())
 
     @pytest.mark.asyncio
     async def test_trailing_slash_stripped_from_base_url(self):
@@ -226,14 +193,8 @@ class TestScoreWithOpenAICompatible:
             posted_urls.append(url)
             return mock_resp
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=capture_post)
-            mock_client_cls.return_value = mock_client
-
-            score = await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, side_effect=capture_post)
+        score = await ev._score_with_openai_compatible("python", _make_memory())
 
         assert score == pytest.approx(0.7)
         assert posted_urls[0] == "http://localhost:11434/v1/chat/completions"
@@ -249,14 +210,8 @@ class TestScoreWithOpenAICompatible:
             captured_headers.update(headers or {})
             return mock_resp
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=capture_post)
-            mock_client_cls.return_value = mock_client
-
-            await ev._score_with_openai_compatible("python", _make_memory())
+        self._install_mock_post(ev, side_effect=capture_post)
+        await ev._score_with_openai_compatible("python", _make_memory())
 
         assert captured_headers.get("Authorization") == "Bearer none"
 


### PR DESCRIPTION
## Summary

- Adds `openai-compatible` as a new `MCP_QUALITY_AI_PROVIDER` value so homelab / self-hosted users can point quality scoring at any OpenAI `/v1/chat/completions`-compatible endpoint (Ollama, LiteLLM proxy, vLLM, MLX-LM server) without a cloud API key or the ONNX model.
- Three new env vars: `MCP_QUALITY_AI_BASE_URL` (required), `MCP_QUALITY_AI_MODEL` (required), `MCP_QUALITY_AI_API_KEY` (optional). Config validation raises `ValueError` if the provider is set without the required vars.
- New Tier 2 in the fallback chain: local ONNX → **openai-compatible** → Groq → Gemini → implicit signals. Endpoint failures fall through silently — no exception bubbles to the storage path.

## Changed files

- `src/mcp_memory_service/quality/config.py` — new fields, `from_env()` loading, `validate()` checks, `can_use_openai_compatible` property
- `src/mcp_memory_service/quality/ai_evaluator.py` — `_score_with_openai_compatible()` via `httpx` (already a dep), wired into `evaluate_quality()` as Tier 2
- `tests/test_openai_compat_quality.py` — 18 tests: config validation, score parse, `[0,1]` clamping, trailing-slash normalisation, optional API key, HTTP/connect errors, fallback to implicit signals, `quality_provider` metadata tag
- `.env.example` — three new env vars with recommended models and usage notes (Ollama, MLX, LiteLLM, vLLM)
- `README.md` — homelab quick-start block in Quick Start Features
- `.claude/directives/quality-system-details.md` — updated provider list

## Example config

```bash
MCP_QUALITY_AI_PROVIDER=openai-compatible
MCP_QUALITY_AI_BASE_URL=http://localhost:11434/v1   # Ollama
MCP_QUALITY_AI_MODEL=qwen2.5:7b-instruct
# MCP_QUALITY_AI_API_KEY=ollama                     # optional
```

## Test plan

- [x] `pytest tests/test_openai_compat_quality.py` — 18/18 pass
- [x] `pytest tests/test_quality_system.py tests/test_fallback_quality.py tests/test_quality_integration.py` — 47/47 pass, zero regressions
- [x] No new dependencies added (`httpx` was already in `pyproject.toml`)
- [x] Pre-existing pre-PR failures (Gemini CLI not installed, repo-wide coverage <80%) are unrelated to this PR

Closes #788

---
Generated with [Claude Code](https://claude.ai/claude-code)