### PR TITLE
fix(web): surface /server/update failures end-to-end (#729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **[#729] `/server/update` no longer silently fails**: The dashboard's *Update & Restart* button used to show a generic success toast even when `git pull` aborted on a dirty working tree, when `pip install` failed, or when the process never actually restarted. Three changes fix this end-to-end: (1) `/api/server/update` now refuses to pull on a dirty working tree (HTTP 409 with the offending paths) unless the new `force=true` flag is set; (2) git/pip failures now return HTTP 500 with the real stderr in `detail` instead of HTTP 200 with `status: "error"` in the body that the frontend never read; (3) `/api/server/restart` and `/api/server/update` now return `pre_restart_pid` + `pre_restart_version`, and the dashboard polls `/api/server/status` after restart to verify the process actually rolled over (pid or version changed). The restart overlay surfaces a clear warning if the process never restarted instead of reloading to the same stale build. The dashboard also offers a force-retry confirmation dialog when a dirty tree blocks an update. 8 new tests in `tests/web/api/test_server_management.py`. Closes #729.
+
 ## [10.47.0] - 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,7 +569,10 @@ python scripts/validation/diagnose_backend_config.py          # Backend-specific
 - **CLAUDE.md** - Architecture changes, new patterns, development workflows
 - **README.md** - New features, installation changes, user-facing updates
 - **CHANGELOG.md** - Every version bump (use github-release-manager agent)
-- **docs/index.html** - Landing page: MINOR/MAJOR releases only (version badge, test count, features). Auto-deployed via GitHub Pages. Also re-publish to here.now (`--slug merry-realm-j835`)
+- **docs/index.html** - Landing page: MINOR/MAJOR releases only (version badge, test count, features). Auto-deployed via GitHub Pages. Also re-publish to here.now:
+  ```bash
+  cd docs && ~/.agents/skills/here-now/scripts/publish.sh index.html --slug merry-realm-j835
+  ```
 - **Wiki** - Detailed guides, troubleshooting, tutorials
 
 ## Additional Resources

--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -107,6 +107,18 @@ class UpdateResponse(BaseModel):
 
 
 # Helper functions
+def _sanitize_log_value(value: object) -> str:
+    """
+    Sanitize a user-controlled value for safe inclusion in log messages.
+
+    OAuth-derived fields (``user.client_id``, ``user.auth_method``) reach
+    these audit logs from authenticated requests but are still attacker-
+    controllable for clients that successfully authenticated, so we strip
+    CR/LF/escape characters to prevent log forging (CodeQL py/log-injection).
+    """
+    return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\x1b", "\\x1b")
+
+
 def _get_project_root() -> str:
     """Get the project root directory by searching for the .git folder."""
     from pathlib import Path
@@ -326,7 +338,11 @@ async def restart_server(
             detail="Restart confirmation required. Set 'confirm' to true."
         )
 
-    logger.warning(f"AUDIT: Server restart requested by user: {user.client_id} (auth: {user.auth_method})")
+    logger.warning(
+        "AUDIT: Server restart requested by user: %s (auth: %s)",
+        _sanitize_log_value(user.client_id),
+        _sanitize_log_value(user.auth_method),
+    )
 
     # Schedule restart in background
     background_tasks.add_task(_restart_server_delayed)
@@ -360,8 +376,10 @@ async def update_server(
         )
 
     logger.warning(
-        f"AUDIT: Server update requested by user: {user.client_id} "
-        f"(auth: {user.auth_method}, force: {request.force})"
+        "AUDIT: Server update requested by user: %s (auth: %s, force: %s)",
+        _sanitize_log_value(user.client_id),
+        _sanitize_log_value(user.auth_method),
+        request.force,
     )
 
     # Step 0: Refuse to pull on a dirty working tree unless force=True.
@@ -405,7 +423,10 @@ async def update_server(
     # Step 3: Schedule restart
     background_tasks.add_task(_restart_server_delayed)
 
-    logger.warning(f"AUDIT: Server update completed by {user.client_id}, restart scheduled")
+    logger.warning(
+        "AUDIT: Server update completed by %s, restart scheduled",
+        _sanitize_log_value(user.client_id),
+    )
 
     return UpdateResponse(
         status="success",

--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -107,18 +107,6 @@ class UpdateResponse(BaseModel):
 
 
 # Helper functions
-def _sanitize_log_value(value: object) -> str:
-    """
-    Sanitize a user-controlled value for safe inclusion in log messages.
-
-    OAuth-derived fields (``user.client_id``, ``user.auth_method``) reach
-    these audit logs from authenticated requests but are still attacker-
-    controllable for clients that successfully authenticated, so we strip
-    CR/LF/escape characters to prevent log forging (CodeQL py/log-injection).
-    """
-    return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\x1b", "\\x1b")
-
-
 def _get_project_root() -> str:
     """Get the project root directory by searching for the .git folder."""
     from pathlib import Path
@@ -338,10 +326,14 @@ async def restart_server(
             detail="Restart confirmation required. Set 'confirm' to true."
         )
 
+    # Sanitize user-controlled fields inline so CodeQL py/log-injection
+    # tracks the .replace() barriers in the same function as the log call.
+    safe_client_id = str(user.client_id).replace("\r", "").replace("\n", "")
+    safe_auth_method = str(user.auth_method).replace("\r", "").replace("\n", "")
     logger.warning(
         "AUDIT: Server restart requested by user: %s (auth: %s)",
-        _sanitize_log_value(user.client_id),
-        _sanitize_log_value(user.auth_method),
+        safe_client_id,
+        safe_auth_method,
     )
 
     # Schedule restart in background
@@ -375,10 +367,14 @@ async def update_server(
             detail="Update confirmation required. Set 'confirm' to true."
         )
 
+    # Sanitize user-controlled fields inline so CodeQL py/log-injection
+    # tracks the .replace() barriers in the same function as the log call.
+    safe_client_id = str(user.client_id).replace("\r", "").replace("\n", "")
+    safe_auth_method = str(user.auth_method).replace("\r", "").replace("\n", "")
     logger.warning(
         "AUDIT: Server update requested by user: %s (auth: %s, force: %s)",
-        _sanitize_log_value(user.client_id),
-        _sanitize_log_value(user.auth_method),
+        safe_client_id,
+        safe_auth_method,
         request.force,
     )
 
@@ -425,7 +421,7 @@ async def update_server(
 
     logger.warning(
         "AUDIT: Server update completed by %s, restart scheduled",
-        _sanitize_log_value(user.client_id),
+        safe_client_id,
     )
 
     return UpdateResponse(

--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -85,11 +85,14 @@ class RestartResponse(BaseModel):
     status: str
     message: str
     restart_in_seconds: int
+    pre_restart_pid: int = Field(..., description="PID of the process scheduling the restart; clients compare to verify a real restart occurred")
+    pre_restart_version: str = Field(..., description="Version of the running process before restart")
 
 
 class UpdateRequest(BaseModel):
     """Request model for server update."""
     confirm: bool = Field(..., description="Must be true to confirm update")
+    force: bool = Field(False, description="If true, proceed even when the git working tree is dirty (uncommitted changes may block the pull)")
 
 
 class UpdateResponse(BaseModel):
@@ -99,6 +102,8 @@ class UpdateResponse(BaseModel):
     git_output: Optional[str] = None
     pip_output: Optional[str] = None
     restart_scheduled: bool
+    pre_restart_pid: Optional[int] = Field(None, description="PID of the process scheduling the restart; clients compare to verify a real restart occurred")
+    pre_restart_version: Optional[str] = Field(None, description="Version of the running process before restart")
 
 
 # Helper functions
@@ -117,6 +122,9 @@ def _run_command(command: List[str], timeout: int, command_name: str) -> Tuple[s
     """
     Run a command and return output.
 
+    On failure, stderr is appended to stdout so callers can surface the actual
+    error to the user (previous behaviour silently dropped stderr — see #729).
+
     Returns:
         Tuple of (output_string, success_boolean)
     """
@@ -128,13 +136,36 @@ def _run_command(command: List[str], timeout: int, command_name: str) -> Tuple[s
             timeout=timeout,
             cwd=_get_project_root()
         )
-        return result.stdout.strip(), result.returncode == 0
+        success = result.returncode == 0
+        if success:
+            return result.stdout.strip(), True
+        combined = "\n".join(s for s in (result.stdout.strip(), result.stderr.strip()) if s)
+        if not combined:
+            combined = f"{command_name} exited with code {result.returncode}"
+        return combined, False
     except FileNotFoundError:
         return f"{command_name} command not found. Please install {command_name.lower()}.", False
     except subprocess.TimeoutExpired:
         return f"{command_name} command timed out after {timeout} seconds", False
     except Exception as e:
         return f"{command_name} command failed: {str(e)}", False
+
+
+def _check_working_tree_clean() -> Tuple[bool, List[str]]:
+    """
+    Check whether the git working tree is clean.
+
+    Returns ``(is_clean, dirty_paths)``. ``is_clean`` is False if
+    ``git status --porcelain`` reports any modified/untracked files OR if
+    the command itself fails (defensive — refuse to pull on unknown state).
+    """
+    output, success = _run_git_command(['status', '--porcelain'])
+    if not success:
+        return False, [f"git status failed: {output}"]
+    if not output:
+        return True, []
+    dirty = [line.strip() for line in output.split('\n') if line.strip()]
+    return False, dirty
 
 
 def _run_git_command(args: List[str], timeout: int = GIT_TIMEOUT_SECONDS) -> Tuple[str, bool]:
@@ -303,7 +334,9 @@ async def restart_server(
     return RestartResponse(
         status="accepted",
         message=f"Server restarting in {RESTART_DELAY_SECONDS} seconds",
-        restart_in_seconds=RESTART_DELAY_SECONDS
+        restart_in_seconds=RESTART_DELAY_SECONDS,
+        pre_restart_pid=os.getpid(),
+        pre_restart_version=__version__,
     )
 
 
@@ -326,30 +359,47 @@ async def update_server(
             detail="Update confirmation required. Set 'confirm' to true."
         )
 
-    logger.warning(f"AUDIT: Server update requested by user: {user.client_id} (auth: {user.auth_method})")
+    logger.warning(
+        f"AUDIT: Server update requested by user: {user.client_id} "
+        f"(auth: {user.auth_method}, force: {request.force})"
+    )
+
+    # Step 0: Refuse to pull on a dirty working tree unless force=True.
+    # Previously we just ran `git pull`; if it aborted on a conflict the
+    # error was swallowed and the user saw a generic success toast (#729).
+    if not request.force:
+        is_clean, dirty = _check_working_tree_clean()
+        if not is_clean:
+            preview = "\n".join(dirty[:20])
+            if len(dirty) > 20:
+                preview += f"\n... and {len(dirty) - 20} more"
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Working tree has uncommitted changes — refusing to pull. "
+                    "Commit/stash them or retry with force=true.\n\n"
+                    f"{preview}"
+                ),
+            )
 
     # Step 1: Git pull
     git_output, git_success = _run_git_command(['pull', 'origin', 'main'])
 
     if not git_success:
-        return UpdateResponse(
-            status="error",
-            message="Git pull failed",
-            git_output=git_output,
-            pip_output=None,
-            restart_scheduled=False
+        logger.error(f"AUDIT: Server update aborted — git pull failed: {git_output}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Git pull failed: {git_output}",
         )
 
     # Step 2: Pip install
     pip_output, pip_success = _run_pip_command(['install', '-e', '.'])
 
     if not pip_success:
-        return UpdateResponse(
-            status="error",
-            message="Pip install failed",
-            git_output=git_output,
-            pip_output=pip_output,
-            restart_scheduled=False
+        logger.error(f"AUDIT: Server update aborted — pip install failed: {pip_output}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Pip install failed (git pull already succeeded — repository is at the new revision but dependencies are not installed): {pip_output}",
         )
 
     # Step 3: Schedule restart
@@ -362,5 +412,7 @@ async def update_server(
         message=f"Update completed successfully, server restarting in {RESTART_DELAY_SECONDS} seconds",
         git_output=git_output,
         pip_output=pip_output,
-        restart_scheduled=True
+        restart_scheduled=True,
+        pre_restart_pid=os.getpid(),
+        pre_restart_version=__version__,
     )

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -3719,10 +3719,15 @@ class MemoryDashboard {
     }
 
     /**
-     * Update and restart the server
+     * Update and restart the server.
+     *
+     * Backend may refuse with HTTP 409 if the working tree is dirty (#729);
+     * we surface the detail and offer a force-retry confirmation. On success
+     * we capture pre-restart pid + version so pollServerHealth can verify
+     * the process actually rolled over instead of trusting /api/health.
      */
-    async updateAndRestart() {
-        if (!confirm('This will pull the latest code, install dependencies, and restart the server. Continue?')) {
+    async updateAndRestart(force = false) {
+        if (!force && !confirm('This will pull the latest code, install dependencies, and restart the server. Continue?')) {
             return;
         }
 
@@ -3733,18 +3738,33 @@ class MemoryDashboard {
         if (actionText) { actionText.textContent = 'Pulling updates and installing...'; }
 
         try {
-            const data = await this.apiCall('/server/update', 'POST', { confirm: true });
+            const data = await this.apiCall('/server/update', 'POST', { confirm: true, force });
 
             if (actionText) { actionText.textContent = 'Update complete. Server restarting...'; }
-            this.showRestartOverlay();
+            // Show captured git/pip output in console for diagnostics
+            if (data.git_output) { console.info('git pull:\n' + data.git_output); }
+            if (data.pip_output) { console.info('pip install:\n' + data.pip_output); }
+            this.showRestartOverlay(data.pre_restart_pid, data.pre_restart_version);
         } catch (error) {
             if (actionStatus) { actionStatus.style.display = 'none'; }
-            this.showToast('Update failed: ' + error.message, 'error');
+            const msg = error.message || String(error);
+
+            // 409 → dirty working tree. Offer force retry.
+            if (msg.includes('uncommitted changes')) {
+                this.showToast('Update blocked: ' + msg, 'error');
+                if (confirm('The server has uncommitted local changes that will block the pull.\n\n' + msg + '\n\nForce-pull anyway? (Local changes may be overwritten.)')) {
+                    return this.updateAndRestart(true);
+                }
+                return;
+            }
+
+            this.showToast('Update failed: ' + msg, 'error');
         }
     }
 
     /**
-     * Restart the server
+     * Restart the server (no update). Captures pre-restart pid + version
+     * so pollServerHealth can verify the process actually rolled over.
      */
     async restartServer() {
         if (!confirm('Are you sure you want to restart the server? This will temporarily disconnect all clients.')) {
@@ -3752,12 +3772,12 @@ class MemoryDashboard {
         }
 
         try {
-            await this.apiCall('/server/restart', 'POST', { confirm: true });
-            this.showRestartOverlay();
+            const data = await this.apiCall('/server/restart', 'POST', { confirm: true });
+            this.showRestartOverlay(data.pre_restart_pid, data.pre_restart_version);
         } catch (error) {
-            // Server may have already started shutting down
+            // Server may have already started shutting down before responding
             if (error.message && error.message.includes('fetch')) {
-                this.showRestartOverlay();
+                this.showRestartOverlay(null, null);
             } else {
                 this.showToast('Restart failed: ' + error.message, 'error');
             }
@@ -3765,9 +3785,14 @@ class MemoryDashboard {
     }
 
     /**
-     * Show restart overlay and poll for server recovery
+     * Show restart overlay and poll for server recovery.
+     *
+     * preRestartPid / preRestartVersion are captured before we kicked off
+     * the restart so we can detect the silent-no-op case (#729): the server
+     * answers /api/health (process never died) but pid+version are unchanged
+     * → user thinks the update worked but is still on the old build.
      */
-    showRestartOverlay() {
+    showRestartOverlay(preRestartPid, preRestartVersion) {
         const overlay = document.getElementById('restartOverlay');
         const countdownEl = document.getElementById('restartCountdown');
         const statusEl = document.getElementById('restartStatus');
@@ -3783,15 +3808,17 @@ class MemoryDashboard {
             if (countdownEl) { countdownEl.textContent = countdown; }
             if (countdown <= 0) {
                 clearInterval(countdownInterval);
-                this.pollServerHealth(statusEl, overlay, attempts, maxAttempts);
+                this.pollServerHealth(statusEl, overlay, attempts, maxAttempts, preRestartPid, preRestartVersion);
             }
         }, 1000);
     }
 
     /**
-     * Poll server health after restart
+     * Poll /server/status after restart and verify the process actually
+     * rolled over (pid changed OR version changed). /api/health alone is
+     * not enough because it answers OK on the original stale process.
      */
-    async pollServerHealth(statusEl, overlay, attempts, maxAttempts) {
+    async pollServerHealth(statusEl, overlay, attempts, maxAttempts, preRestartPid, preRestartVersion) {
         if (attempts >= maxAttempts) {
             if (statusEl) { statusEl.textContent = 'Server did not come back online. Please check manually.'; }
             setTimeout(() => {
@@ -3803,20 +3830,55 @@ class MemoryDashboard {
         if (statusEl) { statusEl.textContent = `Attempt ${attempts + 1}/${maxAttempts} - Waiting for server...`; }
 
         try {
-            const response = await fetch('/api/health');
-            if (response.ok) {
-                if (statusEl) { statusEl.textContent = 'Server is back online! Reloading...'; }
-                setTimeout(() => {
-                    window.location.reload();
-                }, 1500);
-                return;
+            // Probe /server/status (auth-protected); fall back to /api/health
+            // if the call fails (e.g. before auth is re-established) so the
+            // overlay still progresses for unauthenticated dashboards.
+            let restarted = false;
+            try {
+                const status = await this.apiCall('/server/status');
+                if (preRestartPid != null || preRestartVersion != null) {
+                    const pidChanged = preRestartPid != null && status.pid !== preRestartPid;
+                    const versionChanged = preRestartVersion != null && status.version !== preRestartVersion;
+                    restarted = pidChanged || versionChanged;
+                } else {
+                    // No pre-restart baseline (e.g. shutdown before response) — accept any status response as recovery
+                    restarted = true;
+                }
+
+                if (restarted) {
+                    if (statusEl) { statusEl.textContent = `Server is back online (v${status.version}, pid ${status.pid})! Reloading...`; }
+                    setTimeout(() => {
+                        window.location.reload();
+                    }, 1500);
+                    return;
+                }
+                // Status responded but pid+version unchanged — process didn't actually restart.
+                // Keep polling; on the final attempt we surface a warning below.
+                if (attempts === maxAttempts - 1) {
+                    if (statusEl) {
+                        statusEl.textContent = `Process did not restart (still pid ${status.pid}, v${status.version}). The update may have failed silently — check server logs.`;
+                    }
+                    setTimeout(() => {
+                        if (overlay) { overlay.style.display = 'none'; }
+                    }, 8000);
+                    return;
+                }
+            } catch (apiErr) {
+                // /server/status unavailable (server still down or auth-gated) — try /api/health as a liveness probe
+                const response = await fetch('/api/health');
+                if (response.ok && preRestartPid == null && preRestartVersion == null) {
+                    if (statusEl) { statusEl.textContent = 'Server is back online! Reloading...'; }
+                    setTimeout(() => { window.location.reload(); }, 1500);
+                    return;
+                }
+                // /api/health up but we have a baseline to compare — keep polling /server/status
             }
         } catch (e) {
             // Server not ready yet
         }
 
         setTimeout(() => {
-            this.pollServerHealth(statusEl, overlay, attempts + 1, maxAttempts);
+            this.pollServerHealth(statusEl, overlay, attempts + 1, maxAttempts, preRestartPid, preRestartVersion);
         }, 2000);
     }
 

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -3500,7 +3500,15 @@ class MemoryDashboard {
 
         if (!response.ok) {
             const errorData = await response.json().catch(() => ({}));
-            throw new Error(errorData.detail || `HTTP ${response.status}`);
+            // Preserve the HTTP status + parsed detail on the thrown Error so
+            // callers can branch on machine-readable values instead of
+            // substring-matching the human-readable message (which breaks on
+            // wording / translation changes — see PR #807 review).
+            const err = new Error(errorData.detail || `HTTP ${response.status}`);
+            err.status = response.status;
+            err.detail = errorData.detail;
+            err.body = errorData;
+            throw err;
         }
 
         return await response.json();
@@ -3749,8 +3757,11 @@ class MemoryDashboard {
             if (actionStatus) { actionStatus.style.display = 'none'; }
             const msg = error.message || String(error);
 
-            // 409 → dirty working tree. Offer force retry.
-            if (msg.includes('uncommitted changes')) {
+            // 409 Conflict → dirty working tree. Offer force retry.
+            // Gate on the HTTP status code (set by apiCall) instead of
+            // substring-matching the message — error wording can change
+            // between releases and gets translated, status codes don't.
+            if (error.status === 409) {
                 this.showToast('Update blocked: ' + msg, 'error');
                 if (confirm('The server has uncommitted local changes that will block the pull.\n\n' + msg + '\n\nForce-pull anyway? (Local changes may be overwritten.)')) {
                     return this.updateAndRestart(true);

--- a/tests/web/api/test_server_management.py
+++ b/tests/web/api/test_server_management.py
@@ -33,6 +33,16 @@ import pytest
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 
+# Import the route module + auth result type at module load so monkeypatch /
+# unittest.mock.patch can target attributes via the live module objects.
+# Dotted-string targets (e.g. "mcp_memory_service.web.api.server._foo") fail
+# under non-editable installs (uvx CI) because pytest's monkeypatch resolves
+# each path segment via getattr on the parent package, and the `web` submodule
+# isn't always set as an attribute on `mcp_memory_service` at that point.
+# Holding a direct module reference dodges that resolution path entirely.
+from mcp_memory_service.web.api import server as server_module
+from mcp_memory_service.web.oauth.middleware import AuthenticationResult
+
 
 @pytest.fixture
 def test_app(monkeypatch):
@@ -42,13 +52,11 @@ def test_app(monkeypatch):
     # middleware module reads that env var at import time and other test files
     # in the suite assert on the production default (auth required).
     from mcp_memory_service.web.app import app
-    from mcp_memory_service.web.oauth.middleware import AuthenticationResult
     # CRITICAL: Override using the SAME function objects the route holds in its
     # Depends(...) — the route imported these at module-load time. If we
     # imported them again from middleware here, a reload elsewhere in the test
     # suite would have rebound middleware's symbols and our overrides would
     # miss, leaving the real auth path active (HTTP 403 in tests).
-    from mcp_memory_service.web.api import server as server_module
 
     async def mock_admin_user():
         return AuthenticationResult(
@@ -66,10 +74,7 @@ def test_app(monkeypatch):
     async def noop_restart():
         return None
 
-    monkeypatch.setattr(
-        'mcp_memory_service.web.api.server._restart_server_delayed',
-        noop_restart,
-    )
+    monkeypatch.setattr(server_module, '_restart_server_delayed', noop_restart)
 
     client = TestClient(app)
     yield client
@@ -80,8 +85,9 @@ def test_app(monkeypatch):
 @pytest.mark.integration
 def test_update_refuses_dirty_working_tree(test_app):
     """Dirty working tree → HTTP 409 with the offending paths in detail."""
-    with patch(
-        'mcp_memory_service.web.api.server._check_working_tree_clean',
+    with patch.object(
+        server_module,
+        '_check_working_tree_clean',
         return_value=(False, ['M  src/foo.py', '?? config/local.yaml']),
     ):
         response = test_app.post('/api/server/update', json={'confirm': True})
@@ -96,14 +102,17 @@ def test_update_refuses_dirty_working_tree(test_app):
 @pytest.mark.integration
 def test_update_with_force_skips_dirty_check(test_app):
     """force=true bypasses the dirty-tree refusal and proceeds to git pull."""
-    with patch(
-        'mcp_memory_service.web.api.server._check_working_tree_clean',
+    with patch.object(
+        server_module,
+        '_check_working_tree_clean',
         return_value=(False, ['M  src/foo.py']),
-    ) as mock_check, patch(
-        'mcp_memory_service.web.api.server._run_git_command',
+    ) as mock_check, patch.object(
+        server_module,
+        '_run_git_command',
         return_value=('Already up to date.', True),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_pip_command',
+    ), patch.object(
+        server_module,
+        '_run_pip_command',
         return_value=('Successfully installed', True),
     ):
         response = test_app.post(
@@ -122,11 +131,13 @@ def test_update_with_force_skips_dirty_check(test_app):
 @pytest.mark.integration
 def test_update_returns_500_when_git_pull_fails(test_app):
     """git pull failure → HTTP 500 with stderr in detail (not silent 200)."""
-    with patch(
-        'mcp_memory_service.web.api.server._check_working_tree_clean',
+    with patch.object(
+        server_module,
+        '_check_working_tree_clean',
         return_value=(True, []),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_git_command',
+    ), patch.object(
+        server_module,
+        '_run_git_command',
         return_value=('error: Your local changes would be overwritten by merge', False),
     ):
         response = test_app.post('/api/server/update', json={'confirm': True})
@@ -140,14 +151,17 @@ def test_update_returns_500_when_git_pull_fails(test_app):
 @pytest.mark.integration
 def test_update_returns_500_when_pip_install_fails(test_app):
     """pip install failure → HTTP 500 (not silent 200) with output in detail."""
-    with patch(
-        'mcp_memory_service.web.api.server._check_working_tree_clean',
+    with patch.object(
+        server_module,
+        '_check_working_tree_clean',
         return_value=(True, []),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_git_command',
+    ), patch.object(
+        server_module,
+        '_run_git_command',
         return_value=('Updating abc..def', True),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_pip_command',
+    ), patch.object(
+        server_module,
+        '_run_pip_command',
         return_value=('ERROR: Could not find a version that satisfies the requirement foo', False),
     ):
         response = test_app.post('/api/server/update', json={'confirm': True})
@@ -161,14 +175,17 @@ def test_update_returns_500_when_pip_install_fails(test_app):
 @pytest.mark.integration
 def test_update_success_returns_pre_restart_identity(test_app):
     """Successful update returns pid + version captured before restart."""
-    with patch(
-        'mcp_memory_service.web.api.server._check_working_tree_clean',
+    with patch.object(
+        server_module,
+        '_check_working_tree_clean',
         return_value=(True, []),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_git_command',
+    ), patch.object(
+        server_module,
+        '_run_git_command',
         return_value=('Updating abc..def', True),
-    ), patch(
-        'mcp_memory_service.web.api.server._run_pip_command',
+    ), patch.object(
+        server_module,
+        '_run_pip_command',
         return_value=('Successfully installed', True),
     ):
         response = test_app.post('/api/server/update', json={'confirm': True})

--- a/tests/web/api/test_server_management.py
+++ b/tests/web/api/test_server_management.py
@@ -1,0 +1,208 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for /api/server management endpoints (#729).
+
+Covers the silent-failure modes the original issue described:
+- /server/update used to return HTTP 200 with {"status": "error"} on failure,
+  so the dashboard never noticed and showed a success toast.
+- /server/update used to run `git pull` directly, with no dirty-tree check,
+  so a conflicting working tree silently aborted the pull.
+- /server/restart used to return without any way for the client to verify
+  the process actually restarted.
+
+These tests pin the new contract: failures raise HTTPException with the
+real reason in `detail`, and both endpoints return pre_restart_pid +
+pre_restart_version so the client can verify rollover.
+"""
+
+import os
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def test_app(monkeypatch):
+    """FastAPI test client with admin auth bypassed and restart task neutered."""
+    # Note: Auth is bypassed entirely via FastAPI dependency_overrides below,
+    # so we deliberately do NOT touch MCP_ALLOW_ANONYMOUS_ACCESS — the OAuth
+    # middleware module reads that env var at import time and other test files
+    # in the suite assert on the production default (auth required).
+    from mcp_memory_service.web.app import app
+    from mcp_memory_service.web.oauth.middleware import AuthenticationResult
+    # CRITICAL: Override using the SAME function objects the route holds in its
+    # Depends(...) — the route imported these at module-load time. If we
+    # imported them again from middleware here, a reload elsewhere in the test
+    # suite would have rebound middleware's symbols and our overrides would
+    # miss, leaving the real auth path active (HTTP 403 in tests).
+    from mcp_memory_service.web.api import server as server_module
+
+    async def mock_admin_user():
+        return AuthenticationResult(
+            authenticated=True,
+            client_id="test_admin",
+            scope="read write admin",
+            auth_method="test",
+        )
+
+    app.dependency_overrides[server_module.require_read_access] = mock_admin_user
+    app.dependency_overrides[server_module.require_admin_access] = mock_admin_user
+
+    # Replace the background restart task with a no-op so tests don't try to
+    # exec a new Python process / kill the test runner.
+    async def noop_restart():
+        return None
+
+    monkeypatch.setattr(
+        'mcp_memory_service.web.api.server._restart_server_delayed',
+        noop_restart,
+    )
+
+    client = TestClient(app)
+    yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_update_refuses_dirty_working_tree(test_app):
+    """Dirty working tree → HTTP 409 with the offending paths in detail."""
+    with patch(
+        'mcp_memory_service.web.api.server._check_working_tree_clean',
+        return_value=(False, ['M  src/foo.py', '?? config/local.yaml']),
+    ):
+        response = test_app.post('/api/server/update', json={'confirm': True})
+
+    assert response.status_code == 409
+    detail = response.json()['detail']
+    assert 'uncommitted changes' in detail
+    assert 'force=true' in detail
+    assert 'src/foo.py' in detail
+
+
+@pytest.mark.integration
+def test_update_with_force_skips_dirty_check(test_app):
+    """force=true bypasses the dirty-tree refusal and proceeds to git pull."""
+    with patch(
+        'mcp_memory_service.web.api.server._check_working_tree_clean',
+        return_value=(False, ['M  src/foo.py']),
+    ) as mock_check, patch(
+        'mcp_memory_service.web.api.server._run_git_command',
+        return_value=('Already up to date.', True),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_pip_command',
+        return_value=('Successfully installed', True),
+    ):
+        response = test_app.post(
+            '/api/server/update',
+            json={'confirm': True, 'force': True},
+        )
+
+    # Dirty check should not even be called when force=true
+    assert mock_check.call_count == 0
+    assert response.status_code == 200
+    body = response.json()
+    assert body['status'] == 'success'
+    assert body['restart_scheduled'] is True
+
+
+@pytest.mark.integration
+def test_update_returns_500_when_git_pull_fails(test_app):
+    """git pull failure → HTTP 500 with stderr in detail (not silent 200)."""
+    with patch(
+        'mcp_memory_service.web.api.server._check_working_tree_clean',
+        return_value=(True, []),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_git_command',
+        return_value=('error: Your local changes would be overwritten by merge', False),
+    ):
+        response = test_app.post('/api/server/update', json={'confirm': True})
+
+    assert response.status_code == 500
+    detail = response.json()['detail']
+    assert 'Git pull failed' in detail
+    assert 'local changes would be overwritten' in detail
+
+
+@pytest.mark.integration
+def test_update_returns_500_when_pip_install_fails(test_app):
+    """pip install failure → HTTP 500 (not silent 200) with output in detail."""
+    with patch(
+        'mcp_memory_service.web.api.server._check_working_tree_clean',
+        return_value=(True, []),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_git_command',
+        return_value=('Updating abc..def', True),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_pip_command',
+        return_value=('ERROR: Could not find a version that satisfies the requirement foo', False),
+    ):
+        response = test_app.post('/api/server/update', json={'confirm': True})
+
+    assert response.status_code == 500
+    detail = response.json()['detail']
+    assert 'Pip install failed' in detail
+    assert 'Could not find a version' in detail
+
+
+@pytest.mark.integration
+def test_update_success_returns_pre_restart_identity(test_app):
+    """Successful update returns pid + version captured before restart."""
+    with patch(
+        'mcp_memory_service.web.api.server._check_working_tree_clean',
+        return_value=(True, []),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_git_command',
+        return_value=('Updating abc..def', True),
+    ), patch(
+        'mcp_memory_service.web.api.server._run_pip_command',
+        return_value=('Successfully installed', True),
+    ):
+        response = test_app.post('/api/server/update', json={'confirm': True})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['restart_scheduled'] is True
+    assert body['pre_restart_pid'] == os.getpid()
+    assert isinstance(body['pre_restart_version'], str)
+    assert body['pre_restart_version']
+
+
+@pytest.mark.integration
+def test_restart_returns_pre_restart_identity(test_app):
+    """Restart endpoint exposes pre-restart pid + version for verification."""
+    response = test_app.post('/api/server/restart', json={'confirm': True})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['status'] == 'accepted'
+    assert body['pre_restart_pid'] == os.getpid()
+    assert isinstance(body['pre_restart_version'], str)
+    assert body['pre_restart_version']
+
+
+@pytest.mark.integration
+def test_restart_requires_confirm(test_app):
+    """Restart without confirm=true → HTTP 400."""
+    response = test_app.post('/api/server/restart', json={'confirm': False})
+    assert response.status_code == 400
+
+
+@pytest.mark.integration
+def test_update_requires_confirm(test_app):
+    """Update without confirm=true → HTTP 400."""
+    response = test_app.post('/api/server/update', json={'confirm': False})
+    assert response.status_code == 400


### PR DESCRIPTION
Closes #729.

## Summary

The dashboard's *Settings → Update & Restart* button used to show a generic success toast even when the underlying operation silently aborted — a dirty working tree blocked `git pull`, `pip install` failed, or the process was never actually restarted. The user saw no error and the version badge in the header continued to display the old build (the original repro on the issue).

This PR fixes the silent-failure mode end-to-end across the backend route, the frontend handler, and the post-restart verification poll.

## Changes

### Backend (`src/mcp_memory_service/web/api/server.py`)

- **Dirty-tree precheck**: New `_check_working_tree_clean()` runs `git status --porcelain` before pulling. `/api/server/update` now refuses with HTTP 409 and the offending paths in `detail` unless the new `force=true` flag is set.
- **Real HTTP status codes**: Git/pip failures now raise `HTTPException(500, detail=...)` with the actual stderr instead of returning HTTP 200 with `status: \"error\"` in the body that the frontend never inspected.
- **Stderr captured**: `_run_command()` now combines stdout + stderr on failure (previously stderr was silently dropped — invisible to both logs and the API response).
- **Pre-restart identity**: `/api/server/restart` and `/api/server/update` now return `pre_restart_pid` + `pre_restart_version` so the client can verify the rollover.

### Frontend (`src/mcp_memory_service/web/static/app.js`)

- `updateAndRestart()` passes the `force` flag, surfaces `git_output` / `pip_output` to the console, and on HTTP 409 prompts a force-retry confirmation showing the dirty paths.
- `pollServerHealth()` now polls `/api/server/status` and compares pid + version against the captured pre-restart values. If they're unchanged after `maxAttempts`, the overlay surfaces a warning that the process didn't restart — instead of reloading to the same stale build. Falls back to `/api/health` for liveness when no baseline is available (e.g. shutdown beat the response).

### Tests (`tests/web/api/test_server_management.py`, +8)

- Dirty tree → 409 with paths
- `force=true` skips the dirty check
- Git pull failure → 500 with stderr in detail
- Pip install failure → 500 with recovery hint (\"git pull already succeeded — repository is at the new revision but dependencies are not installed\")
- Successful update returns `pre_restart_pid` + `pre_restart_version`
- Restart returns `pre_restart_pid` + `pre_restart_version`
- `confirm=false` returns 400 on both endpoints

The fixture overrides FastAPI dependencies via the route module's symbol references (`server_module.require_admin_access`) rather than via `oauth.middleware.require_admin_access` directly, because other tests in the suite reload the middleware module — the route's `Depends(...)` holds the original symbol from import time and overrides keyed off a re-bound symbol miss.

## API contract changes

This is an additive change to the request/response models — no removed fields. Existing clients that POST `{ \"confirm\": true }` to `/api/server/update` continue to work; they simply get HTTP 409 / 500 instead of HTTP 200 with an error body when something goes wrong, which matches what the dashboard already (mistakenly) treated as success.

| Endpoint | Field | Direction | Type | Notes |
|----------|-------|-----------|------|-------|
| POST `/api/server/update` | `force` | request | `bool` (default `false`) | Bypass the dirty-tree refusal |
| POST `/api/server/update` | `pre_restart_pid` | response | `int?` | Present on success |
| POST `/api/server/update` | `pre_restart_version` | response | `str?` | Present on success |
| POST `/api/server/restart` | `pre_restart_pid` | response | `int` | Always |
| POST `/api/server/restart` | `pre_restart_version` | response | `str` | Always |

## Test plan

- [x] `pytest tests/web/api/test_server_management.py` — 8 new tests pass
- [x] `pytest tests/web/ tests/integration/test_http_server_startup.py` — 76 pass, 1 pre-existing failure (`test_harvest_requires_auth`, unrelated to this PR — confirmed by running `pytest tests/web/ --ignore=tests/web/api/test_server_management.py` on the base branch)
- [ ] Manual smoke (dashboard): trigger \"Update & Restart\" with a dirty working tree → confirmation dialog appears with the offending paths; click cancel → no action taken; click force → proceeds.
- [ ] Manual smoke (dashboard): trigger \"Update & Restart\" on a clean tree, kill the spawned new process before it answers `/server/status` → overlay shows \"Process did not restart\" warning instead of reloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)