### PR TITLE
fix(consolidation): schedule defaults to 'disabled' (closes #808)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,6 +270,43 @@ MCP_HYBRID_SEMANTIC_WEIGHT=0.7
 # MCP_CUSTOM_MEMORY_TYPES='{"legal": ["contract", "clause", "obligation"]}'
 
 # =============================================================================
+# CONSOLIDATION SCHEDULING (v8.23.0+)
+# =============================================================================
+# Dream-inspired memory maintenance: decay scoring, association discovery,
+# semantic compression, and quality-based archival. Runs via APScheduler.
+#
+# Master switch (consolidation logic itself):
+# MCP_CONSOLIDATION_ENABLED=true
+#
+# Schedule values control WHEN automatic consolidation runs. ALL schedules
+# default to 'disabled' (manual-only mode). Uncomment AND set a value to
+# enable each interval. Use 'disabled' (or leave commented) to skip.
+#
+# Behavior change in v10.48: previously, daily/weekly/monthly defaults were
+# active (02:00 / SUN 03:00 / 01 04:00) even when these env vars were not
+# set, which silently archived files on deployments expecting manual-only
+# operation (issue #808). All defaults are now 'disabled'.
+#
+# Format reference:
+#   daily:     HH:MM             (e.g. '02:00' = every day at 2 AM local)
+#   weekly:    DAY HH:MM         (e.g. 'SUN 03:00' = Sundays at 3 AM)
+#   monthly:   DD HH:MM          (e.g. '01 04:00' = 1st of month at 4 AM)
+#   quarterly: DAY HH:MM         (first day of quarter)
+#   yearly:    MM-DD HH:MM       (e.g. '01-01 05:00' = Jan 1 at 5 AM)
+#
+# Recommended values when enabling automatic consolidation:
+# MCP_SCHEDULE_DAILY=02:00
+# MCP_SCHEDULE_WEEKLY=SUN 03:00
+# MCP_SCHEDULE_MONTHLY=01 04:00
+# MCP_SCHEDULE_QUARTERLY=disabled
+# MCP_SCHEDULE_YEARLY=disabled
+#
+# To run consolidation on demand without a schedule, leave all the above
+# commented (or set to 'disabled') and call the API/MCP tool manually:
+#   curl -X POST http://localhost:8000/api/consolidation/run -d '{"horizon":"daily"}'
+#   memory_consolidate(action="run", horizon="daily")
+
+# =============================================================================
 # TROUBLESHOOTING
 # =============================================================================
 # Common issues:

--- a/.env.example
+++ b/.env.example
@@ -291,7 +291,9 @@ MCP_HYBRID_SEMANTIC_WEIGHT=0.7
 #   daily:     HH:MM             (e.g. '02:00' = every day at 2 AM local)
 #   weekly:    DAY HH:MM         (e.g. 'SUN 03:00' = Sundays at 3 AM)
 #   monthly:   DD HH:MM          (e.g. '01 04:00' = 1st of month at 4 AM)
-#   quarterly: DAY HH:MM         (first day of quarter)
+#   quarterly: MM-DD HH:MM       (e.g. '01-01 04:00' — month part is ignored;
+#                                  always fires on the given DD at quarter
+#                                  starts: Jan, Apr, Jul, Oct)
 #   yearly:    MM-DD HH:MM       (e.g. '01-01 05:00' = Jan 1 at 5 AM)
 #
 # Recommended values when enabling automatic consolidation:

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -739,12 +739,16 @@ CONSOLIDATION_CONFIG = {
 }
 
 # Consolidation scheduling settings (for APScheduler integration)
+# All schedules default to 'disabled' so consolidation is opt-in. Users must
+# explicitly set MCP_SCHEDULE_* env vars to enable automatic runs (issue #808).
+# Recommended values when enabling: daily='02:00', weekly='SUN 03:00',
+# monthly='01 04:00'. See .env.example for full documentation.
 CONSOLIDATION_SCHEDULE = {
-    'daily': os.getenv('MCP_SCHEDULE_DAILY', '02:00'),      # 2 AM daily
-    'weekly': os.getenv('MCP_SCHEDULE_WEEKLY', 'SUN 03:00'), # 3 AM on Sundays
-    'monthly': os.getenv('MCP_SCHEDULE_MONTHLY', '01 04:00'), # 4 AM on 1st of month
-    'quarterly': os.getenv('MCP_SCHEDULE_QUARTERLY', 'disabled'), # Disabled by default
-    'yearly': os.getenv('MCP_SCHEDULE_YEARLY', 'disabled')        # Disabled by default
+    'daily': os.getenv('MCP_SCHEDULE_DAILY', 'disabled'),
+    'weekly': os.getenv('MCP_SCHEDULE_WEEKLY', 'disabled'),
+    'monthly': os.getenv('MCP_SCHEDULE_MONTHLY', 'disabled'),
+    'quarterly': os.getenv('MCP_SCHEDULE_QUARTERLY', 'disabled'),
+    'yearly': os.getenv('MCP_SCHEDULE_YEARLY', 'disabled')
 }
 
 logger.info(f"Consolidation enabled: {CONSOLIDATION_ENABLED}")


### PR DESCRIPTION
## Summary

Fix silent monthly archival on deployments expecting manual-only operation (issue #808).

Previously, `MCP_SCHEDULE_DAILY` / `_WEEKLY` / `_MONTHLY` had hardcoded fallback values (`02:00` / `SUN 03:00` / `01 04:00`) used whenever the env vars were unset. Users who commented out the schedule lines (or never set them) — believing they had manual-only operation — got automatic consolidation firing on the code defaults. The reporter saw 1,369 entries accumulated in `compressed/` plus a monthly run silently archiving 76+ files on a deployment owner thought was manual-only.

This PR makes the defaults match the documentation: all five schedules now default to `'disabled'`, so commenting out (or never setting) the env vars yields the manual-only mode users expect.

## Changes

- `src/mcp_memory_service/config.py:741-752` — all five schedule defaults set to `'disabled'`. Inline comment points to `.env.example` and links #808.
- `.env.example` — new **CONSOLIDATION SCHEDULING** section documenting:
  - The master switch (`MCP_CONSOLIDATION_ENABLED`) vs. timing controls
  - Recommended values when enabling automatic consolidation
  - The behavior change vs. prior versions (with explicit reference to #808)
  - Format reference for each interval
  - How to run manually via API/MCP tool

## Behavioral change

Deployments that **never set** `MCP_SCHEDULE_*` but were getting daily/weekly/monthly runs from the implicit defaults will now run in manual-only mode after this lands. Operators who want the prior automatic schedule must add three lines to `.env`:

```bash
MCP_SCHEDULE_DAILY=02:00
MCP_SCHEDULE_WEEKLY=SUN 03:00
MCP_SCHEDULE_MONTHLY=01 04:00
```

This matches what the docs already claim and aligns with `MCP_CONSOLIDATION_ENABLED` being the master switch, with schedule values controlling *when* (not *whether*) it fires.

## Test plan

- [x] No new logic — only default-value change in a config dict + .env.example documentation
- [x] No tests reference these defaults (verified via grep)
- [x] Existing consolidation handlers in `server_impl.py:757` and `web/app.py:139` already gate on `any(schedule != 'disabled')`, so the all-disabled state cleanly skips scheduler init
- [ ] Manual verification: with no `MCP_SCHEDULE_*` env vars set, `memory_consolidate(action="scheduler")` reports no jobs scheduled

## Pre-PR check notes

`bash scripts/pr/pre_pr_check.sh` reports 3 pre-existing failures, none caused by this diff:
- Gemini CLI not installed in local env (Quality gate)
- Repo baseline coverage 62% (Test coverage check; this PR adds no code)
- Pre-existing inline imports elsewhere in `config.py` (Import ordering; this PR adds zero imports)

`git diff` confirms only the schedule dict + comments + `.env.example` changed.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)