### PR TITLE
feat(docker): quantize deberta ONNX classifier at build time

### DIFF
--- a/tools/docker/Dockerfile.quality-cpu
+++ b/tools/docker/Dockerfile.quality-cpu
@@ -52,6 +52,7 @@ RUN python -m uv pip install \
     "huggingface_hub>=0.20.0" \
     "onnx>=1.14.0" \
     "onnxscript>=0.1.0" \
+    "onnxconverter-common>=1.14.0" \
     "safetensors>=0.4.0" \
     "onnxruntime>=1.15.0" \
     "tokenizers>=0.20.0" \
@@ -63,6 +64,17 @@ RUN python -m uv pip install \
 # Copy and run the export script
 COPY tools/docker/scripts/export_quality_models.py /build/export_quality_models.py
 RUN python /build/export_quality_models.py
+
+# Quantize the deberta classifier in-place (fp16 / int8) to shrink the runtime image.
+# Picks the smallest variant with Pearson correlation >= 0.98 vs fp32 baseline,
+# falls back to fp32 if no variant meets the threshold (build does not fail).
+# Override behavior with build args (e.g. --build-arg QUANTIZE_MODE=fp16).
+ARG QUANTIZE_MODE=best
+ARG QUANTIZE_MIN_CORR=0.98
+COPY tools/docker/scripts/quantize_quality_models.py /build/quantize_quality_models.py
+RUN python /build/quantize_quality_models.py \
+        --mode "${QUANTIZE_MODE}" \
+        --min-correlation "${QUANTIZE_MIN_CORR}"
 
 # ---------------------------------------------------------------------------
 # Stage 2 — runtime: slim image with baked ONNX artifacts

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -6,7 +6,7 @@
 |-----|-------------|------------------------|
 | `:latest` | Standard image, full feature set | baseline |
 | `:slim` | CPU-only, no PyTorch/CUDA | ~90% smaller |
-| `:quality-cpu` | Slim + pre-exported ONNX quality models, no runtime PyTorch | ~250-300 MB larger than `:slim` |
+| `:quality-cpu` | Slim + pre-exported ONNX quality models, no runtime PyTorch | ~600 MB larger than `:slim` (deberta classifier quantized to fp16/int8 at build) |
 
 ### `:quality-cpu` — local quality scoring without runtime PyTorch
 
@@ -34,6 +34,35 @@ artifacts at `/root/.cache/mcp_memory/onnx_models/`.
 
 **Homelab use case:** ideal for Raspberry Pi, NAS, or any always-on box where
 you want quality scoring without pulling a 2 GB PyTorch wheel every restart.
+
+#### Build-time quantization
+
+The `nvidia-quality-classifier-deberta` ONNX model ships ~702 MB of fp32 external
+weights, which dominates the image size. The build pipeline runs
+`tools/docker/scripts/quantize_quality_models.py` after export to:
+
+1. Convert fp32 → fp16 (via `onnxconverter-common`)
+2. Apply dynamic int8 to MatMul + Gather (via `onnxruntime.quantization`)
+3. Benchmark each variant: file size, mean inference latency, and Pearson
+   correlation against the fp32 baseline on 100 sample texts
+4. Replace fp32 with the smallest variant whose correlation is ≥ 0.98
+5. Fall back to fp32 (no failure) if no variant meets the threshold
+
+Override the strategy at build time:
+
+```bash
+# Force fp16 only (safer on ARM)
+docker build --build-arg QUANTIZE_MODE=fp16 -f tools/docker/Dockerfile.quality-cpu .
+
+# Tighten the correlation gate
+docker build --build-arg QUANTIZE_MIN_CORR=0.99 -f tools/docker/Dockerfile.quality-cpu .
+
+# Skip quantization entirely (set mode to fp16 with an unreachable corr; falls back to fp32)
+docker build --build-arg QUANTIZE_MIN_CORR=1.01 -f tools/docker/Dockerfile.quality-cpu .
+```
+
+`ms-marco-MiniLM-L-6-v2` is intentionally not quantized — it's already ~80 MB
+and not worth the engineering risk.
 
 ## 🚀 Quick Start
 

--- a/tools/docker/scripts/quantize_quality_models.py
+++ b/tools/docker/scripts/quantize_quality_models.py
@@ -78,10 +78,13 @@ def _ensure_quantization_deps() -> None:
     try:
         import onnx  # noqa: F401
         import onnxruntime  # noqa: F401
+        import onnxconverter_common  # noqa: F401
+        import tokenizers  # noqa: F401
         from onnxruntime.quantization import quantize_dynamic, QuantType  # noqa: F401
     except ImportError as exc:
         raise SystemExit(
-            f"Missing quantization dependency ({exc}). Install onnx + onnxruntime in the builder stage."
+            f"Missing quantization dependency ({exc}). Install onnx, onnxruntime, "
+            "onnxconverter-common, and tokenizers in the builder stage."
         )
 
 
@@ -90,15 +93,38 @@ def _model_dir(model_name: str) -> Path:
 
 
 def _model_size_bytes(model_path: Path) -> int:
-    """Total size of the .onnx file plus any external-data sidecar files in the same dir."""
+    """Total size of the .onnx file plus its external-data sidecars.
+
+    Sidecars must share the same stem prefix as the model file (e.g.
+    `model.fp16.onnx` -> `model.fp16.onnx_data` / `model.fp16.onnx_data_*`).
+    Files belonging to other variants in the same directory are ignored, which
+    is what allows variants to coexist for benchmarking without polluting each
+    other's measured size.
+    """
     total = model_path.stat().st_size
+    prefix = model_path.name + "_"  # e.g. "model.fp16.onnx_"
     for sibling in model_path.parent.iterdir():
         if sibling == model_path or not sibling.is_file():
             continue
-        # External weights for ONNX models (e.g. weights, model.onnx_data) live alongside.
-        if sibling.name.endswith(".onnx_data") or sibling.suffix in {".weight", ".bin"}:
+        if sibling.name.startswith(prefix):
             total += sibling.stat().st_size
     return total
+
+
+def _onnx_artifact_files(model_path: Path) -> list[Path]:
+    """All files that belong to a given ONNX artifact (.onnx + sidecars).
+
+    Used for cleanup after a variant is rejected or replaced. Mirrors the
+    sibling-detection rule in `_model_size_bytes` to stay consistent.
+    """
+    files = [model_path]
+    prefix = model_path.name + "_"
+    for sibling in model_path.parent.iterdir():
+        if sibling == model_path or not sibling.is_file():
+            continue
+        if sibling.name.startswith(prefix):
+            files.append(sibling)
+    return files
 
 
 def _quantize_fp16(src: Path, dst: Path) -> None:
@@ -211,13 +237,24 @@ def _benchmark(
 
 
 def _to_scalar(logits: np.ndarray) -> np.ndarray:
-    """Reduce per-sample logits to a single scalar score for correlation."""
+    """Reduce per-sample logits to the same scalar score the production code uses.
+
+    Mirrors `quality/onnx_ranker.py::score_quality` for the DeBERTa classifier:
+    softmax over 3 classes (label order: 0=High, 1=Medium, 2=Low) and dot
+    product with [1.0, 0.5, 0.0]. Using the same reduction here means the
+    correlation we measure is the correlation that actually matters at runtime.
+    """
     if logits.ndim == 1:
-        return logits
-    # Softmax-then-take-positive-class is a stable reduction for binary/3-class classifiers.
+        # Already scalar (binary / cross-encoder). Apply sigmoid to match runtime.
+        return 1.0 / (1.0 + np.exp(-logits))
     exp = np.exp(logits - logits.max(axis=-1, keepdims=True))
     probs = exp / exp.sum(axis=-1, keepdims=True)
-    return probs[..., -1]
+    class_values = np.array([1.0, 0.5, 0.0], dtype=np.float64)
+    if probs.shape[-1] != class_values.shape[0]:
+        # Defensive: unknown classifier shape — fall back to top-class probability
+        # so we still produce a usable correlation rather than crashing the build.
+        return probs.max(axis=-1)
+    return probs @ class_values
 
 
 def _pick_winner(variants: list[Variant], min_corr: float) -> Optional[Variant]:
@@ -280,21 +317,29 @@ def quantize_model(model_name: str, mode: str, min_correlation: float, strict: b
             logger.error(msg + " (--strict): failing build.")
             return 2
         logger.warning(msg)
-        # Clean up rejected artifacts.
+        # Clean up rejected variants (file + their sidecars).
         for v in candidates:
-            v.path.unlink(missing_ok=True)
+            for f in _onnx_artifact_files(v.path):
+                f.unlink(missing_ok=True)
         return 0
 
     logger.info(f"Winner: {winner.name} (size {winner.size_bytes / 1e6:.1f} MB, corr {winner.correlation:.4f}).")
 
-    # Replace fp32 with winner; remove other variants.
-    backup = fp32_path.with_suffix(".fp32.onnx.bak")
-    shutil.move(str(fp32_path), str(backup))
-    shutil.move(str(winner.path), str(fp32_path))
-    backup.unlink(missing_ok=True)
+    # Delete the fp32 artifact set (model.onnx + every sidecar like model.onnx_data).
+    # This is the critical step: without it the ~700 MB external-weights file
+    # would remain in the image even though model.onnx itself was replaced.
+    for f in _onnx_artifact_files(fp32_path):
+        f.unlink(missing_ok=True)
+
+    # Delete losing variants (file + their sidecars).
     for v in candidates:
         if v.name != winner.name:
-            v.path.unlink(missing_ok=True)
+            for f in _onnx_artifact_files(v.path):
+                f.unlink(missing_ok=True)
+
+    # Promote the winner into model.onnx. fp16/int8 variants are single-file,
+    # so a plain rename is sufficient — there are no sidecars to move.
+    shutil.move(str(winner.path), str(fp32_path))
 
     final_size = _model_size_bytes(fp32_path)
     logger.info(f"Final model.onnx: {final_size / 1e6:.1f} MB")

--- a/tools/docker/scripts/quantize_quality_models.py
+++ b/tools/docker/scripts/quantize_quality_models.py
@@ -1,0 +1,335 @@
+"""
+Quantize the deberta quality classifier ONNX model at Docker build time.
+
+The fp32 export of nvidia-quality-classifier-deberta is ~702 MB of external
+weights, which dominates the :quality-cpu image size delta vs :latest. This
+script produces fp16 and dynamic-int8 variants, benchmarks each against the
+fp32 baseline (size, Pearson correlation, latency), and replaces the fp32
+artifact with the winner.
+
+Decision rule:
+  * Correlation with fp32 must be >= MIN_CORRELATION (default 0.98).
+  * Among passing variants, pick the smallest.
+  * Tie-break by latency.
+  * If no variant passes, keep fp32 and exit non-zero (fail the build only
+    when --strict is passed; otherwise warn and keep fp32).
+
+ms-marco-MiniLM-L-6-v2 is intentionally skipped — it's already ~80 MB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "nvidia-quality-classifier-deberta"
+MIN_CORRELATION = 0.98
+NUM_SAMPLES = 100
+MAX_SEQ_LEN = 256
+
+
+# Synthetic but realistic memory-like texts. Kept inline so the script has no
+# external dataset dependency at build time.
+SAMPLE_TEXTS = [
+    "Fixed bug in auth middleware where session tokens were not refreshed on rotation.",
+    "Reminder: meeting with the platform team on Thursday at 2pm to discuss the migration plan.",
+    "User prefers terse responses without trailing summaries.",
+    "Decision: standardize on hybrid storage backend for all production deployments.",
+    "Refactored consolidation/graph.py to extract relationship inference into its own module.",
+    "Cloudflare token rotated 2026-04-15 — remember to update .env on production hosts.",
+    "Performance: SQLite-vec reads measured at 5ms median, 12ms p99 over 10k memories.",
+    "Note: the dashboard JS lacks automated test coverage; verify visually before merging.",
+    "TODO: remove the legacy /api/v1 endpoint after the v11 release.",
+    "Investigation: the flaky concurrent SQLite test is caused by busy_timeout interactions.",
+    "User authored issue #793 about quantizing the deberta ONNX model.",
+    "PR #773 introduced Reciprocal Rank Fusion for hybrid search.",
+    "OAuth public clients use PKCE without a client_secret per OAuth 2.1.",
+    "Hybrid sync owner setting: only the HTTP server should sync to Cloudflare.",
+    "Memory consolidation runs daily at 2am UTC via APScheduler.",
+    "The :quality-cpu image is currently 2.44 GB and needs to drop below 1 GB.",
+    "Henry's email is henry.krupp@gmail.com per the user-info memory.",
+    "Test cleanup deleted production memories on 2026-02-08; PR #438 added safeguards.",
+    "Always tag memories with 'mcp-memory-service' as the first tag.",
+    "Use github-release-manager agent for all version bumps and releases.",
+] * 5  # 100 samples
+
+
+@dataclass
+class Variant:
+    name: str
+    path: Path
+    size_bytes: int
+    correlation: float
+    mean_latency_ms: float
+
+
+def _ensure_quantization_deps() -> None:
+    try:
+        import onnx  # noqa: F401
+        import onnxruntime  # noqa: F401
+        from onnxruntime.quantization import quantize_dynamic, QuantType  # noqa: F401
+    except ImportError as exc:
+        raise SystemExit(
+            f"Missing quantization dependency ({exc}). Install onnx + onnxruntime in the builder stage."
+        )
+
+
+def _model_dir(model_name: str) -> Path:
+    return Path.home() / ".cache" / "mcp_memory" / "onnx_models" / model_name
+
+
+def _model_size_bytes(model_path: Path) -> int:
+    """Total size of the .onnx file plus any external-data sidecar files in the same dir."""
+    total = model_path.stat().st_size
+    for sibling in model_path.parent.iterdir():
+        if sibling == model_path or not sibling.is_file():
+            continue
+        # External weights for ONNX models (e.g. weights, model.onnx_data) live alongside.
+        if sibling.name.endswith(".onnx_data") or sibling.suffix in {".weight", ".bin"}:
+            total += sibling.stat().st_size
+    return total
+
+
+def _quantize_fp16(src: Path, dst: Path) -> None:
+    import onnx
+    from onnxconverter_common import float16
+
+    logger.info(f"[fp16] Converting {src.name} -> {dst.name}")
+    model = onnx.load(str(src))
+    model_fp16 = float16.convert_float_to_float16(model, keep_io_types=True)
+    onnx.save(model_fp16, str(dst), save_as_external_data=False)
+
+
+def _quantize_int8(src: Path, dst: Path) -> None:
+    from onnxruntime.quantization import quantize_dynamic, QuantType
+
+    logger.info(f"[int8] Dynamic-quantizing {src.name} -> {dst.name}")
+    quantize_dynamic(
+        model_input=str(src),
+        model_output=str(dst),
+        weight_type=QuantType.QInt8,
+        # MatMul + Gather cover the bulk of DeBERTa weight volume.
+        op_types_to_quantize=["MatMul", "Gather"],
+    )
+
+
+def _tokenize_samples(model_dir: Path, texts: list[str]) -> tuple[np.ndarray, np.ndarray]:
+    """Tokenize sample texts using the saved tokenizer.json. Returns padded input_ids + attention_mask."""
+    from tokenizers import Tokenizer
+
+    tokenizer_json = model_dir / "tokenizer.json"
+    if not tokenizer_json.exists():
+        raise FileNotFoundError(
+            f"tokenizer.json not found at {tokenizer_json} — was the model exported correctly?"
+        )
+
+    tok = Tokenizer.from_file(str(tokenizer_json))
+    tok.enable_truncation(max_length=MAX_SEQ_LEN)
+    tok.enable_padding(length=MAX_SEQ_LEN)
+
+    encodings = tok.encode_batch(texts)
+    input_ids = np.array([enc.ids for enc in encodings], dtype=np.int64)
+    attention_mask = np.array([enc.attention_mask for enc in encodings], dtype=np.int64)
+    return input_ids, attention_mask
+
+
+def _run_inference(onnx_path: Path, input_ids: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    output_name = sess.get_outputs()[0].name
+    # Run per-sample to keep peak memory low and to simulate realistic single-text scoring.
+    logits = []
+    for i in range(input_ids.shape[0]):
+        out = sess.run(
+            [output_name],
+            {
+                "input_ids": input_ids[i : i + 1],
+                "attention_mask": attention_mask[i : i + 1],
+            },
+        )
+        logits.append(out[0].squeeze())
+    return np.array(logits)
+
+
+def _benchmark(
+    name: str,
+    onnx_path: Path,
+    input_ids: np.ndarray,
+    attention_mask: np.ndarray,
+    fp32_logits: Optional[np.ndarray],
+) -> Variant:
+    import onnxruntime as ort
+
+    size_bytes = _model_size_bytes(onnx_path)
+
+    # Latency: warmup 3, measure 10
+    sess = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    output_name = sess.get_outputs()[0].name
+    feed = {"input_ids": input_ids[:1], "attention_mask": attention_mask[:1]}
+    for _ in range(3):
+        sess.run([output_name], feed)
+    samples = []
+    for _ in range(10):
+        t0 = time.perf_counter()
+        sess.run([output_name], feed)
+        samples.append((time.perf_counter() - t0) * 1000)
+    mean_latency_ms = float(np.mean(samples))
+
+    # Correlation against fp32
+    logits = _run_inference(onnx_path, input_ids, attention_mask)
+    if fp32_logits is None:
+        correlation = 1.0
+    else:
+        # Reduce multi-class logits to scalar by taking the argmax-class probability,
+        # which is what the quality scorer actually consumes.
+        fp32_scalar = _to_scalar(fp32_logits)
+        var_scalar = _to_scalar(logits)
+        correlation = float(np.corrcoef(fp32_scalar, var_scalar)[0, 1])
+
+    logger.info(
+        f"[{name}] size={size_bytes / 1e6:.1f} MB | corr={correlation:.4f} | latency={mean_latency_ms:.1f} ms"
+    )
+    return Variant(
+        name=name,
+        path=onnx_path,
+        size_bytes=size_bytes,
+        correlation=correlation,
+        mean_latency_ms=mean_latency_ms,
+    )
+
+
+def _to_scalar(logits: np.ndarray) -> np.ndarray:
+    """Reduce per-sample logits to a single scalar score for correlation."""
+    if logits.ndim == 1:
+        return logits
+    # Softmax-then-take-positive-class is a stable reduction for binary/3-class classifiers.
+    exp = np.exp(logits - logits.max(axis=-1, keepdims=True))
+    probs = exp / exp.sum(axis=-1, keepdims=True)
+    return probs[..., -1]
+
+
+def _pick_winner(variants: list[Variant], min_corr: float) -> Optional[Variant]:
+    passing = [v for v in variants if v.correlation >= min_corr]
+    if not passing:
+        return None
+    # Smallest size first; latency tie-break.
+    passing.sort(key=lambda v: (v.size_bytes, v.mean_latency_ms))
+    return passing[0]
+
+
+def quantize_model(model_name: str, mode: str, min_correlation: float, strict: bool) -> int:
+    _ensure_quantization_deps()
+
+    model_dir = _model_dir(model_name)
+    fp32_path = model_dir / "model.onnx"
+    if not fp32_path.exists():
+        logger.error(f"fp32 model not found at {fp32_path} — run export_quality_models.py first.")
+        return 1
+
+    fp16_path = model_dir / "model.fp16.onnx"
+    int8_path = model_dir / "model.int8.onnx"
+
+    input_ids, attention_mask = _tokenize_samples(model_dir, SAMPLE_TEXTS[:NUM_SAMPLES])
+    fp32_logits = _run_inference(fp32_path, input_ids, attention_mask)
+
+    variants: list[Variant] = [
+        _benchmark("fp32", fp32_path, input_ids, attention_mask, fp32_logits=None)
+    ]
+
+    if mode in ("fp16", "best"):
+        try:
+            _quantize_fp16(fp32_path, fp16_path)
+            variants.append(_benchmark("fp16", fp16_path, input_ids, attention_mask, fp32_logits))
+        except Exception as exc:
+            logger.warning(f"fp16 quantization failed: {exc}", exc_info=True)
+
+    if mode in ("int8", "best"):
+        try:
+            _quantize_int8(fp32_path, int8_path)
+            variants.append(_benchmark("int8", int8_path, input_ids, attention_mask, fp32_logits))
+        except Exception as exc:
+            logger.warning(f"int8 quantization failed: {exc}", exc_info=True)
+
+    logger.info("=" * 60)
+    logger.info(f"{'variant':>8} | {'size (MB)':>10} | {'corr':>6} | {'latency':>8}")
+    logger.info("-" * 60)
+    for v in variants:
+        logger.info(
+            f"{v.name:>8} | {v.size_bytes / 1e6:>10.1f} | {v.correlation:>6.4f} | {v.mean_latency_ms:>6.1f}ms"
+        )
+    logger.info("=" * 60)
+
+    candidates = [v for v in variants if v.name != "fp32"]
+    winner = _pick_winner(candidates, min_correlation)
+
+    if winner is None:
+        msg = f"No quantized variant met correlation >= {min_correlation}; keeping fp32."
+        if strict:
+            logger.error(msg + " (--strict): failing build.")
+            return 2
+        logger.warning(msg)
+        # Clean up rejected artifacts.
+        for v in candidates:
+            v.path.unlink(missing_ok=True)
+        return 0
+
+    logger.info(f"Winner: {winner.name} (size {winner.size_bytes / 1e6:.1f} MB, corr {winner.correlation:.4f}).")
+
+    # Replace fp32 with winner; remove other variants.
+    backup = fp32_path.with_suffix(".fp32.onnx.bak")
+    shutil.move(str(fp32_path), str(backup))
+    shutil.move(str(winner.path), str(fp32_path))
+    backup.unlink(missing_ok=True)
+    for v in candidates:
+        if v.name != winner.name:
+            v.path.unlink(missing_ok=True)
+
+    final_size = _model_size_bytes(fp32_path)
+    logger.info(f"Final model.onnx: {final_size / 1e6:.1f} MB")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model name to quantize.")
+    parser.add_argument(
+        "--mode",
+        choices=["fp16", "int8", "best"],
+        default="best",
+        help="Quantization mode. 'best' tries fp16 + int8 and picks the winner.",
+    )
+    parser.add_argument(
+        "--min-correlation",
+        type=float,
+        default=MIN_CORRELATION,
+        help="Minimum Pearson correlation with fp32 baseline (default: 0.98).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail with non-zero exit if no variant meets the correlation threshold.",
+    )
+    args = parser.parse_args()
+
+    return quantize_model(
+        model_name=args.model,
+        mode=args.mode,
+        min_correlation=args.min_correlation,
+        strict=args.strict,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #793.

Adds build-time quantization of `nvidia-quality-classifier-deberta` to shrink the `:quality-cpu` image. The fp32 export is ~702 MB of external weights and was the dominant size contributor.

## How it works

`tools/docker/scripts/quantize_quality_models.py` runs after the existing export step:

1. Converts fp32 → fp16 (`onnxconverter-common`)
2. Applies dynamic int8 to MatMul + Gather (`onnxruntime.quantization.quantize_dynamic`)
3. Benchmarks each variant: file size, mean inference latency, Pearson correlation vs fp32 on 100 sample texts
4. Picks the smallest variant with correlation ≥ 0.98
5. Replaces `model.onnx` in place; falls back to fp32 if no variant passes (no build failure)

CI builds the `:quality-cpu` image on PR — see the build log for the actual size/correlation/latency table once this lands.

## Build-arg knobs

- `QUANTIZE_MODE={fp16|int8|best}` — default `best`
- `QUANTIZE_MIN_CORR=<float>` — default `0.98`

## Acceptance criteria (from #793)

- [ ] `:quality-cpu` size delta vs `:latest` ≤ ~600 MB → verified once CI runs the build
- [x] Correlation gate ≥ 0.98 enforced in script
- [x] Documented in `tools/docker/README.md`
- [ ] Multi-arch (amd64, arm64) — fp16 is the safe ARM path; gate catches int8 regressions

## Out of scope

- Quantizing `ms-marco-MiniLM-L-6-v2` — already ~80 MB
- Runtime re-quantization

## Test plan

- [ ] Verify CI Docker build succeeds for `:quality-cpu` (linux/amd64 + linux/arm64)
- [ ] Inspect build log for the variant comparison table
- [ ] Confirm chosen variant meets correlation ≥ 0.98
- [ ] Pull resulting image and confirm `get_onnx_ranker_model('nvidia-quality-classifier-deberta')` loads + scores

Draft until CI numbers are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)