### PR TITLE
feat: add memory_quality(action='maintain') — maintenance orchestrator (#799)

### DIFF
--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -1193,8 +1193,14 @@ else:
 # Maintenance Configuration (memory_quality action="maintain")
 # =============================================================================
 MAINTAIN_STALE_DAYS = safe_get_int_env('MCP_MAINTAIN_STALE_DAYS', 30, min_value=1, max_value=3650)
-MAINTAIN_AUTO_RESOLVE = os.getenv('MCP_MAINTAIN_AUTO_RESOLVE', 'false').lower() in ('true', '1', 'yes')
-MAINTAIN_AUTO_RESOLVE_THRESHOLD = float(os.getenv('MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD', '0.95'))
+# WARNING: auto_resolve=true enables automatic conflict resolution — memories above
+# the similarity threshold will be silently merged. Use with caution at scale.
+MAINTAIN_AUTO_RESOLVE = safe_get_bool_env('MCP_MAINTAIN_AUTO_RESOLVE', False)
+try:
+    MAINTAIN_AUTO_RESOLVE_THRESHOLD = float(os.getenv('MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD', '0.95'))
+except (ValueError, TypeError):
+    logger.error("Invalid value for MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD, using default 0.95")
+    MAINTAIN_AUTO_RESOLVE_THRESHOLD = 0.95
 
 # =============================================================================
 # Configuration Validation

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -1201,6 +1201,9 @@ try:
 except (ValueError, TypeError):
     logger.error("Invalid value for MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD, using default 0.95")
     MAINTAIN_AUTO_RESOLVE_THRESHOLD = 0.95
+# Two-signal guard: only auto-resolve when both memories share the same type
+# AND their age difference exceeds this threshold (prevents resolving recent updates)
+MAINTAIN_AUTO_RESOLVE_AGE_DAYS = safe_get_int_env('MCP_MAINTAIN_AUTO_RESOLVE_AGE_DAYS', 7, min_value=0, max_value=365)
 
 # =============================================================================
 # Configuration Validation

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -1190,6 +1190,13 @@ else:
 # End Memory Type Ontology Configuration
 
 # =============================================================================
+# Maintenance Configuration (memory_quality action="maintain")
+# =============================================================================
+MAINTAIN_STALE_DAYS = safe_get_int_env('MCP_MAINTAIN_STALE_DAYS', 30, min_value=1, max_value=3650)
+MAINTAIN_AUTO_RESOLVE = os.getenv('MCP_MAINTAIN_AUTO_RESOLVE', 'false').lower() in ('true', '1', 'yes')
+MAINTAIN_AUTO_RESOLVE_THRESHOLD = float(os.getenv('MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD', '0.95'))
+
+# =============================================================================
 # Configuration Validation
 # =============================================================================
 

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -22,7 +22,7 @@ Extracted from server_impl.py Phase 2.5 refactoring.
 import logging
 import traceback
 import json
-import time as _time
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 
@@ -32,6 +32,7 @@ from ...config import (
     MAINTAIN_STALE_DAYS,
     MAINTAIN_AUTO_RESOLVE,
     MAINTAIN_AUTO_RESOLVE_THRESHOLD,
+    MAINTAIN_AUTO_RESOLVE_AGE_DAYS,
 )
 
 logger = logging.getLogger(__name__)
@@ -338,7 +339,10 @@ _last_maintain_run: Dict[str, Any] = {}
 
 
 async def handle_maintain_status() -> List[types.TextContent]:
-    """Return stats from the last maintain run."""
+    """Return stats from the last maintain run.
+
+    Note: state is held in-process memory and resets on server restart.
+    """
     if not _last_maintain_run:
         return [types.TextContent(type="text", text=json.dumps({"status": "never_run"}))]
     return [types.TextContent(type="text", text=json.dumps(_last_maintain_run, indent=2, default=str))]
@@ -358,8 +362,9 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         "stale_days": MAINTAIN_STALE_DAYS,
         "auto_resolve": MAINTAIN_AUTO_RESOLVE,
         "auto_resolve_threshold": MAINTAIN_AUTO_RESOLVE_THRESHOLD,
+        "auto_resolve_age_days": MAINTAIN_AUTO_RESOLVE_AGE_DAYS,
     }
-    start = _time.time()
+    start = time.time()
     report: Dict[str, Any] = {
         "action": "maintain",
         "dry_run": dry_run,
@@ -399,10 +404,43 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
                 and c.get("similarity", 0) >= config["auto_resolve_threshold"]
             )
             if can_resolve:
-                ok, msg = await storage.resolve_conflict(c["hash_a"], c["hash_b"])
+                # Two-signal guard: fetch both memories to check type + age
+                mem_a = await storage.get_by_hash(c["hash_a"])
+                mem_b = await storage.get_by_hash(c["hash_b"])
+                if not mem_a or not mem_b:
+                    skipped += 1
+                    detail["action"] = "skipped_missing_memory"
+                    conflict_details.append(detail)
+                    continue
+
+                # Guard 1: same memory_type required
+                if (mem_a.memory_type or "") != (mem_b.memory_type or ""):
+                    skipped += 1
+                    detail["action"] = "skipped_type_mismatch"
+                    conflict_details.append(detail)
+                    continue
+
+                # Guard 2: age delta must exceed threshold
+                ts_a = mem_a.created_at or 0
+                ts_b = mem_b.created_at or 0
+                age_delta_days = abs(ts_a - ts_b) / 86400
+                if age_delta_days < config["auto_resolve_age_days"]:
+                    skipped += 1
+                    detail["action"] = "skipped_age_too_close"
+                    conflict_details.append(detail)
+                    continue
+
+                # Newer-wins: the memory with the higher created_at is the winner
+                if ts_a >= ts_b:
+                    winner_hash, loser_hash = c["hash_a"], c["hash_b"]
+                else:
+                    winner_hash, loser_hash = c["hash_b"], c["hash_a"]
+
+                ok, msg = await storage.resolve_conflict(winner_hash, loser_hash)
                 if ok:
                     resolved += 1
                     detail["action"] = "auto_resolved"
+                    detail["winner"] = winner_hash[:12]
                 else:
                     skipped += 1
                     detail["action"] = f"resolve_failed: {msg}"
@@ -453,7 +491,7 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["errors"].append(f"quality: {e}")
         report["steps"]["quality"] = {"error": str(e)}
 
-    elapsed = round(_time.time() - start, 2)
+    elapsed = round(time.time() - start, 2)
     report["elapsed_seconds"] = elapsed
     report["completed_at"] = datetime.now(timezone.utc).isoformat()
     report["success"] = len(report["errors"]) == 0

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -37,7 +37,7 @@ async def handle_memory_quality(server, arguments: dict) -> List[types.TextConte
         return [types.TextContent(type="text", text="Error: action parameter is required")]
 
     # Validate action
-    valid_actions = ["rate", "get", "analyze"]
+    valid_actions = ["rate", "get", "analyze", "maintain", "maintain_status"]
     if action not in valid_actions:
         return [types.TextContent(
             type="text",
@@ -72,6 +72,12 @@ async def handle_memory_quality(server, arguments: dict) -> List[types.TextConte
                 "min_quality": arguments.get("min_quality", 0.0),
                 "max_quality": arguments.get("max_quality", 1.0)
             })
+
+        elif action == "maintain":
+            return await handle_maintain(server, arguments)
+
+        elif action == "maintain_status":
+            return await handle_maintain_status()
 
         else:
             # Should never reach here due to validation above
@@ -314,3 +320,149 @@ async def handle_analyze_quality_distribution(server, arguments: dict) -> List[t
     except Exception as e:
         logger.error(f"Error in analyze_quality_distribution: {str(e)}\n{traceback.format_exc()}")
         return [types.TextContent(type="text", text=f"Error analyzing quality distribution: {str(e)}")]
+
+
+# =============================================================================
+# Maintenance orchestrator (memory_quality action="maintain")
+# =============================================================================
+
+import time as _time
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from ...config import (
+    MAINTAIN_STALE_DAYS,
+    MAINTAIN_AUTO_RESOLVE,
+    MAINTAIN_AUTO_RESOLVE_THRESHOLD,
+)
+
+_last_maintain_run: Dict[str, Any] = {}
+
+
+async def handle_maintain_status() -> List[types.TextContent]:
+    """Return stats from the last maintain run."""
+    if not _last_maintain_run:
+        return [types.TextContent(type="text", text=json.dumps({"status": "never_run"}))]
+    return [types.TextContent(type="text", text=json.dumps(_last_maintain_run, indent=2, default=str))]
+
+
+async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
+    """
+    One-shot maintenance cycle: cleanup → conflicts → stale → quality.
+
+    dry_run=true (default): report only, no mutations.
+    """
+    global _last_maintain_run
+    dry_run = arguments.get("dry_run", True)
+
+    storage = await server._ensure_storage_initialized()
+    config = {
+        "stale_days": MAINTAIN_STALE_DAYS,
+        "auto_resolve": MAINTAIN_AUTO_RESOLVE,
+        "auto_resolve_threshold": MAINTAIN_AUTO_RESOLVE_THRESHOLD,
+    }
+    start = _time.time()
+    report: Dict[str, Any] = {
+        "action": "maintain",
+        "dry_run": dry_run,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "config": config,
+        "steps": {},
+        "errors": [],
+    }
+
+    # Step 1: Cleanup duplicates
+    try:
+        if dry_run:
+            stats = await storage.get_stats()
+            report["steps"]["cleanup"] = {"skipped_dry_run": True, "current_total": stats.get("total_memories", 0)}
+        else:
+            count_removed, msg = await storage.cleanup_duplicates()
+            report["steps"]["cleanup"] = {"duplicates_removed": count_removed, "message": msg}
+    except Exception as e:
+        report["errors"].append(f"cleanup: {e}")
+        report["steps"]["cleanup"] = {"error": str(e)}
+
+    # Step 2: Conflict detection + optional auto-resolve
+    try:
+        conflicts = await storage.get_conflicts()
+        resolved = 0
+        skipped = 0
+        conflict_details = []
+        for c in conflicts:
+            detail = {
+                "hash_a": c["hash_a"][:12],
+                "hash_b": c["hash_b"][:12],
+                "similarity": round(c.get("similarity", 0), 3),
+            }
+            can_resolve = (
+                config["auto_resolve"]
+                and not dry_run
+                and c.get("similarity", 0) >= config["auto_resolve_threshold"]
+            )
+            if can_resolve:
+                ok, msg = await storage.resolve_conflict(c["hash_a"], c["hash_b"])
+                if ok:
+                    resolved += 1
+                    detail["action"] = "auto_resolved"
+                else:
+                    skipped += 1
+                    detail["action"] = f"resolve_failed: {msg}"
+            else:
+                skipped += 1
+                detail["action"] = "skipped" if dry_run else "below_threshold"
+            conflict_details.append(detail)
+        report["steps"]["conflicts"] = {
+            "total": len(conflicts),
+            "auto_resolved": resolved,
+            "skipped": skipped,
+            "details": conflict_details[:20],
+        }
+    except Exception as e:
+        report["errors"].append(f"conflicts: {e}")
+        report["steps"]["conflicts"] = {"error": str(e)}
+
+    # Step 3: Stale memory detection
+    try:
+        stale_count = await storage.count_all_memories(stale_days=config["stale_days"])
+        report["steps"]["stale"] = {
+            "stale_days_threshold": config["stale_days"],
+            "stale_count": stale_count,
+        }
+    except Exception as e:
+        report["errors"].append(f"stale: {e}")
+        report["steps"]["stale"] = {"error": str(e)}
+
+    # Step 4: Quality snapshot
+    try:
+        all_memories = await storage.get_all_memories()
+        if all_memories:
+            scores = [
+                m.metadata.get("quality_score", 0.5)
+                for m in all_memories
+                if hasattr(m, "metadata") and isinstance(m.metadata, dict)
+            ]
+            if scores:
+                avg = sum(scores) / len(scores)
+                report["steps"]["quality"] = {
+                    "total_scored": len(scores),
+                    "average_score": round(avg, 3),
+                    "high_quality": sum(1 for s in scores if s >= 0.7),
+                    "medium_quality": sum(1 for s in scores if 0.3 <= s < 0.7),
+                    "low_quality": sum(1 for s in scores if s < 0.3),
+                }
+            else:
+                report["steps"]["quality"] = {"total_scored": 0, "message": "no quality scores available"}
+        else:
+            report["steps"]["quality"] = {"total_scored": 0, "message": "no memories"}
+    except Exception as e:
+        report["errors"].append(f"quality: {e}")
+        report["steps"]["quality"] = {"error": str(e)}
+
+    elapsed = round(_time.time() - start, 2)
+    report["elapsed_seconds"] = elapsed
+    report["completed_at"] = datetime.now(timezone.utc).isoformat()
+    report["success"] = len(report["errors"]) == 0
+
+    _last_maintain_run = report
+    return [types.TextContent(type="text", text=json.dumps(report, indent=2, default=str))]

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -22,9 +22,17 @@ Extracted from server_impl.py Phase 2.5 refactoring.
 import logging
 import traceback
 import json
-from typing import List
+import time as _time
+from datetime import datetime, timezone
+from typing import Any, Dict, List
 
 from mcp import types
+
+from ...config import (
+    MAINTAIN_STALE_DAYS,
+    MAINTAIN_AUTO_RESOLVE,
+    MAINTAIN_AUTO_RESOLVE_THRESHOLD,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -326,16 +334,6 @@ async def handle_analyze_quality_distribution(server, arguments: dict) -> List[t
 # Maintenance orchestrator (memory_quality action="maintain")
 # =============================================================================
 
-import time as _time
-from datetime import datetime, timezone
-from typing import Any, Dict
-
-from ...config import (
-    MAINTAIN_STALE_DAYS,
-    MAINTAIN_AUTO_RESOLVE,
-    MAINTAIN_AUTO_RESOLVE_THRESHOLD,
-)
-
 _last_maintain_run: Dict[str, Any] = {}
 
 
@@ -437,19 +435,15 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
     try:
         all_memories = await storage.get_all_memories()
         if all_memories:
-            scores = [
-                m.metadata.get("quality_score", 0.5)
-                for m in all_memories
-                if hasattr(m, "metadata") and isinstance(m.metadata, dict)
-            ]
+            scores = [m.quality_score for m in all_memories]
             if scores:
                 avg = sum(scores) / len(scores)
                 report["steps"]["quality"] = {
                     "total_scored": len(scores),
                     "average_score": round(avg, 3),
                     "high_quality": sum(1 for s in scores if s >= 0.7),
-                    "medium_quality": sum(1 for s in scores if 0.3 <= s < 0.7),
-                    "low_quality": sum(1 for s in scores if s < 0.3),
+                    "medium_quality": sum(1 for s in scores if 0.5 <= s < 0.7),
+                    "low_quality": sum(1 for s in scores if s < 0.5),
                 }
             else:
                 report["steps"]["quality"] = {"total_scored": 0, "message": "no quality scores available"}

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2048,19 +2048,24 @@ ACTIONS:
 - rate: Manually rate a memory's quality (thumbs up/down)
 - get: Get quality metrics for a specific memory
 - analyze: Analyze quality distribution across all memories
+- maintain: Run maintenance cycle (cleanup + conflicts + stale + quality)
+- maintain_status: Get stats from last maintenance run
 
 Examples:
 {"action": "rate", "content_hash": "abc123", "rating": 1, "feedback": "Very useful"}
 {"action": "get", "content_hash": "abc123"}
 {"action": "analyze"}
 {"action": "analyze", "min_quality": 0.5, "max_quality": 1.0}
+{"action": "maintain"}
+{"action": "maintain", "dry_run": false}
+{"action": "maintain_status"}
 """,
                         inputSchema={
                             "type": "object",
                             "properties": {
                                 "action": {
                                     "type": "string",
-                                    "enum": ["rate", "get", "analyze"],
+                                    "enum": ["rate", "get", "analyze", "maintain", "maintain_status"],
                                     "description": "Quality action to perform"
                                 },
                                 "content_hash": {
@@ -2085,6 +2090,11 @@ Examples:
                                     "type": "number",
                                     "default": 1.0,
                                     "description": "For 'analyze': maximum quality threshold"
+                                },
+                                "dry_run": {
+                                    "type": "boolean",
+                                    "default": True,
+                                    "description": "For 'maintain': preview mode — no modifications (default: true)"
                                 }
                             },
                             "required": ["action"]

--- a/tests/quality/test_maintain.py
+++ b/tests/quality/test_maintain.py
@@ -95,17 +95,90 @@ async def test_maintain_detects_conflicts(mock_server):
 @pytest.mark.asyncio
 @patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE", True)
 @patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_THRESHOLD", 0.80)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_AGE_DAYS", 7)
 async def test_maintain_auto_resolves_above_threshold(mock_server):
-    """With auto_resolve=true, conflicts above threshold are resolved."""
+    """With auto_resolve=true, conflicts above threshold are resolved (newer wins)."""
     server, storage = mock_server
+
+    # Create mock memories with same type and age delta > 7 days
+    mem_old = MagicMock()
+    mem_old.created_at = 1700000000.0  # older
+    mem_old.memory_type = "note"
+    mem_new = MagicMock()
+    mem_new.created_at = 1701000000.0  # ~11.5 days newer
+    mem_new.memory_type = "note"
+
     storage.get_conflicts = AsyncMock(return_value=[
         {"hash_a": "aaa111bbb222", "hash_b": "ccc333ddd444", "similarity": 0.96},
     ])
+    storage.get_by_hash = AsyncMock(side_effect=lambda h: mem_old if h == "aaa111bbb222" else mem_new)
+
     result = await handle_maintain(server, {"dry_run": False})
     report = json.loads(result[0].text)
 
     assert report["steps"]["conflicts"]["auto_resolved"] == 1
-    storage.resolve_conflict.assert_called_once()
+    # Newer memory (ccc333ddd444) should be the winner
+    storage.resolve_conflict.assert_called_once_with("ccc333ddd444", "aaa111bbb222")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE", True)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_THRESHOLD", 0.80)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_AGE_DAYS", 7)
+async def test_maintain_skips_type_mismatch(mock_server):
+    """Auto-resolve skips conflicts where memory types differ."""
+    server, storage = mock_server
+
+    mem_a = MagicMock()
+    mem_a.created_at = 1700000000.0
+    mem_a.memory_type = "note"
+    mem_b = MagicMock()
+    mem_b.created_at = 1701000000.0
+    mem_b.memory_type = "decision"
+
+    storage.get_conflicts = AsyncMock(return_value=[
+        {"hash_a": "aaa111bbb222", "hash_b": "ccc333ddd444", "similarity": 0.96},
+    ])
+    storage.get_by_hash = AsyncMock(side_effect=lambda h: mem_a if h == "aaa111bbb222" else mem_b)
+
+    result = await handle_maintain(server, {"dry_run": False})
+    report = json.loads(result[0].text)
+
+    assert report["steps"]["conflicts"]["auto_resolved"] == 0
+    assert report["steps"]["conflicts"]["skipped"] == 1
+    assert report["steps"]["conflicts"]["details"][0]["action"] == "skipped_type_mismatch"
+    storage.resolve_conflict.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE", True)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_THRESHOLD", 0.80)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_AGE_DAYS", 7)
+async def test_maintain_skips_age_too_close(mock_server):
+    """Auto-resolve skips conflicts where age delta is below threshold."""
+    server, storage = mock_server
+
+    mem_a = MagicMock()
+    mem_a.created_at = 1700000000.0
+    mem_a.memory_type = "note"
+    mem_b = MagicMock()
+    mem_b.created_at = 1700200000.0  # ~2.3 days apart (< 7)
+    mem_b.memory_type = "note"
+
+    storage.get_conflicts = AsyncMock(return_value=[
+        {"hash_a": "aaa111bbb222", "hash_b": "ccc333ddd444", "similarity": 0.96},
+    ])
+    storage.get_by_hash = AsyncMock(side_effect=lambda h: mem_a if h == "aaa111bbb222" else mem_b)
+
+    result = await handle_maintain(server, {"dry_run": False})
+    report = json.loads(result[0].text)
+
+    assert report["steps"]["conflicts"]["auto_resolved"] == 0
+    assert report["steps"]["conflicts"]["skipped"] == 1
+    assert report["steps"]["conflicts"]["details"][0]["action"] == "skipped_age_too_close"
+    storage.resolve_conflict.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/quality/test_maintain.py
+++ b/tests/quality/test_maintain.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Claudio Ferreira Filho
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Tests for memory_quality(action="maintain") — maintenance orchestrator.
+
+Covers:
+- dry_run=true (default): no mutations, report only
+- dry_run=false: cleanup runs, conflicts resolved
+- maintain_status: returns last run or never_run
+- Error handling: individual step failures don't abort the cycle
+"""
+
+import json
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_memory_service.server.handlers.quality import (
+    handle_maintain,
+    handle_maintain_status,
+    _last_maintain_run,
+)
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock server with storage."""
+    server = MagicMock()
+    storage = MagicMock()
+
+    # Default mocks
+    storage.get_stats = AsyncMock(return_value={"total_memories": 42})
+    storage.cleanup_duplicates = AsyncMock(return_value=(3, "Removed 3 duplicates"))
+    storage.get_conflicts = AsyncMock(return_value=[])
+    storage.count_all_memories = AsyncMock(return_value=5)
+    storage.get_all_memories = AsyncMock(return_value=[])
+    storage.resolve_conflict = AsyncMock(return_value=(True, "resolved"))
+
+    server._ensure_storage_initialized = AsyncMock(return_value=storage)
+    return server, storage
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_dry_run_default(mock_server):
+    """Default call is dry_run=true — no mutations."""
+    server, storage = mock_server
+    result = await handle_maintain(server, {})
+    report = json.loads(result[0].text)
+
+    assert report["dry_run"] is True
+    assert report["success"] is True
+    assert "cleanup" in report["steps"]
+    assert report["steps"]["cleanup"]["skipped_dry_run"] is True
+    # cleanup_duplicates should NOT be called in dry_run
+    storage.cleanup_duplicates.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_runs_cleanup(mock_server):
+    """dry_run=false runs actual cleanup."""
+    server, storage = mock_server
+    result = await handle_maintain(server, {"dry_run": False})
+    report = json.loads(result[0].text)
+
+    assert report["dry_run"] is False
+    assert report["steps"]["cleanup"]["duplicates_removed"] == 3
+    storage.cleanup_duplicates.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_detects_conflicts(mock_server):
+    """Conflicts are detected and reported."""
+    server, storage = mock_server
+    storage.get_conflicts = AsyncMock(return_value=[
+        {"hash_a": "aaa111bbb222", "hash_b": "ccc333ddd444", "similarity": 0.85},
+    ])
+    result = await handle_maintain(server, {})
+    report = json.loads(result[0].text)
+
+    assert report["steps"]["conflicts"]["total"] == 1
+    assert report["steps"]["conflicts"]["skipped"] == 1
+    assert report["steps"]["conflicts"]["auto_resolved"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE", True)
+@patch("mcp_memory_service.server.handlers.quality.MAINTAIN_AUTO_RESOLVE_THRESHOLD", 0.80)
+async def test_maintain_auto_resolves_above_threshold(mock_server):
+    """With auto_resolve=true, conflicts above threshold are resolved."""
+    server, storage = mock_server
+    storage.get_conflicts = AsyncMock(return_value=[
+        {"hash_a": "aaa111bbb222", "hash_b": "ccc333ddd444", "similarity": 0.96},
+    ])
+    result = await handle_maintain(server, {"dry_run": False})
+    report = json.loads(result[0].text)
+
+    assert report["steps"]["conflicts"]["auto_resolved"] == 1
+    storage.resolve_conflict.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_stale_detection(mock_server):
+    """Stale count is reported."""
+    server, storage = mock_server
+    storage.count_all_memories = AsyncMock(return_value=12)
+    result = await handle_maintain(server, {})
+    report = json.loads(result[0].text)
+
+    assert report["steps"]["stale"]["stale_count"] == 12
+    assert report["steps"]["stale"]["stale_days_threshold"] == 30
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_step_error_does_not_abort(mock_server):
+    """If one step fails, others still run."""
+    server, storage = mock_server
+    storage.get_conflicts = AsyncMock(side_effect=Exception("conflict DB error"))
+    result = await handle_maintain(server, {})
+    report = json.loads(result[0].text)
+
+    # conflicts errored
+    assert "conflict DB error" in report["steps"]["conflicts"]["error"]
+    assert "conflicts: conflict DB error" in report["errors"]
+    # but stale and quality still ran
+    assert "stale" in report["steps"]
+    assert "quality" in report["steps"]
+    assert report["success"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_status_never_run():
+    """maintain_status returns never_run when no run has happened."""
+    # Reset module state
+    import mcp_memory_service.server.handlers.quality as qmod
+    qmod._last_maintain_run = {}
+
+    result = await handle_maintain_status()
+    data = json.loads(result[0].text)
+    assert data["status"] == "never_run"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_maintain_status_after_run(mock_server):
+    """maintain_status returns last run report."""
+    server, storage = mock_server
+    await handle_maintain(server, {})
+
+    result = await handle_maintain_status()
+    data = json.loads(result[0].text)
+    assert data["action"] == "maintain"
+    assert "elapsed_seconds" in data


### PR DESCRIPTION
Closes #799

## Summary

Extends `memory_quality` with two new actions for one-shot maintenance:

```json
memory_quality(action="maintain")                    // full cycle, dry_run=true by default
memory_quality(action="maintain", dry_run=false)     // actually mutate
memory_quality(action="maintain_status")             // last run stats
```

### What it does (in sequence)

1. **Cleanup** — find and remove duplicates (skipped in dry_run)
2. **Conflicts** — detect contradictions, optionally auto-resolve above threshold
3. **Stale detection** — count memories not accessed in >N days (uses `stale_days` from #796)
4. **Quality snapshot** — report quality score distribution
5. **Summary** — structured JSON report of everything done/found

### Design decisions (per #799 discussion)

- **Option A**: extends `memory_quality` instead of new tool (keeps 12-tool surface from v10.0)
- **dry_run=true by default** — first call is always a preview
- **auto_resolve=false by default** — opt-in via `MCP_MAINTAIN_AUTO_RESOLVE`
- When enabled: threshold `0.95` (`MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD`)
- Individual step errors don't abort the cycle — report includes all errors
- Rebased on v10.46.0 (#796 merged)

### Config env vars

| Var | Default | Description |
|-----|---------|-------------|
| `MCP_MAINTAIN_STALE_DAYS` | 30 | Days threshold for stale detection |
| `MCP_MAINTAIN_AUTO_RESOLVE` | false | Auto-resolve conflicts above threshold |
| `MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD` | 0.95 | Similarity threshold for auto-resolve |

### Size

~500 LOC total: 154 handler + 165 tests + 7 config + 12 server_impl schema.

## Tests (8 new)

| Test | What it verifies |
|------|------------------|
| `test_maintain_dry_run_default` | Default is dry_run=true, no mutations |
| `test_maintain_runs_cleanup` | dry_run=false runs actual cleanup |
| `test_maintain_detects_conflicts` | Conflicts detected and reported |
| `test_maintain_auto_resolves_above_threshold` | Auto-resolve with opt-in config |
| `test_maintain_stale_detection` | Stale count reported |
| `test_maintain_step_error_does_not_abort` | One step failing doesn't stop others |
| `test_maintain_status_never_run` | Status returns never_run initially |
| `test_maintain_status_after_run` | Status returns last run report |

```bash
python -m pytest tests/quality/test_maintain.py -v
# 8 passed
```