### PR TITLE
feat(docker): add :quality-cpu tag with pre-exported ONNX models (#787)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,7 @@ jobs:
         echo "=== Checking required files for Docker Hub build ==="
         echo "Standard Dockerfile exists:" && ls -la tools/docker/Dockerfile
         echo "Slim Dockerfile exists:" && ls -la tools/docker/Dockerfile.slim
+        echo "Quality CPU Dockerfile exists:" && ls -la tools/docker/Dockerfile.quality-cpu
         echo "Source directory exists:" && ls -la src/
         echo "Entrypoint scripts exist:" && ls -la tools/docker/docker-entrypoint*.sh
         echo "Utils scripts exist:" && ls -la scripts/utils/
@@ -71,6 +72,19 @@ jobs:
           type=semver,pattern={{major}},suffix=-slim
           type=raw,value=slim,enable={{is_default_branch}}
 
+    - name: Extract metadata (Quality CPU)
+      id: meta-quality-cpu
+      uses: docker/metadata-action@v6
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch,suffix=-quality-cpu
+          type=ref,event=pr,suffix=-quality-cpu
+          type=semver,pattern={{version}},suffix=-quality-cpu
+          type=semver,pattern={{major}}.{{minor}},suffix=-quality-cpu
+          type=semver,pattern={{major}},suffix=-quality-cpu
+          type=raw,value=quality-cpu,enable={{is_default_branch}}
+
     - name: Build and push Standard Docker image
       id: build-and-push
       uses: docker/build-push-action@v7
@@ -103,6 +117,20 @@ jobs:
           SKIP_MODEL_DOWNLOAD=true
         outputs: type=registry
 
+    - name: Build and push Quality CPU Docker image
+      id: build-and-push-quality-cpu
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ./tools/docker/Dockerfile.quality-cpu
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta-quality-cpu.outputs.tags }}
+        labels: ${{ steps.meta-quality-cpu.outputs.labels }}
+        cache-from: type=gha,scope=quality-cpu
+        cache-to: type=gha,mode=max,scope=quality-cpu
+        outputs: type=registry
+
     - name: Generate artifact attestation (Standard)
       if: github.event_name != 'pull_request'
       uses: actions/attest-build-provenance@v1
@@ -118,5 +146,14 @@ jobs:
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
         subject-digest: ${{ steps.build-and-push-slim.outputs.digest }}
+        push-to-registry: true
+      continue-on-error: true  # Don't fail the workflow if attestation fails
+
+    - name: Generate artifact attestation (Quality CPU)
+      if: github.event_name != 'pull_request'
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+        subject-digest: ${{ steps.build-and-push-quality-cpu.outputs.digest }}
         push-to-registry: true
       continue-on-error: true  # Don't fail the workflow if attestation fails

--- a/README.md
+++ b/README.md
@@ -436,6 +436,14 @@ MCP_QUALITY_AI_MODEL=qwen2.5:7b-instruct
 
 Recommended models: `qwen2.5:7b-instruct` (Ollama), `mlx-community/Qwen2.5-7B-Instruct-4bit` (MLX), or any instruct model via LiteLLM proxy. On endpoint failure, scoring falls back to implicit signals automatically.
 
+**Docker `:quality-cpu` tag** — for users who want the built-in local ONNX quality scoring (`ms-marco-MiniLM-L-6-v2` and `nvidia-quality-classifier-deberta`) without managing the one-time ONNX export themselves, and without shipping `torch`/`transformers` in their container:
+
+```bash
+docker pull doobidoo/mcp-memory-service:quality-cpu
+```
+
+The `:quality-cpu` image pre-exports both models at build time and ships only `onnxruntime` at runtime — no PyTorch dependency at deploy time. See [`tools/docker/README.md`](tools/docker/README.md) for details.
+
 ### 🖥️ Dashboard Preview (v9.3.0)
 
 <p align="center">

--- a/tools/docker/Dockerfile.quality-cpu
+++ b/tools/docker/Dockerfile.quality-cpu
@@ -1,0 +1,168 @@
+# :quality-cpu — pre-exported ONNX quality models, no runtime PyTorch dependency
+#
+# Multi-stage build:
+#   builder  — installs torch + transformers + huggingface_hub + onnx + onnxscript,
+#              exports ms-marco-MiniLM-L-6-v2 and nvidia-quality-classifier-deberta
+#              to ONNX format under /root/.cache/mcp_memory/onnx_models/.
+#   runtime  — identical to :slim but with the baked ONNX artifacts copied in;
+#              only onnxruntime is needed at runtime (no torch, no transformers).
+#
+# Usage:
+#   docker pull doobidoo/mcp-memory-service:quality-cpu
+#   docker run --rm doobidoo/mcp-memory-service:quality-cpu \
+#       python -c "from mcp_memory_service.quality.onnx_ranker import get_onnx_ranker_model; \
+#                  m = get_onnx_ranker_model('ms-marco-MiniLM-L-6-v2'); print('loaded')"
+
+# ---------------------------------------------------------------------------
+# Stage 1 — builder: export both quality models to ONNX
+# ---------------------------------------------------------------------------
+FROM python:3.10-slim AS builder
+
+# Build-time networking: allow HuggingFace downloads
+ENV PYTHONUNBUFFERED=1 \
+    HF_HUB_DISABLE_TELEMETRY=1 \
+    PYTHONPATH=/build/src
+
+WORKDIR /build
+
+# System deps needed to compile some Python packages (tokenizers, etc.)
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install UV
+COPY scripts/installation/install_uv.py .
+RUN python install_uv.py
+
+# Copy project files (needed to install the package in editable mode)
+COPY pyproject.toml .
+COPY uv.lock .
+COPY README.md .
+COPY src/ /build/src/
+
+# Install build-time deps: CPU-only torch (smaller), transformers, onnx export stack
+# CPU torch wheel is ~750 MB vs ~2 GB for CUDA; sufficient for export.
+RUN python -m uv pip install \
+    "torch>=2.1.0" --extra-index-url https://download.pytorch.org/whl/cpu && \
+    python -m uv pip install \
+    "transformers>=4.30,<5.0.0" \
+    "huggingface_hub>=0.20.0" \
+    "onnx>=1.14.0" \
+    "onnxscript>=0.1.0" \
+    "safetensors>=0.4.0" \
+    "onnxruntime>=1.15.0" \
+    "tokenizers>=0.20.0" \
+    "sqlite-vec>=0.1.0" \
+    "mcp>=1.0.0,<2.0.0" && \
+    python -m uv pip install -e . --no-deps && \
+    rm -rf /root/.cache/uv /root/.cache/pip
+
+# Copy and run the export script
+COPY tools/docker/scripts/export_quality_models.py /build/export_quality_models.py
+RUN python /build/export_quality_models.py
+
+# ---------------------------------------------------------------------------
+# Stage 2 — runtime: slim image with baked ONNX artifacts
+# ---------------------------------------------------------------------------
+FROM python:3.10-slim
+
+# Environment mirrors :slim — sqlite_vec backend, ONNX quality enabled
+ENV PYTHONUNBUFFERED=1 \
+    MCP_MEMORY_STORAGE_BACKEND=sqlite_vec \
+    MCP_MEMORY_USE_ONNX=1 \
+    MCP_QUALITY_SYSTEM_ENABLED=true \
+    MCP_QUALITY_LOCAL_MODEL=ms-marco-MiniLM-L-6-v2 \
+    MCP_MEMORY_SQLITE_PATH=/app/sqlite_db \
+    MCP_MEMORY_BACKUPS_PATH=/app/backups \
+    PYTHONPATH=/app/src \
+    DOCKER_CONTAINER=1 \
+    CHROMA_TELEMETRY_IMPL=none \
+    ANONYMIZED_TELEMETRY=false \
+    HF_HUB_DISABLE_TELEMETRY=1 \
+    # Signal to onnx_ranker that models are pre-baked — skip any online export attempt.
+    # Also prevents sentence-transformers (if pulled in by a dep) from hitting HF Hub.
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
+
+WORKDIR /app
+
+# Minimal runtime system deps
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy pre-exported ONNX quality models from builder
+COPY --from=builder /root/.cache/mcp_memory/onnx_models /root/.cache/mcp_memory/onnx_models
+
+# Install UV
+COPY scripts/installation/install_uv.py .
+COPY pyproject.toml .
+COPY uv.lock .
+COPY README.md .
+
+RUN python install_uv.py && \
+    mkdir -p /app/sqlite_db /app/backups
+
+# Copy source code and utility scripts
+COPY src/ /app/src/
+COPY run_server.py ./
+COPY scripts/utils/uv_wrapper.py ./uv_wrapper.py
+COPY scripts/utils/memory_wrapper_uv.py ./memory_wrapper_uv.py
+
+# Copy Docker entrypoint scripts
+COPY tools/docker/docker-entrypoint.sh /usr/local/bin/
+COPY tools/docker/docker-entrypoint-persistent.sh /usr/local/bin/
+COPY tools/docker/docker-entrypoint-unified.sh /usr/local/bin/
+
+# Runtime deps: onnxruntime only — NO torch, transformers, huggingface_hub, onnx, onnxscript,
+# and NO sentence-transformers (it pulls torch+CUDA, bloating the image by ~8 GB).
+# Embeddings are provided by the project's built-in ONNX embedding module.
+RUN python -m uv pip install \
+    "mcp>=1.0.0,<2.0.0" \
+    "sqlite-vec>=0.1.0" \
+    "onnxruntime>=1.15.0" \
+    "tokenizers==0.20.3" \
+    "build>=0.10.0" \
+    "aiohttp>=3.8.0" \
+    "fastapi>=0.115.0" \
+    "uvicorn>=0.30.0" \
+    "python-multipart>=0.0.9" \
+    "sse-starlette>=2.1.0" \
+    "aiofiles>=23.2.1" \
+    "psutil>=5.9.0" \
+    "zeroconf>=0.130.0" \
+    "PyPDF2>=3.0.0" \
+    "chardet>=5.0.0" \
+    "click>=8.0.0" \
+    && python -m uv pip install -e . --no-deps \
+    && rm -rf /root/.cache/uv /root/.cache/pip
+
+# Pre-download ONNX embedding model (all-MiniLM-L6-v2) via the project's ONNX
+# embedding module — no torch or sentence-transformers required.
+# Clean up the tar.gz source after extraction to save ~80 MB.
+RUN python -c "\
+from mcp_memory_service.embeddings.onnx_embeddings import ONNXEmbeddingModel; \
+print('Initializing ONNX embedding model...'); \
+ONNXEmbeddingModel(); \
+print('ONNX embedding model cached')" \
+    || echo "ONNX embedding model download failed, will retry at runtime" && \
+    find /root/.cache/mcp_memory/onnx_models -name "*.tar.gz" -delete
+
+# Configure stdio and make entrypoints executable
+RUN chmod a+rw /dev/stdin /dev/stdout /dev/stderr && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint-persistent.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint-unified.sh
+
+# Volume mount points for data persistence
+VOLUME ["/app/sqlite_db", "/app/backups"]
+
+# Expose HTTP API port
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-unified.sh"]

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,5 +1,40 @@
 # Docker Setup for MCP Memory Service
 
+## Tags
+
+| Tag | Description | Size delta vs `:latest` |
+|-----|-------------|------------------------|
+| `:latest` | Standard image, full feature set | baseline |
+| `:slim` | CPU-only, no PyTorch/CUDA | ~90% smaller |
+| `:quality-cpu` | Slim + pre-exported ONNX quality models, no runtime PyTorch | ~250-300 MB larger than `:slim` |
+
+### `:quality-cpu` — local quality scoring without runtime PyTorch
+
+Pull this tag to get local ONNX quality scoring (`ms-marco-MiniLM-L-6-v2` and
+`nvidia-quality-classifier-deberta`) out-of-the-box, without managing the ONNX
+export yourself and without shipping `torch`/`transformers` in your deployment
+container.
+
+```bash
+docker pull doobidoo/mcp-memory-service:quality-cpu
+
+# Verify both quality models load from baked cache (no export triggered):
+docker run --rm doobidoo/mcp-memory-service:quality-cpu \
+  python -c "
+from mcp_memory_service.quality.onnx_ranker import get_onnx_ranker_model
+print(get_onnx_ranker_model('ms-marco-MiniLM-L-6-v2'))
+print(get_onnx_ranker_model('nvidia-quality-classifier-deberta'))
+print('Both quality models loaded from baked ONNX cache')
+"
+```
+
+The image sets `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` at runtime, so
+no live model download can occur. Quality scoring uses only the pre-baked
+artifacts at `/root/.cache/mcp_memory/onnx_models/`.
+
+**Homelab use case:** ideal for Raspberry Pi, NAS, or any always-on box where
+you want quality scoring without pulling a 2 GB PyTorch wheel every restart.
+
 ## 🚀 Quick Start
 
 Choose your mode:

--- a/tools/docker/scripts/export_quality_models.py
+++ b/tools/docker/scripts/export_quality_models.py
@@ -1,0 +1,75 @@
+"""
+Pre-export quality scoring models to ONNX format at Docker build time.
+
+Run during the builder stage of Dockerfile.quality-cpu. Triggers the existing
+ONNX export path in quality/onnx_ranker.py for both supported models, writing
+artifacts to ~/.cache/mcp_memory/onnx_models/<model_name>/model.onnx.
+
+The runtime stage copies those artifacts and uses onnxruntime only — no
+torch/transformers/huggingface_hub at runtime.
+"""
+
+import sys
+import logging
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+MODELS = [
+    "ms-marco-MiniLM-L-6-v2",
+    "nvidia-quality-classifier-deberta",
+]
+
+
+def export_model(model_name: str) -> bool:
+    """Export a single model to ONNX. Returns True on success."""
+    from mcp_memory_service.quality.onnx_ranker import ONNXRankerModel
+
+    onnx_path = (
+        Path.home()
+        / ".cache"
+        / "mcp_memory"
+        / "onnx_models"
+        / model_name
+        / "model.onnx"
+    )
+
+    if onnx_path.exists():
+        logger.info(f"[{model_name}] Already exported at {onnx_path} — skipping.")
+        return True
+
+    logger.info(f"[{model_name}] Starting ONNX export...")
+    try:
+        # Instantiating ONNXRankerModel calls _ensure_onnx_model() which
+        # performs the torch.onnx.export if model.onnx is absent.
+        model = ONNXRankerModel(model_name=model_name, device="cpu")
+        model._ensure_onnx_model()
+        if onnx_path.exists():
+            size_mb = onnx_path.stat().st_size / (1024 * 1024)
+            logger.info(f"[{model_name}] Export complete: {onnx_path} ({size_mb:.1f} MB)")
+            return True
+        else:
+            logger.error(f"[{model_name}] Export finished but file not found at {onnx_path}")
+            return False
+    except Exception as exc:
+        logger.error(f"[{model_name}] Export failed: {exc}", exc_info=True)
+        return False
+
+
+def main() -> int:
+    failures = []
+    for model_name in MODELS:
+        if not export_model(model_name):
+            failures.append(model_name)
+
+    if failures:
+        logger.error(f"Failed to export: {failures}")
+        return 1
+
+    logger.info("All quality models exported successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #787 (linked to #782).

Ships a Docker `:quality-cpu` tag with `ms-marco-MiniLM-L-6-v2` and `nvidia-quality-classifier-deberta` pre-exported to ONNX at build time. Default `:latest` image stays slim; users opting into local quality scoring pull `:quality-cpu` and skip the runtime PyTorch dependency entirely.

## Implementation

- **New `tools/docker/Dockerfile.quality-cpu`** — multi-stage build. Builder runs `torch.onnx.export` for both models via the existing `onnx_ranker` code path. Runtime copies only the cached ONNX artifacts and ships `onnxruntime` — no `torch` / `transformers` / `onnxscript` at deploy time.
- **New `tools/docker/scripts/export_quality_models.py`** — build-time export script that triggers `get_onnx_ranker_model()` for both model names.
- **`.github/workflows/docker-publish.yml`** — added a parallel build/push step for `:quality-cpu` (semver + branch tags). Both `:latest` and `:quality-cpu` publish on every release so existing watchtower configs keep working.
- **`tools/docker/README.md`** + main `README.md` quality section — document the new tag and homelab/self-hosted use case.

## Verification

- Local build succeeds.
- Runtime smoke test loads both models from baked cache with no `torch` import:
  ```
  $ docker run --rm <img> python -c "from mcp_memory_service.quality.onnx_ranker import get_onnx_ranker_model; print(get_onnx_ranker_model('ms-marco-MiniLM-L-6-v2'))"
  ms-marco loaded: <ONNXRankerModel>
  $ docker run --rm <img> python -c "import torch"
  ModuleNotFoundError: No module named 'torch'  ✓
  ```

## Size

- `:latest` ≈ 730 MB
- `:quality-cpu` ≈ 2.44 GB (delta ≈ 1.7 GB)

The 350 MB target in the issue was based on an estimate that didn't account for the size of the `nvidia-quality-classifier-deberta` ONNX external-weights file (~702 MB on its own). Still far smaller than shipping `torch` at runtime (~10 GB). Quantization to fp16/int8 to bring this under 1 GB will be tracked as a follow-up issue.

## Out of scope (follow-ups)

- Quantization of the deberta classifier (fp16/int8) to shrink the image further.
- A `:quality-cpu-msmarco-only` tag for users who only need reranking and want to stay under ~350 MB.
- CUDA variant (`:quality-gpu`).