### PR TITLE
fix(opencode): client-side tag filter for project scoping

### DIFF
--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -261,13 +261,14 @@ function formatMemories(projectName, memories, config, options = {}) {
 }
 
 async function searchMemories(config, query, tags, limit) {
+  // /api/search is semantic-only and ignores tag filters server-side
+  // (see SemanticSearchRequest in src/mcp_memory_service/web/api/search.py).
+  // When the caller passes tags, over-fetch and filter client-side so
+  // project-scoped searches actually stay scoped.
+  const hasTagFilter = tags.length > 0
   const payload = {
     query,
-    n_results: limit,
-  }
-
-  if (tags.length) {
-    payload.tags = tags
+    n_results: hasTagFilter ? Math.max(limit * 4, 20) : limit,
   }
 
   const result = await requestJson(config, "/api/search", {
@@ -286,7 +287,17 @@ async function searchMemories(config, query, tags, limit) {
         ? result.results
         : []
 
-  return memories.map(normalizeMemory).filter(Boolean)
+  let normalized = memories.map(normalizeMemory).filter(Boolean)
+
+  if (hasTagFilter) {
+    const wanted = new Set(tags)
+    normalized = normalized.filter((memory) =>
+      memory.tags.some((tag) => wanted.has(tag)),
+    )
+    normalized = normalized.slice(0, limit)
+  }
+
+  return normalized
 }
 
 async function getHealth(config) {


### PR DESCRIPTION
## Summary

Follow-up to #847 / #850. The path + field fix (`/api/memories/search` → `/api/search`, `limit` → `n_results`) already landed via #850. This PR adds the second half: client-side tag filtering.

`/api/search` (`SemanticSearchRequest`) ignores the `tags` field server-side, so the project tag the OpenCode plugin appends was a no-op — searches were returning memories from any project. Gemini flagged this in [the original review](https://github.com/doobidoo/mcp-memory-service/pull/849#pullrequestreview-PRR_kwDONic2f8778t8Q).

When tags are present, `searchMemories()` now over-fetches (`max(limit * 4, 20)`) and filters to memories whose tags intersect the requested set, then trims back to the caller's limit. No server-side changes needed.

## Test plan
- [ ] OpenCode session in project A retrieves only memories tagged `A` (not memories from project B), with semantic relevance preserved
- [ ] No tags configured → behaves as before (raw semantic top-N)
- [ ] No HTTP 405 in `memory server --http` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)