### PR TITLE
fix: remove redundant json import in mistake_note_add (CodeQL)

### DIFF
--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -790,7 +790,6 @@ class MemoryService:
                         content_hash = mem["content_hash"]
                         old_meta = mem.get("metadata") or {}
                         if isinstance(old_meta, str):
-                            import json
                             old_meta = json.loads(old_meta) if old_meta else {}
                         count = old_meta.get("failure_count", 1) + 1
                         old_meta["failure_count"] = count


### PR DESCRIPTION
Follow-up to #786 — addresses CodeQL finding.

## Changes

Removes redundant `import json` inside `mistake_note_add()` (line 793). The module-level import at line 9 already covers this.

Flagged by CodeQL automated review on #786: [code-scanning/393](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/393)

## Other Gemini Code Assist findings from #786

Reviewed the other 3 findings — all were already addressed in commit 269ad7e before merge:
- ✅ `similarity_score` key — already correct (lines 787, 868)
- ✅ `store_memory` success check — already present (line 815)
- ✅ `MCP_MISTAKE_NOTE_DEDUP_THRESHOLD` range validation — already has `max(0.0, min(1.0, ...))` (line 1062)

## Testing

5/5 mistake notes tests passing.