### PR TITLE
chore: release v10.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.48.0] - 2026-05-02
+
+### Added
+
+- **[#732] `include_superseded` retrieval filter — opt in to see the full contradiction chain**: All retrieval paths (`memory_search`, `retrieve`, `retrieve_with_quality_boost`, `retrieve_hybrid`) and all storage backends (sqlite_vec, cloudflare, hybrid, milvus, http_client) now accept an `include_superseded: bool = False` parameter. Default behavior is unchanged — superseded memories stay filtered out — but callers can pass `include_superseded=True` to retrieve the complete contradiction chain. Partial implementation of RFC #732. Thanks to @filhocf. (PR #814)
+- **[#732] Auto-mark `superseded_by` on high-confidence contradiction**: The consolidator now automatically marks the older memory with `superseded_by` pointing to the newer one whenever a `contradicts` relationship is detected with confidence ≥ 0.75. Executed in a single batched transaction via the new `mark_superseded_batch()` storage method (thread-safe via `_conn_lock` / `_execute_with_retry`). No DB migration needed — uses existing `superseded_by` column from migration 011. 5 new tests in `tests/storage/test_superseded_filter.py`. Thanks to @filhocf. (PR #814)
+
 ## [10.47.2] - 2026-05-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.47.2 - fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation (PR #821, closes #808) — ~1,780 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.48.0 - feat: include_superseded retrieval filter + auto-mark on contradiction (PR #814, @filhocf) — ~1,785 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -457,18 +457,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.47.2** (May 2, 2026)
+## Latest Release: **v10.48.0** (May 2, 2026)
 
-**fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation**
+**feat: include_superseded retrieval filter + auto-mark on contradiction**
 
-**What's Fixed:**
-- **Consolidation schedule defaults changed to `'disabled'`**: Previously, omitting `MCP_SCHEDULE_*` env vars activated daily (`02:00`), weekly (`SUN 03:00`), and monthly (`01 04:00`) consolidation automatically. Deployments that believed they were running in manual-only mode were silently accumulating scheduled runs. Defaults are now `'disabled'` — operators must explicitly set `MCP_SCHEDULE_DAILY`, `MCP_SCHEDULE_WEEKLY`, and `MCP_SCHEDULE_MONTHLY` to opt in to automatic consolidation. If you relied on the prior automatic behavior, add those three env vars to restore it. Closes #808. (PR #821)
-- **`.env.example` `CONSOLIDATION SCHEDULING` section**: New documented block makes the three schedule env vars discoverable with their expected cron/time syntax.
-- **Quarterly format docstring fix**: Corrected the docstring example for the monthly/quarterly schedule format (caught by gemini-code-assist, commit `0d4a658`).
+**What's New:**
+- **`include_superseded` parameter on all retrieval paths**: `memory_search`, `retrieve`, `retrieve_with_quality_boost`, and `retrieve_hybrid` across all backends (sqlite_vec, cloudflare, hybrid, milvus, http_client) now accept `include_superseded: bool = False`. Default behavior unchanged — pass `True` to retrieve the full contradiction chain. Partial implementation of RFC #732. (PR #814, @filhocf)
+- **Auto-mark `superseded_by` on high-confidence contradiction**: The consolidator automatically marks the older memory as `superseded_by` the newer one when a `contradicts` relationship is detected with confidence ≥ 0.75. Single batched transaction via new `mark_superseded_batch()` storage method. No DB migration needed. (PR #814, @filhocf)
 
 ---
 
 **Previous Releases**:
+- **v10.47.2** - fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation (PR #821, closes #808)
 - **v10.47.1** - fix(web): surface /server/update failures end-to-end (PR #807, closes #729)
 - **v10.47.0** - feat: memory_quality maintain orchestrator + Docker DeBERTa quantization (PRs #802, #803, @filhocf, closes #799, #793)
 - **v10.46.0** - feat: stale_days filter for memory_list — dormant memory detection (PR #796, @filhocf, closes #784)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.47.2</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.48.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.47.2">
-<meta property="og:description" content="One-call maintenance orchestrator: memory_quality(action='maintain') runs cleanup, conflict detection, stale detection, and quality snapshot in a single cycle. Pre-quantized DeBERTa in Docker cuts image size from ~1.7 GB to ~600 MB. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.48.0">
+<meta property="og:description" content="include_superseded filter on all retrieval paths + auto-mark on high-confidence contradiction. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.47 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.48 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.47</h2>
-    <p class="section-subtitle">One-call maintenance orchestrator + pre-quantized DeBERTa Docker images. ~1,780 tests.</p>
+    <h2 class="section-title">What's New in v10.48</h2>
+    <p class="section-subtitle">Contradiction chain retrieval + auto-supersession on high-confidence conflicts. ~1,785 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon search">&#9881;</div>
-        <h3>maintenance Orchestrator</h3>
-        <p>Call <code>memory_quality(action='maintain')</code> to run a full maintenance cycle — cleanup, conflict detection, stale detection, and quality snapshot — in one shot. <code>dry_run=true</code> by default: always safe to explore. (PR #802, @filhocf, closes #799)</p>
+        <h3>include_superseded Filter</h3>
+        <p>All retrieval paths (<code>memory_search</code>, <code>retrieve</code>, <code>retrieve_with_quality_boost</code>, <code>retrieve_hybrid</code>) and all backends now accept <code>include_superseded=True</code> to surface the full contradiction chain. Default behavior unchanged. (PR #814, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon consolidation">&#128202;</div>
-        <h3>Auto-Resolve Conflicts</h3>
-        <p>Opt-in via <code>MCP_MAINTAIN_AUTO_RESOLVE</code>. Pairs with similarity &ge; 0.95, same memory type, and age delta &gt; 7 days are resolved automatically — newer memory wins. Threshold and age are configurable.</p>
+        <h3>Auto-Mark Superseded</h3>
+        <p>The consolidator automatically marks the older memory as <code>superseded_by</code> the newer one when a <code>contradicts</code> relationship is detected with confidence &ge; 0.75. Single batched transaction, thread-safe. No DB migration needed. (PR #814, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon http">&#128230;</div>
-        <h3>Leaner Docker Images</h3>
-        <p>DeBERTa ONNX classifier is now quantized (fp16 / int8) at Docker build time. <code>:quality-cpu</code> image drops from ~1.7 GB to ~600 MB. Cold starts no longer re-run quantization. (PR #803, closes #793)</p>
+        <h3>Full Contradiction Chain</h3>
+        <p>Contradiction chains are now first-class: store, auto-link, and retrieve conflicting memories across all storage backends. Partial implementation of RFC #732 — write-side counterpart coming in a follow-up PR.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1780">0</div>
+        <div class="stat-number" data-target="1785">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.47.2" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.48.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.47.2"
+version = "10.48.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.47.2"
+__version__ = "10.48.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.47.2"
+version = "10.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to **v10.48.0** (MINOR — new public API parameter + new automatic behavior, both backward-compatible)
- Add CHANGELOG entry for PR #814 (`include_superseded` filter + auto-mark on contradiction)
- Update README Latest Release section; promote v10.47.2 to Previous Releases
- Update CLAUDE.md version callout + test count (~1,785)
- Update `docs/index.html`: version badge (`v10.48`), `<title>`, `<meta og:title>`, `<meta og:description>`, "What's New in v10.48" section, test count stat (`1785`), Release Notes link
- Run `uv lock` to sync lockfile

## What shipped (PR #814, @filhocf)

`include_superseded: bool = False` parameter on `memory_search` / `retrieve` / `retrieve_with_quality_boost` / `retrieve_hybrid` across all backends (sqlite_vec, cloudflare, hybrid, milvus, http_client). Default unchanged — superseded memories stay filtered. Clients pass `True` to retrieve the full contradiction chain.

Consolidator auto-marks the older memory as `superseded_by` the newer one when a `contradicts` relationship has confidence ≥ 0.75. Batched transaction via new `mark_superseded_batch()` storage method. No DB migration needed (uses existing `superseded_by` column from migration 011). 5 new tests in `tests/storage/test_superseded_filter.py`.

## Special Thanks

Huge thanks to @filhocf (Claudio Ferreira Filho) for this contribution — partial implementation of RFC #732 with clean cross-backend coverage and thread-safe batched writes.

## Test plan

- [ ] Verify CI passes on this branch
- [ ] Confirm `_version.py`, `pyproject.toml`, CHANGELOG, README, CLAUDE.md, `docs/index.html`, `uv.lock` all reflect v10.48.0
- [ ] After merge: tag `v10.48.0` on main, create GitHub release, re-publish `docs/index.html` to here.now

🤖 Generated with [Claude Code](https://claude.com/claude-code)