### PR TITLE
fix(ontology): register custom base types with empty subtype lists (#842)

### DIFF
--- a/src/mcp_memory_service/models/ontology.py
+++ b/src/mcp_memory_service/models/ontology.py
@@ -244,9 +244,18 @@ def _load_custom_types_from_config() -> Dict[str, List[str]]:
                 if isinstance(st, str) and st.replace('_', '').isalnum()
             ]
 
-            if valid_subtypes:
-                validated_types[base_type.lower()] = valid_subtypes
-                logger.info(f"Loaded custom memory type '{base_type}' with {len(valid_subtypes)} subtypes")
+            # Register the base type even when no (valid) subtypes were provided
+            # so that callers can use `{"foo": []}` to add a bare custom type.
+            # Issue #842: empty subtype lists were silently dropped.
+            if subtypes and not valid_subtypes:
+                logger.warning(
+                    f"All subtypes for custom memory type '{base_type}' were invalid; "
+                    f"registering base type with no subtypes"
+                )
+            validated_types[base_type.lower()] = valid_subtypes
+            logger.info(
+                f"Loaded custom memory type '{base_type}' with {len(valid_subtypes)} subtypes"
+            )
 
         return validated_types
 

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -500,6 +500,37 @@ class TestBurst21CustomMemoryTypeConfiguration:
         all_types = ontology.get_all_types()
         assert "observation" in all_types  # Built-in type still works
 
+    def test_custom_base_type_with_empty_subtypes(self, monkeypatch):
+        """Issue #842: `{"foo": []}` must register `foo` as a base type.
+
+        The MCP coercion warning explicitly tells users to register custom
+        types with `'{"<type>": []}'`. Empty subtype lists were silently
+        dropped, so the bare custom type never reached the validator and
+        kept getting coerced to 'observation'.
+        """
+        import json
+
+        monkeypatch.setenv('MCP_CUSTOM_MEMORY_TYPES', json.dumps({"foo": []}))
+        ontology.clear_ontology_caches()
+
+        all_types = ontology.get_all_types()
+        assert "foo" in all_types
+        assert ontology.validate_memory_type("foo") is True
+        # Bare custom base types map to themselves
+        assert ontology.get_parent_type("foo") == "foo"
+
+    def test_custom_type_with_only_invalid_subtypes_still_registers_base(self, monkeypatch):
+        """If every subtype is filtered out, the base type must still register."""
+        import json
+
+        # `@@bad` fails the `replace('_','').isalnum()` check
+        monkeypatch.setenv('MCP_CUSTOM_MEMORY_TYPES', json.dumps({"foo": ["@@bad"]}))
+        ontology.clear_ontology_caches()
+
+        all_types = ontology.get_all_types()
+        assert "foo" in all_types
+        assert "@@bad" not in all_types
+
     def test_no_custom_types_default_behavior(self, monkeypatch):
         """Test default behavior when no custom types configured."""
         import os


### PR DESCRIPTION
## Summary
- Fixes the root cause of issue #842: `MCP_CUSTOM_MEMORY_TYPES='{\"foo\": []}'` had no effect, and `foo` was still coerced to `observation`.
- `_load_custom_types_from_config` was filtering subtypes into `valid_subtypes`, then doing `if valid_subtypes:` before registering the base type. An empty subtype list is falsy, so the base type was silently dropped.
- The MCP coercion warning ([handlers/memory.py:237](https://github.com/doobidoo/mcp-memory-service/blob/main/src/mcp_memory_service/server/handlers/memory.py#L237)) and the `store_memory` tool description ([server_impl.py:1343](https://github.com/doobidoo/mcp-memory-service/blob/main/src/mcp_memory_service/server_impl.py#L1343)) both explicitly tell users to use `'{\"<type>\": []}'`, so the documented usage was broken.

## Relationship to PR #844
PR #844 surfaced the coercion warning in the response so the user could see what was happening. It did not fix the underlying registration path — the user still cannot register a custom type. This PR fixes the registration path.

## Fix
- Register the base type unconditionally, even when no valid subtypes are provided.
- Emit a warning when subtypes were supplied but all were filtered out (e.g. `{\"foo\": [\"@@bad\"]}`), so silent loss is still observable.

## Tests
Added two regression tests in `tests/test_ontology.py`:
- `test_custom_base_type_with_empty_subtypes` — exact reproducer from #842.
- `test_custom_type_with_only_invalid_subtypes_still_registers_base` — guards the all-invalid branch.

All 65 ontology + memory model + handler tests pass:
```
tests/test_ontology.py ................................................. [ 75%]
tests/test_memory_ontology_integration.py ...........                    [ 92%]
tests/server/test_store_memory_handler.py .....                          [100%]
======================== 65 passed, 1 warning in 4.38s =========================
```

## Test plan
- [x] Reproducer test passes (`{\"foo\": []}` registers `foo`)
- [x] Existing `test_load_custom_types_json` still passes
- [x] Existing `test_merge_with_builtin_types` still passes
- [x] Existing `test_invalid_json_graceful_fallback` still passes
- [x] Existing `test_no_custom_types_default_behavior` still passes
- [x] `test_store_memory_handler` warning surfacing still works

Closes #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)