### PR TITLE
feat(benchmark): add hybrid ingestion mode combining session + turn storage

### DIFF
--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -309,11 +309,11 @@ async def run_benchmark(args: argparse.Namespace):
     items = load_dataset(data_path=data_path, limit=limit)
     logger.info("Loaded %d items", len(items))
 
-    _ingest_fn = (
-        ingest_item_session if ingestion_mode == "session"
-        else ingest_item_hybrid if ingestion_mode == "hybrid"
-        else ingest_item
-    )
+    _ingest_fn = {
+        "turn": ingest_item,
+        "session": ingest_item_session,
+        "hybrid": ingest_item_hybrid,
+    }[ingestion_mode]
 
     all_per_item: List[Dict] = []
 

--- a/scripts/benchmarks/benchmark_longmemeval.py
+++ b/scripts/benchmarks/benchmark_longmemeval.py
@@ -90,6 +90,13 @@ async def ingest_item_session(storage: SqliteVecMemoryStorage, item: LongMemEval
     return stored
 
 
+async def ingest_item_hybrid(storage: SqliteVecMemoryStorage, item: LongMemEvalItem) -> int:
+    """Store both session units and individual turns. Returns total count."""
+    session_count = await ingest_item_session(storage, item)
+    turn_count = await ingest_item(storage, item)
+    return session_count + turn_count
+
+
 def _match_evidence(
     retrieved_results,
     answer_session_ids: List[str],
@@ -288,10 +295,10 @@ async def run_benchmark(args: argparse.Namespace):
     limit = getattr(args, "limit", None)
     ingestion_mode = getattr(args, "ingestion_mode", "turn")
 
-    # "both" mode: run turn-level then session-level and compare
+    # "both" mode: run all three ingestion modes and compare
     if ingestion_mode == "both":
         results = []
-        for mode in ("turn", "session"):
+        for mode in ("turn", "session", "hybrid"):
             args_copy = argparse.Namespace(**vars(args))
             args_copy.ingestion_mode = mode
             logger.info("--- Running ingestion_mode=%s ---", mode)
@@ -302,7 +309,11 @@ async def run_benchmark(args: argparse.Namespace):
     items = load_dataset(data_path=data_path, limit=limit)
     logger.info("Loaded %d items", len(items))
 
-    _ingest_fn = ingest_item_session if ingestion_mode == "session" else ingest_item
+    _ingest_fn = (
+        ingest_item_session if ingestion_mode == "session"
+        else ingest_item_hybrid if ingestion_mode == "hybrid"
+        else ingest_item
+    )
 
     all_per_item: List[Dict] = []
 
@@ -395,11 +406,12 @@ def parse_args(argv=None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--ingestion-mode",
-        choices=["turn", "session", "both"],
+        choices=["turn", "session", "hybrid", "both"],
         default="turn",
         help="Ingestion granularity: 'turn' stores each message separately (default), "
              "'session' stores a full conversation as one memory, "
-             "'both' runs both and prints a comparison table.",
+             "'hybrid' stores both session units and individual turns, "
+             "'both' runs all three modes and prints a comparison table.",
     )
     parser.add_argument(
         "--markdown",

--- a/tests/benchmarks/test_benchmark_longmemeval.py
+++ b/tests/benchmarks/test_benchmark_longmemeval.py
@@ -13,6 +13,8 @@ from benchmark_longmemeval import (
     _match_evidence,
     create_isolated_storage,
     ingest_item,
+    ingest_item_hybrid,
+    ingest_item_session,
     evaluate_retrieval,
     run_ablation,
 )
@@ -68,6 +70,22 @@ class TestIngestItem:
     async def _run_ingest(self, storage, item):
         await storage.initialize()
         return await ingest_item(storage, item)
+
+
+class TestIngestItemHybrid:
+    def test_hybrid_stores_sessions_and_turns(self):
+        item = _make_test_item()
+        storage, tmp_dir = create_isolated_storage()
+        try:
+            count = asyncio.run(self._run_hybrid(storage, item))
+            # 2 sessions + 4 turns = 6 total
+            assert count == 6
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def _run_hybrid(self, storage, item):
+        await storage.initialize()
+        return await ingest_item_hybrid(storage, item)
 
 
 class TestEvaluateRetrieval:

--- a/tests/benchmarks/test_benchmark_longmemeval.py
+++ b/tests/benchmarks/test_benchmark_longmemeval.py
@@ -73,19 +73,17 @@ class TestIngestItem:
 
 
 class TestIngestItemHybrid:
-    def test_hybrid_stores_sessions_and_turns(self):
+    @pytest.mark.asyncio
+    async def test_hybrid_stores_sessions_and_turns(self):
         item = _make_test_item()
         storage, tmp_dir = create_isolated_storage()
         try:
-            count = asyncio.run(self._run_hybrid(storage, item))
+            await storage.initialize()
+            count = await ingest_item_hybrid(storage, item)
             # 2 sessions + 4 turns = 6 total
             assert count == 6
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    async def _run_hybrid(self, storage, item):
-        await storage.initialize()
-        return await ingest_item_hybrid(storage, item)
 
 
 class TestEvaluateRetrieval:


### PR DESCRIPTION
Closes #667 (partial — hybrid ingestion mode)

## What

Adds `--ingestion-mode hybrid` to the LongMemEval benchmark. Hybrid mode stores **both** the session unit (one memory per conversation) **and** individual turns, giving the best of both worlds:
- Session-level retrieval for temporal/multi-session queries
- Turn-level retrieval for specific fact lookups

## Changes

- `scripts/benchmarks/benchmark_longmemeval.py`: Added `ingest_item_hybrid()` function and `hybrid` choice to `--ingestion-mode`
- `--ingestion-mode both` now runs all three modes (turn, session, hybrid) for comparison
- `tests/benchmarks/test_benchmark_longmemeval.py`: Added test for hybrid ingestion

## Testing

- 8/8 benchmark tests pass
- 91/91 existing benchmark tests pass (no regressions)

## Context

As discussed in #667, this follows the plan: benchmark flag → baseline numbers → hybrid mode. The `store_session` tool and `--ingestion-mode session` already exist. This PR adds the hybrid mode that was the recommended first piece.