### PR TITLE
chore: release v10.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.47.0] - 2026-05-01
+
+### Added
+
+- **[#799] `memory_quality(action='maintain')` — one-call maintenance orchestrator**: New `maintain` action runs cleanup → conflict detection → stale detection → quality snapshot in a single cycle. `dry_run=true` by default so the tool is always safe to call. New `maintain_status` action returns last-run stats. Auto-resolve is opt-in via `MCP_MAINTAIN_AUTO_RESOLVE` (default `false`); when enabled, conflict pairs are auto-resolved when three signals all pass: cosine similarity ≥ `MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD` (default `0.95`), same `memory_type`, and age delta > `MCP_MAINTAIN_AUTO_RESOLVE_AGE_DAYS` (default `7`). Winner is the newer memory (`created_at`). New env vars: `MCP_MAINTAIN_STALE_DAYS`, `MCP_MAINTAIN_AUTO_RESOLVE`, `MCP_MAINTAIN_AUTO_RESOLVE_THRESHOLD`, `MCP_MAINTAIN_AUTO_RESOLVE_AGE_DAYS`. 10 new tests. Closes #799. Thanks to @filhocf for the contribution. (PR #802)
+
 ### Changed
 
 - **[#793] Quantize deberta quality classifier at Docker build time**: New `tools/docker/scripts/quantize_quality_models.py` runs after the existing ONNX export in `Dockerfile.quality-cpu`. Produces fp16 (`onnxconverter-common`) and dynamic int8 (`onnxruntime.quantization.quantize_dynamic` on MatMul + Gather) variants of `nvidia-quality-classifier-deberta`, benchmarks each against the fp32 baseline (file size, mean inference latency, and Pearson correlation on 100 sample texts), and replaces `model.onnx` in place with the smallest variant whose correlation is ≥ 0.98. The correlation reduction mirrors the production scoring path in `onnx_ranker.py::score_quality` (softmax + weighted sum `[High=1.0, Medium=0.5, Low=0.0]`) so the metric reflects the score that actually drives quality decisions at runtime. Cleanup deletes the fp32 external-weights sidecar (`model.onnx_data`, ~700 MB) along with rejected variants. Falls back to fp32 (no build failure) if no variant meets the gate; pass `--strict` to make a missed gate hard-fail. Strategy is overridable at build time via `--build-arg QUANTIZE_MODE={fp16|int8|best}` and `--build-arg QUANTIZE_MIN_CORR=<float>`. Expected size delta vs `:slim` drops from ~1.7 GB to ~600 MB on the next tagged build. `ms-marco-MiniLM-L-6-v2` is intentionally not quantized (already ~80 MB). Closes #793. (PR #803)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.46.0 - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784) — ~1,772 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.47.0 - feat: memory_quality maintain orchestrator + Docker DeBERTa quantization (PRs #802, #803, @filhocf, closes #799, #793) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,17 +457,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.46.0** (April 30, 2026)
+## Latest Release: **v10.47.0** (May 1, 2026)
 
-**feat: stale_days filter for memory_list — dormant memory detection**
+**feat: memory_quality maintain orchestrator + Docker DeBERTa quantization**
 
 **What's New:**
-- **`stale_days` filter**: Pass `stale_days=N` to `memory_list` to surface memories not accessed in N days. Falls back to `created_at` for never-read memories. Strict `<` semantics. Composes with `tags`, `memory_type`, and pagination. Fully implemented on SQLite-vec; stub (no-op) on Cloudflare/Hybrid/Milvus. (PR #796, @filhocf, closes #784)
-- **8 new tests** in `tests/storage/test_stale_days.py` covering boundary conditions, tag/type composition, pagination, and backward compatibility.
+- **`memory_quality(action='maintain')`**: One-call maintenance cycle — cleanup, conflict detection, stale detection, quality snapshot. `dry_run=true` by default, so it's always safe to explore. `maintain_status` returns last-run stats. Auto-resolve conflicts opt-in via `MCP_MAINTAIN_AUTO_RESOLVE`. (PR #802, @filhocf, closes #799)
+- **DeBERTa ONNX quantization at Docker build time**: `:quality-cpu` images now ship a pre-quantized DeBERTa model (fp16 or int8), cutting the image size from ~1.7 GB to ~600 MB. Cold start no longer re-runs quantization. (PR #803, closes #793)
+- **10 new tests** for the maintain orchestrator.
 
 ---
 
 **Previous Releases**:
+- **v10.46.0** - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784)
 - **v10.45.1** - fix: CodeQL redundant import cleanup + soft-delete regression tests (PRs #794, #795, @filhocf)
 - **v10.45.0** - feat(quality): OpenAI-compatible provider for LiteLLM/Ollama/MLX + soft-delete UPDATE guards (PRs #790, #783, @filhocf)
 - **v10.44.0** - feat: Mistake Notes — structured error replay (`mistake_note_add`, `mistake_note_search`, PR #786, @filhocf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Memory Service v10.46 — Semantic Memory Layer for AI Applications</title>
+<title>MCP Memory Service v10.47 — Semantic Memory Layer for AI Applications</title>
 <meta name="description" content="Semantic memory layer for AI applications. REST API + MCP transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, self-hosted, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.46">
-<meta property="og:description" content="Stale memory detection: filter memory_list by days since last access to surface dormant memories. Falls back to created_at for never-read memories. Composes with tags, memory_type, and pagination. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.47">
+<meta property="og:description" content="One-call maintenance orchestrator: memory_quality(action='maintain') runs cleanup, conflict detection, stale detection, and quality snapshot in a single cycle. Pre-quantized DeBERTa in Docker cuts image size from ~1.7 GB to ~600 MB. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="MCP Memory Service" class="hero-logo">
-  <span class="hero-badge">v10.46 &mdash; Now Available</span>
+  <span class="hero-badge">v10.47 &mdash; Now Available</span>
   <h1>MCP Memory Service</h1>
   <p>Persistent memory for AI agents. Semantic search, knowledge graph, automatic consolidation &mdash; now accessible from Claude.ai via Streamable HTTP.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.46</h2>
-    <p class="section-subtitle">Stale memory detection: surface dormant memories with the new stale_days filter. ~1,772 tests.</p>
+    <h2 class="section-title">What's New in v10.47</h2>
+    <p class="section-subtitle">One-call maintenance orchestrator + pre-quantized DeBERTa Docker images. ~1,780 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon search">&#128337;</div>
-        <h3>Stale Memory Detection</h3>
-        <p>Pass <code>stale_days=N</code> to <code>memory_list</code> to surface memories not accessed in N days. Ideal for reviewing and consolidating dormant knowledge. (PR #796, @filhocf, closes #784)</p>
+        <div class="feature-icon search">&#9881;</div>
+        <h3>maintenance Orchestrator</h3>
+        <p>Call <code>memory_quality(action='maintain')</code> to run a full maintenance cycle — cleanup, conflict detection, stale detection, and quality snapshot — in one shot. <code>dry_run=true</code> by default: always safe to explore. (PR #802, @filhocf, closes #799)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon graph">&#9881;</div>
-        <h3>Smart Fallback to created_at</h3>
-        <p>Never-accessed memories (<code>last_accessed IS NULL</code>) fall back to <code>created_at</code>, ensuring they appear in stale results when old enough. Strict <code>&lt;</code> semantics: memories at the exact threshold are not stale.</p>
+        <div class="feature-icon consolidation">&#128202;</div>
+        <h3>Auto-Resolve Conflicts</h3>
+        <p>Opt-in via <code>MCP_MAINTAIN_AUTO_RESOLVE</code>. Pairs with similarity &ge; 0.95, same memory type, and age delta &gt; 7 days are resolved automatically — newer memory wins. Threshold and age are configurable.</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon consolidation">&#128202;</div>
-        <h3>Composable Filters</h3>
-        <p>The <code>stale_days</code> filter composes freely with existing <code>tags</code>, <code>memory_type</code>, and pagination parameters. Fully implemented on SQLite-vec; accepted (no-op) on Cloudflare, Hybrid, and Milvus backends.</p>
+        <div class="feature-icon http">&#128230;</div>
+        <h3>Leaner Docker Images</h3>
+        <p>DeBERTa ONNX classifier is now quantized (fp16 / int8) at Docker build time. <code>:quality-cpu</code> image drops from ~1.7 GB to ~600 MB. Cold starts no longer re-run quantization. (PR #803, closes #793)</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1772">0</div>
+        <div class="stat-number" data-target="1780">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.46.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.46.0"
+version = "10.47.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.46.0"
+__version__ = "10.47.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.46.0"
+version = "10.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **`memory_quality(action='maintain')`**: One-call maintenance orchestrator — cleanup, conflict detection, stale detection, quality snapshot. `dry_run=true` by default. `maintain_status` returns last-run stats. Auto-resolve opt-in via `MCP_MAINTAIN_AUTO_RESOLVE`. (PR #802, @filhocf, closes #799)
- **Docker DeBERTa quantization at build time**: `:quality-cpu` images now ship a pre-quantized DeBERTa model (fp16/int8), cutting image size from ~1.7 GB to ~600 MB. Cold starts no longer re-run quantization. (PR #803, closes #793)

## Files changed

- `CHANGELOG.md` — promoted `[Unreleased]` to `[10.47.0] - 2026-05-01`, added #802 entry alongside #803
- `pyproject.toml` + `src/mcp_memory_service/_version.py` — bumped to `10.47.0`
- `uv.lock` — updated
- `README.md` — Latest Release updated to v10.47.0, v10.46.0 moved to Previous Releases
- `CLAUDE.md` — version callout updated
- `docs/index.html` — badge, What's New section, test count (1772→1780), release notes link

## Test plan

- [ ] CI green on this branch
- [ ] `pyproject.toml` version == `_version.py` version == `10.47.0`
- [ ] CHANGELOG `[Unreleased]` is empty, `[10.47.0]` section present
- [ ] Landing page badge shows v10.47

🤖 Generated with [Claude Code](https://claude.com/claude-code)