### PR TITLE
chore: release v10.47.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.47.1] - 2026-05-01
+
 ### Fixed
 
-- **[#729] `/server/update` no longer silently fails**: The dashboard's *Update & Restart* button used to show a generic success toast even when `git pull` aborted on a dirty working tree, when `pip install` failed, or when the process never actually restarted. Three changes fix this end-to-end: (1) `/api/server/update` now refuses to pull on a dirty working tree (HTTP 409 with the offending paths) unless the new `force=true` flag is set; (2) git/pip failures now return HTTP 500 with the real stderr in `detail` instead of HTTP 200 with `status: "error"` in the body that the frontend never read; (3) `/api/server/restart` and `/api/server/update` now return `pre_restart_pid` + `pre_restart_version`, and the dashboard polls `/api/server/status` after restart to verify the process actually rolled over (pid or version changed). The restart overlay surfaces a clear warning if the process never restarted instead of reloading to the same stale build. The dashboard also offers a force-retry confirmation dialog when a dirty tree blocks an update. 8 new tests in `tests/web/api/test_server_management.py`. Closes #729.
+- **[#729] `/server/update` no longer silently fails**: The dashboard's *Update & Restart* button used to show a generic success toast even when `git pull` aborted on a dirty working tree, when `pip install` failed, or when the process never actually restarted. Three changes fix this end-to-end: (1) `/api/server/update` now refuses to pull on a dirty working tree (HTTP 409 with the offending paths) unless the new `force=true` flag is set; (2) git/pip failures now return HTTP 500 with the real stderr in `detail` instead of HTTP 200 with `status: "error"` in the body that the frontend never read; (3) `/api/server/restart` and `/api/server/update` now return `pre_restart_pid` + `pre_restart_version`, and the dashboard polls `/api/server/status` after restart to verify the process actually rolled over (pid or version changed). The restart overlay surfaces a clear warning if the process never restarted instead of reloading to the same stale build. The dashboard also offers a force-retry confirmation dialog when a dirty tree blocks an update. 8 new tests in `tests/web/api/test_server_management.py`. Closes #729. (PR #807)
+- **[Security] CodeQL log injection fix**: Inline CR/LF sanitization on all user-controlled strings written to `server.py` audit logs, preventing log-forging via malicious input.
+- **[Frontend] `apiCall` now attaches `.status` to thrown errors**: `app.js` error objects surface the HTTP status code so callers can branch on specific failure codes (e.g. 409 dirty-tree vs 500 subprocess failure).
+- **[Tests] `test_server_management.py` monkeypatch switched to module-object refs**: Fixes `uvx`/isolated-env CI failures where dotted-string patch targets resolved to the wrong module copy.
 
 ## [10.47.0] - 2026-05-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.47.0 - feat: memory_quality maintain orchestrator + Docker DeBERTa quantization (PRs #802, #803, @filhocf, closes #799, #793) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.47.1 - fix(web): surface /server/update failures end-to-end (PR #807, closes #729) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,18 +457,20 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.47.0** (May 1, 2026)
+## Latest Release: **v10.47.1** (May 1, 2026)
 
-**feat: memory_quality maintain orchestrator + Docker DeBERTa quantization**
+**fix(web): surface /server/update failures end-to-end**
 
-**What's New:**
-- **`memory_quality(action='maintain')`**: One-call maintenance cycle — cleanup, conflict detection, stale detection, quality snapshot. `dry_run=true` by default, so it's always safe to explore. `maintain_status` returns last-run stats. Auto-resolve conflicts opt-in via `MCP_MAINTAIN_AUTO_RESOLVE`. (PR #802, @filhocf, closes #799)
-- **DeBERTa ONNX quantization at Docker build time**: `:quality-cpu` images now ship a pre-quantized DeBERTa model (fp16 or int8), cutting the image size from ~1.7 GB to ~600 MB. Cold start no longer re-runs quantization. (PR #803, closes #793)
-- **10 new tests** for the maintain orchestrator.
+**What's Fixed:**
+- **`/server/update` no longer silently fails**: Dirty-tree check (HTTP 409), real stderr on git/pip failure (HTTP 500), post-restart PID/version polling, and force-retry dialog on dirty tree. 8 new tests. Closes #729. (PR #807)
+- **CodeQL log injection**: CR/LF sanitization on audit log inputs in `server.py`.
+- **Frontend status propagation**: `apiCall` in `app.js` now attaches `.status` to thrown errors for proper 409/500 branching.
+- **CI monkeypatch fix**: `test_server_management.py` uses module-object refs instead of dotted strings — fixes `uvx` isolated-env CI failures.
 
 ---
 
 **Previous Releases**:
+- **v10.47.0** - feat: memory_quality maintain orchestrator + Docker DeBERTa quantization (PRs #802, #803, @filhocf, closes #799, #793)
 - **v10.46.0** - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784)
 - **v10.45.1** - fix: CodeQL redundant import cleanup + soft-delete regression tests (PRs #794, #795, @filhocf)
 - **v10.45.0** - feat(quality): OpenAI-compatible provider for LiteLLM/Ollama/MLX + soft-delete UPDATE guards (PRs #790, #783, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.47.0"
+version = "10.47.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.47.0"
+__version__ = "10.47.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.47.0"
+version = "10.47.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

PATCH release v10.47.1 — bug fixes only, no new features, no breaking changes.

### What changed
- **`/server/update` silent failure fixed** (closes #729, PR #807): Dirty-tree check returns HTTP 409; git/pip failures return HTTP 500 with real stderr; post-restart PID/version polling confirms process rolled over; force-retry confirmation dialog on dirty tree. 8 new tests.
- **CodeQL log injection fix**: CR/LF sanitization on audit log inputs in `server.py`.
- **Frontend status propagation**: `app.js` `apiCall` attaches `.status` to thrown errors for 409/500 branching.
- **CI monkeypatch fix**: `test_server_management.py` uses module-object refs instead of dotted strings — fixes `uvx` isolated-env CI failures.

### Files bumped
- `pyproject.toml`: 10.47.0 → 10.47.1
- `src/mcp_memory_service/_version.py`: 10.47.0 → 10.47.1
- `CHANGELOG.md`: [Unreleased] → [10.47.1] - 2026-05-01
- `README.md`: Latest Release updated, v10.47.0 added to Previous Releases
- `CLAUDE.md`: Version callout updated
- `uv.lock`: Regenerated

No landing page update (PATCH release — MINOR/MAJOR only per CLAUDE.md).