### PR TITLE
chore: release v10.46.0 — stale_days filter for memory_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.46.0] - 2026-04-30
+
+### Added
+
+- **[#784] `stale_days` filter for `memory_list`**: Adds an optional `stale_days` integer parameter to the `memory_list` tool and REST endpoint. Memories whose `COALESCE(last_accessed, created_at)` timestamp falls strictly before `now - stale_days * 86400 seconds` are considered stale. Memories accessed exactly at the threshold are NOT stale (strict `<` semantics). Memories that have never been read (`last_accessed IS NULL`) fall back to `created_at`, so never-accessed memories are included in stale results when their creation date is old enough. The filter composes freely with the existing `tags`, `memory_type`, and pagination parameters. Backend coverage: fully implemented in SQLite-vec; Cloudflare, Hybrid, and Milvus backends accept the parameter but ignore it (returning all memories as before — no silent wrong results). Refactors `_apply_stale_days_filter` as a static helper shared between `get_all_memories` and `count_all_memories` to avoid duplication (per code review). 8 new tests in `tests/storage/test_stale_days.py`. Closes #784. Thanks to @filhocf for the contribution. (PR #796)
+
 ## [10.45.1] - 2026-04-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.45.1 - fix: CodeQL redundant import cleanup (PR #794) + regression tests for soft-delete UPDATE guards (PR #795, @filhocf) — ~1,764 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.46.0 - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784) — ~1,772 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,17 +457,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.45.1** (April 30, 2026)
+## Latest Release: **v10.46.0** (April 30, 2026)
 
-**fix: CodeQL cleanup + soft-delete regression tests**
+**feat: stale_days filter for memory_list — dormant memory detection**
 
 **What's New:**
-- **CodeQL fix**: Remove redundant `import json` inside `mistake_note_add()` — module-level import already present. Addresses CodeQL alert #393. (PR #794, @filhocf)
-- **Regression tests**: 6 new tests in `tests/storage/test_soft_delete_guards.py` verifying `AND deleted_at IS NULL` guards silently skip tombstoned rows across all 6 affected call sites. Closes #791. (PR #795, @filhocf)
+- **`stale_days` filter**: Pass `stale_days=N` to `memory_list` to surface memories not accessed in N days. Falls back to `created_at` for never-read memories. Strict `<` semantics. Composes with `tags`, `memory_type`, and pagination. Fully implemented on SQLite-vec; stub (no-op) on Cloudflare/Hybrid/Milvus. (PR #796, @filhocf, closes #784)
+- **8 new tests** in `tests/storage/test_stale_days.py` covering boundary conditions, tag/type composition, pagination, and backward compatibility.
 
 ---
 
 **Previous Releases**:
+- **v10.45.1** - fix: CodeQL redundant import cleanup + soft-delete regression tests (PRs #794, #795, @filhocf)
 - **v10.45.0** - feat(quality): OpenAI-compatible provider for LiteLLM/Ollama/MLX + soft-delete UPDATE guards (PRs #790, #783, @filhocf)
 - **v10.44.0** - feat: Mistake Notes — structured error replay (`mistake_note_add`, `mistake_note_search`, PR #786, @filhocf)
 - **v10.43.0** - feat(search): Reciprocal Rank Fusion (RRF) for SQLite-vec hybrid search (PR #773, @filhocf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.45 — Semantic Memory Layer for AI Applications</title>
+<title>MCP Memory Service v10.46 — Semantic Memory Layer for AI Applications</title>
 <meta name="description" content="Semantic memory layer for AI applications. REST API + MCP transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, self-hosted, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.45">
-<meta property="og:description" content="OpenAI-compatible quality scoring: point memory scoring at Ollama, LiteLLM, MLX-LM, or vLLM — no cloud API key needed. Soft-delete UPDATE guards prevent operations on tombstoned rows. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.46">
+<meta property="og:description" content="Stale memory detection: filter memory_list by days since last access to surface dormant memories. Falls back to created_at for never-read memories. Composes with tags, memory_type, and pagination. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.45 &mdash; Now Available</span>
+  <span class="hero-badge">v10.46 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.45</h2>
-    <p class="section-subtitle">OpenAI-compatible quality scoring: point memory scoring at Ollama, LiteLLM, MLX-LM, or vLLM. Soft-delete UPDATE guards. ~1,758 tests.</p>
+    <h2 class="section-title">What's New in v10.46</h2>
+    <p class="section-subtitle">Stale memory detection: surface dormant memories with the new stale_days filter. ~1,772 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon search">&#127968;</div>
-        <h3>Homelab Quality Scoring</h3>
-        <p>Set <code>MCP_QUALITY_AI_PROVIDER=openai-compatible</code> to score memories with any OpenAI <code>/v1/chat/completions</code>-compatible endpoint — Ollama, LiteLLM, MLX-LM server, or vLLM. No cloud API key required. (PR #790)</p>
+        <div class="feature-icon search">&#128337;</div>
+        <h3>Stale Memory Detection</h3>
+        <p>Pass <code>stale_days=N</code> to <code>memory_list</code> to surface memories not accessed in N days. Ideal for reviewing and consolidating dormant knowledge. (PR #796, @filhocf, closes #784)</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon graph">&#9881;</div>
-        <h3>Graceful Fallback Chain</h3>
-        <p>New Tier 2 in the quality scoring chain: local ONNX &rarr; openai-compatible &rarr; Groq &rarr; Gemini &rarr; implicit signals. Endpoint failures fall through silently — no exception reaches the storage path.</p>
+        <h3>Smart Fallback to created_at</h3>
+        <p>Never-accessed memories (<code>last_accessed IS NULL</code>) fall back to <code>created_at</code>, ensuring they appear in stale results when old enough. Strict <code>&lt;</code> semantics: memories at the exact threshold are not stale.</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon consolidation">&#128202;</div>
-        <h3>Soft-Delete UPDATE Guards</h3>
-        <p>Seven <code>UPDATE memories SET ...</code> statements in <code>sqlite_vec.py</code> now include <code>AND deleted_at IS NULL</code>, preventing accidental modification of tombstoned rows. (PR #783, @filhocf)</p>
+        <h3>Composable Filters</h3>
+        <p>The <code>stale_days</code> filter composes freely with existing <code>tags</code>, <code>memory_type</code>, and pagination parameters. Fully implemented on SQLite-vec; accepted (no-op) on Cloudflare, Hybrid, and Milvus backends.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1758">0</div>
+        <div class="stat-number" data-target="1772">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.45.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.46.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.45.1"
+version = "10.46.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.45.1"
+__version__ = "10.46.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.45.1"
+version = "10.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version from v10.45.1 to v10.46.0 (MINOR — new feature)
- Adds CHANGELOG entry for v10.46.0 crediting @filhocf, closes #784
- Updates README.md Latest Release section; moves v10.45.1 to Previous Releases
- Updates CLAUDE.md version callout (~1,772 tests)
- Updates `docs/index.html` landing page: v10.46 badge, What's New section, test counter 1,758 → 1,772, release notes link
- Runs `uv lock` to sync lock file

## What's in this release

**PR #796** (@filhocf) — `feat: add stale_days filter to memory_list (#784)`

- New optional `stale_days` integer parameter on `memory_list` tool and REST endpoint
- `WHERE COALESCE(last_accessed, created_at) < (now - stale_days*86400)` — strict `<` semantics
- Falls back to `created_at` when `last_accessed IS NULL` (never-read memories included when old enough)
- Composes with `tags`, `memory_type`, and pagination filters
- Fully implemented on SQLite-vec; no-op stub on Cloudflare/Hybrid/Milvus (no silent wrong results)
- Refactors `_apply_stale_days_filter` static helper (per Gemini Code Assist review)
- 8 new tests in `tests/storage/test_stale_days.py`

## Test plan

- [ ] CI passes on this PR
- [ ] Version consistent in `pyproject.toml` and `_version.py` (both v10.46.0)
- [ ] CHANGELOG has exactly one `[10.46.0]` entry, `[Unreleased]` empty, reverse chronological
- [ ] README Latest Release shows v10.46.0, Previous Releases has v10.45.1 at top
- [ ] Landing page badge shows v10.46

🤖 Generated with [Claude Code](https://claude.com/claude-code)