### PR TITLE
chore: repository housekeeping audit + drift fixes (audit 2026-05-02)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -7,12 +7,18 @@ on:
       - 'docs/**'
       - 'README.md'
       - '*.md'
+      - 'src/mcp_memory_service/_version.py'
+      - 'scripts/ci/check_*.sh'
+      - '.github/workflows/docs-check.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'README.md'
       - '*.md'
+      - 'src/mcp_memory_service/_version.py'
+      - 'scripts/ci/check_*.sh'
+      - '.github/workflows/docs-check.yml'
 
 jobs:
   link-check:
@@ -36,3 +42,11 @@ jobs:
 
       - name: Check for dead references
         run: bash scripts/ci/check_dead_refs.sh
+
+  version-drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for version drift on landing page
+        run: bash scripts/ci/check_versions.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ python scripts/server/run_http_server.py
 
 ### Testing
 ```bash
-# Run all tests (968 tests total)
+# Run all tests (~1,780 tests total)
 pytest
 
 # Run specific test file
@@ -230,7 +230,7 @@ src/mcp_memory_service/
 
 ## Test Architecture
 
-### Structure (968 tests)
+### Structure (~1,780 tests)
 ```
 tests/
 ├── api/              # API layer tests (compact types, operations)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 
 ### vs. MCP-Native Alternatives
 
-[MemPalace](https://github.com/milla-jovovich/mempalace) is an MCP-native alternative that went viral in April 2026 with strong LongMemEval claims. A [community code review (Issue #27)](https://github.com/milla-jovovich/mempalace/issues/27) subsequently showed that the headline numbers reflect the underlying vector store rather than the advertised Palace architecture, and the maintainers acknowledged most points. We keep the comparison here for transparency, but readers should interpret the scores with that context in mind.
+[MemPalace](https://github.com/MemPalace/mempalace) is an MCP-native alternative that went viral in April 2026 with strong LongMemEval claims. A [community code review (Issue #27)](https://github.com/MemPalace/mempalace/issues/27) subsequently showed that the headline numbers reflect the underlying vector store rather than the advertised Palace architecture, and the maintainers acknowledged most points. We keep the comparison here for transparency, but readers should interpret the scores with that context in mind.
 
 | | **MemPalace** | **mcp-memory-service** |
 |---|---|---|
@@ -202,7 +202,7 @@ A production-tested self-hosted deployment using Docker containers behind a Clou
 1. **Ingestion granularity.** MemPalace stores each conversation as a single unit (session-level). LongMemEval asks "which session contains the answer?" — a question that session-level storage answers structurally. mcp-memory-service defaults to turn-level storage (one entry per message), which enables fine-grained retrieval ("what exactly did the user say about X?") but spreads a session's signal across many entries. Using `memory_store_session` (added in v10.35.0) brings our score to **86.0% R@5**.
 2. **What the 96.6% actually measures.** Per Issue #27, MemPalace's headline number is produced in "raw mode" — plain text stored in ChromaDB with default embeddings. The Palace architecture (Wings, Rooms, Halls) is **not active** in that configuration; "Halls" exist only as metadata strings with no effect on ranking. The 96.6% is therefore a ChromaDB + default-embedding baseline, not a measurement of MemPalace's structural retrieval features. A direct "apples-to-apples" architectural comparison is not possible with the published numbers.
 
-> ¹ Measured in MemPalace "raw mode" (plain text in ChromaDB with default embeddings). Per [Issue #27](https://github.com/milla-jovovich/mempalace/issues/27), the Palace structural features are bypassed in this configuration.
+> ¹ Measured in MemPalace "raw mode" (plain text in ChromaDB with default embeddings). Per [Issue #27](https://github.com/MemPalace/mempalace/issues/27), the Palace structural features are bypassed in this configuration.
 >
 > ² 100% result uses optional LLM reranking (~500 API calls) on a partially tuned test set. Clean held-out score (as reported by the maintainers): **98.4% R@5**.
 

--- a/docs/guides/memory-consolidation-guide.md
+++ b/docs/guides/memory-consolidation-guide.md
@@ -93,7 +93,7 @@ curl -X POST http://127.0.0.1:8000/api/consolidation/trigger \
 
 ### 2. MCP Tools
 ```python
-mcp__memory__trigger_consolidation(time_horizon="daily", immediate=true)
+mcp__memory__memory_consolidate(action="run", time_horizon="daily", immediate=true)
 ```
 
 ### 3. Code Execution API (Most Token-Efficient)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.47</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.47.2</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.47">
+<meta property="og:title" content="MCP Memory Service v10.47.2">
 <meta property="og:description" content="One-call maintenance orchestrator: memory_quality(action='maintain') runs cleanup, conflict detection, stale detection, and quality snapshot in a single cycle. Pre-quantized DeBERTa in Docker cuts image size from ~1.7 GB to ~600 MB. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.2" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/mastery/api-reference.md
+++ b/docs/mastery/api-reference.md
@@ -4,27 +4,24 @@ This document catalogs available APIs exposed via the MCP servers and summarizes
 
 ## MCP (FastMCP HTTP) Tools
 
-Defined in `src/mcp_memory_service/mcp_server.py` using `@mcp.tool()`:
+The v10.0.0 unified MCP tool surface (12 tools — see `src/mcp_memory_service/server_impl.py` for the authoritative list):
 
-- `store_memory(content, tags=None, memory_type="note", metadata=None, client_hostname=None)`
-  - Stores a new memory; tags and metadata optional. If `INCLUDE_HOSTNAME=true`, a `source:<hostname>` tag and `hostname` metadata are added.
-  - Response: `{ success: bool, message: str, content_hash: str }`.
+| Tool | Purpose |
+|------|---------|
+| `memory_store` | Store a new memory (replaces `store_memory`) |
+| `memory_search` | Hybrid semantic + keyword search (replaces `retrieve_memory`, `search_by_tag` family) |
+| `memory_list` | List/filter memories (replaces tag-listing variants) |
+| `memory_delete` | Delete by hash, tag, timeframe, or filter (replaces `delete_*` family) |
+| `memory_health` | Server + storage health check (replaces `check_database_health`) |
+| `memory_stats` | Usage and storage statistics |
+| `memory_update` | Update memory metadata (replaces `update_memory_metadata`) |
+| `memory_cleanup` | Remove duplicates / orphans (replaces `cleanup_duplicates`) |
+| `memory_consolidate` | Run/manage consolidation (replaces `trigger_consolidation`, `scheduler_status`) |
+| `memory_quality` | Rate / get / analyze quality (replaces `rate_memory`, `get_memory_quality`, `analyze_quality_distribution`) |
+| `memory_ingest` | Ingest documents (PDF/DOCX/TXT/JSON) |
+| `memory_graph` | Knowledge-graph queries |
 
-- `retrieve_memory(query, n_results=5, min_similarity=0.0)`
-  - Semantic search by query; returns up to `n_results` matching memories.
-  - Response: `{ memories: [{ content, content_hash, tags, memory_type, created_at, similarity_score }...], query, total_results }`.
-
-- `search_by_tag(tags, match_all=False)`
-  - Search by a tag or list of tags. `match_all=true` requires all tags; otherwise any.
-  - Response: `{ memories: [{ content, content_hash, tags, memory_type, created_at }...], search_tags: [...], match_all, total_results }`.
-
-- `delete_memory(content_hash)`
-  - Deletes a memory by its content hash.
-  - Response: `{ success: bool, message: str, content_hash }`.
-
-- `check_database_health()`
-  - Health and status of the configured backend.
-  - Response: `{ status: "healthy"|"error", backend, statistics: { total_memories, total_tags, storage_size, last_backup }, timestamp? }`.
+Deprecated v9-and-earlier names continue to work via `compat.py` until v11.0 — see `docs/MIGRATION.md` for the full mapping.
 
 Transport: `mcp.run("streamable-http")`, default host `0.0.0.0`, default port `8000` or `MCP_SERVER_PORT`/`MCP_SERVER_HOST`.
 
@@ -34,7 +31,7 @@ Defined in `src/mcp_memory_service/server.py` using `mcp.server.Server`. Exposes
 
 Highlights:
 
-- Core memory ops: store, retrieve/search, search_by_tag(s), delete, delete_by_tag, cleanup_duplicates, update_memory_metadata, time-based recall.
+- Core memory ops via the unified memory_* tool surface: memory_store, memory_search, memory_list (tag/filter), memory_delete (by hash/tag/timeframe), memory_cleanup, memory_update.
 - Analysis/export: knowledge_analysis, knowledge_export (supports `format: json|markdown|text`, optional filters).
 - Maintenance: memory_cleanup (duplicate detection heuristics), health/stats, tag listing.
 - Consolidation (optional): association, clustering, compression, forgetting tasks and schedulers when enabled.
@@ -56,21 +53,21 @@ Note: The stdio server dynamically picks storage mode for multi-client scenarios
 Store memory:
 
 ```
-tool: store_memory
+tool: memory_store
 args: { "content": "Refactored auth flow to use OAuth 2.1", "tags": ["auth", "refactor"], "memory_type": "note" }
 ```
 
 Retrieve by query:
 
 ```
-tool: retrieve_memory
-args: { "query": "OAuth refactor", "n_results": 5 }
+tool: memory_search
+args: { "query": "OAuth refactor", "limit": 5 }
 ```
 
 Search by tags:
 
 ```
-tool: search_by_tag
+tool: memory_list
 args: { "tags": ["auth", "refactor"], "match_all": true }
 ```
 

--- a/docs/mastery/architecture-overview.md
+++ b/docs/mastery/architecture-overview.md
@@ -45,7 +45,7 @@ This document summarizes the Memory Service architecture, components, data flow,
   - Coordination: detects if an HTTP sidecar is needed for multi-client access; starts/uses `HTTPClientStorage` when appropriate.
 
 - FastMCP (`mcp_server.py`):
-  - Wraps storage via `lifespan` context; exposes core tools like `store_memory`, `retrieve_memory`, `search_by_tag`, `delete_memory`, `check_database_health` using `@mcp.tool()`.
+  - Wraps storage via `lifespan` context; exposes core tools like `memory_store`, `memory_search`, `memory_list`, `memory_delete`, `memory_health` using `@mcp.tool()`.
   - Designed for remote/HTTP access and Claude Code compatibility via `streamable-http` transport.
 
 ## Storage Layer Abstraction

--- a/docs/superpowers/plans/2026-05-02-housekeeping-audit.md
+++ b/docs/superpowers/plans/2026-05-02-housekeeping-audit.md
@@ -1,0 +1,1058 @@
+# Repository Housekeeping Audit & Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect documentation drift across `docs/`, `README.md`, `CLAUDE.md`, `docs/index.html`, and the `mcp-memory-service.wiki` repo, then fix critical/major findings via 1-2 main-repo PRs + direct wiki commits, and add a new version-drift CI check to prevent regression.
+
+**Architecture:** Discovery-first, four-phase flow — (1) audit all six drift categories into a single triage report, (2) user marks each finding `ship-now` / `defer-issue` / `skip`, (3) execute fixes with bundled tooling extensions, (4) verify via extended dead-ref check + new version-drift check + manual re-scan.
+
+**Tech Stack:** bash scripts, GitHub Actions (`gaurav-nelson/github-action-markdown-link-check`), markdown, GitHub CLI (`gh`), git, Python (`_version.py` parsing).
+
+**Reference state:** v10.47.2, ~1,780 tests, 40+ wiki pages, 60+ doc files.
+
+**Spec:** [`docs/superpowers/specs/2026-05-02-housekeeping-audit-design.md`](../specs/2026-05-02-housekeeping-audit-design.md)
+
+---
+
+## Phase 1 — Audit
+
+Goal: produce `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md` with all findings classified by severity. No code changes in this phase.
+
+Each task in this phase is a discovery scan. Findings from all tasks accumulate into the single report file. The report file is created in Task 1.0 and appended to by each subsequent task.
+
+### Task 1.0: Bootstrap audit report
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Determine canonical reference state**
+
+```bash
+# Canonical version
+grep -E '__version__\s*=' src/mcp_memory_service/_version.py
+
+# Test count (best-effort approximation)
+grep -rE '^\s*def test_' tests/ --include='*.py' | wc -l
+```
+
+Record both values. Use the canonical version from `_version.py` for all version comparisons.
+
+- [ ] **Step 2: Create report skeleton**
+
+Write `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`:
+
+```markdown
+# Housekeeping Audit — 2026-05-02
+
+**Scope**: docs/, README.md, CLAUDE.md, docs/index.html, mcp-memory-service.wiki/
+**Reference state**: v<CANONICAL>, ~<TEST_COUNT> tests
+**Categories scanned**: version, feature, wiki↔repo, cross-doc, links, structural
+
+## Summary
+- 🔴 Critical: 0 findings
+- 🟡 Major:    0 findings
+- 🟢 Minor:    0 findings
+- ⚪ Noise:    0 findings (excluded)
+
+## Findings
+
+<!-- Findings appended below by audit tasks. ID format: F-NNN. -->
+```
+
+Replace `<CANONICAL>` and `<TEST_COUNT>` with the values from Step 1. Do not commit yet.
+
+### Task 1.1: Version drift scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Grep for hardcoded version refs**
+
+```bash
+# Repo: docs/, README.md, CLAUDE.md, docs/index.html
+grep -rEn 'v[0-9]+\.[0-9]+\.[0-9]+' \
+  docs/ README.md CLAUDE.md \
+  --include='*.md' --include='*.html' \
+  | grep -vE '/(archive|legacy|plans|migrations)/|CHANGELOG'
+
+# Wiki: separate repo
+grep -rEn 'v[0-9]+\.[0-9]+\.[0-9]+' \
+  /Users/hkr/Repositories/mcp-memory-service.wiki/ \
+  --include='*.md' \
+  | grep -vE '/archive/'
+```
+
+- [ ] **Step 2: Grep for test-count refs**
+
+```bash
+grep -rEn '[0-9],?[0-9]{3}\s*tests' docs/ README.md CLAUDE.md --include='*.md' \
+  | grep -v CHANGELOG
+
+grep -rEn '[0-9],?[0-9]{3}\s*tests' \
+  /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+```
+
+- [ ] **Step 3: Compare each match against canonical**
+
+For each match where the version is older than canonical (semver comparison), record it. Skip matches inside CHANGELOG, archive/, legacy/, plans/, migrations/. Skip matches that are intentionally pinned (e.g. `pip install mcp-memory-service==X.Y.Z` where X.Y.Z is an old known-good version — judgment call).
+
+- [ ] **Step 4: Append findings to report**
+
+Append each finding under `## Findings` using this format:
+
+```markdown
+### F-001 🟡 Major · version drift · docs/index.html:42
+**Current**: `v10.13.0` (in `<span class="version">`)
+**Expected**: `v10.47.2`
+**Fix**: edit + re-publish to here.now (`merry-realm-j835`)
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+```
+
+Use F-NNN sequential IDs starting at F-001. Severity per rubric in spec.
+
+### Task 1.2: Feature drift scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Build dead-feature term list**
+
+```bash
+# Pull all [Removed] / [Deprecated] sections from CHANGELOG (last 12 months)
+grep -nE '^### \[(Removed|Deprecated)\]' CHANGELOG.md | head -40
+
+# Inspect each section, extract feature names, env vars, ports, CLI flags
+# that have been removed or deprecated
+```
+
+Build a list `DEAD_TERMS=(...)` of strings to grep for. Include obvious ones from the existing `check_dead_refs.sh` `DEAD_REFS` array as a seed.
+
+- [ ] **Step 2: Scan active docs + wiki for dead terms**
+
+For each term in `DEAD_TERMS`:
+
+```bash
+TERM='--storage-backend chromadb'  # example
+
+# Repo
+grep -rln "$TERM" docs/ README.md CLAUDE.md --include='*.md' --include='*.html' \
+  | grep -vE '/(archive|legacy|plans|migrations)/|CHANGELOG'
+
+# Wiki
+grep -rln "$TERM" /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md' \
+  | grep -v /archive/
+```
+
+- [ ] **Step 3: Classify each match**
+
+Severity:
+- 🔴 Critical: dead term in install/setup path (would break user)
+- 🟡 Major: dead term in feature description (misleading but recoverable)
+- 🟢 Minor: dead term in passing reference / older guide
+
+- [ ] **Step 4: Append findings to report**
+
+Same format as Task 1.1, with `feature drift` as category. For each finding, also include the **Replacement** field naming the current term.
+
+### Task 1.3: Wiki↔repo drift scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Define spot-check fact list**
+
+Fixed list to verify against current code/config:
+
+| Fact | Source of truth |
+|------|----------------|
+| Default HTTP port | `src/mcp_memory_service/config.py` (`HTTP_PORT`) |
+| Default storage backend | `src/mcp_memory_service/config.py` (`STORAGE_BACKEND`) |
+| Default consolidation schedule | `src/mcp_memory_service/config.py` (consolidation section) |
+| MCP tool count | `src/mcp_memory_service/server_impl.py` (count `@self.server.tool()` decorators) |
+| Required Python version | `pyproject.toml` (`requires-python`) |
+| Install command | `README.md` (canonical install section) |
+| Cloudflare env var names | `src/mcp_memory_service/config.py` (`CLOUDFLARE_*`) |
+| OAuth env var names | `src/mcp_memory_service/config.py` + `web/oauth/` |
+| MCP server entrypoint | `src/mcp_memory_service/server.py` (`__main__`) |
+
+- [ ] **Step 2: Read each source-of-truth value**
+
+Use `grep` / `Read` tool to capture the current value for each fact above.
+
+- [ ] **Step 3: Spot-check each wiki page for those facts**
+
+```bash
+# For each fact, grep wiki pages for old/wrong values
+grep -rEn 'port\s*[:=]\s*[0-9]+' /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+grep -rEn 'MCP_HTTP_PORT' /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+# ... etc
+```
+
+- [ ] **Step 4: Append findings to report**
+
+Format:
+
+```markdown
+### F-NNN 🟡 Major · wiki↔repo · 04-Advanced-Configuration.md:L
+**Current**: claims `MCP_HTTP_PORT` defaults to 8443
+**Expected**: defaults to 8000 (per src/mcp_memory_service/config.py)
+**Fix**: wiki direct commit
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+```
+
+### Task 1.4: Cross-doc inconsistency scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Define high-traffic facts**
+
+Same fact list as Task 1.3, but the question is now: **does each doc/page state the same value?** Not: does each match the code (that's Task 1.3).
+
+- [ ] **Step 2: Grep across ALL doc surfaces for each fact**
+
+```bash
+FACT='HTTP_PORT'
+grep -rln "$FACT" docs/ README.md CLAUDE.md /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+# Read each match, record the stated value
+```
+
+- [ ] **Step 3: Flag where stated values disagree**
+
+If `README.md` says port 8000 but `wiki/Hybrid_Setup_Configuration.md` says port 8443, that's a cross-doc inconsistency. Severity is usually 🟡 Major. (If both are wrong vs code, Task 1.3 already caught that — this catches "different docs say different things".)
+
+- [ ] **Step 4: Append findings to report**
+
+Format includes a `**Locations**` field listing all variants:
+
+```markdown
+### F-NNN 🟡 Major · cross-doc · MCP_HTTP_PORT default
+**Locations**:
+  - README.md:120 → `8000`
+  - wiki/04-Advanced-Configuration.md:55 → `8443`
+  - docs/http-server-management.md:30 → `8000`
+**Expected** (per code): `8000`
+**Fix**: align wiki to `8000` (covered by F-002 if this overlaps)
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+```
+
+If a finding overlaps with Task 1.3, cross-reference and don't double-count toward summary.
+
+### Task 1.5: Link rot scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Run markdown-link-check on repo docs**
+
+Use the same tool the CI workflow uses, locally via npx:
+
+```bash
+npx markdown-link-check -c .mlc-config.json -q docs/**/*.md README.md 2>&1 | tee /tmp/linkcheck-repo.log
+```
+
+If `.mlc-config.json` doesn't exist, inspect `.github/workflows/docs-check.yml` for config.
+
+- [ ] **Step 2: Run markdown-link-check on wiki**
+
+```bash
+cd /Users/hkr/Repositories/mcp-memory-service.wiki
+npx markdown-link-check -q *.md 2>&1 | tee /tmp/linkcheck-wiki.log
+cd -
+```
+
+- [ ] **Step 3: Parse results, classify**
+
+For each broken link:
+- 🔴 Critical: link in install/setup section, broken to internal repo file
+- 🟡 Major: broken internal link (wiki→wiki, doc→doc)
+- 🟢 Minor: broken external link to non-critical resource
+
+Skip known-flaky external sites (e.g. `glama.ai` per existing `.mlc-config.json` ignore list — see [project_glama_link_ignore.md] reference in MEMORY.md).
+
+- [ ] **Step 4: Append findings to report**
+
+```markdown
+### F-NNN 🟡 Major · link rot · docs/integration/claude-desktop.md:80
+**Broken URL**: `./docs/old-setup.md` (404 — file does not exist)
+**Fix**: replace with `./first-time-setup.md` or remove
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+```
+
+### Task 1.6: Structural drift scan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Find orphaned `.md` files in repo**
+
+```bash
+# List all docs
+find docs/ -name '*.md' -not -path '*/archive/*' -not -path '*/legacy/*' > /tmp/all_docs.txt
+
+# For each doc, grep all OTHER docs + README + CLAUDE.md for incoming links
+# Flag any doc that has zero incoming links
+```
+
+Use a small bash loop, or a one-off Python script. Don't commit the script.
+
+- [ ] **Step 2: Find orphaned `.md` files in wiki**
+
+Wiki linking is via gollum: `[[Page Name]]` syntax + plain markdown links. Check both forms.
+
+```bash
+# Pages potentially referenced via gollum syntax
+grep -rEn '\[\[[^]]+\]\]' /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+# Plus plain markdown links
+grep -rEn '\]\([^)]+\.md\)' /Users/hkr/Repositories/mcp-memory-service.wiki/ --include='*.md'
+```
+
+Flag wiki pages with no inbound references from `Home.md` or any other page.
+
+- [ ] **Step 3: Find duplicate guides**
+
+Group `.md` files by similar titles or filenames (e.g. `Cloudflare-Backup-Sync-Setup.md` + `Cloudflare-Based-Multi-Machine-Sync.md` + `quick-setup-cloudflare-dual-environment.md` may overlap). Open each group and judge whether they're redundant.
+
+- [ ] **Step 4: Append findings to report**
+
+Always 🟢 Minor for orphans/dups (default → `defer-issue`).
+
+```markdown
+### F-NNN 🟢 Minor · structural · docs/enhancement-roadmap-issue-14.md
+**Issue**: orphaned (no incoming links from any active doc)
+**Fix**: archive (move to docs/archive/) OR add inbound link if still relevant
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+```
+
+### Task 1.7: Finalize report + commit
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Update Summary counts**
+
+Recount findings by severity, update the `## Summary` block at top of report.
+
+- [ ] **Step 2: Sort findings**
+
+Sort `## Findings` section: Critical first, then Major, then Minor, then Noise. Within each severity, group by category for readability.
+
+- [ ] **Step 3: Commit report**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+git commit -m "docs(audit): housekeeping audit findings — $(date +%Y-%m-%d)"
+```
+
+- [ ] **Step 4: Push to feature branch**
+
+```bash
+git checkout -b chore/housekeeping-fixes
+git push -u origin chore/housekeeping-fixes
+```
+
+(Or if main has been the working branch up to now, branch off here so report + fixes ship together in PR-1.)
+
+---
+
+## Phase 2 — User triage gate
+
+### Task 2.0: User reviews + dispositions findings
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Present report to user**
+
+Tell user: "Audit complete. Report at `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md` with N total findings. Please mark each finding's `**Disposition**` checkbox: `ship-now`, `defer-issue`, or `skip`. When done, tell me to proceed."
+
+- [ ] **Step 2: Wait for user**
+
+User edits checkboxes in the report file. Do not advance until user signals done.
+
+- [ ] **Step 3: Parse decisions**
+
+Re-read the report, extract:
+- `ship_now_repo`: list of findings with disposition = ship-now AND location is `docs/`, `README.md`, `CLAUDE.md`, or `docs/index.html`
+- `ship_now_wiki`: list of findings with disposition = ship-now AND location is in wiki repo
+- `defer_issue`: list of findings to file as GitHub issues
+- `skipped`: list of findings to ignore
+
+- [ ] **Step 4: Commit dispositions**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+git commit -m "docs(audit): user dispositions for housekeeping findings"
+```
+
+---
+
+## Phase 3 — Execute fixes
+
+Order: tooling first (TDD), then repo doc fixes, then wiki commits, then issues, then CI wire-up + landing page republish, then PR.
+
+### Task 3.0: TDD `check_versions.sh` — fixture + failing test
+
+**Files:**
+- Create: `tests/ci/test_check_versions.bats`
+- Create: `tests/ci/fixtures/version_drift_pos.md` (positive case — has stale version)
+- Create: `tests/ci/fixtures/version_drift_neg.md` (negative case — only canonical version)
+
+- [ ] **Step 1: Verify bats is available**
+
+```bash
+which bats || echo "bats not installed; install via: brew install bats-core"
+```
+
+If bats unavailable, use a plain bash test harness in `tests/ci/test_check_versions.sh` instead. Adapt the test format below accordingly. Document the chosen harness in a comment at the top of the test file.
+
+- [ ] **Step 2: Create fixture files**
+
+`tests/ci/fixtures/version_drift_pos.md`:
+
+```markdown
+# Test Doc — Stale Version
+
+This doc references v9.0.0 which is way older than canonical.
+
+Install: `pip install mcp-memory-service==v9.0.0`
+```
+
+`tests/ci/fixtures/version_drift_neg.md`:
+
+```markdown
+# Test Doc — Current Only
+
+References to v999.999.999 (above canonical) and CHANGELOG-style historical
+versions like v1.0.0 should be allowed when in excluded paths only.
+
+This file in scan path mentions only the canonical version.
+```
+
+(The negative fixture file should NOT have any old version references when used with the script's default scan paths. Use it as a baseline that produces zero drift.)
+
+- [ ] **Step 3: Write failing test**
+
+`tests/ci/test_check_versions.bats`:
+
+```bash
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/ci/check_versions.sh"
+  FIXTURES="$BATS_TEST_DIRNAME/fixtures"
+}
+
+@test "exits 0 when no drift" {
+  # Point script at a clean fixture dir (override SCAN_TARGETS via env)
+  MCS_VERSION_SCAN_TARGETS="$FIXTURES/version_drift_neg.md" \
+    bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "exits 1 when drift found" {
+  run env MCS_VERSION_SCAN_TARGETS="$FIXTURES/version_drift_pos.md" \
+    bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"v9.0.0"* ]]
+}
+
+@test "skips CHANGELOG even with old refs" {
+  echo "This file references v1.0.0" > "$BATS_TMPDIR/CHANGELOG.md"
+  run env MCS_VERSION_SCAN_TARGETS="$BATS_TMPDIR/CHANGELOG.md" \
+    bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+```bash
+bats tests/ci/test_check_versions.bats
+```
+
+Expected: FAIL with "script not found: scripts/ci/check_versions.sh".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/ci/test_check_versions.bats tests/ci/fixtures/
+git commit -m "test(ci): add failing tests for check_versions.sh"
+```
+
+### Task 3.1: Implement `check_versions.sh`
+
+**Files:**
+- Create: `scripts/ci/check_versions.sh`
+
+- [ ] **Step 1: Write minimal implementation**
+
+`scripts/ci/check_versions.sh`:
+
+```bash
+#!/bin/bash
+#
+# Version Drift Check
+#
+# Reads canonical version from src/mcp_memory_service/_version.py.
+# Greps SCAN_TARGETS for hardcoded vN.N.N refs.
+# Fails if any non-excluded match references a version older than canonical.
+#
+# Override SCAN_TARGETS for testing via MCS_VERSION_SCAN_TARGETS env var.
+#
+# Exit codes:
+#   0 - No drift found
+#   1 - Drift found
+
+set -uo pipefail
+
+# Locate canonical version. Use grep+sed (no Python import — script runs in CI
+# without venv).
+VERSION_FILE="${MCS_VERSION_FILE:-src/mcp_memory_service/_version.py}"
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "❌ Version file not found: $VERSION_FILE"
+  exit 1
+fi
+
+CANONICAL=$(grep -E '^__version__\s*=' "$VERSION_FILE" \
+  | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+if [ -z "$CANONICAL" ]; then
+  echo "❌ Could not parse __version__ from $VERSION_FILE"
+  exit 1
+fi
+
+# Default scan targets; overridable for tests.
+if [ -n "${MCS_VERSION_SCAN_TARGETS:-}" ]; then
+  # Space-separated list of paths/files
+  read -ra SCAN_TARGETS <<< "$MCS_VERSION_SCAN_TARGETS"
+else
+  SCAN_TARGETS=("docs/" "README.md" "CLAUDE.md")
+fi
+
+EXCLUDE_PATHS=(
+  "docs/archive"
+  "docs/legacy"
+  "docs/plans"
+  "docs/migrations"
+  "CHANGELOG"
+)
+
+# Semver compare: returns 0 if $1 < $2, 1 otherwise.
+older_than() {
+  local a="$1" b="$2"
+  [ "$a" = "$b" ] && return 1
+  local lower
+  lower=$(printf '%s\n%s\n' "$a" "$b" | sort -V | head -1)
+  [ "$lower" = "$a" ]
+}
+
+FOUND=0
+declare -a DRIFT_LINES
+
+for target in "${SCAN_TARGETS[@]}"; do
+  [ -e "$target" ] || continue
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(echo "$line" | cut -d: -f1)
+    skip=false
+    for excl in "${EXCLUDE_PATHS[@]}"; do
+      if [[ "$file" == *"$excl"* ]]; then
+        skip=true
+        break
+      fi
+    done
+    [ "$skip" = true ] && continue
+
+    # Extract version from line
+    version=$(echo "$line" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+    [ -z "$version" ] && continue
+
+    if older_than "$version" "$CANONICAL"; then
+      DRIFT_LINES+=("$line  →  expected v$CANONICAL (or excluded path)")
+      FOUND=1
+    fi
+  done < <(grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' "$target" --include='*.md' --include='*.html' 2>/dev/null || true)
+done
+
+if [ $FOUND -eq 0 ]; then
+  echo "✅ No version drift found (canonical: v$CANONICAL)"
+  exit 0
+fi
+
+echo "❌ Version drift detected (canonical: v$CANONICAL):"
+for line in "${DRIFT_LINES[@]}"; do
+  echo "   $line"
+done
+echo ""
+echo "Fix: update each occurrence to v$CANONICAL or move under an excluded path."
+exit 1
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x scripts/ci/check_versions.sh
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+```bash
+bats tests/ci/test_check_versions.bats
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 4: Run script against real repo (sanity check)**
+
+```bash
+bash scripts/ci/check_versions.sh
+```
+
+Expected: depends on Phase 3.3 fixes — for now it likely reports drift on the real repo. That's expected; the next tasks fix it. Note the violations for cross-checking against Phase 1 findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ci/check_versions.sh
+git commit -m "feat(ci): add check_versions.sh — version drift detection"
+```
+
+### Task 3.2: Extend `check_dead_refs.sh`
+
+**Files:**
+- Modify: `scripts/ci/check_dead_refs.sh`
+
+- [ ] **Step 1: Identify new dead-term findings from audit**
+
+From the audit report, list every `feature drift` finding where the disposition is `ship-now` AND the term should be permanently blocked from re-entering active docs. These go into `DEAD_REFS`.
+
+- [ ] **Step 2: Edit `DEAD_REFS` array**
+
+Add new entries to the `DEAD_REFS=(...)` block in `scripts/ci/check_dead_refs.sh`. Keep alphabetical or grouped-by-feature ordering. One entry per line. Comment if the term needs context.
+
+Example:
+
+```bash
+DEAD_REFS=(
+  "--storage-backend chromadb"
+  "storage-backend chromadb"
+  ...
+  # Added 2026-05-02 housekeeping audit
+  "MCP_OLD_FEATURE_FLAG"
+  "--legacy-flag-name"
+)
+```
+
+- [ ] **Step 3: Update `SOFT_REF_ALLOWLIST` only if needed**
+
+Only add a path to `SOFT_REF_ALLOWLIST` if a doc legitimately needs to retain a historical pointer (per existing rule 5 from issue #713). Do not add new entries casually — every new entry weakens the script.
+
+- [ ] **Step 4: Run script to verify**
+
+```bash
+bash scripts/ci/check_dead_refs.sh
+```
+
+Expected: still passes against current repo state (because Phase 3.3 hasn't yet fixed the docs that contain those terms). If it fails, that's expected — proceed to 3.3 to fix the violations, then re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ci/check_dead_refs.sh
+git commit -m "ci(dead-refs): add new dead terms from housekeeping audit"
+```
+
+### Task 3.3: Apply main-repo doc fixes
+
+**Files:**
+- Modify: any of `docs/`, `README.md`, `CLAUDE.md`, `docs/index.html` per audit findings
+
+- [ ] **Step 1: Group findings by file**
+
+From the audit report, collect all `ship_now_repo` findings grouped by target file. Each file should be edited exactly once (to avoid touching the same file in multiple commits).
+
+- [ ] **Step 2: Apply fixes file-by-file**
+
+For each file, use the `Edit` tool with the **Current** → **Expected** mapping from each finding. Verify edits match the finding's stated location.
+
+- [ ] **Step 3: Verify CI checks pass locally**
+
+After all fixes:
+
+```bash
+bash scripts/ci/check_dead_refs.sh
+bash scripts/ci/check_versions.sh
+```
+
+Both must exit 0. If not, the fixes missed something — re-read findings, re-edit, re-run.
+
+- [ ] **Step 4: Re-run audit one-liners (subset)**
+
+Re-run the version-drift grep from Task 1.1 Step 1, and the feature-drift greps from Task 1.2 Step 2, against the repo. Compare against the audit report — every `ship-now` finding's match should no longer appear.
+
+- [ ] **Step 5: Commit per logical group**
+
+If multiple files were touched for the same finding category, group them in one commit. Example:
+
+```bash
+git add docs/index.html docs/README.md README.md CLAUDE.md
+git commit -m "docs: bump stale version refs to v10.47.2"
+
+git add docs/integration/*.md
+git commit -m "docs: remove references to retired CLI flags (housekeeping audit)"
+```
+
+Use as many commits as makes sense — each commit should be one logical fix group.
+
+### Task 3.4: Apply wiki direct commits
+
+**Files:**
+- Modify: files under `/Users/hkr/Repositories/mcp-memory-service.wiki/`
+
+- [ ] **Step 1: Group wiki findings by file**
+
+From the audit report, collect all `ship_now_wiki` findings grouped by wiki page.
+
+- [ ] **Step 2: Apply fixes per wiki file**
+
+```bash
+cd /Users/hkr/Repositories/mcp-memory-service.wiki
+git pull --ff-only  # ensure up-to-date
+```
+
+Use the `Edit` tool for each wiki file. Wiki uses gollum format — most files are plain markdown, page links use `[[Page Name]]` syntax.
+
+- [ ] **Step 3: Commit per logical group**
+
+```bash
+cd /Users/hkr/Repositories/mcp-memory-service.wiki
+git add 04-Advanced-Configuration.md
+git commit -m "fix: correct MCP_HTTP_PORT default to 8000 (housekeeping audit)"
+
+git add Hybrid_Setup_Configuration.md Cloudflare-Backup-Sync-Setup.md
+git commit -m "docs: align Cloudflare guide version refs to v10.47.2"
+```
+
+- [ ] **Step 4: Push wiki commits**
+
+```bash
+cd /Users/hkr/Repositories/mcp-memory-service.wiki
+git push origin main  # or master, check default branch
+cd -
+```
+
+- [ ] **Step 5: Verify wiki online**
+
+Open `https://github.com/doobidoo/mcp-memory-service/wiki` in browser, confirm one of the changed pages reflects the fix.
+
+### Task 3.5: File GitHub issues for `defer-issue` findings
+
+**Files:** none (GitHub issues, external state)
+
+- [ ] **Step 1: Group `defer-issue` findings**
+
+Group related deferred findings (e.g. all orphaned docs → one umbrella issue; all minor link rot in old guides → one issue). Standalone findings get their own issue.
+
+- [ ] **Step 2: File issues via gh CLI**
+
+For each issue group:
+
+```bash
+gh issue create \
+  --title "Housekeeping: <short description>" \
+  --label documentation,housekeeping \
+  --body "$(cat <<'EOF'
+Discovered during housekeeping audit on 2026-05-02.
+
+**Source**: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md` finding F-NNN
+
+**Issue**: <restate finding>
+
+**Fix sketch**: <restate fix>
+
+**Severity**: 🟢 Minor (deferred from audit)
+EOF
+)"
+```
+
+Record issue numbers as they're created.
+
+- [ ] **Step 3: Update audit report with issue links**
+
+For each `defer-issue` finding in the report, append `**Issue**: #NNN` to the finding block.
+
+- [ ] **Step 4: Commit report update**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+git commit -m "docs(audit): link deferred findings to GitHub issues"
+```
+
+### Task 3.6: Wire `check_versions.sh` into CI workflow
+
+**Files:**
+- Modify: `.github/workflows/docs-check.yml`
+
+- [ ] **Step 1: Add new job**
+
+Edit `.github/workflows/docs-check.yml`. After the existing `dead-ref-check` job, add:
+
+```yaml
+  version-drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check for version drift
+        run: bash scripts/ci/check_versions.sh
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+```bash
+# Use yq if available, else cat to eyeball
+yq eval '.jobs | keys' .github/workflows/docs-check.yml 2>/dev/null \
+  || cat .github/workflows/docs-check.yml
+```
+
+Expected: `link-check`, `dead-ref-check`, `version-drift-check` listed.
+
+- [ ] **Step 3: Run script one more time as final sanity**
+
+```bash
+bash scripts/ci/check_versions.sh
+```
+
+Expected: exit 0 (because Task 3.3 fixed all violations).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/docs-check.yml
+git commit -m "ci(docs): add version drift check to docs-check workflow"
+```
+
+### Task 3.7: Republish landing page to here.now
+
+**Files:** none (external state — here.now publish)
+
+- [ ] **Step 1: Confirm landing page version is current**
+
+```bash
+grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' docs/index.html
+```
+
+Should show v10.47.2 (or current canonical) after Task 3.3.
+
+- [ ] **Step 2: Republish**
+
+```bash
+cd docs && ~/.agents/skills/here-now/scripts/publish.sh index.html --slug merry-realm-j835
+cd -
+```
+
+- [ ] **Step 3: Verify**
+
+Open the here.now URL in browser, confirm version badge shows current canonical.
+
+If `~/.agents/skills/here-now/scripts/publish.sh` is not present, ask user to republish manually and skip this task. Do NOT block on this — note in PR description.
+
+### Task 3.8: Open PR-1
+
+**Files:** none (PR creation)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push origin chore/housekeeping-fixes
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "chore: repository housekeeping audit + drift fixes" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Discovery-first housekeeping audit + execution. Fixes documentation drift across `docs/`, `README.md`, `CLAUDE.md`, `docs/index.html`. Adds `check_versions.sh` CI guard. Extends `check_dead_refs.sh` with new dead-term findings.
+
+Wiki fixes shipped as direct commits (gollum, separate repo). Minor findings filed as GitHub issues for follow-up.
+
+## Audit Report
+
+See `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md` for full findings, dispositions, and resolution mapping.
+
+## Changes
+
+- 🔴 N critical drift fixes
+- 🟡 N major drift fixes
+- 🟢 N minor findings → GitHub issues #...
+- ✅ New: `scripts/ci/check_versions.sh` + workflow wire-up
+- ✅ Extended: `scripts/ci/check_dead_refs.sh` (data-only)
+
+## Validation
+
+- [ ] `bash scripts/ci/check_dead_refs.sh` exits 0
+- [ ] `bash scripts/ci/check_versions.sh` exits 0
+- [ ] Markdown link-check passes
+- [ ] Wiki direct commits pushed to mcp-memory-service.wiki
+- [ ] Landing page republished to here.now (`merry-realm-j835`)
+- [ ] All `defer-issue` findings have linked GitHub issues
+- [ ] Audit report updated with `## Resolution` section
+
+## Test Plan
+
+- [ ] Run `bash scripts/ci/check_versions.sh` locally → exits 0
+- [ ] Run `bats tests/ci/test_check_versions.bats` → 3/3 pass
+- [ ] CI green on docs-check.yml workflow
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Note PR URL**
+
+Record the PR URL for Phase 4 verification.
+
+---
+
+## Phase 4 — Validation
+
+### Task 4.0: Run all checks + finalize report
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+- [ ] **Step 1: Run all CI scripts locally**
+
+```bash
+bash scripts/ci/check_dead_refs.sh && echo "✅ dead refs OK"
+bash scripts/ci/check_versions.sh && echo "✅ versions OK"
+bats tests/ci/test_check_versions.bats && echo "✅ version test OK"
+```
+
+All three must exit 0.
+
+- [ ] **Step 2: Watch CI on PR**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Wait for `link-check`, `dead-ref-check`, `version-drift-check` jobs → all green.
+
+- [ ] **Step 3: Manual re-scan**
+
+Re-run the high-signal audit one-liners from Task 1.1 Step 1, Task 1.2 Step 2, and confirm zero `ship-now` findings remain in active docs.
+
+- [ ] **Step 4: Verify wiki**
+
+```bash
+cd /Users/hkr/Repositories/mcp-memory-service.wiki
+git log --oneline -10
+cd -
+```
+
+Confirm expected commits are present.
+
+- [ ] **Step 5: Verify landing page**
+
+Open here.now URL (`merry-realm-j835` slug). Confirm version badge is canonical.
+
+- [ ] **Step 6: Append Resolution section to audit report**
+
+Append at end of `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`:
+
+```markdown
+---
+
+## Resolution
+
+**Status**: Complete (YYYY-MM-DD)
+
+### Shipped (PR-1: #NNN)
+- F-001, F-002, ... → docs/ + README.md fixes
+- check_versions.sh + workflow wired
+- check_dead_refs.sh extended
+
+### Wiki commits (mcp-memory-service.wiki)
+- F-NNN → 04-Advanced-Configuration.md (commit SHA)
+- F-NNN → ...
+
+### Deferred to issues
+- F-NNN → #NNN
+- F-NNN → #NNN
+
+### Skipped (intentional)
+- F-NNN, F-NNN, ...
+```
+
+- [ ] **Step 7: Commit resolution**
+
+```bash
+git add docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+git commit -m "docs(audit): add resolution mapping for housekeeping audit"
+git push origin chore/housekeeping-fixes
+```
+
+### Task 4.1: Merge PR + cleanup
+
+**Files:** none
+
+- [ ] **Step 1: Merge PR**
+
+Per CLAUDE.md release workflow: verify CI green first, then merge with `--admin` if needed (branch protection).
+
+```bash
+gh pr checks <PR_NUMBER>  # confirm all green
+gh pr merge <PR_NUMBER> --squash --admin --delete-branch
+```
+
+- [ ] **Step 2: Pull main locally**
+
+```bash
+git checkout main
+git pull origin main
+```
+
+- [ ] **Step 3: Delete local branch**
+
+```bash
+git branch -d chore/housekeeping-fixes
+```
+
+- [ ] **Step 4: Save learnings to MCP Memory**
+
+Per CLAUDE.md auto-save directive, store key findings/patterns from this audit. Tag: `mcp-memory-service`, `housekeeping`, `documentation`, `learnings`. Include: notable drift patterns found, what tooling caught what, recommended cadence for next audit (suggest scheduling a routine via `/schedule`).
+
+---
+
+## Self-Review Notes
+
+(Per writing-plans skill — verifying plan against spec)
+
+**Spec coverage check:**
+- ✅ Phase 1 (audit) → Tasks 1.0–1.7
+- ✅ Phase 2 (triage gate) → Task 2.0
+- ✅ Phase 3 (execute) → Tasks 3.0–3.8
+- ✅ Phase 4 (verify) → Tasks 4.0–4.1
+- ✅ All 6 drift categories scanned (Tasks 1.1–1.6)
+- ✅ Severity rubric applied per finding-append step
+- ✅ Triage report format matches spec
+- ✅ Tooling: extend dead-refs (Task 3.2) + new check_versions.sh (Tasks 3.0, 3.1) + workflow wire-up (Task 3.6)
+- ✅ Wiki direct commits (Task 3.4)
+- ✅ Issues for defer-issue (Task 3.5)
+- ✅ Landing-page republish (Task 3.7)
+- ✅ Validation checklist (Task 4.0)
+
+**Placeholder scan:** No TBD/TODO/etc. in steps. All code blocks complete. All commands exact.
+
+**Type/name consistency:** `check_versions.sh`, `MCS_VERSION_SCAN_TARGETS`, `MCS_VERSION_FILE`, `chore/housekeeping-fixes`, `2026-05-02-housekeeping-audit-report.md` — used consistently throughout.
+
+**Known soft spots (not blockers):**
+- Task 1.6 orphan detection script is described but not provided as code — left as judgment call to keep plan size reasonable; agent can write the small loop ad-hoc.
+- Task 3.0 assumes `bats` is available; fallback to plain bash test harness documented inline.
+- Task 3.7 here.now publish step is best-effort (gracefully skips if script absent).

--- a/docs/superpowers/specs/2026-05-02-housekeeping-audit-design.md
+++ b/docs/superpowers/specs/2026-05-02-housekeeping-audit-design.md
@@ -1,0 +1,203 @@
+# Repository Housekeeping Audit & Fix — Design
+
+**Date**: 2026-05-02
+**Status**: Design approved, awaiting implementation plan
+**Owner**: Henry
+**Reference state**: v10.47.2, ~1,780 tests
+
+## Goal
+
+Detect and fix documentation drift across the repository (`docs/`, `README.md`, `CLAUDE.md`, `docs/index.html`) and the GitHub Wiki (separate `mcp-memory-service.wiki` repo), then add lightweight CI guards to prevent regression.
+
+Drift categories in scope:
+
+- **Version drift** — stale version refs, wrong test counts, outdated badges
+- **Feature drift** — removed/renamed features still mentioned in active docs
+- **Wiki↔repo drift** — wiki claims that contradict current code/config
+- **Cross-doc inconsistency** — same fact stated differently across docs/wiki/CLAUDE.md
+- **Link rot** — broken internal/external links (partial CI coverage today)
+- **Structural drift** — orphaned docs, duplicate guides, archive candidates
+
+## Non-Goals
+
+- Wiki CI integration (separate-repo handling is deferred — file as follow-up issue)
+- Cross-repo automated drift detection
+- Spell-check / prose-style linting
+- Adding new documentation pages (this work only fixes existing drift)
+- Restructuring `docs/` hierarchy (orphan/dup cleanup is `defer-issue`, not inline)
+
+## Approach
+
+**Discovery-first, four-phase flow:**
+
+1. **Audit** — scan all six categories, collect findings into single triage report. No code changes.
+2. **User triage gate** — user marks each finding `ship-now` / `defer-issue` / `skip`.
+3. **Execute fixes** — main-repo PR(s) for `ship-now` items, direct wiki commits for wiki items, GitHub issues for `defer-issue` items.
+4. **Verify** — extended dead-ref check + new version-drift check pass; manual re-scan confirms zero remaining `ship-now` findings.
+
+Discovery-first chosen over fix-as-you-go to enable batching related fixes (e.g. one PR for all version bumps across landing + README + wiki) instead of touching the same file multiple times.
+
+## Audit Mechanics
+
+| # | Category | How scanned | Output |
+|---|----------|-------------|--------|
+| a | **Version drift** | grep `docs/`, `README.md`, `docs/index.html`, `wiki/` for `v\d+\.\d+\.\d+` patterns + "test count" + badges; compare vs `_version.py` (10.47.2) and current test count | `file:line`, found version, expected |
+| b | **Feature drift** | Cross-ref CHANGELOG `[Removed]` / `[Deprecated]` sections + recent rename PRs against current docs/wiki text | `file:line`, dead term, replacement |
+| c | **Wiki↔repo drift** | Spot-check wiki claims against current code/config: ports, env vars, CLI commands, file paths, default values | wiki page:section, claim, current reality |
+| d | **Cross-doc inconsistency** | Pick high-traffic facts (storage backends, ports, install commands, version count) and grep all docs/wiki — flag where they disagree | fact, locations + variants |
+| e | **Link rot** | Run existing markdown-link-check on `docs/` + README locally; run separately on wiki dir | `file:line`, broken URL, status code |
+| f | **Structural drift** | Find orphaned `.md` files (no incoming links from any other doc/README); flag duplicate guides (similar titles, similar content) | orphan files, dup-set candidates |
+
+Each scan is a bash one-liner or short ad-hoc script (not committed — discovery-only). Findings collated into the report by hand.
+
+## Severity Rubric
+
+| Severity | Definition | Default disposition |
+|----------|------------|---------------------|
+| **🔴 Critical** | Wrong info that misleads users into broken state — wrong setup commands, removed features documented as available, broken install steps, broken links in install path | `ship-now` |
+| **🟡 Major** | Stale but recoverable — wrong version on landing page, outdated test count, wiki claim contradicts current default but user can figure it out | `ship-now` |
+| **🟢 Minor** | Cosmetic — orphaned doc with no harm, duplicate guide where both still accurate, broken external link to non-critical resource | `defer-issue` |
+| **⚪ Noise** | Intentional historical refs (chromadb in `archive/`), version refs in CHANGELOG, migration guides | `skip` |
+
+User can override per-finding during triage gate.
+
+## Triage Report Format
+
+Path: `docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`
+
+```markdown
+# Housekeeping Audit — 2026-05-02
+
+**Scope**: docs/, README.md, CLAUDE.md, docs/index.html, wiki/
+**Reference state**: v10.47.2, ~1,780 tests
+**Categories scanned**: version, feature, wiki↔repo, cross-doc, links, structural
+
+## Summary
+- 🔴 Critical: N findings
+- 🟡 Major:    N findings
+- 🟢 Minor:    N findings
+- ⚪ Noise:    N findings (excluded)
+
+## Findings
+
+### F-001 🔴 Critical · version drift · docs/index.html:42
+**Current**: `<span class="version">v10.13.0</span>`
+**Expected**: `v10.47.2`
+**Fix**: edit + re-publish to here.now (`merry-realm-j835`)
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-002 🟡 Major · wiki↔repo · wiki/04-Advanced-Configuration.md
+**Current**: claims `MCP_HTTP_PORT` defaults to 8443
+**Expected**: defaults to 8000 (per src/mcp_memory_service/config.py)
+**Fix**: wiki direct commit
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+...
+```
+
+User edits checkboxes during triage gate. The implementer parses decisions and executes accordingly.
+
+After Phase 4 ships, append a `## Resolution` section noting what shipped where (PR/commit/issue links).
+
+## Fix Delivery
+
+**Main-repo PRs:**
+
+- **PR-1: `chore/housekeeping-fixes`** — all `ship-now` fixes for `docs/`, `README.md`, `CLAUDE.md`, `docs/index.html` plus tooling extensions (b: extended `check_dead_refs.sh`, c: new `check_versions.sh` + workflow wire-up).
+- **PR-2 (only if PR-1 grows past ~30 files or mixes concerns badly)**: split off the structural/cosmetic batch.
+
+No version bump → do **not** invoke `github-release-manager`. Use `commit-commands:commit-push-pr` (or equivalent) to ship the PR.
+
+**Wiki direct commits:**
+
+- One commit per logical group (e.g. "fix: port references in 04-Advanced-Configuration", "fix: stale version refs across guides").
+- Push to `mcp-memory-service.wiki` `main` directly (gollum, no PR mechanism).
+- After landing-page version bump in main repo, also re-publish to here.now per CLAUDE.md:
+  ```bash
+  cd docs && ~/.agents/skills/here-now/scripts/publish.sh index.html --slug merry-realm-j835
+  ```
+
+**Issues filed:**
+
+- One GitHub issue per `defer-issue` finding (or grouped if related).
+- Labels: `documentation`, `housekeeping`.
+- Each issue links back to the audit report via permalink.
+
+## Tooling Extensions
+
+### Extension b — extend `scripts/ci/check_dead_refs.sh`
+
+Add new `DEAD_REFS` entries for any feature/command/env-var renames discovered during audit. Add to `SOFT_REF_ALLOWLIST` only when a doc legitimately needs to retain a historical pointer. No structural change to the script — data-only updates.
+
+### Extension c — new `scripts/ci/check_versions.sh`
+
+Pseudocode (real script lives in PR-1):
+
+```text
+1. Read canonical version from src/mcp_memory_service/_version.py
+   (use grep + sed, or `python -c "from mcp_memory_service._version import __version__; print(__version__)"`)
+2. SCAN_TARGETS = docs/, README.md
+3. EXCLUDE_PATHS = docs/archive, docs/legacy, docs/plans, docs/migrations, CHANGELOG
+4. For each *.md and docs/index.html under SCAN_TARGETS:
+   - grep for /v\d+\.\d+\.\d+/
+   - filter out EXCLUDE_PATHS
+   - compare each match against CANONICAL via semver compare
+   - if any match < CANONICAL, record as drift finding
+5. Exit 1 if any drift found, 0 otherwise
+6. Print drift report in same format as check_dead_refs.sh
+```
+
+**Scope guards** (avoid noise):
+
+- Skip CHANGELOG (intentionally references all historical versions)
+- Skip `archive/`, `legacy/`, `plans/`, `migrations/`
+- Skip code-block content tagged with explicit version (e.g. install snippets pinning a specific version are OK)
+- Optional post-rollout tunable: only fail on `docs/index.html` and `README.md`; warn-only elsewhere
+
+**Wire-up** in `.github/workflows/docs-check.yml`:
+
+```yaml
+  version-drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for version drift
+        run: bash scripts/ci/check_versions.sh
+```
+
+**Important**: tooling ships in PR-1 alongside the fixes those tools enforce. Do not ship enforcement without first cleaning all violations — CI would fail immediately.
+
+## Validation (Phase 4)
+
+PR-1 description must include this checklist:
+
+- [ ] `bash scripts/ci/check_dead_refs.sh` exits 0 locally
+- [ ] `bash scripts/ci/check_versions.sh` exits 0 locally
+- [ ] Markdown link-check (via `gaurav-nelson/github-action-markdown-link-check`) passes on PR CI
+- [ ] Manual re-scan: re-run audit one-liners from Phase 1 → confirm no `ship-now` findings remain
+- [ ] Wiki repo: each direct commit pushed; `git log` shows expected fixes
+- [ ] Landing-page (`docs/index.html`) re-published to here.now (`merry-realm-j835`)
+- [ ] Issues filed for each `defer-issue` finding; linked to audit report
+- [ ] Audit report updated with `## Resolution` section
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Audit produces too many findings to triage in one session | Severity rubric biases toward `defer-issue` for minor; cap PR-1 at ~30 files, split if needed |
+| Version-drift script false-positives on intentional pinned-version snippets | Exclude code-block-internal version pins; tunable warn-only mode for non-landing-page paths |
+| Wiki commits land but landing page not republished | Phase 4 checklist explicit step; CLAUDE.md already documents the `here-now` republish command |
+| New CI check fails immediately on existing repo state | Tooling ships in same PR as cleanup; verify locally before push |
+| Subjective "wiki↔repo drift" findings (what's truly contradictory vs out-of-date phrasing) | Spot-check a fixed list of high-traffic facts (ports, env vars, install commands, defaults) — not exhaustive prose review |
+
+## Open Questions
+
+None at design stage. All Q1–Q4 from brainstorming resolved:
+
+- Q1: Audit + fix (B), tooling extension where cheap
+- Q2: All six drift categories
+- Q3: Severity-gated, 1–2 main-repo PRs + direct wiki commits + issues for low-pri
+- Q4: Extend `check_dead_refs.sh` + add `check_versions.sh`; defer wiki CI
+
+## Next Step
+
+User reviews this spec → invoke `superpowers:writing-plans` to produce phase-by-phase implementation plan.

--- a/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+++ b/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
@@ -7,7 +7,7 @@
 ## Summary
 
 - 🔴 Critical: 4 findings (F-007, F-008, F-015, F-016)
-- 🟡 Major:    19 findings
+- 🟡 Major:    18 findings (F-020 verified false → reclassified Noise)
 - 🟢 Minor:    13 findings (F-031 groups 46 repo orphans; F-032 groups 21 wiki orphans)
 - ⚪ Noise:    excluded (historical "introduced in vX" annotations, per-release test counts in old changelog entries, PR template examples, HTTPS port 8443 config examples in wiki)
 
@@ -23,13 +23,13 @@
 **Current**: `<a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.0">`
 **Expected**: `v10.47.2`
 **Fix**: Change release URL to `.../releases/tag/v10.47.2` so "Release Notes" button on landing page links to latest patch release.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-002 🟢 Minor · version drift · docs/index.html:6,8
 **Current**: `v10.47` (title tag and og:title — no patch version)
 **Expected**: `v10.47.2`
 **Fix**: Update `<title>` and `<meta property="og:title">` to `v10.47.2` for consistency. Per CLAUDE.md "MINOR/MAJOR releases only" policy, the `v10.47` form is technically allowed; this is cosmetic.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-003 🔴 Critical · cross-doc · test count drift (multiple files)
 **Current** (3 contradictory sources):
@@ -41,25 +41,25 @@
   - `wiki/13-Development-Roadmap.md:11` → `~1,780 tests passing`
 **Expected**: `~1,780 tests` (current canonical per CLAUDE.md header)
 **Fix**: Update CLAUDE.md:73 and CLAUDE.md:233 from `968 tests` → `~1,780 tests`. Per-release historical counts in README are correct as historical data and stay.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-004 🟡 Major · version drift · wiki/13-Development-Roadmap.md:9
 **Current**: `**Current Version**: v10.47.0 (Production-ready)`
 **Expected**: `v10.47.2`
 **Fix**: Bump to `v10.47.2` so the wiki roadmap header matches latest release.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-005 🟢 Minor · version drift · wiki/13-Development-Roadmap.md:289
 **Current**: `- **Version at Review**: v10.47.0`
 **Expected**: `v10.47.2`
 **Fix**: Update Q1 2026 review version marker to `v10.47.2`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-006 🟢 Minor · version drift · docs/BENCHMARKS.md:13
 **Current**: `**Date:** 2026-04-08 · **Version:** v10.34.0`
 **Expected**: Note reflects benchmark run version, not current.
 **Fix**: Add parenthetical `(benchmark run version; latest release: v10.47.2)` or link to updated benchmark. Existing value is historically correct for that run but may mislead.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ---
 
@@ -67,37 +67,37 @@
 **Current**: Entire "MCP (FastMCP HTTP) Tools" section documents pre-v10 deprecated tool names as canonical: `store_memory`, `retrieve_memory(query, n_results=5)`, `search_by_tag`, `delete_memory`, `check_database_health`.
 **Replacement**: v10 unified names — `memory_store`, `memory_search`, `memory_list`, `memory_delete`, `memory_health`. Parameter `n_results` → `limit`.
 **Fix**: Rewrite the "MCP Tools" table to list the 12 unified `memory_*` tools. Remove the `mcp_server.py` reference (still exists but is a compat shim, not primary).
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-008 🔴 Critical · feature drift · wiki/03-Integration-Guide.md:44–48
 **Current**: "Verify Connection" step (the actual install/setup verification path) tells users to look for `store_memory`, `retrieve_memory`, `search_by_tag`, `delete_memory`, `check_database_health` in tool list.
 **Replacement**: `memory_store`, `memory_search`, `memory_list`, `memory_delete`, `memory_health`.
 **Fix**: Update bullet list to v10 names. Critical because this is what users follow to confirm setup worked.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-009 🟡 Major · feature drift · docs/mastery/api-reference.md:66–73 (Examples)
 **Current**: Example snippets use `tool: store_memory`, `tool: retrieve_memory` with `n_results: 5`, `tool: search_by_tag`.
 **Replacement**: `memory_store`, `memory_search` (with `limit` param), `memory_list` for tag search.
 **Fix**: Update all three example blocks.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-010 🟡 Major · feature drift · wiki/14-Memory-Quality-System-Guide.md:235,273,298,318,708,792,809,812
 **Current**: Multiple code examples use deprecated quality tool names — `rate_memory`, `retrieve_with_quality_boost`, `get_memory_quality`, `analyze_quality_distribution`.
 **Replacement**: `memory_quality(action="rate"|"get"|"analyze")` and `memory_search(mode="hybrid", quality_boost=...)`.
 **Fix**: Update all code blocks; add migration note at top.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-011 🟡 Major · feature drift · wiki/10-Complete-Feature-List.md:560–563
 **Current**: Quality System "MCP Tools" subsection lists 4 deprecated names as the current inventory.
 **Replacement**: `memory_quality` actions + `memory_search` with quality_boost.
 **Fix**: Replace the 4 lines with correct unified signatures.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-012 🟡 Major · feature drift · docs/mastery/api-reference.md:37 + docs/mastery/architecture-overview.md:48,53
 **Current**: Architecture/overview docs describe tool surface using deprecated names: `store_memory`, `retrieve_memory`, `search_by_tag`, `delete_memory`, `check_database_health`, `cleanup_duplicates`, `update_memory_metadata`.
 **Replacement**: v10 unified names. Note `cleanup_duplicates` → `memory_cleanup`, `update_memory_metadata` → `memory_update`.
 **Fix**: Rewrite prose descriptions.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-013 🟡 Major · feature drift · `n_results` parameter (4 locations)
 **Current**: `n_results` parameter used in user-facing examples — deprecated since v10.0.0.
@@ -107,13 +107,13 @@
   - `docs/mastery/api-reference.md:67`: `args: { "query": "OAuth refactor", "n_results": 5 }`
 **Replacement**: `limit`.
 **Fix**: Replace `n_results` → `limit` in all 4 locations.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-014 🟡 Major · feature drift · docs/guides/memory-consolidation-guide.md:96 + wiki/Memory-Consolidation-System-Guide.md:203
 **Current**: Both guides show `trigger_consolidation` as the recommended MCP tool.
 **Replacement**: `memory_consolidate(action="run", ...)`.
 **Fix**: Update invocation in both files. Also update `consolidate_memories`, `scheduler_status`, `pause_consolidation` references to `memory_consolidate` action equivalents.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ---
 
@@ -126,40 +126,36 @@
 **Expected** (per `src/mcp_memory_service/config.py:306`): `SUPPORTED_BACKENDS = ['sqlite_vec', 'sqlite-vec', 'cloudflare', 'hybrid', 'milvus']`. Setting `chroma` falls through to fallback warning + reverts to `sqlite_vec`.
 **Fix**: Remove all `chroma` references from wiki; for "team sharing" use case, replace with `milvus` or note feature was retired.
 **VERIFY BEFORE FIX**: Re-grep `src/mcp_memory_service/config.py` to confirm `chroma` truly absent from `SUPPORTED_BACKENDS`. If subagent's read was stale, downgrade to Major.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-016 🔴 Critical · wiki↔repo · OAuth env vars don't exist in code
 **Current** (5 env vars documented in `wiki/04-Advanced-Configuration.md:466,469,472,546,547`): `MCP_OAUTH_CLIENT_STORAGE`, `MCP_OAUTH_REGISTRATION_RATE_LIMIT`, `MCP_OAUTH_AUDIT_LOG`, `MCP_OAUTH_CLEANUP_EXPIRED_TOKENS`, `MCP_OAUTH_TOKEN_CLEANUP_INTERVAL`.
 **Expected**: None exist in `src/mcp_memory_service/config.py` per subagent grep — would be silently ignored if set.
 **Fix**: Audit which OAuth env vars are actually implemented; remove or correct the rest. Note: `MCP_OAUTH_STORAGE_BACKEND` and `MCP_OAUTH_SQLITE_PATH` ARE real (per CLAUDE.md) — don't remove those.
 **VERIFY BEFORE FIX**: Re-grep `src/` for each env var name. False positive risk if vars live in `web/oauth/` modules outside `config.py`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-017 🟡 Major · wiki↔repo · wiki/01-Installation-Guide.md:9
 **Current**: Banner says "Hybrid backend as default" (under v8.9.0 Highlights).
 **Expected**: Default is `sqlite_vec` per `config.py:307`. Hybrid is recommended for production but requires explicit configuration.
 **Fix**: Update banner to "SQLite-Vec is the default; Hybrid is recommended for production with Cloudflare credentials".
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-018 🟡 Major · wiki↔repo · MCP tool count "12" vs actual 18 in code
 **Current**: Wiki and `server_impl.py` docstring both claim "12 total" tools.
 **Expected** (per `grep -c 'types\.Tool(' src/mcp_memory_service/server_impl.py`): 18 distinct registrations — `memory_store`, `memory_store_session`, `memory_search`, `memory_list`, `memory_delete`, `memory_cleanup`, `memory_health`, `memory_stats`, `memory_update`, `memory_consolidate`, `memory_ingest`, `memory_harvest`, `memory_quality`, `memory_graph`, `memory_conflicts`, `memory_resolve`, `mistake_note_add`, `mistake_note_search`.
 **Fix**: Update `handle_list_tools` docstring + wiki references to "18 total" (or reconcile if some are deprecated/conditional).
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-019 🟡 Major · wiki↔repo · wiki/04-Advanced-Configuration.md missing `MCP_SCHEDULE_*` env vars
 **Current**: Wiki Advanced Configuration doesn't document `MCP_SCHEDULE_DAILY/WEEKLY/MONTHLY/QUARTERLY/YEARLY` env vars at all. Existing consolidation section (line 104) only covers manual triggering.
 **Expected**: All 5 schedule env vars exist per `config.py`, default `'disabled'` (per v10.47.2 PR #821). These are the primary opt-in mechanism for automatic consolidation.
 **Fix**: Add a schedule configuration table documenting all 5 vars with format examples (e.g. `MCP_SCHEDULE_DAILY=03:00`).
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
-### F-020 🟡 Major · wiki↔repo · `MCP_MEMORY_HTTP_ENDPOINT` undocumented
-**Current**: 3 wiki locations document `MCP_MEMORY_HTTP_ENDPOINT` as a client env var.
-  - `wiki/03-Integration-Guide.md:87,103,640`
-**Expected**: Per subagent grep, var doesn't exist in `src/mcp_memory_service/`. May be consumed by client-side bridge/shim, not the server.
-**Fix**: Verify whether this is a client-side bridge variable. If so, annotate clearly. If never existed, remove.
-**VERIFY BEFORE FIX**: Check `claude-code-memory-awareness/` hooks repo + any bridge scripts.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+### F-020 ⚪ Noise (FALSE FINDING — verified) · wiki↔repo · `MCP_MEMORY_HTTP_ENDPOINT` undocumented
+**Status**: VERIFIED FALSE — var IS implemented in `examples/http-mcp-bridge.js:157` (`process.env.MCP_MEMORY_HTTP_ENDPOINT`) and documented in `examples/claude-desktop-http-config.json:7`. Wiki references in `03-Integration-Guide.md` correctly document the client-side bridge env var. No fix needed.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [x] skip
 
 ### F-021 🟡 Major · cross-doc · default storage backend (FAQ vs Installation Guide vs CLAUDE.md)
 **Locations**:
@@ -169,7 +165,7 @@
   - `CLAUDE.md` Claude Desktop config example → recommends `"hybrid"`
 **Expected** (per code): Effective runtime default is `sqlite_vec`. `hybrid` requires Cloudflare credentials and is recommended-for-production but not out-of-box.
 **Fix**: Align all three wiki/docs to: "Default is SQLite-Vec. Hybrid is recommended for production deployment when Cloudflare credentials are configured." (Fix bundled with F-017.)
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ---
 
@@ -180,28 +176,28 @@
   - line 205: another `issues/27` reference
 **Context**: Repo transferred from user `milla-jovovich` to org `MemPalace`. Issue is live at `https://github.com/MemPalace/mempalace/issues/27`.
 **Fix**: Replace all 3 `milla-jovovich/mempalace` → `MemPalace/mempalace` in README.md.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-023 🟡 Major · link rot · wiki/01-Installation-Guide.md:118,445 → `./Claude-Code-Memory-Awareness-Guide`
 **Broken URL**: `./Claude-Code-Memory-Awareness-Guide` (page does not exist)
 **Context**: Referenced as the primary "complete setup" guide and in "Next Steps".
 **Fix**: Create the wiki page OR redirect to `./Claude-Code-Commands-Wiki` (exists) or `./06-Development-Reference`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-024 🟡 Major · link rot · wiki/01-Installation-Guide.md:446 + 03-Integration-Guide.md:809 → `./Claude-Code-Quick-Reference`
 **Broken URL**: `./Claude-Code-Quick-Reference` (page does not exist)
 **Fix**: Point to `./Claude-Code-Commands-Wiki` (exists, covers same ground) OR create the page.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-025 🟢 Minor · link rot · wiki/01-Installation-Guide.md:433 → `./macOS-Intel-Legacy-Guide`
 **Broken URL**: `./macOS-Intel-Legacy-Guide` (page does not exist).
 **Fix**: Remove link (keep text plain) or fold into `./07-TROUBLESHOOTING`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-026 🟢 Minor · link rot · wiki/01-Installation-Guide.md:447 → `./Tag-System-Migration-and-Management`
 **Broken URL**: `./Tag-System-Migration-and-Management` (page does not exist).
 **Fix**: Remove link or redirect to `./04-Advanced-Configuration`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-027 🟡 Major · link rot · 3× `./TROUBLESHOOTING` should be `./07-TROUBLESHOOTING`
 **Locations**:
@@ -209,24 +205,24 @@
   - `wiki/01-Installation-Guide.md:458`
   - `wiki/03-Integration-Guide.md:809`
 **Fix**: Rename all 3 occurrences `./TROUBLESHOOTING` → `./07-TROUBLESHOOTING`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-028 🟢 Minor · anchor rot · wiki/06-Development-Reference.md:10 → `#debugging--testing`
 **Broken anchor**: TOC links `#debugging--testing` but heading at line 216 generates `#debugging--troubleshooting` (renamed).
 **Fix**: Change TOC link to `#debugging--troubleshooting`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-029 🟢 Minor · anchor rot · wiki/05-Performance-Optimization.md:8 → emoji variation selector
 **Broken anchor**: TOC links `#️-critical-cloudflare-service-limitations`. GitHub Wiki strips U+FE0F variation selector → actual anchor is `#-critical-cloudflare-service-limitations`.
 **Fix**: Update TOC anchor.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ---
 
 ### F-030 🟡 Major · structural · Wiki Home.md navigation broken — entire numbered series invisible
 **Issue**: Wiki Home.md has only 1 outbound link (to CONTRIBUTING.md on GitHub). The numbered wiki pages (01-Installation-Guide through 19-Graph-Database-Architecture) are referenced only from `Backend-Synchronization-Guide.md`'s docs table — and that file is itself orphaned. **Result**: the entire numbered wiki series is effectively invisible from Home.md navigation.
 **Fix**: Rewrite `wiki/Home.md` to include direct links to all 19 numbered guides + key non-numbered pages (OAuth setup, Web Dashboard, Claude AI Remote MCP, etc.). This is the highest-leverage wiki fix — single page change, unblocks navigation for all numbered guides.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [x] ship-now  [ ] defer-issue  [ ] skip
 
 ### F-031 🟢 Minor · structural · 46 orphaned docs in repo
 **Issue**: 46 `.md` files under `docs/` have no incoming links from any active doc/wiki. Examples (full list — see audit transcript):
@@ -254,7 +250,7 @@
 - `docs/images/dashboard-placeholder.md`
 - `docs/remote-configuration-wiki-section.md`
 **Fix**: Triage each — archive (move to `docs/archive/`), delete (placeholder/artifact files), or add inbound link if still relevant. Recommend filing as single umbrella issue for follow-up.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-032 🟢 Minor · structural · 21 orphaned wiki pages
 **Issue**: 21 wiki pages have no incoming links from Home.md or any other wiki page. Examples:
@@ -269,7 +265,7 @@
 - `wiki/Windows-Hybrid-Backend-Setup-Example.md`, `wiki/Windows-Setup-Summary-Example.md`
 - `wiki/Development-Sprint-‐-November-2025.md`
 **Fix**: Largely solved by F-030 (Home.md rewrite). Remaining: archive sprint planning artifact, dedupe the dashboard guides.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-033 🟢 Minor · structural · Cloudflare guide cluster (3-way duplicate)
 **Issue**: Three wiki guides cover the same Cloudflare hybrid setup territory:
@@ -277,26 +273,26 @@
 - `wiki/Cloudflare-Based-Multi-Machine-Sync.md` (problem/solution narrative)
 - `wiki/Hybrid_Setup_Configuration.md` (v8.9.0 reference config dump)
 **Fix**: Consolidate into single canonical guide (Cloudflare-Backup-Sync-Setup.md is best base — has step-by-step structure). Absorb multi-machine narrative + full config example. Retire other two with redirects or archive notes.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-034 🟢 Minor · structural · Windows guide cluster (2-way duplicate)
 **Issue**: Two wiki files split a single Windows hybrid setup guide:
 - `wiki/Windows-Setup-Summary-Example.md` (status/summary)
 - `wiki/Windows-Hybrid-Backend-Setup-Example.md` (JSON config blocks)
 **Fix**: Merge into single Windows Hybrid Setup guide; link from `wiki/02-Platform-Setup-Guide.md`.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-035 🟢 Minor · structural · `wiki/Backend-Synchronization-Guide.md` is misnamed
 **Issue**: Filename suggests sync documentation but content is actually a near-full project README from ~v7.1.3 era (features overview, what's new, docs table). Competes with `Cloudflare-Backup-Sync-Setup.md` for the "backend sync" search term.
 **Fix**: Archive or rename. `Cloudflare-Backup-Sync-Setup.md` is the real sync guide.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ### F-036 🟢 Minor · structural · `docs/deployment/` duplicate guides
 **Issue**: Both orphaned, both cover production deployment with overlapping audience but no cross-reference:
 - `docs/deployment/dual-service.md` (FastMCP+HTTP two-service setup)
 - `docs/deployment/production-guide.md` (single consolidated service with systemd, mDNS, HTTPS, consolidation)
 **Fix**: Add cross-references and link both from README deployment section, OR merge into one "Production Deployment Guide" with sections for each topology.
-**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+**Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
 
 ---
 

--- a/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+++ b/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
@@ -54,12 +54,14 @@
 **Expected**: `v10.47.2`
 **Fix**: Update Q1 2026 review version marker to `v10.47.2`.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #826
 
 ### F-006 🟢 Minor · version drift · docs/BENCHMARKS.md:13
 **Current**: `**Date:** 2026-04-08 · **Version:** v10.34.0`
 **Expected**: Note reflects benchmark run version, not current.
 **Fix**: Add parenthetical `(benchmark run version; latest release: v10.47.2)` or link to updated benchmark. Existing value is historically correct for that run but may mislead.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #826
 
 ---
 
@@ -193,11 +195,13 @@
 **Broken URL**: `./macOS-Intel-Legacy-Guide` (page does not exist).
 **Fix**: Remove link (keep text plain) or fold into `./07-TROUBLESHOOTING`.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #825
 
 ### F-026 🟢 Minor · link rot · wiki/01-Installation-Guide.md:447 → `./Tag-System-Migration-and-Management`
 **Broken URL**: `./Tag-System-Migration-and-Management` (page does not exist).
 **Fix**: Remove link or redirect to `./04-Advanced-Configuration`.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #825
 
 ### F-027 🟡 Major · link rot · 3× `./TROUBLESHOOTING` should be `./07-TROUBLESHOOTING`
 **Locations**:
@@ -211,11 +215,13 @@
 **Broken anchor**: TOC links `#debugging--testing` but heading at line 216 generates `#debugging--troubleshooting` (renamed).
 **Fix**: Change TOC link to `#debugging--troubleshooting`.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #824
 
 ### F-029 🟢 Minor · anchor rot · wiki/05-Performance-Optimization.md:8 → emoji variation selector
 **Broken anchor**: TOC links `#️-critical-cloudflare-service-limitations`. GitHub Wiki strips U+FE0F variation selector → actual anchor is `#-critical-cloudflare-service-limitations`.
 **Fix**: Update TOC anchor.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #824
 
 ---
 
@@ -251,6 +257,7 @@
 - `docs/remote-configuration-wiki-section.md`
 **Fix**: Triage each — archive (move to `docs/archive/`), delete (placeholder/artifact files), or add inbound link if still relevant. Recommend filing as single umbrella issue for follow-up.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ### F-032 🟢 Minor · structural · 21 orphaned wiki pages
 **Issue**: 21 wiki pages have no incoming links from Home.md or any other wiki page. Examples:
@@ -266,6 +273,7 @@
 - `wiki/Development-Sprint-‐-November-2025.md`
 **Fix**: Largely solved by F-030 (Home.md rewrite). Remaining: archive sprint planning artifact, dedupe the dashboard guides.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ### F-033 🟢 Minor · structural · Cloudflare guide cluster (3-way duplicate)
 **Issue**: Three wiki guides cover the same Cloudflare hybrid setup territory:
@@ -274,6 +282,7 @@
 - `wiki/Hybrid_Setup_Configuration.md` (v8.9.0 reference config dump)
 **Fix**: Consolidate into single canonical guide (Cloudflare-Backup-Sync-Setup.md is best base — has step-by-step structure). Absorb multi-machine narrative + full config example. Retire other two with redirects or archive notes.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ### F-034 🟢 Minor · structural · Windows guide cluster (2-way duplicate)
 **Issue**: Two wiki files split a single Windows hybrid setup guide:
@@ -281,11 +290,13 @@
 - `wiki/Windows-Hybrid-Backend-Setup-Example.md` (JSON config blocks)
 **Fix**: Merge into single Windows Hybrid Setup guide; link from `wiki/02-Platform-Setup-Guide.md`.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ### F-035 🟢 Minor · structural · `wiki/Backend-Synchronization-Guide.md` is misnamed
 **Issue**: Filename suggests sync documentation but content is actually a near-full project README from ~v7.1.3 era (features overview, what's new, docs table). Competes with `Cloudflare-Backup-Sync-Setup.md` for the "backend sync" search term.
 **Fix**: Archive or rename. `Cloudflare-Backup-Sync-Setup.md` is the real sync guide.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ### F-036 🟢 Minor · structural · `docs/deployment/` duplicate guides
 **Issue**: Both orphaned, both cover production deployment with overlapping audience but no cross-reference:
@@ -293,6 +304,7 @@
 - `docs/deployment/production-guide.md` (single consolidated service with systemd, mDNS, HTTPS, consolidation)
 **Fix**: Add cross-references and link both from README deployment section, OR merge into one "Production Deployment Guide" with sections for each topology.
 **Disposition**: [ ] ship-now  [x] defer-issue  [ ] skip
+**Issue**: #823
 
 ---
 

--- a/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+++ b/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
@@ -1,0 +1,328 @@
+# Housekeeping Audit — 2026-05-02
+
+**Scope**: docs/, README.md, CLAUDE.md, docs/index.html, mcp-memory-service.wiki/
+**Reference state**: v10.47.2, ~1,780 tests (CLAUDE.md authoritative — counts parameterized + integration variants; raw `def test_` count is 787)
+**Categories scanned**: version, feature, wiki↔repo, cross-doc, links, structural
+
+## Summary
+
+- 🔴 Critical: 4 findings (F-007, F-008, F-015, F-016)
+- 🟡 Major:    19 findings
+- 🟢 Minor:    13 findings (F-031 groups 46 repo orphans; F-032 groups 21 wiki orphans)
+- ⚪ Noise:    excluded (historical "introduced in vX" annotations, per-release test counts in old changelog entries, PR template examples, HTTPS port 8443 config examples in wiki)
+
+**Total findings**: 36 (after grouping 67 individual orphan findings into 2 cluster findings)
+
+**How to triage**: For each finding below, mark exactly one disposition checkbox: `ship-now` / `defer-issue` / `skip`. When done, tell the controller to proceed.
+
+---
+
+## Findings
+
+### F-001 🟡 Major · version drift · docs/index.html:245
+**Current**: `<a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.0">`
+**Expected**: `v10.47.2`
+**Fix**: Change release URL to `.../releases/tag/v10.47.2` so "Release Notes" button on landing page links to latest patch release.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-002 🟢 Minor · version drift · docs/index.html:6,8
+**Current**: `v10.47` (title tag and og:title — no patch version)
+**Expected**: `v10.47.2`
+**Fix**: Update `<title>` and `<meta property="og:title">` to `v10.47.2` for consistency. Per CLAUDE.md "MINOR/MAJOR releases only" policy, the `v10.47` form is technically allowed; this is cosmetic.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-003 🔴 Critical · cross-doc · test count drift (multiple files)
+**Current** (3 contradictory sources):
+  - `CLAUDE.md:73` → `# Run all tests (968 tests total)`
+  - `CLAUDE.md:233` → `### Structure (968 tests)`
+  - `CLAUDE.md:48` → `~1,780 tests` (same file contradicts itself)
+  - `README.md:493–499` → per-release counts show `1,537–1,547` tests
+  - `docs/index.html:140` → `~1,780 tests`
+  - `wiki/13-Development-Roadmap.md:11` → `~1,780 tests passing`
+**Expected**: `~1,780 tests` (current canonical per CLAUDE.md header)
+**Fix**: Update CLAUDE.md:73 and CLAUDE.md:233 from `968 tests` → `~1,780 tests`. Per-release historical counts in README are correct as historical data and stay.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-004 🟡 Major · version drift · wiki/13-Development-Roadmap.md:9
+**Current**: `**Current Version**: v10.47.0 (Production-ready)`
+**Expected**: `v10.47.2`
+**Fix**: Bump to `v10.47.2` so the wiki roadmap header matches latest release.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-005 🟢 Minor · version drift · wiki/13-Development-Roadmap.md:289
+**Current**: `- **Version at Review**: v10.47.0`
+**Expected**: `v10.47.2`
+**Fix**: Update Q1 2026 review version marker to `v10.47.2`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-006 🟢 Minor · version drift · docs/BENCHMARKS.md:13
+**Current**: `**Date:** 2026-04-08 · **Version:** v10.34.0`
+**Expected**: Note reflects benchmark run version, not current.
+**Fix**: Add parenthetical `(benchmark run version; latest release: v10.47.2)` or link to updated benchmark. Existing value is historically correct for that run but may mislead.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+---
+
+### F-007 🔴 Critical · feature drift · docs/mastery/api-reference.md:9–37
+**Current**: Entire "MCP (FastMCP HTTP) Tools" section documents pre-v10 deprecated tool names as canonical: `store_memory`, `retrieve_memory(query, n_results=5)`, `search_by_tag`, `delete_memory`, `check_database_health`.
+**Replacement**: v10 unified names — `memory_store`, `memory_search`, `memory_list`, `memory_delete`, `memory_health`. Parameter `n_results` → `limit`.
+**Fix**: Rewrite the "MCP Tools" table to list the 12 unified `memory_*` tools. Remove the `mcp_server.py` reference (still exists but is a compat shim, not primary).
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-008 🔴 Critical · feature drift · wiki/03-Integration-Guide.md:44–48
+**Current**: "Verify Connection" step (the actual install/setup verification path) tells users to look for `store_memory`, `retrieve_memory`, `search_by_tag`, `delete_memory`, `check_database_health` in tool list.
+**Replacement**: `memory_store`, `memory_search`, `memory_list`, `memory_delete`, `memory_health`.
+**Fix**: Update bullet list to v10 names. Critical because this is what users follow to confirm setup worked.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-009 🟡 Major · feature drift · docs/mastery/api-reference.md:66–73 (Examples)
+**Current**: Example snippets use `tool: store_memory`, `tool: retrieve_memory` with `n_results: 5`, `tool: search_by_tag`.
+**Replacement**: `memory_store`, `memory_search` (with `limit` param), `memory_list` for tag search.
+**Fix**: Update all three example blocks.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-010 🟡 Major · feature drift · wiki/14-Memory-Quality-System-Guide.md:235,273,298,318,708,792,809,812
+**Current**: Multiple code examples use deprecated quality tool names — `rate_memory`, `retrieve_with_quality_boost`, `get_memory_quality`, `analyze_quality_distribution`.
+**Replacement**: `memory_quality(action="rate"|"get"|"analyze")` and `memory_search(mode="hybrid", quality_boost=...)`.
+**Fix**: Update all code blocks; add migration note at top.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-011 🟡 Major · feature drift · wiki/10-Complete-Feature-List.md:560–563
+**Current**: Quality System "MCP Tools" subsection lists 4 deprecated names as the current inventory.
+**Replacement**: `memory_quality` actions + `memory_search` with quality_boost.
+**Fix**: Replace the 4 lines with correct unified signatures.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-012 🟡 Major · feature drift · docs/mastery/api-reference.md:37 + docs/mastery/architecture-overview.md:48,53
+**Current**: Architecture/overview docs describe tool surface using deprecated names: `store_memory`, `retrieve_memory`, `search_by_tag`, `delete_memory`, `check_database_health`, `cleanup_duplicates`, `update_memory_metadata`.
+**Replacement**: v10 unified names. Note `cleanup_duplicates` → `memory_cleanup`, `update_memory_metadata` → `memory_update`.
+**Fix**: Rewrite prose descriptions.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-013 🟡 Major · feature drift · `n_results` parameter (4 locations)
+**Current**: `n_results` parameter used in user-facing examples — deprecated since v10.0.0.
+  - `wiki/03-Integration-Guide.md:475`: `'{"query": "integration test", "n_results": 5}'`
+  - `wiki/03-Integration-Guide.md:586`: `body: JSON.stringify({ query, n_results: nResults })`
+  - `docs/mastery/api-reference.md:13`: `retrieve_memory(query, n_results=5, min_similarity=0.0)`
+  - `docs/mastery/api-reference.md:67`: `args: { "query": "OAuth refactor", "n_results": 5 }`
+**Replacement**: `limit`.
+**Fix**: Replace `n_results` → `limit` in all 4 locations.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-014 🟡 Major · feature drift · docs/guides/memory-consolidation-guide.md:96 + wiki/Memory-Consolidation-System-Guide.md:203
+**Current**: Both guides show `trigger_consolidation` as the recommended MCP tool.
+**Replacement**: `memory_consolidate(action="run", ...)`.
+**Fix**: Update invocation in both files. Also update `consolidate_memories`, `scheduler_status`, `pause_consolidation` references to `memory_consolidate` action equivalents.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+---
+
+### F-015 🔴 Critical · wiki↔repo · `chroma` backend referenced as valid (4 wiki locations)
+**Current** (4 locations document `chroma` as a valid `MCP_MEMORY_STORAGE_BACKEND` value):
+  - `wiki/03-Integration-Guide.md:68`
+  - `wiki/03-Integration-Guide.md:627` (full "ChromaDB Backend for Team Sharing" code block)
+  - `wiki/01-Installation-Guide.md:271`
+  - `wiki/01-Installation-Guide.md:335`
+**Expected** (per `src/mcp_memory_service/config.py:306`): `SUPPORTED_BACKENDS = ['sqlite_vec', 'sqlite-vec', 'cloudflare', 'hybrid', 'milvus']`. Setting `chroma` falls through to fallback warning + reverts to `sqlite_vec`.
+**Fix**: Remove all `chroma` references from wiki; for "team sharing" use case, replace with `milvus` or note feature was retired.
+**VERIFY BEFORE FIX**: Re-grep `src/mcp_memory_service/config.py` to confirm `chroma` truly absent from `SUPPORTED_BACKENDS`. If subagent's read was stale, downgrade to Major.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-016 🔴 Critical · wiki↔repo · OAuth env vars don't exist in code
+**Current** (5 env vars documented in `wiki/04-Advanced-Configuration.md:466,469,472,546,547`): `MCP_OAUTH_CLIENT_STORAGE`, `MCP_OAUTH_REGISTRATION_RATE_LIMIT`, `MCP_OAUTH_AUDIT_LOG`, `MCP_OAUTH_CLEANUP_EXPIRED_TOKENS`, `MCP_OAUTH_TOKEN_CLEANUP_INTERVAL`.
+**Expected**: None exist in `src/mcp_memory_service/config.py` per subagent grep — would be silently ignored if set.
+**Fix**: Audit which OAuth env vars are actually implemented; remove or correct the rest. Note: `MCP_OAUTH_STORAGE_BACKEND` and `MCP_OAUTH_SQLITE_PATH` ARE real (per CLAUDE.md) — don't remove those.
+**VERIFY BEFORE FIX**: Re-grep `src/` for each env var name. False positive risk if vars live in `web/oauth/` modules outside `config.py`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-017 🟡 Major · wiki↔repo · wiki/01-Installation-Guide.md:9
+**Current**: Banner says "Hybrid backend as default" (under v8.9.0 Highlights).
+**Expected**: Default is `sqlite_vec` per `config.py:307`. Hybrid is recommended for production but requires explicit configuration.
+**Fix**: Update banner to "SQLite-Vec is the default; Hybrid is recommended for production with Cloudflare credentials".
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-018 🟡 Major · wiki↔repo · MCP tool count "12" vs actual 18 in code
+**Current**: Wiki and `server_impl.py` docstring both claim "12 total" tools.
+**Expected** (per `grep -c 'types\.Tool(' src/mcp_memory_service/server_impl.py`): 18 distinct registrations — `memory_store`, `memory_store_session`, `memory_search`, `memory_list`, `memory_delete`, `memory_cleanup`, `memory_health`, `memory_stats`, `memory_update`, `memory_consolidate`, `memory_ingest`, `memory_harvest`, `memory_quality`, `memory_graph`, `memory_conflicts`, `memory_resolve`, `mistake_note_add`, `mistake_note_search`.
+**Fix**: Update `handle_list_tools` docstring + wiki references to "18 total" (or reconcile if some are deprecated/conditional).
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-019 🟡 Major · wiki↔repo · wiki/04-Advanced-Configuration.md missing `MCP_SCHEDULE_*` env vars
+**Current**: Wiki Advanced Configuration doesn't document `MCP_SCHEDULE_DAILY/WEEKLY/MONTHLY/QUARTERLY/YEARLY` env vars at all. Existing consolidation section (line 104) only covers manual triggering.
+**Expected**: All 5 schedule env vars exist per `config.py`, default `'disabled'` (per v10.47.2 PR #821). These are the primary opt-in mechanism for automatic consolidation.
+**Fix**: Add a schedule configuration table documenting all 5 vars with format examples (e.g. `MCP_SCHEDULE_DAILY=03:00`).
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-020 🟡 Major · wiki↔repo · `MCP_MEMORY_HTTP_ENDPOINT` undocumented
+**Current**: 3 wiki locations document `MCP_MEMORY_HTTP_ENDPOINT` as a client env var.
+  - `wiki/03-Integration-Guide.md:87,103,640`
+**Expected**: Per subagent grep, var doesn't exist in `src/mcp_memory_service/`. May be consumed by client-side bridge/shim, not the server.
+**Fix**: Verify whether this is a client-side bridge variable. If so, annotate clearly. If never existed, remove.
+**VERIFY BEFORE FIX**: Check `claude-code-memory-awareness/` hooks repo + any bridge scripts.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-021 🟡 Major · cross-doc · default storage backend (FAQ vs Installation Guide vs CLAUDE.md)
+**Locations**:
+  - `wiki/01-Installation-Guide.md:9` → "Hybrid backend as default" (overlaps F-017)
+  - `wiki/08-FAQ.md:29` → "stored locally by default (SQLite-vec backend)"
+  - `docs/glama-deployment.md:45` → table shows default `sqlite_vec`
+  - `CLAUDE.md` Claude Desktop config example → recommends `"hybrid"`
+**Expected** (per code): Effective runtime default is `sqlite_vec`. `hybrid` requires Cloudflare credentials and is recommended-for-production but not out-of-box.
+**Fix**: Align all three wiki/docs to: "Default is SQLite-Vec. Hybrid is recommended for production deployment when Cloudflare credentials are configured." (Fix bundled with F-017.)
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+---
+
+### F-022 🟡 Major · link rot · README.md:185,205 (MemPalace org rename)
+**Broken URLs** (3 occurrences in README.md):
+  - `https://github.com/milla-jovovich/mempalace` (301 → moved)
+  - `https://github.com/milla-jovovich/mempalace/issues/27` (404 — issue links don't redirect)
+  - line 205: another `issues/27` reference
+**Context**: Repo transferred from user `milla-jovovich` to org `MemPalace`. Issue is live at `https://github.com/MemPalace/mempalace/issues/27`.
+**Fix**: Replace all 3 `milla-jovovich/mempalace` → `MemPalace/mempalace` in README.md.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-023 🟡 Major · link rot · wiki/01-Installation-Guide.md:118,445 → `./Claude-Code-Memory-Awareness-Guide`
+**Broken URL**: `./Claude-Code-Memory-Awareness-Guide` (page does not exist)
+**Context**: Referenced as the primary "complete setup" guide and in "Next Steps".
+**Fix**: Create the wiki page OR redirect to `./Claude-Code-Commands-Wiki` (exists) or `./06-Development-Reference`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-024 🟡 Major · link rot · wiki/01-Installation-Guide.md:446 + 03-Integration-Guide.md:809 → `./Claude-Code-Quick-Reference`
+**Broken URL**: `./Claude-Code-Quick-Reference` (page does not exist)
+**Fix**: Point to `./Claude-Code-Commands-Wiki` (exists, covers same ground) OR create the page.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-025 🟢 Minor · link rot · wiki/01-Installation-Guide.md:433 → `./macOS-Intel-Legacy-Guide`
+**Broken URL**: `./macOS-Intel-Legacy-Guide` (page does not exist).
+**Fix**: Remove link (keep text plain) or fold into `./07-TROUBLESHOOTING`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-026 🟢 Minor · link rot · wiki/01-Installation-Guide.md:447 → `./Tag-System-Migration-and-Management`
+**Broken URL**: `./Tag-System-Migration-and-Management` (page does not exist).
+**Fix**: Remove link or redirect to `./04-Advanced-Configuration`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-027 🟡 Major · link rot · 3× `./TROUBLESHOOTING` should be `./07-TROUBLESHOOTING`
+**Locations**:
+  - `wiki/01-Installation-Guide.md:448`
+  - `wiki/01-Installation-Guide.md:458`
+  - `wiki/03-Integration-Guide.md:809`
+**Fix**: Rename all 3 occurrences `./TROUBLESHOOTING` → `./07-TROUBLESHOOTING`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-028 🟢 Minor · anchor rot · wiki/06-Development-Reference.md:10 → `#debugging--testing`
+**Broken anchor**: TOC links `#debugging--testing` but heading at line 216 generates `#debugging--troubleshooting` (renamed).
+**Fix**: Change TOC link to `#debugging--troubleshooting`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-029 🟢 Minor · anchor rot · wiki/05-Performance-Optimization.md:8 → emoji variation selector
+**Broken anchor**: TOC links `#️-critical-cloudflare-service-limitations`. GitHub Wiki strips U+FE0F variation selector → actual anchor is `#-critical-cloudflare-service-limitations`.
+**Fix**: Update TOC anchor.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+---
+
+### F-030 🟡 Major · structural · Wiki Home.md navigation broken — entire numbered series invisible
+**Issue**: Wiki Home.md has only 1 outbound link (to CONTRIBUTING.md on GitHub). The numbered wiki pages (01-Installation-Guide through 19-Graph-Database-Architecture) are referenced only from `Backend-Synchronization-Guide.md`'s docs table — and that file is itself orphaned. **Result**: the entire numbered wiki series is effectively invisible from Home.md navigation.
+**Fix**: Rewrite `wiki/Home.md` to include direct links to all 19 numbered guides + key non-numbered pages (OAuth setup, Web Dashboard, Claude AI Remote MCP, etc.). This is the highest-leverage wiki fix — single page change, unblocks navigation for all numbered guides.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-031 🟢 Minor · structural · 46 orphaned docs in repo
+**Issue**: 46 `.md` files under `docs/` have no incoming links from any active doc/wiki. Examples (full list — see audit transcript):
+- `docs/ROADMAP.md` (superseded by wiki Development-Roadmap)
+- `docs/HOOK_IMPROVEMENTS.md`, `docs/IMAGE_RETENTION_POLICY.md`, `docs/HARK_*` planning docs
+- `docs/development/code-quality/phase-2*.md` (5 phase artifacts)
+- `docs/releases/release-notes-v8.61.0.md`, `docs/releases/v8.72.0-testing.md`
+- `docs/blog/2026-03-30-memory-evolution-v10-31-0.md`
+- `docs/integrations/gemini.md` (orphaned despite being a real integration guide)
+- `docs/natural-memory-triggers/installation-guide.md`, `cli-reference.md`
+- `docs/architecture/search-enhancement-spec.md`, `docs/architecture/search-examples.md`
+- `docs/deployment/dual-service.md`, `docs/deployment/production-guide.md`
+- `docs/maintenance/changelog-housekeeping-prompt.md`
+- `docs/wiki-Graph-Database-Architecture.md`, `docs/wiki-documentation-plan.md`
+- `docs/api/PHASE2_REPORT.md`, `docs/DOCUMENTATION_AUDIT.md`
+- `docs/development/COMMIT_MESSAGE.md`, `docs/development/refactoring-notes.md`, `docs/development/pr-280-post-mortem.md`
+- `docs/research/locomo-benchmark-analysis.md`, `docs/statistics/REPOSITORY_STATISTICS.md`
+- `docs/migrations/010-asymmetric-relationships.md`
+- `docs/quality-system-ui-implementation.md`, `docs/demo-recording-script.md`, `docs/hybrid-graph-sync-plan.md`, `docs/CLAUDE_CODE_QUICK_REFERENCE.md`
+- `docs/guides/advanced-command-examples.md`, `docs/guides/mdns-service-discovery.md`, `docs/guides/commands-vs-mcp-server.md`
+- `docs/integrations.md`, `docs/mastery/local-setup-and-run.md`
+- `docs/testing/integrity-monitoring-test-report.md`, `docs/verification/v9.0.0-knowledge-graph-verification.md`
+- `docs/reviews/bug-fixes-issues-441-447.md`
+- `docs/testing-cloudflare-backend.md`, `docs/technical/migration-log.md`, `docs/technical/sqlite-vec-embedding-fixes.md`
+- `docs/images/dashboard-placeholder.md`
+- `docs/remote-configuration-wiki-section.md`
+**Fix**: Triage each — archive (move to `docs/archive/`), delete (placeholder/artifact files), or add inbound link if still relevant. Recommend filing as single umbrella issue for follow-up.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-032 🟢 Minor · structural · 21 orphaned wiki pages
+**Issue**: 21 wiki pages have no incoming links from Home.md or any other wiki page. Examples:
+- `wiki/08-FAQ.md`, `wiki/13-Development-Roadmap.md`, `wiki/14-Contributor-Promotion.md`
+- `wiki/15-ONNX-Quality-Evaluation.md`, `wiki/16-Metadata-Compression-System.md`, `wiki/17-Quality-Hooks-Integration.md`
+- `wiki/18-Dashboard-UI-Guide.md`, `wiki/19-Graph-Database-Architecture.md`
+- `wiki/AppleScript-Integration-with-Memory.md`, `wiki/Claude-AI-Remote-MCP-Integration.md`
+- `wiki/Claude-Code-Commands-Wiki.md`
+- `wiki/Cloudflare-Based-Multi-Machine-Sync.md`, `wiki/Hybrid_Setup_Configuration.md`
+- `wiki/Memory-Consolidation-System-Guide.md`, `wiki/Memory-Quality-System-Evaluation.md`
+- `wiki/Pull-Request-Templates.md`, `wiki/Issue-Templates.md`, `wiki/Screenshot-Automation-Guide.md`
+- `wiki/Windows-Hybrid-Backend-Setup-Example.md`, `wiki/Windows-Setup-Summary-Example.md`
+- `wiki/Development-Sprint-‐-November-2025.md`
+**Fix**: Largely solved by F-030 (Home.md rewrite). Remaining: archive sprint planning artifact, dedupe the dashboard guides.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-033 🟢 Minor · structural · Cloudflare guide cluster (3-way duplicate)
+**Issue**: Three wiki guides cover the same Cloudflare hybrid setup territory:
+- `wiki/Cloudflare-Backup-Sync-Setup.md` (step-by-step)
+- `wiki/Cloudflare-Based-Multi-Machine-Sync.md` (problem/solution narrative)
+- `wiki/Hybrid_Setup_Configuration.md` (v8.9.0 reference config dump)
+**Fix**: Consolidate into single canonical guide (Cloudflare-Backup-Sync-Setup.md is best base — has step-by-step structure). Absorb multi-machine narrative + full config example. Retire other two with redirects or archive notes.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-034 🟢 Minor · structural · Windows guide cluster (2-way duplicate)
+**Issue**: Two wiki files split a single Windows hybrid setup guide:
+- `wiki/Windows-Setup-Summary-Example.md` (status/summary)
+- `wiki/Windows-Hybrid-Backend-Setup-Example.md` (JSON config blocks)
+**Fix**: Merge into single Windows Hybrid Setup guide; link from `wiki/02-Platform-Setup-Guide.md`.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-035 🟢 Minor · structural · `wiki/Backend-Synchronization-Guide.md` is misnamed
+**Issue**: Filename suggests sync documentation but content is actually a near-full project README from ~v7.1.3 era (features overview, what's new, docs table). Competes with `Cloudflare-Backup-Sync-Setup.md` for the "backend sync" search term.
+**Fix**: Archive or rename. `Cloudflare-Backup-Sync-Setup.md` is the real sync guide.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+### F-036 🟢 Minor · structural · `docs/deployment/` duplicate guides
+**Issue**: Both orphaned, both cover production deployment with overlapping audience but no cross-reference:
+- `docs/deployment/dual-service.md` (FastMCP+HTTP two-service setup)
+- `docs/deployment/production-guide.md` (single consolidated service with systemd, mDNS, HTTPS, consolidation)
+**Fix**: Add cross-references and link both from README deployment section, OR merge into one "Production Deployment Guide" with sections for each topology.
+**Disposition**: [ ] ship-now  [ ] defer-issue  [ ] skip
+
+---
+
+## Triage Notes
+
+**Quick-pick recommendations** (override freely):
+- All 🔴 Critical (F-003, F-007, F-008, F-015, F-016) → `ship-now` mandatory.
+  - F-015 + F-016: **verify code first** before fixing — re-grep `src/` to confirm subagent's claims.
+- All 🟡 Major content fixes (F-001, F-004, F-009 through F-014, F-017 through F-024, F-027) → `ship-now`.
+- 🟡 Major structural (F-030 wiki Home navigation) → `ship-now` (single high-leverage fix).
+- All 🟢 Minor cosmetic (F-002, F-005, F-006, F-025, F-026, F-028, F-029) → `defer-issue` (cheap to fix later).
+- All 🟢 Minor structural (F-031 through F-036) → `defer-issue` (umbrella issues for cleanup waves).
+
+**Categories with cleanest fixes (low risk):**
+- F-013 (`n_results` → `limit`): mechanical sed-style replace.
+- F-027 (`./TROUBLESHOOTING` → `./07-TROUBLESHOOTING`): mechanical rename.
+- F-022 (MemPalace org): mechanical org-name replace.
+- F-001, F-002, F-004, F-005 (version bumps): mechanical.
+
+**Categories needing judgment:**
+- F-007, F-008, F-018: requires confirming the v10 unified tool surface count (12 vs 18 vs claimed) by reading current `server_impl.py`.
+- F-015, F-016, F-020: require verifying the env vars/backend names truly absent from code before deleting from wiki.
+- F-031–F-036: structural cleanup — defer to follow-up work.
+
+**Estimated PR size if all 🔴 + 🟡 marked ship-now:**
+- ~12 main-repo files touched (CLAUDE.md, README.md, docs/index.html, docs/mastery/api-reference.md, docs/mastery/architecture-overview.md, docs/guides/memory-consolidation-guide.md, docs/BENCHMARKS.md if expanded, etc.)
+- ~6 wiki files touched (01, 03, 04, 06, 10, 13, 14, Memory-Consolidation, Home)
+- 1 new CI script + workflow change
+- Comfortable single-PR scope (well under the ~30-file threshold).

--- a/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
+++ b/docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md
@@ -334,3 +334,57 @@
 - ~6 wiki files touched (01, 03, 04, 06, 10, 13, 14, Memory-Consolidation, Home)
 - 1 new CI script + workflow change
 - Comfortable single-PR scope (well under the ~30-file threshold).
+
+---
+
+## Resolution
+
+**Status**: Complete (2026-05-02)
+
+### Shipped in PR-1: [#827](https://github.com/doobidoo/mcp-memory-service/pull/827)
+
+**Branch**: `chore/housekeeping-fixes` → `main` (15 commits, 16 files changed)
+
+**Critical fixes** (4 of 4):
+- F-003 → `3ca8595` (CLAUDE.md test count)
+- F-007 → `36917f3` (api-reference.md MCP Tools rewrite)
+- F-008 → wiki commit `2742b42` (Verify Connection tool names)
+- F-015 → wiki commit `7c376af` (chroma backend removed)
+- F-016 → wiki commit `7c376af` (5 non-existent OAuth env vars removed)
+
+**Major fixes** (18 of 18):
+- Main-repo: F-001, F-002 → `3ca8595` (landing page); F-009, F-012, F-013 → `36917f3`; F-014 → `5990371` (consolidation guide); F-022 → `3ca8595` (MemPalace org); F-018 → `177de87` (server docstring)
+- Wiki: F-004, F-010, F-011, F-013-wiki, F-014-wiki, F-017, F-018-wiki, F-019, F-021, F-023, F-024, F-027, F-030 → wiki commits `9ccd9d8`, `2742b42`, `7c376af`, `9f7ca65`
+
+### Wiki direct commits (`mcp-memory-service.wiki` master)
+
+- `9ccd9d8` — Home navigation rewrite (F-030, highest leverage)
+- `2742b42` — v10.0.0 unified tool surface alignment (F-008, F-010, F-011, F-013, F-014, F-018)
+- `7c376af` — config + storage backend defaults (F-015, F-016, F-017, F-019, F-021)
+- `9f7ca65` — version bump + broken page links (F-004, F-023, F-024, F-027)
+
+### Tooling shipped
+
+- New: `scripts/ci/check_versions.sh` + `tests/ci/test_check_versions.sh` (TDD, 3/3 pass)
+- New: `version-drift-check` job in `.github/workflows/docs-check.yml` (GREEN on first PR run)
+- Extended: `scripts/ci/check_dead_refs.sh` — added `docs/superpowers/` to EXCLUDE_PATHS
+
+### Deferred to issues
+
+- [#823](https://github.com/doobidoo/mcp-memory-service/issues/823) — Doc structural cleanup: orphans + duplicates (F-031, F-032, F-033, F-034, F-035, F-036)
+- [#824](https://github.com/doobidoo/mcp-memory-service/issues/824) — Wiki TOC anchor rot (F-028, F-029) [`good first issue`]
+- [#825](https://github.com/doobidoo/mcp-memory-service/issues/825) — Wiki broken page-link redirects (F-025, F-026)
+- [#826](https://github.com/doobidoo/mcp-memory-service/issues/826) — Cosmetic version-ref bumps (F-005, F-006) [`good first issue`]
+
+### Skipped (intentional)
+
+- F-020 (`MCP_MEMORY_HTTP_ENDPOINT`): verified FALSE — var IS implemented in `examples/http-mcp-bridge.js:157`. Wiki references are correct documentation of the client-side bridge env var.
+
+### Manual follow-up
+
+- Landing page (`docs/index.html`) re-publish to here.now (`merry-realm-j835`): `~/.agents/skills/here-now/scripts/publish.sh` not present at the documented path. Owner to republish manually after merge per CLAUDE.md instructions.
+
+### Future tooling work (intentionally deferred from PR-1)
+
+- Adding v10.0.0 deprecated MCP tool names (`store_memory(`, `retrieve_memory(`, etc.) to `check_dead_refs.sh` — deferred because 25+ active docs still use them as primary examples (mostly tutorials/agents/examples). Adding term-by-term as docs are migrated to the unified `memory_*` surface (tracked as part of #823 cleanup waves).
+- Wiki CI link-check (cross-repo handling) — non-trivial; deferred per design spec.

--- a/scripts/ci/check_dead_refs.sh
+++ b/scripts/ci/check_dead_refs.sh
@@ -23,6 +23,28 @@ DEAD_REFS=(
   "localhost:8443"
   "127.0.0.1:8443"
   "python install.py"
+  # Added 2026-05-02 housekeeping audit (PR for findings F-007 through F-014)
+  # v10.0.0 deprecated MCP tool names — compat aliases still work but docs
+  # must use unified memory_* names. Migration docs are excluded below.
+  "store_memory("
+  "retrieve_memory("
+  "delete_memory("
+  "check_database_health("
+  "search_by_tag("
+  "search_by_tags("
+  "delete_by_tag("
+  "delete_by_tags("
+  "delete_by_all_tags("
+  "delete_by_timeframe("
+  "delete_before_date("
+  "cleanup_duplicates("
+  "update_memory_metadata("
+  "trigger_consolidation("
+  "consolidate_memories("
+  "rate_memory("
+  "get_memory_quality("
+  "analyze_quality_distribution("
+  "retrieve_with_quality_boost("
 )
 
 # Soft dead reference: bare "chromadb". Checked separately because some active
@@ -42,6 +64,10 @@ EXCLUDE_PATHS=(
   "docs/DOCUMENTATION_AUDIT"
   "docs/IMPLEMENTATION_PLAN"
   "CHANGELOG"
+  # Added 2026-05-02: migration docs intentionally reference deprecated
+  # tool names as part of explaining the v10.0.0 rename
+  "docs/MIGRATION"
+  "docs/migration"
 )
 
 # Allow-list for the SOFT_DEAD_REF only. Files below intentionally retain

--- a/scripts/ci/check_dead_refs.sh
+++ b/scripts/ci/check_dead_refs.sh
@@ -23,28 +23,13 @@ DEAD_REFS=(
   "localhost:8443"
   "127.0.0.1:8443"
   "python install.py"
-  # Added 2026-05-02 housekeeping audit (PR for findings F-007 through F-014)
-  # v10.0.0 deprecated MCP tool names — compat aliases still work but docs
-  # must use unified memory_* names. Migration docs are excluded below.
-  "store_memory("
-  "retrieve_memory("
-  "delete_memory("
-  "check_database_health("
-  "search_by_tag("
-  "search_by_tags("
-  "delete_by_tag("
-  "delete_by_tags("
-  "delete_by_all_tags("
-  "delete_by_timeframe("
-  "delete_before_date("
-  "cleanup_duplicates("
-  "update_memory_metadata("
-  "trigger_consolidation("
-  "consolidate_memories("
-  "rate_memory("
-  "get_memory_quality("
-  "analyze_quality_distribution("
-  "retrieve_with_quality_boost("
+  # NOTE (2026-05-02 housekeeping audit): v10.0.0 deprecated MCP tool names
+  # (store_memory, retrieve_memory, delete_memory, check_database_health,
+  # search_by_tag(s), rate_memory, trigger_consolidation, etc.) deliberately
+  # NOT added here yet — 25+ active docs still use them as primary examples.
+  # Adding to DEAD_REFS would require a much larger doc-cleanup wave than
+  # the housekeeping PR scope. Add term-by-term as docs are migrated to the
+  # unified memory_* surface. Tracked in follow-up issue.
 )
 
 # Soft dead reference: bare "chromadb". Checked separately because some active
@@ -64,10 +49,10 @@ EXCLUDE_PATHS=(
   "docs/DOCUMENTATION_AUDIT"
   "docs/IMPLEMENTATION_PLAN"
   "CHANGELOG"
-  # Added 2026-05-02: migration docs intentionally reference deprecated
-  # tool names as part of explaining the v10.0.0 rename
-  "docs/MIGRATION"
-  "docs/migration"
+  # Added 2026-05-02: superpowers/ holds spec/plan/audit artifacts that
+  # legitimately reference dead terms when documenting historical context
+  # (e.g. housekeeping audit reports listing what was removed).
+  "docs/superpowers"
 )
 
 # Allow-list for the SOFT_DEAD_REF only. Files below intentionally retain

--- a/scripts/ci/check_versions.sh
+++ b/scripts/ci/check_versions.sh
@@ -29,13 +29,26 @@ if [ -z "$CANONICAL" ]; then
   exit 1
 fi
 
-# Default scan targets; overridable for tests.
+# Default scan target: docs/index.html only (the project landing page).
+#
+# Rationale: the landing page is the one surface where ANY older-than-canonical
+# version reference is unambiguously wrong (it's the "current state" page).
+# README.md and CLAUDE.md intentionally cite historical versions:
+#   - README has a "Latest Releases" section enumerating all recent versions
+#   - CLAUDE.md uses "introduced in vX" / "vX+" annotations throughout
+# Distinguishing intentional historical refs from real drift in those files
+# requires semantic context this regex-based script doesn't have.
+#
+# To widen the scan (e.g. to catch only specific version-claim phrases in
+# README/CLAUDE.md), override via:
+#   MCS_VERSION_SCAN_TARGETS="docs/index.html README.md" bash check_versions.sh
 if [ -n "${MCS_VERSION_SCAN_TARGETS:-}" ]; then
   read -ra SCAN_TARGETS <<< "$MCS_VERSION_SCAN_TARGETS"
 else
-  SCAN_TARGETS=("docs/" "README.md" "CLAUDE.md")
+  SCAN_TARGETS=("docs/index.html")
 fi
 
+# Path-substring excludes applied even within scoped scan targets.
 EXCLUDE_PATHS=(
   "docs/archive"
   "docs/legacy"

--- a/scripts/ci/check_versions.sh
+++ b/scripts/ci/check_versions.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Version Drift Check
+#
+# Reads canonical version from src/mcp_memory_service/_version.py.
+# Greps SCAN_TARGETS for hardcoded vN.N.N refs.
+# Fails if any non-excluded match references a version older than canonical.
+#
+# Override SCAN_TARGETS for testing via MCS_VERSION_SCAN_TARGETS env var.
+#
+# Exit codes:
+#   0 - No drift found
+#   1 - Drift found
+
+set -uo pipefail
+
+# Locate canonical version. Use grep+sed (no Python import — script runs in CI
+# without venv).
+VERSION_FILE="${MCS_VERSION_FILE:-src/mcp_memory_service/_version.py}"
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "❌ Version file not found: $VERSION_FILE"
+  exit 1
+fi
+
+CANONICAL=$(grep -E '^__version__\s*=' "$VERSION_FILE" \
+  | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+if [ -z "$CANONICAL" ]; then
+  echo "❌ Could not parse __version__ from $VERSION_FILE"
+  exit 1
+fi
+
+# Default scan targets; overridable for tests.
+if [ -n "${MCS_VERSION_SCAN_TARGETS:-}" ]; then
+  read -ra SCAN_TARGETS <<< "$MCS_VERSION_SCAN_TARGETS"
+else
+  SCAN_TARGETS=("docs/" "README.md" "CLAUDE.md")
+fi
+
+EXCLUDE_PATHS=(
+  "docs/archive"
+  "docs/legacy"
+  "docs/plans"
+  "docs/migrations"
+  "CHANGELOG"
+)
+
+# Semver compare: returns 0 if $1 < $2, 1 otherwise.
+older_than() {
+  local a="$1" b="$2"
+  [ "$a" = "$b" ] && return 1
+  local lower
+  lower=$(printf '%s\n%s\n' "$a" "$b" | sort -V | head -1)
+  [ "$lower" = "$a" ]
+}
+
+FOUND=0
+declare -a DRIFT_LINES
+
+for target in "${SCAN_TARGETS[@]}"; do
+  [ -e "$target" ] || continue
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file=$(echo "$line" | cut -d: -f1)
+    skip=false
+    for excl in "${EXCLUDE_PATHS[@]}"; do
+      if [[ "$file" == *"$excl"* ]]; then
+        skip=true
+        break
+      fi
+    done
+    [ "$skip" = true ] && continue
+
+    # Extract version from line
+    version=$(echo "$line" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+    [ -z "$version" ] && continue
+
+    if older_than "$version" "$CANONICAL"; then
+      DRIFT_LINES+=("$line  →  expected v$CANONICAL (or excluded path)")
+      FOUND=1
+    fi
+  done < <(grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' "$target" --include='*.md' --include='*.html' 2>/dev/null || true)
+done
+
+if [ $FOUND -eq 0 ]; then
+  echo "✅ No version drift found (canonical: v$CANONICAL)"
+  exit 0
+fi
+
+echo "❌ Version drift detected (canonical: v$CANONICAL):"
+for line in "${DRIFT_LINES[@]}"; do
+  echo "   $line"
+done
+echo ""
+echo "Fix: update each occurrence to v$CANONICAL or move under an excluded path."
+exit 1

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1255,7 +1255,12 @@ class MemoryServer:
         async def handle_list_tools() -> List[types.Tool]:
             """Return list of available MCP tools.
 
-            Note: This list only includes modern unified tools (12 total).
+            Note: This list only includes modern unified tools (18 total:
+            memory_store, memory_store_session, memory_search, memory_list,
+            memory_delete, memory_cleanup, memory_health, memory_stats,
+            memory_update, memory_consolidate, memory_ingest, memory_harvest,
+            memory_quality, memory_graph, memory_conflicts, memory_resolve,
+            mistake_note_add, mistake_note_search).
             Deprecated tools continue working via the backwards
             compatibility layer in compat.py but are not advertised to clients.
             """

--- a/tests/ci/fixtures/version_drift_neg.md
+++ b/tests/ci/fixtures/version_drift_neg.md
@@ -1,0 +1,5 @@
+# Test Doc — Current Only
+
+This file in scan path mentions only the canonical version (v10.47.2).
+
+For historical changes, see CHANGELOG.md.

--- a/tests/ci/fixtures/version_drift_pos.md
+++ b/tests/ci/fixtures/version_drift_pos.md
@@ -1,0 +1,5 @@
+# Test Doc — Stale Version
+
+This doc references v9.0.0 which is way older than canonical.
+
+Install: `pip install mcp-memory-service==v9.0.0`

--- a/tests/ci/test_check_versions.sh
+++ b/tests/ci/test_check_versions.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Test harness for scripts/ci/check_versions.sh
+# Uses plain bash (bats not available; install via: brew install bats-core)
+# Each test is a function; run_test tracks pass/fail counts.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ci/check_versions.sh"
+FIXTURES="$(dirname "$0")/fixtures"
+TMPDIR_LOCAL="$(mktemp -d)"
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@" 2>&1; then
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  else
+    echo "not ok - $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test: exits 0 when no drift ---
+test_no_drift() {
+  local output status
+  output=$(env MCS_VERSION_SCAN_TARGETS="$FIXTURES/version_drift_neg.md" \
+    bash "$SCRIPT" 2>&1) && status=0 || status=$?
+  [ "$status" -eq 0 ]
+}
+
+# --- Test: exits 1 when drift found ---
+test_drift_found() {
+  local output status
+  output=$(env MCS_VERSION_SCAN_TARGETS="$FIXTURES/version_drift_pos.md" \
+    bash "$SCRIPT" 2>&1) && status=0 || status=$?
+  [ "$status" -eq 1 ] && echo "$output" | grep -q "v9.0.0"
+}
+
+# --- Test: skips CHANGELOG even with old refs ---
+test_skip_changelog() {
+  local tmpfile="$TMPDIR_LOCAL/CHANGELOG.md"
+  echo "This file references v1.0.0" > "$tmpfile"
+  local output status
+  output=$(env MCS_VERSION_SCAN_TARGETS="$tmpfile" \
+    bash "$SCRIPT" 2>&1) && status=0 || status=$?
+  [ "$status" -eq 0 ]
+}
+
+# Run tests
+run_test "exits 0 when no drift"            test_no_drift
+run_test "exits 1 when drift found"         test_drift_found
+run_test "skips CHANGELOG even with old refs" test_skip_changelog
+
+# Cleanup
+rm -rf "$TMPDIR_LOCAL"
+
+# Summary
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Discovery-first housekeeping audit + execution. Fixes documentation drift across `docs/`, `README.md`, `CLAUDE.md`, `docs/index.html`, and `src/mcp_memory_service/server_impl.py`. Adds new `check_versions.sh` CI guard for landing-page version drift. Wiki fixes shipped as direct commits (gollum, separate repo). Minor findings filed as 4 grouped GitHub issues for follow-up.

## Audit Report

Full findings, dispositions, and resolution mapping: [`docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md`](docs/superpowers/specs/2026-05-02-housekeeping-audit-report.md).

**36 findings classified across 6 drift categories** (version, feature, wiki↔repo, cross-doc, links, structural):
- 🔴 4 Critical (test count drift, deprecated MCP tool names in setup paths, `chroma` referenced in wiki, OAuth env vars don't exist in code)
- 🟡 18 Major (versions, deprecated tool names elsewhere, wiki↔repo contradictions, link rot incl MemPalace org rename, broken wiki Home navigation)
- 🟢 13 Minor (mostly grouped orphans/dup guides — deferred to follow-up issues)
- ⚪ 1 Noise (F-020 `MCP_MEMORY_HTTP_ENDPOINT` — verified false: var IS implemented in `examples/http-mcp-bridge.js`)

## Changes in this PR

### Documentation fixes (10 ship-now main-repo findings)

- `docs/index.html`: release URL v10.47.0 → v10.47.2; title v10.47 → v10.47.2 (F-001, F-002)
- `CLAUDE.md`: test count `968` → `~1,780` in 2 locations (F-003)
- `README.md`: `milla-jovovich/mempalace` → `MemPalace/mempalace` org rename (F-022)
- `docs/mastery/api-reference.md`: full MCP Tools table rewrite + examples + n_results→limit (F-007, F-009, F-012, F-013)
- `docs/mastery/architecture-overview.md`: tool surface description updated to v10 unified names (F-012; preserved actual `MemoryStorage` Python interface methods which are unchanged)
- `docs/guides/memory-consolidation-guide.md`: `trigger_consolidation` → `memory_consolidate(action="run")` (F-014)
- `src/mcp_memory_service/server_impl.py`: docstring tool count 12 → 18 (F-018)

### CI tooling

- ✅ **New**: `scripts/ci/check_versions.sh` + `tests/ci/test_check_versions.sh` (TDD, 3/3 pass)
  - Reads canonical version from `_version.py`, scans `docs/index.html` for older-than-canonical refs, fails CI if found
  - Default scope narrowed to landing page only (README + CLAUDE.md intentionally cite historical versions)
  - Override via `MCS_VERSION_SCAN_TARGETS` env var to widen scope
- ✅ **Extended**: `scripts/ci/check_dead_refs.sh` — added `docs/superpowers/` to EXCLUDE_PATHS (audit/spec artifacts legitimately reference removed features as historical context)
- ✅ **Wired**: new `version-drift-check` job in `.github/workflows/docs-check.yml`; widened path triggers to also fire on `_version.py` and `scripts/ci/check_*.sh` edits

### Wiki fixes (13 ship-now wiki findings, shipped as direct commits)

Pushed to `mcp-memory-service.wiki` `master` (gollum — no PR mechanism). 4 commits:

1. `9ccd9d8` — `fix(wiki): Home navigation rewrite — full page index visible from Home` (F-030 — highest leverage)
2. `2742b42` — `docs(wiki): align tool names + parameters to v10.0.0 unified surface` (F-008, F-010, F-011, F-013, F-014, F-018)
3. `7c376af` — `fix(wiki): correct stale config + storage backend defaults` (F-015, F-016, F-017, F-019, F-021)
4. `9f7ca65` — `fix(wiki): version bump + broken page links` (F-004, F-023, F-024, F-027)

### Deferred to follow-up issues (12 minor findings)

- #823 — Doc structural cleanup: orphans + duplicates (F-031, F-032, F-033, F-034, F-035, F-036)
- #824 — Wiki TOC anchor rot (F-028, F-029) [`good first issue`]
- #825 — Wiki broken page-link redirects (F-025, F-026)
- #826 — Cosmetic version-ref bumps (F-005, F-006) [`good first issue`]

## Verified before fix (subagent claims double-checked against code)

- F-015: `chroma` truly absent from `SUPPORTED_BACKENDS` in `src/mcp_memory_service/config.py:306` ✅
- F-016: 5 OAuth env vars (`MCP_OAUTH_CLIENT_STORAGE`, `MCP_OAUTH_REGISTRATION_RATE_LIMIT`, `MCP_OAUTH_AUDIT_LOG`, `MCP_OAUTH_CLEANUP_EXPIRED_TOKENS`, `MCP_OAUTH_TOKEN_CLEANUP_INTERVAL`) truly absent from entire codebase ✅
- F-018: 18 distinct `types.Tool()` registrations confirmed in `server_impl.py` ✅
- F-020: `MCP_MEMORY_HTTP_ENDPOINT` IS implemented (`examples/http-mcp-bridge.js:157`) — reclassified Noise/skip ✅

## Validation

- [x] `bash scripts/ci/check_dead_refs.sh` exits 0 locally
- [x] `bash scripts/ci/check_versions.sh` exits 0 locally
- [x] `bash tests/ci/test_check_versions.sh` — 3/3 pass
- [ ] Markdown link-check passes on PR CI (verify in checks)
- [ ] `version-drift-check` CI job passes (verify in checks)
- [x] Wiki: 4 direct commits pushed to `mcp-memory-service.wiki` master
- [ ] Landing page (`docs/index.html`) re-published to here.now (`merry-realm-j835`) — **MANUAL**: `~/.agents/skills/here-now/scripts/publish.sh` not present at the documented path; @doobidoo to republish manually after merge
- [x] Issues filed for each `defer-issue` finding; all 12 linked to issue numbers in audit report
- [x] Audit report committed with disposition decisions + issue links

## Test Plan

- [ ] CI green on docs-check.yml workflow (link-check, dead-ref-check, version-drift-check)
- [ ] Spot-check `docs/mastery/api-reference.md` rendering on GitHub
- [ ] Spot-check wiki Home.md navigation in browser (https://github.com/doobidoo/mcp-memory-service/wiki)
- [ ] Confirm `MemPalace/mempalace` link redirects work in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)