### PR TITLE
chore: release v10.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.47.2] - 2026-05-02
+
 ### Fixed
+
+- **[#808] Consolidation schedule defaults changed to `'disabled'` — operators must now opt in to automatic consolidation**: Previously, omitting `MCP_SCHEDULE_DAILY`, `MCP_SCHEDULE_WEEKLY`, and `MCP_SCHEDULE_MONTHLY` env vars silently activated automatic consolidation runs at `02:00` daily, `SUN 03:00` weekly, and `01 04:00` monthly. One affected deployment accumulated 1,369 unintended `compressed/` entries and had 76+ files silently archived in a monthly run they believed was disabled. The defaults are now `'disabled'` — automatic consolidation no longer runs unless the env vars are explicitly set. **If you relied on the prior automatic behavior**, add the following to your `.env` to restore it: `MCP_SCHEDULE_DAILY=02:00`, `MCP_SCHEDULE_WEEKLY=SUN 03:00`, `MCP_SCHEDULE_MONTHLY=01 04:00`. A new `CONSOLIDATION SCHEDULING` section in `.env.example` documents the syntax. Quarterly schedule format docstring corrected (caught by gemini-code-assist). Closes #808. (PR #821, commit `0d4a658`)
+
+### Added
 
 - **[#811] Docker `:slim` and `:quality-cpu` images missing `aiosqlite` and other core deps**: The hand-curated dependency lists in `tools/docker/Dockerfile.slim` and `tools/docker/Dockerfile.quality-cpu` had drifted from `pyproject.toml`'s `dependencies` block. Both Dockerfiles use `pip install -e . --no-deps` to skip the heavy ML stack (`torch`, `transformers`, `sentence-transformers`) but were also accidentally skipping `aiosqlite>=0.20.0` (the visible failure: `ModuleNotFoundError: No module named 'aiosqlite'` on first memory tool call with `MCP_MEMORY_STORAGE_BACKEND=sqlite_vec`), plus `apscheduler` (consolidation), `authlib`/`PyJWT[crypto]`/`cryptography` (OAuth), `httpx`/`requests`, `python-dotenv`, and `pypdf`. The list was also still installing the deprecated `PyPDF2` while the code imports `pypdf`. Both Dockerfiles now ship the full pyproject `dependencies` set minus the heavy ML deps, with `mcp` and `tokenizers` version specifiers re-aligned to pyproject. The `Dockerfile.slim` install step also strips uv/pip caches at the end of the RUN, mirroring `Dockerfile.quality-cpu`. Closes #811. (PR #815)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.47.1 - fix(web): surface /server/update failures end-to-end (PR #807, closes #729) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.47.2 - fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation (PR #821, closes #808) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,19 +457,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.47.1** (May 1, 2026)
+## Latest Release: **v10.47.2** (May 2, 2026)
 
-**fix(web): surface /server/update failures end-to-end**
+**fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation**
 
 **What's Fixed:**
-- **`/server/update` no longer silently fails**: Dirty-tree check (HTTP 409), real stderr on git/pip failure (HTTP 500), post-restart PID/version polling, and force-retry dialog on dirty tree. 8 new tests. Closes #729. (PR #807)
-- **CodeQL log injection**: CR/LF sanitization on audit log inputs in `server.py`.
-- **Frontend status propagation**: `apiCall` in `app.js` now attaches `.status` to thrown errors for proper 409/500 branching.
-- **CI monkeypatch fix**: `test_server_management.py` uses module-object refs instead of dotted strings — fixes `uvx` isolated-env CI failures.
+- **Consolidation schedule defaults changed to `'disabled'`**: Previously, omitting `MCP_SCHEDULE_*` env vars activated daily (`02:00`), weekly (`SUN 03:00`), and monthly (`01 04:00`) consolidation automatically. Deployments that believed they were running in manual-only mode were silently accumulating scheduled runs. Defaults are now `'disabled'` — operators must explicitly set `MCP_SCHEDULE_DAILY`, `MCP_SCHEDULE_WEEKLY`, and `MCP_SCHEDULE_MONTHLY` to opt in to automatic consolidation. If you relied on the prior automatic behavior, add those three env vars to restore it. Closes #808. (PR #821)
+- **`.env.example` `CONSOLIDATION SCHEDULING` section**: New documented block makes the three schedule env vars discoverable with their expected cron/time syntax.
+- **Quarterly format docstring fix**: Corrected the docstring example for the monthly/quarterly schedule format (caught by gemini-code-assist, commit `0d4a658`).
 
 ---
 
 **Previous Releases**:
+- **v10.47.1** - fix(web): surface /server/update failures end-to-end (PR #807, closes #729)
 - **v10.47.0** - feat: memory_quality maintain orchestrator + Docker DeBERTa quantization (PRs #802, #803, @filhocf, closes #799, #793)
 - **v10.46.0** - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784)
 - **v10.45.1** - fix: CodeQL redundant import cleanup + soft-delete regression tests (PRs #794, #795, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.47.1"
+version = "10.47.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.47.1"
+__version__ = "10.47.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.47.1"
+version = "10.47.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to **v10.47.2**
- CHANGELOG: consolidation schedule defaults changed to `'disabled'` — operators must now explicitly set `MCP_SCHEDULE_*` env vars (#808, PR #821)
- CHANGELOG: absorbs Docker slim/quality-cpu missing deps fix (#811, PR #815) from `[Unreleased]`
- README, CLAUDE.md: updated current version callout

## Operator Action Required

If you omitted `MCP_SCHEDULE_*` env vars and relied on the prior automatic consolidation behavior, add these to your `.env` to restore it:

```
MCP_SCHEDULE_DAILY=02:00
MCP_SCHEDULE_WEEKLY=SUN 03:00
MCP_SCHEDULE_MONTHLY=01 04:00
```

## Test plan

- [ ] CI passes on this branch
- [ ] Version strings consistent across `pyproject.toml`, `_version.py`, CHANGELOG, README, CLAUDE.md
- [ ] CHANGELOG: no duplicate version entries, `[Unreleased]` empty at top, reverse-chronological order

🤖 Generated with [Claude Code](https://claude.com/claude-code)