### PR TITLE
ci(pypi-placeholders): manual workflow to upload placeholders via existing PYPI_TOKEN

### DIFF
--- a/.github/workflows/publish-placeholders.yml
+++ b/.github/workflows/publish-placeholders.yml
@@ -1,0 +1,87 @@
+name: Publish PyPI Placeholders
+
+# Manually-triggered workflow that builds and uploads the four defensive
+# name-reservation placeholder packages under tools/pypi-placeholders/ to
+# PyPI. See issue #809 and PRs #817/#818 for context.
+#
+# This is intended to be run ONCE for the initial registration of each
+# name. After upload, the four PyPI projects exist and don't need further
+# action — they sit at version 0.0.1 indefinitely. Re-running the workflow
+# is safe (twine --skip-existing), but pointless.
+#
+# Required secret: PYPI_TOKEN (account-scoped, since these are NEW projects
+# that don't exist on PyPI yet — project-scoped tokens cannot register new
+# projects). After first successful upload, you can rotate to project-scoped
+# tokens per placeholder if you want stricter security.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to upload"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+      skip_existing:
+        description: "Pass --skip-existing to twine (safe for re-runs)"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish-placeholders:
+    name: Build & upload placeholder packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - agent-memory-service
+          - ai-memory-service
+          - agent-memory
+          - memory-for-agents
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build placeholder
+        working-directory: tools/pypi-placeholders/${{ matrix.package }}
+        run: python -m build
+
+      - name: Verify artifacts
+        working-directory: tools/pypi-placeholders/${{ matrix.package }}
+        run: python -m twine check dist/*
+
+      - name: Upload to selected index
+        working-directory: tools/pypi-placeholders/${{ matrix.package }}
+        env:
+          # `target` is a `type: choice` enum so the substitution is bounded
+          # to one of two literal strings — but we still pipe it through env
+          # vars and avoid any direct ${{ ... }} interpolation in the run
+          # script body (workflow injection hardening).
+          TARGET: ${{ inputs.target }}
+          SKIP_EXISTING: ${{ inputs.skip_existing }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ inputs.target == 'pypi' && secrets.PYPI_TOKEN || secrets.TEST_PYPI_TOKEN }}
+          TWINE_REPOSITORY: ${{ inputs.target }}
+        run: |
+          if [ "${SKIP_EXISTING}" = "true" ]; then
+            python -m twine upload --skip-existing dist/*
+          else
+            python -m twine upload dist/*
+          fi
+          echo "Uploaded to ${TARGET}."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-placeholders.yml` — a `workflow_dispatch`-triggered job that builds and uploads the four defensive name-reservation placeholder packages (PR #817) to PyPI or TestPyPI using the existing `PYPI_TOKEN` GitHub secret. No need to put a PyPI token on the maintainer's local machine for a one-time registration.

Why this PR exists:
- Maintainer pointed out the project's PyPI token is stored as a GitHub Actions secret, not locally — same path the standard `mcp-memory-service` package release uses (`publish-dual.yml` → `secrets.PYPI_TOKEN`).
- Local upload would require either fetching that token onto the local box (security risk) or generating a fresh one (extra step). A manual-trigger workflow is cleaner and matches the existing release pattern.

## How to run

After merge, go to **Actions → Publish PyPI Placeholders → Run workflow**.

Inputs:
- **target**: `testpypi` (default) or `pypi`. **Test on TestPyPI first** to validate, then re-run targeting `pypi`.
- **skip_existing**: `true` (default). Safe for re-runs — `twine --skip-existing` makes already-uploaded versions no-ops.

The matrix runs each placeholder as its own job (`fail-fast: false`), so a failure on one name doesn't block the others.

## Token-scope caveat

The four packages are **new** on PyPI. Project-scoped tokens cannot register new projects on PyPI — only account-scoped tokens can. If `PYPI_TOKEN` happens to be project-scoped to `mcp-memory-service`, the first upload will fail with a 403 and we'll need to rotate to a wider-scoped token for the bootstrap upload, then rotate back. The workflow's per-package matrix means a 403 on the first job doesn't poison the others.

## Hardening

- Workflow inputs (`target`, `skip_existing`) are piped through env vars and never interpolated directly into the `run:` script body, per the GitHub Actions workflow-injection guide.
- `target` is a `type: choice` enum, so its value is bounded to one of two literal strings.
- Runs only on `workflow_dispatch` — no automatic triggers.

## Test plan

- [ ] Merge this PR
- [ ] Trigger workflow with `target=testpypi` — verify all 4 jobs succeed
- [ ] Trigger workflow with `target=pypi` — verify all 4 jobs succeed
- [ ] Visit each PyPI project page (`https://pypi.org/project/<name>/`) and confirm the placeholder README renders and the `Real Package` URL is set

## Out of scope

- Adding `TEST_PYPI_TOKEN` as a secret if it doesn't already exist. The workflow references it conditionally; if missing, the `testpypi` path fails. The `pypi` path doesn't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)