### PR TITLE
chore: release v10.49.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.49.2] - 2026-05-05
+
+### Fixed
+
+- **[#842] Custom base types with empty subtype lists were silently dropped**: `_load_custom_types_from_config` in [`models/ontology.py`](src/mcp_memory_service/models/ontology.py) guarded registration with `if valid_subtypes:`, so a type declared as `MCP_CUSTOM_MEMORY_TYPES='{"foo": []}'` — the exact form documented in the v10.49.1 coercion warning and in the `memory_store` tool description — was never added to the ontology. The validator never saw `foo`, so `Memory.__post_init__` kept coercing it to `"observation"` even after the user had correctly configured the env var. Fix: register the base type unconditionally; emit a warning only when subtypes were supplied but all failed validation. Two regression tests added. Closes #842. (PR #846)
+
 ## [10.49.1] - 2026-05-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.49.1 - fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844) — ~1,803 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.49.2 - fix(ontology): register custom base types with empty subtype lists (PR #846) — ~1,803 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,18 +490,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.49.1** (May 5, 2026)
+## Latest Release: **v10.49.2** (May 5, 2026)
 
-**fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844)**
+**fix(ontology): register custom base types with empty subtype lists (PR #846)**
 
 **What's New:**
-- **Ontology coercion UX**: `memory_store` (MCP) and `POST /memories` (HTTP) now surface a visible warning when an unknown `memory_type` is silently coerced to `"observation"`. Callers can register custom types via `MCP_CUSTOM_MEMORY_TYPES`. Closes #843.
-- **New docs**: [`docs/memory-ontology.md`](docs/memory-ontology.md) documents the built-in taxonomy (12 base types, ~60 subtypes), coercion behaviour, and `MCP_CUSTOM_MEMORY_TYPES` JSON format.
-- **uvx CI flake fixed**: Removed `importlib.reload` in test files that poisoned FastAPI route deps, causing intermittent `test_harvest_requires_auth` failures in the `Test uvx compatibility` run.
+- **Custom type registration fixed**: `MCP_CUSTOM_MEMORY_TYPES='{"foo": []}'` now correctly registers `foo` as a valid type. Previously, the `if valid_subtypes:` guard in `_load_custom_types_from_config` silently dropped any custom type whose subtype list was empty — meaning the coercion warning added in v10.49.1 would fire forever, even after the user configured the env var correctly. Closes #842.
 
 ---
 
 **Previous Releases**:
+- **v10.49.1** - fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844)
 - **v10.49.0** - feat(cli): lazy lifecycle commands and faster startup (PR #841, @creativelaides)
 - **v10.48.0** - feat: include_superseded retrieval filter + auto-mark on contradiction (PR #814, @filhocf)
 - **v10.47.2** - fix(consolidation): disable-by-default schedule prevents unintended automatic consolidation (PR #821, closes #808)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.49.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.49.2</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.49.0">
+<meta property="og:title" content="MCP Memory Service v10.49.2">
 <meta property="og:description" content="CLI lifecycle commands (launch/stop/restart/info/health/logs) + lazy imports for &lt;3s startup. Security fixes: command injection, FD leak, anonymous-access pass-through. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.49.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.49.2" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.49.1"
+version = "10.49.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.49.1"
+__version__ = "10.49.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.49.1"
+version = "10.49.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Patch release v10.49.2 — fixes the root cause of #842 that was left open after v10.49.1.

- Closes #842: `_load_custom_types_from_config` in `models/ontology.py` had `if valid_subtypes:` which silently dropped any custom base type with an empty subtype list. `MCP_CUSTOM_MEMORY_TYPES='{"foo": []}'` — the exact form shown in the v10.49.1 coercion warning — never registered `foo`, so `Memory.__post_init__` kept coercing it to `"observation"` regardless. Fix: register base type unconditionally; warn only when subtypes were supplied but all were invalid. (PR #846, squash merge dfd82c6)
- v10.49.1 (PR #844) surfaced the coercion warning to callers; this patch actually fixes the registration path so the warning stops firing.

## Files changed
- `src/mcp_memory_service/_version.py` → `10.49.2`
- `pyproject.toml` → `10.49.2`
- `CHANGELOG.md` — v10.49.2 entry added
- `README.md` — Latest Release updated, v10.49.1 moved to Previous Releases
- `CLAUDE.md` — version callout updated
- `uv.lock` — regenerated

## Test plan
- [ ] CI green on this branch
- [ ] No landing page update needed (PATCH release)
- [ ] Merge with `--admin`, tag `v10.49.2` on main, create GitHub release