### PR TITLE
fix(quality): repair /evaluate self-relevance loop + gpt-5 payload (#797)

### DIFF
--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -353,9 +353,15 @@ class QualityEvaluator:
                 },
                 {"role": "user", "content": prompt},
             ],
-            "max_tokens": 50,
-            "temperature": 0.1,
         }
+        # OpenAI's gpt-5.x family rejects `max_tokens` and custom `temperature`
+        # (HTTP 400 "Unsupported parameter"). Reasoning variants also need extra
+        # headroom for internal reasoning tokens before emitting the score (#797).
+        if model.startswith("gpt-5"):
+            payload["max_completion_tokens"] = 800
+        else:
+            payload["max_tokens"] = 50
+            payload["temperature"] = 0.1
 
         client = self._get_httpx_client()
         try:

--- a/src/mcp_memory_service/web/api/quality.py
+++ b/src/mcp_memory_service/web/api/quality.py
@@ -202,9 +202,12 @@ async def evaluate_memory_quality(
         if not memory:
             raise HTTPException(status_code=404, detail=f"Memory not found: {content_hash}")
 
-        # Use the first 200 chars of content as query context if not provided
-        query = (request.query if request and request.query
-                 else memory.content[:200] if memory.content else "")
+        # When no query is supplied, fall through to the absolute-quality prompt
+        # branch in QualityScorer (handled via _create_scoring_prompt). Using the
+        # memory's own content as the query made the relevance prompt evaluate
+        # "rate how relevant X is to X" — which any LLM scores 1.0 (issue #797).
+        query = (request.query.strip() if request and request.query and request.query.strip()
+                 else "")
 
         # Initialize quality scorer and evaluate
         scorer = QualityScorer()

--- a/tests/test_openai_compat_quality.py
+++ b/tests/test_openai_compat_quality.py
@@ -215,6 +215,63 @@ class TestScoreWithOpenAICompatible:
 
         assert captured_headers.get("Authorization") == "Bearer none"
 
+    @pytest.mark.asyncio
+    async def test_gpt5_uses_max_completion_tokens_and_no_temperature(self):
+        """gpt-5.x family rejects max_tokens/temperature; payload must use max_completion_tokens (#797)."""
+        ev = self._make_evaluator(openai_compat_model="gpt-5.4-mini")
+        mock_resp = _mock_httpx_response("0.7")
+        captured_payloads = []
+
+        async def capture_post(url, json=None, **kwargs):
+            captured_payloads.append(json)
+            return mock_resp
+
+        self._install_mock_post(ev, side_effect=capture_post)
+        await ev._score_with_openai_compatible("python", _make_memory())
+
+        payload = captured_payloads[0]
+        assert "max_tokens" not in payload
+        assert "temperature" not in payload
+        assert payload["max_completion_tokens"] == 800
+
+    @pytest.mark.asyncio
+    async def test_non_gpt5_keeps_max_tokens_and_temperature(self):
+        """Non-gpt-5 models retain the original max_tokens=50 / temperature=0.1 payload (#797)."""
+        ev = self._make_evaluator(openai_compat_model="gpt-4.1-mini")
+        mock_resp = _mock_httpx_response("0.5")
+        captured_payloads = []
+
+        async def capture_post(url, json=None, **kwargs):
+            captured_payloads.append(json)
+            return mock_resp
+
+        self._install_mock_post(ev, side_effect=capture_post)
+        await ev._score_with_openai_compatible("python", _make_memory())
+
+        payload = captured_payloads[0]
+        assert payload["max_tokens"] == 50
+        assert payload["temperature"] == 0.1
+        assert "max_completion_tokens" not in payload
+
+    @pytest.mark.asyncio
+    async def test_gpt5_reasoning_variant_also_uses_max_completion_tokens(self):
+        """gpt-5-mini (reasoning variant) and gpt-5-nano both take the gpt-5 branch (#797)."""
+        for model_name in ("gpt-5-mini", "gpt-5-nano", "gpt-5"):
+            ev = self._make_evaluator(openai_compat_model=model_name)
+            mock_resp = _mock_httpx_response("0.6")
+            captured_payloads = []
+
+            async def capture_post(url, json=None, **kwargs):
+                captured_payloads.append(json)
+                return mock_resp
+
+            self._install_mock_post(ev, side_effect=capture_post)
+            await ev._score_with_openai_compatible("q", _make_memory())
+
+            payload = captured_payloads[0]
+            assert "max_completion_tokens" in payload, f"{model_name} should use max_completion_tokens"
+            assert "max_tokens" not in payload, f"{model_name} should not use max_tokens"
+
 
 # ---------------------------------------------------------------------------
 # Fallback integration — endpoint failure → implicit_signals

--- a/tests/web/api/test_quality_evaluate.py
+++ b/tests/web/api/test_quality_evaluate.py
@@ -1,0 +1,100 @@
+"""Tests for POST /api/quality/memories/{hash}/evaluate.
+
+Regression coverage for issue #797 — the endpoint must not pass the memory's
+own content as the relevance query when no body is supplied. Doing so collapsed
+the relevance prompt to "rate how relevant X is to X", causing every memory
+to score 1.0.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_memory_service.web.api.quality import router
+from mcp_memory_service.web.dependencies import get_storage
+from mcp_memory_service.web.oauth.middleware import require_write_access
+from mcp_memory_service.models.memory import Memory
+
+
+@pytest.fixture
+def mock_memory():
+    return Memory(
+        content="A long memory body that would have been used as a self-relevance query.",
+        content_hash="abc123",
+        tags=["test"],
+    )
+
+
+@pytest.fixture
+def mock_storage(mock_memory):
+    storage = MagicMock()
+    storage.get_by_hash = AsyncMock(return_value=mock_memory)
+    storage.update_memory_metadata = AsyncMock(return_value=(True, "ok"))
+    return storage
+
+
+@pytest.fixture
+def app(mock_storage):
+    app = FastAPI()
+    app.include_router(router, prefix="/api/quality")
+    app.dependency_overrides[get_storage] = lambda: mock_storage
+    app.dependency_overrides[require_write_access] = lambda: None
+    return app
+
+
+def _patch_scorer(captured_queries: list, score: float = 0.6):
+    """Patch QualityScorer.calculate_quality_score to capture the query argument."""
+
+    async def fake_calculate(memory, query):
+        captured_queries.append(query)
+        memory.metadata['quality_score'] = score
+        memory.metadata['quality_provider'] = 'openai_compatible'
+        memory.metadata['quality_components'] = {'implicit_score': 0.5}
+        memory.metadata['ai_scores'] = [{'score': score}]
+        return score
+
+    return patch(
+        'mcp_memory_service.web.api.quality.QualityScorer',
+        return_value=MagicMock(calculate_quality_score=AsyncMock(side_effect=fake_calculate)),
+    )
+
+
+def test_evaluate_with_no_body_uses_empty_query(app):
+    """No body → scorer must be called with empty query, NOT memory.content[:200] (#797)."""
+    captured = []
+    with _patch_scorer(captured):
+        client = TestClient(app)
+        response = client.post("/api/quality/memories/abc123/evaluate")
+
+    assert response.status_code == 200, response.text
+    assert captured == [""], f"Expected empty query, got {captured!r}"
+
+
+def test_evaluate_with_explicit_query_passes_through(app):
+    """Body with non-empty query → that query reaches the scorer unchanged."""
+    captured = []
+    with _patch_scorer(captured):
+        client = TestClient(app)
+        response = client.post(
+            "/api/quality/memories/abc123/evaluate",
+            json={"query": "python decorators"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured == ["python decorators"]
+
+
+def test_evaluate_with_whitespace_query_treated_as_empty(app):
+    """Body with whitespace-only query → empty query (force absolute-quality prompt)."""
+    captured = []
+    with _patch_scorer(captured):
+        client = TestClient(app)
+        response = client.post(
+            "/api/quality/memories/abc123/evaluate",
+            json={"query": "   "},
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured == [""]


### PR DESCRIPTION
## Summary

Closes #797 — two bugs in the quality evaluation path that, together, made the \`openai-compatible\` AI tier appear fully broken on v10.45.0+ deployments.

## Bug 1 — self-relevance loop returns 1.0 for everything

\`web/api/quality.py:206\` defaulted the relevance query to the memory's own first 200 chars when no request body was supplied. The relevance prompt then asked the model to *"rate how relevant X is to X"* — a tautology any LLM scores at the ceiling.

\`QualityScorer._create_scoring_prompt\` already handles the empty-query case correctly: it emits an *absolute-quality* prompt that yields a calibrated 0.0–1.0 score with proper discrimination across content quality. Fix: pass an empty query through when none is supplied so the absolute-quality branch fires.

**Reproducer** (per #797 opener): three memories of very different quality all returned \`ai_score=1.0\` from \`openai-compatible\`. Same memories with explicit \`query=" "\` in body → 0.4 / 0.6 / 0.8 — real spread.

## Bug 2 — gpt-5.x family rejects max_tokens / temperature

\`quality/ai_evaluator.py:347-358\` hardcoded \`max_tokens=50\` and \`temperature=0.1\` in the openai-compatible payload. OpenAI's \`gpt-5.x\` family — including non-reasoning variants — rejects both with HTTP 400:

> Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.

Result: every \`gpt-5.*\` model returned HTTP 400, the AI tier silently fell through to \`implicit_signals\`, and the provider _appeared_ to work because the score was non-1.0 — but it was the implicit algorithm doing the work, not the AI tier.

Fix: branch on \`model.startswith("gpt-5")\` to use \`max_completion_tokens=800\` (sized for reasoning variants which spend ~200–400 tokens reasoning internally before emitting the score) and skip \`temperature\` entirely. Non-gpt-5 models keep the original payload to preserve cost and determinism for established providers.

## Tests

| File | Tests added | Covers |
|---|---|---|
| \`tests/web/api/test_quality_evaluate.py\` (new) | 3 | empty body → empty query; explicit query passes through; whitespace → empty |
| \`tests/test_openai_compat_quality.py\` (extended) | 3 | gpt-5.4-mini payload shape; gpt-4.1-mini regression guard; gpt-5 / gpt-5-mini / gpt-5-nano all take gpt-5 branch |

\`\`\`
71 passed, 12 skipped (network-only), 0 failed
\`\`\`

## Credit

- **Bug 1** reported and root-caused with reproducer + fix proposal by the #797 opener
- **Bug 2** reported and root-caused with patch proposal by @thewusman2025 in #797 comment (including verification on real gpt-5.4-mini)

## Test plan

- [x] \`pytest tests/test_openai_compat_quality.py tests/web/api/test_quality_evaluate.py\` passes locally
- [x] Full quality suite (\`tests/test_quality_*.py\` + new files) green: 71 passed, no regressions
- [ ] CI link-check / dead-ref / lint pass on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)