### PR TITLE
docs: add inbound links for legitimate orphan guides (#823 wave 2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,11 +20,17 @@ Welcome to the comprehensive documentation for MCP Memory Service - a Model Cont
 - **[Multi-Client Setup](integration/multi-client.md)** - Share memory across multiple applications
 - **[Homebrew Integration](integration/homebrew.md)** - Use system-installed PyTorch via Homebrew
 - **[IDE Compatibility](ide-compatability.md)** - VS Code, Continue, and other IDE integrations
+- **[Gemini Integration](integrations/gemini.md)** - Use MCP Memory Service with Google Gemini
+- **[Groq Bridge](integrations/groq-bridge.md)** · **[Groq Integration Summary](integrations/groq-integration-summary.md)** · **[Groq Model Comparison](integrations/groq-model-comparison.md)** - Groq LLM integration for quality scoring
 
 ### 🚀 Deployment
 
 - **[Docker Deployment](deployment/docker.md)** - Containerized deployment with various configurations
 - **[Cloud Deployment](glama-deployment.md)** - Cloud platform deployment guides
+- **[Production Guide](deployment/production-guide.md)** - Single-process production deployment
+- **[Dual-Service Deployment](deployment/dual-service.md)** - FastMCP + HTTP two-service architecture
+- **[External Embeddings](deployment/external-embeddings.md)** - Use vLLM, Ollama, TEI or OpenAI-compatible embedding APIs
+- **[systemd Service](deployment/systemd-service.md)** - Linux systemd service unit setup
 
 ### 📚 User Guides
 
@@ -32,6 +38,18 @@ Welcome to the comprehensive documentation for MCP Memory Service - a Model Cont
 - **[Storage Backends](guides/STORAGE_BACKENDS.md)** - SQLite-vec / Cloudflare / Hybrid comparison and configuration
 - **[Migration Guide](guides/migration.md)** - Migrate between storage backends and versions
 - **[Scripts Reference](guides/scripts.md)** - Available utility scripts
+
+### 🎯 Natural Memory Triggers
+
+- **[Installation Guide](natural-memory-triggers/installation-guide.md)** - Set up automatic memory triggers in Claude Code
+- **[CLI Reference](natural-memory-triggers/cli-reference.md)** - Trigger CLI command reference
+- **[Performance Optimization](natural-memory-triggers/performance-optimization.md)** - Tune trigger sensitivity and latency
+
+### 🏛️ Architecture & Design
+
+- **[Graph Database Design](architecture/graph-database-design.md)** - Memory graph schema and relationships
+- **[Search Enhancement Spec](architecture/search-enhancement-spec.md)** - Hybrid search architecture
+- **[Search Examples](architecture/search-examples.md)** - Worked examples of search modes
 
 ### 🎯 Tutorials & Examples
 


### PR DESCRIPTION
## Summary

Wave 2 of #823 cleanup. Adds 13 inbound links from \`docs/README.md\` to legitimate guides that the 2026-05-02 housekeeping audit flagged as F-031 orphans.

These guides were already substantive and current — they just had no incoming links from active docs.

Refs #823 (does not close — F-033/F-034/F-035/F-036 cluster work being split into focused follow-up issues).

## Sections updated in \`docs/README.md\`

### Integration & Connectivity (+4 entries)
- \`integrations/gemini.md\`
- \`integrations/groq-bridge.md\`, \`groq-integration-summary.md\`, \`groq-model-comparison.md\`

### Deployment (+4 entries)
- \`deployment/production-guide.md\`
- \`deployment/dual-service.md\`
- \`deployment/external-embeddings.md\`
- \`deployment/systemd-service.md\`

### Natural Memory Triggers (new section, +3 entries)
- \`natural-memory-triggers/installation-guide.md\`
- \`natural-memory-triggers/cli-reference.md\`
- \`natural-memory-triggers/performance-optimization.md\`

### Architecture & Design (new section, +3 entries)
- \`architecture/graph-database-design.md\`
- \`architecture/search-enhancement-spec.md\`
- \`architecture/search-examples.md\`

## Verification

- [x] \`bash scripts/ci/check_dead_refs.sh\` exits 0 locally
- [x] All linked files exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)