### PR TITLE
fix(pypi-placeholders): README upload snippet now works in zsh

### DIFF
--- a/tools/pypi-placeholders/README.md
+++ b/tools/pypi-placeholders/README.md
@@ -25,17 +25,22 @@ Each placeholder is a self-contained `pyproject.toml` project. Build all four an
 ```bash
 cd tools/pypi-placeholders
 
-PKGS="agent-memory-service ai-memory-service agent-memory memory-for-agents"
+# Bash + zsh array (zsh does NOT word-split a plain "x y z" string by default,
+# so `for d in $PKGS` would treat the whole list as a single path. Arrays
+# work in both shells.)
+PKGS=(agent-memory-service ai-memory-service agent-memory memory-for-agents)
 
 # Build + check all four. Use `break` instead of `exit 1` so a failure in
 # this copy-pasted snippet does not terminate the user's interactive shell.
-for d in $PKGS; do
+for d in "${PKGS[@]}"; do
   ( cd "$d" && python -m build && twine check dist/* ) || break
 done
 
 # Upload all four to PyPI (interactive — twine will prompt for token / use ~/.pypirc)
-for d in $PKGS; do
-  twine upload "$d/dist/*"
+# The glob must be OUTSIDE the quotes so the shell expands it; "$d/dist/*" as
+# one quoted string is a literal path and twine will fail with InvalidDistribution.
+for d in "${PKGS[@]}"; do
+  twine upload "$d"/dist/*
 done
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to PR #817. Reported by maintainer running the upload snippet on stock macOS zsh:

```
cd: no such file or directory: agent-memory-service ai-memory-service agent-memory memory-for-agents
ERROR    InvalidDistribution: Cannot find file (or expand pattern):
         'agent-memory-service ai-memory-service agent-memory memory-for-agents/dist/*'
```

Two zsh-specific issues in the snippet:

1. **`PKGS="a b c d"` + `for d in \$PKGS`** — zsh does not word-split unquoted parameter expansions by default, so the whole string was treated as one path. Switched to a shell array (`PKGS=(a b c d)` + `\"\${PKGS[@]}\"`), which behaves the same in bash and zsh.
2. **`twine upload \"\$d/dist/*\"`** — the glob is inside the quotes, so it stays a literal path. Moved the glob outside: `twine upload \"\$d\"/dist/*`.

Inline comments in the snippet flag both gotchas so future readers don't hit them.

No code change beyond the README. Placeholder packages themselves unchanged.

## Test plan

- [x] Maintainer ran the previous (broken) snippet and reported the exact error.
- [ ] Maintainer reruns the corrected snippet and confirms all four packages build + upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)