### PR TITLE
chore: release v10.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.45.1] - 2026-04-30
+
+### Fixed
+
+- **[#794] Remove redundant `import json` inside `mistake_note_add()`**: The `json` module was already imported at the top of `memory_service.py`; the duplicate import inside the function body was flagged by CodeQL alert #393. One-line cleanup with no behavioral change. Thanks to @filhocf. (PR #794)
+
+### Tests
+
+- **[#795] Regression coverage for soft-delete UPDATE guards** (`tests/storage/test_soft_delete_guards.py`): 6 new tests verifying that the `AND deleted_at IS NULL` guards added in PR #783 silently skip tombstoned rows. Covers `_persist_access_metadata_batch`, `_record_conflicts`, `resolve_conflict` (deleted winner and deleted loser), `_touch`, and `update_memory_versioned`. Closes #791. Thanks to @filhocf. (PR #795)
+
 ## [10.45.0] - 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.45.0 - feat(quality): OpenAI-compatible provider for LiteLLM/Ollama/MLX (PR #790) + fix(storage): soft-delete UPDATE guards (PR #783, @filhocf) — ~1,758 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.45.1 - fix: CodeQL redundant import cleanup (PR #794) + regression tests for soft-delete UPDATE guards (PR #795, @filhocf) — ~1,764 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,18 +457,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.45.0** (April 30, 2026)
+## Latest Release: **v10.45.1** (April 30, 2026)
 
-**feat(quality): OpenAI-compatible provider for homelab quality scoring**
+**fix: CodeQL cleanup + soft-delete regression tests**
 
 **What's New:**
-- **OpenAI-compatible quality provider**: Set `MCP_QUALITY_AI_PROVIDER=openai-compatible` to score memories with any OpenAI `/v1/chat/completions`-compatible endpoint — Ollama, LiteLLM, MLX-LM server, or vLLM. No cloud API key required. (PR #790)
-- **New fallback tier**: Local ONNX → openai-compatible → Groq → Gemini → implicit signals. Endpoint failures fall through silently.
-- **Soft-delete UPDATE guards**: 7 remaining `UPDATE` statements in `sqlite_vec.py` now include `AND deleted_at IS NULL`, preventing operations on tombstoned rows. (PR #783, @filhocf)
+- **CodeQL fix**: Remove redundant `import json` inside `mistake_note_add()` — module-level import already present. Addresses CodeQL alert #393. (PR #794, @filhocf)
+- **Regression tests**: 6 new tests in `tests/storage/test_soft_delete_guards.py` verifying `AND deleted_at IS NULL` guards silently skip tombstoned rows across all 6 affected call sites. Closes #791. (PR #795, @filhocf)
 
 ---
 
 **Previous Releases**:
+- **v10.45.0** - feat(quality): OpenAI-compatible provider for LiteLLM/Ollama/MLX + soft-delete UPDATE guards (PRs #790, #783, @filhocf)
 - **v10.44.0** - feat: Mistake Notes — structured error replay (`mistake_note_add`, `mistake_note_search`, PR #786, @filhocf)
 - **v10.43.0** - feat(search): Reciprocal Rank Fusion (RRF) for SQLite-vec hybrid search (PR #773, @filhocf)
 - **v10.42.1** - fix(milvus): add missing `anns_field` to search calls for BM25-enabled collections (PR #775, @henry201605)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.45.0"
+version = "10.45.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.45.0"
+__version__ = "10.45.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.45.0"
+version = "10.45.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to v10.45.1 (PATCH)
- Update CHANGELOG.md with v10.45.1 entry crediting @filhocf for PRs #794 and #795
- Update README.md Latest Release section
- Update CLAUDE.md version callout (~1,764 tests)
- `uv lock` updated

## Changes included

**PR #794** (@filhocf) — `fix: remove redundant json import in mistake_note_add (CodeQL)`
- 1-line cleanup, removes duplicate `import json` inside `mistake_note_add()` (already imported at module level)
- Addresses CodeQL finding #393

**PR #795** (@filhocf) — `test: regression coverage for soft-delete UPDATE guards (#791)`
- 6 new regression tests in `tests/storage/test_soft_delete_guards.py`
- Verifies `AND deleted_at IS NULL` UPDATE guards from PR #783 silently skip tombstoned rows
- Covers `_persist_access_metadata_batch`, `_record_conflicts`, `resolve_conflict` (×2), `_touch`, `update_memory_versioned`
- Closes #791

## Test plan

- [ ] CI green on this branch
- [ ] Version consistency: `pyproject.toml` == `_version.py` == `10.45.1`
- [ ] CHANGELOG has `[10.45.1]` entry above `[10.45.0]`, `[Unreleased]` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)