### PR TITLE
docs(deployment): rewrite production-guide as topology selector (#835)

### DIFF
--- a/docs/deployment/production-guide.md
+++ b/docs/deployment/production-guide.md
@@ -1,56 +1,36 @@
-# MCP Memory Service - Production Setup
+# Production Deployment Guide
 
-## 🚀 Quick Start
+Pick the deployment topology that fits your setup. All topologies use the same storage backends (`hybrid`, `cloudflare`, or `sqlite_vec`) and the same configuration via environment variables — they differ only in how the MCP and HTTP surfaces are exposed.
 
-This MCP Memory Service is configured with **consolidation system**, **mDNS auto-discovery**, **HTTPS**, and **automatic startup**.
+## Topology Selector
 
-### **Installation**
-```bash
-# 1. Install the service
-bash install_service.sh
+| Topology | When to use | Guide |
+|----------|-------------|-------|
+| **Docker** | Container-based deploys, CI, Kubernetes, fastest path to running | [docker.md](docker.md) |
+| **Dual-Service (FastMCP + HTTP)** | Linux box serving both MCP clients and the web dashboard, no Node.js SSL bridge needed | [dual-service.md](dual-service.md) |
+| **Single-Process systemd** | Linux box, one service, simplest operational footprint | [systemd-service.md](systemd-service.md) |
+| **External Embeddings** | Offload embedding generation to vLLM / Ollama / TEI / OpenAI-compatible endpoint | [external-embeddings.md](external-embeddings.md) |
 
-# 2. Update configuration (if needed)
-./update_service.sh
+## Common Production Checklist
 
-# 3. Start the service
-sudo systemctl start mcp-memory
-```
+These apply regardless of topology:
 
-### **Verification**
-```bash
-# Check service status
-sudo systemctl status mcp-memory
+- [ ] **Storage backend chosen and tested** — see [Storage Backends](../guides/STORAGE_BACKENDS.md). Hybrid is recommended for production (5 ms local reads + Cloudflare sync).
+- [ ] **WAL mode enabled for SQLite-Vec / Hybrid** — set `MCP_MEMORY_SQLITE_PRAGMAS=journal_mode=WAL,busy_timeout=15000,cache_size=20000`. Without this, concurrent HTTP + MCP access causes "database is locked" errors.
+- [ ] **API key set via environment** — never commit keys to docs or config. Example: `export MCP_API_KEY="$(openssl rand -hex 16 | sed 's/^/mcp-/')"` then put it in `.env` (gitignored) or your secrets manager.
+- [ ] **OAuth storage backend** for production — `MCP_OAUTH_STORAGE_BACKEND=sqlite` (not `memory`), so tokens survive restarts. See [oauth-storage-backends.md](../oauth-storage-backends.md).
+- [ ] **Health check wired up** — `curl -fsS https://your-host/api/health` from a monitoring system. Returns 200 + JSON when ready.
+- [ ] **Backups configured** — for SQLite-Vec and Hybrid, snapshot the SQLite file regularly. For Cloudflare-only, exports go via the dashboard.
+- [ ] **Hybrid sync owner pinned** (Hybrid only) — set `MCP_HYBRID_SYNC_OWNER=http` so only the HTTP server syncs to Cloudflare. The MCP server then runs SQLite-Vec only and needs no Cloudflare credentials.
 
-# Test API health
-curl -k https://localhost:8000/api/health
+## After Deploy
 
-# Verify mDNS discovery
-avahi-browse -t _mcp-memory._tcp
-```
+- Verify health: `curl -fsS https://<your-host>/api/health`
+- Verify mDNS (Linux, optional): `avahi-browse -t _mcp-memory._tcp`
+- Confirm storage backend and version: `curl -fsS https://<your-host>/api/health/detailed | jq '.backend,.version'`
 
-## 📋 **Service Details**
+## Related
 
-- **Service Name**: `memory._mcp-memory._tcp.local.`
-- **HTTPS Address**: https://localhost:8000 
-- **API Key**: `mcp-0b1ccbde2197a08dcb12d41af4044be6`
-- **Auto-Startup**: ✅ Enabled
-- **Consolidation**: ✅ Active
-- **mDNS Discovery**: ✅ Working
-
-## 🛠️ **Management**
-
-```bash
-./service_control.sh start     # Start service
-./service_control.sh stop      # Stop service  
-./service_control.sh status    # Show status
-./service_control.sh logs      # View logs
-./service_control.sh health    # Test API
-```
-
-## 📖 **Documentation**
-
-- **Complete Guide**: `COMPLETE_SETUP_GUIDE.md`
-- **Service Files**: `mcp-memory.service`, management scripts
-- **Archive**: `archive/setup-development/` (development files)
-
-**✅ Ready for production use!**
+- [Multi-Client Setup](../integration/multi-client.md) — share memory across Claude Desktop, VS Code, OpenCode, etc.
+- [Storage Backends](../guides/STORAGE_BACKENDS.md) — backend comparison + tuning
+- [General Troubleshooting](../troubleshooting/general.md)


### PR DESCRIPTION
## Summary

Closes #835 — F-036 reconciliation between `docs/deployment/dual-service.md` and `docs/deployment/production-guide.md`.

## Why

The two guides were **not actually duplicates** — they cover different topologies. But `production-guide.md` had three problems that made it worth rewriting rather than just cross-linking:

1. **🔒 Security**: a hardcoded API key was visible in plaintext (line 35 of old file, also present in `archive/docs-removed-2025-08-23/complete-setup-guide.md` and `archive/setup-development/test_service.sh` — those archived copies were already excluded from the active doc surface, but this one was missed)
2. **Dead references**: pointed to non-existent `COMPLETE_SETUP_GUIDE.md` and `archive/setup-development/` from active doc
3. **Stub-quality**: 56 lines, mostly placeholders and emoji headers, no real production guidance

## What changed

- **`docs/deployment/production-guide.md`** rewritten as a *topology selector* with:
  - Decision table routing readers to docker / dual-service / systemd-service / external-embeddings based on use case
  - Common production checklist applicable to all topologies (WAL pragma, API key generation, OAuth storage, health check, backups, hybrid sync owner)
  - Cross-links to multi-client setup, storage backends, troubleshooting

- **`docs/deployment/dual-service.md`** unchanged

## Diff stats

\`production-guide.md\`: -46 lines / +26 lines (net -20, much higher signal density)

## Verification

- [x] \`bash scripts/ci/check_dead_refs.sh\` exits 0 — no broken references
- [x] All linked files verified to exist (\`docs/guides/STORAGE_BACKENDS.md\`, \`docs/oauth-storage-backends.md\`, \`docs/troubleshooting/general.md\`, etc.)
- [ ] Maintainer review — open to alternate framing (decision tree vs flat list, etc.)

## Test plan

- [ ] CI link-check passes
- [ ] CI dead-ref-check passes
- [ ] Spot-check rendered markdown on GitHub

## Optional follow-up

Consider rotating the leaked API key if it's still active anywhere. The string \`mcp-0b1ccbde2197a08dcb12d41af4044be6\` is still visible in two archived files — those are inert documentation but could be scrubbed in a separate cleanup PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)