### PR TITLE
docs: cosmetic version-ref bumps (#826)

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,7 +10,7 @@ All results use zero LLM API calls (retrieval-only mode) unless noted.
 **Dataset:** [LongMemEval-S](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned) — 500 questions, ~45–62 sessions per question (distractor haystack)  
 **Mode:** Retrieval only (zero LLM API calls)  
 **Backend:** SQLite-Vec with all-MiniLM-L6-v2 ONNX embeddings  
-**Date:** 2026-04-08 · **Version:** v10.34.0
+**Date:** 2026-04-08 · **Version:** v10.34.0 (benchmark run version; latest release: v10.48.0)
 
 ### Overall Metrics
 


### PR DESCRIPTION
## Summary

Closes #826 — cosmetic version-ref drift from 2026-05-02 housekeeping audit.

- **F-006** (`docs/BENCHMARKS.md:13`) — Adds parenthetical clarifying that v10.34.0 is the historical benchmark-run version, current release is v10.47.2. Prevents new readers from interpreting v10.34.0 as "current."
- **F-005** (`wiki/13-Development-Roadmap.md:289`) — Already shipped as direct wiki commit [9fbc4db](https://github.com/doobidoo/mcp-memory-service.wiki/commit/9fbc4db) (gollum, no PR mechanism). Bumps "Version at Review" v10.47.0 → v10.47.2.

## Test plan

- [x] `bash scripts/ci/check_versions.sh` — passes (v10.34.0 ref is now contextually qualified, not asserted as current)
- [ ] Markdown link-check passes on PR CI
- [x] Wiki edit visible in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)