### PR TITLE
fix(security): silence CodeQL false positives (alerts #389, #390, #398, #404)

### DIFF
--- a/src/mcp_memory_service/__init__.py
+++ b/src/mcp_memory_service/__init__.py
@@ -31,8 +31,16 @@ except ImportError:
 # can otherwise resolve this as a plain module and break subpackage imports.
 # Heavy imports (torch/transformers via storage backends) stay deferred via
 # `__getattr__` below.
+from typing import TYPE_CHECKING
+
 from .models import Memory, MemoryQueryResult
 from .utils import generate_content_hash
+
+if TYPE_CHECKING:
+    # Static-analysis-only imports so CodeQL/IDEs see the names listed in
+    # `__all__`. At runtime these are resolved lazily via `__getattr__` to
+    # keep CLI startup fast (avoids loading torch/transformers).
+    from .storage import MemoryStorage, SqliteVecMemoryStorage  # noqa: F401
 
 
 def __getattr__(name):

--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -181,6 +181,9 @@ def _find_process_on_port(port: int) -> int | None:
                     if parts:
                         return int(parts[-1])
         except Exception:
+            # netstat unavailable, timed out, or returned unparseable output —
+            # treat as "no process found" so the caller can fall back to the
+            # PID-file path. Logging would be noise during normal `memory info`.
             pass
     else:
         try:
@@ -191,6 +194,9 @@ def _find_process_on_port(port: int) -> int | None:
             if result.stdout.strip():
                 return int(result.stdout.strip().splitlines()[0])
         except Exception:
+            # lsof not installed, timed out, or returned no listener — treat
+            # as "no process found" so the caller can fall back to the
+            # PID-file path. Logging would be noise during normal `memory info`.
             pass
     return None
 

--- a/src/mcp_memory_service/web/api/server.py
+++ b/src/mcp_memory_service/web/api/server.py
@@ -369,13 +369,17 @@ async def update_server(
 
     # Sanitize user-controlled fields inline so CodeQL py/log-injection
     # tracks the .replace() barriers in the same function as the log call.
+    # `request.force` is typed `bool` by Pydantic, but CodeQL still treats
+    # the request body as tainted — coerce explicitly so the barrier is
+    # visible to static analysis.
     safe_client_id = str(user.client_id).replace("\r", "").replace("\n", "")
     safe_auth_method = str(user.auth_method).replace("\r", "").replace("\n", "")
+    safe_force = bool(request.force)
     logger.warning(
         "AUDIT: Server update requested by user: %s (auth: %s, force: %s)",
         safe_client_id,
         safe_auth_method,
-        request.force,
+        safe_force,
     )
 
     # Step 0: Refuse to pull on a dirty working tree unless force=True.


### PR DESCRIPTION
## Summary

Address all four open CodeQL alerts on `main`. Each is a false positive in the current code path; this PR adds the static-analysis barriers or comments needed to make CodeQL's reasoning explicit. **No behavior change.**

| Alert | Severity | File | Fix |
|---|---|---|---|
| [#398](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/398) `py/log-injection` | medium (security) | `web/api/server.py:378` | Wrap `request.force` in `bool(...)` so CodeQL sees an explicit sanitization barrier in the same function as the audit log call. The two string fields were already scrubbed of CR/LF; this just extends the same treatment to the bool field. |
| [#404](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/404) `py/undefined-export` | error (correctness) | `__init__.py:59` | Add a `TYPE_CHECKING` import block so CodeQL/IDEs see `MemoryStorage` and `SqliteVecMemoryStorage` without loading torch/transformers at import time. Runtime resolution still goes through the lazy `__getattr__` introduced in v10.49.0. |
| [#389](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/389), [#390](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/390) `py/empty-except` | note (quality) | `cli/lifecycle.py:183, 193` | Add explanatory comments to the two empty `except Exception: pass` blocks in `_find_process_on_port`. They are intentional silent fallbacks when `lsof` / `netstat` is missing or times out — so the caller falls back to the PID-file path. |

## Why all false positives?

- **#398**: `request.force: bool` is validated by Pydantic at the model boundary; CodeQL's taint engine treats the whole request body as tainted regardless of type. The explicit `bool(...)` cast is a recognised barrier and matches the existing pattern for the string fields.
- **#404**: `MemoryStorage` is listed in `__all__` because consumers do `from mcp_memory_service import MemoryStorage`. That code path resolves through `__getattr__` (PEP 562) — but `import *` does not, and CodeQL's analyser cannot see through `__getattr__`. The `TYPE_CHECKING` import gives it the names without breaking the lazy-load behaviour we shipped in v10.49.0 (PR #841).
- **#389/#390**: The CLI uses `lsof`/`netstat` opportunistically. On a developer machine without `lsof`, or when `netstat` returns garbage, we want a silent fallback to the PID-file path — adding logging here would be noise during every `memory info` call.

## Test plan

- [x] `python -m pytest tests/unit -x -q` — 359 passed, 6 skipped, 1 xfailed
- [x] `python -m pytest tests/unit/test_cli_lifecycle.py tests/unit/test_cli_lazy.py -x -q` — 17/17 passed
- [x] `python -c "import mcp_memory_service; from mcp_memory_service import MemoryStorage, SqliteVecMemoryStorage"` — both names resolve via lazy load
- [ ] CodeQL run on this PR closes all four alerts (verified post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)