### PR TITLE
chore: release v10.49.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.49.3] - 2026-05-05
+
+### Fixed
+
+- **[#847] OpenCode plugin API path and payload corrected**: The plugin was calling `/api/memories/search` (HTTP 405) instead of `/api/search`, and sending `limit` instead of `n_results` in the request body (per `SemanticSearchRequest` schema). Both issues caused all OpenCode memory searches to fail silently. Fix applied in PR #850. Closes #847.
+- **[#847] OpenCode plugin tag filter now enforced client-side**: `/api/search` ignores the `tags` field server-side, so project-scoped searches were returning unfiltered results. The plugin now over-fetches (`max(limit * 4, 20)`) when tags are present and filters client-side by tag intersection before trimming to the requested limit. Fix applied in PR #849 (Gemini review follow-up).
+- **CI version-drift detection**: `scripts/ci/check_versions.sh` updated to skip landing-page version checks for PATCH releases, matching the documented release protocol that landing-page updates are MINOR/MAJOR only. (PR #850)
+
 ## [10.49.2] - 2026-05-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.49.2 - fix(ontology): register custom base types with empty subtype lists (PR #846) — ~1,803 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.49.3 - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850) — ~1,803 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,16 +490,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.49.2** (May 5, 2026)
+## Latest Release: **v10.49.3** (May 5, 2026)
 
-**fix(ontology): register custom base types with empty subtype lists (PR #846)**
+**fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)**
 
 **What's New:**
-- **Custom type registration fixed**: `MCP_CUSTOM_MEMORY_TYPES='{"foo": []}'` now correctly registers `foo` as a valid type. Previously, the `if valid_subtypes:` guard in `_load_custom_types_from_config` silently dropped any custom type whose subtype list was empty — meaning the coercion warning added in v10.49.1 would fire forever, even after the user configured the env var correctly. Closes #842.
+- **OpenCode plugin works again**: Fixed wrong API path (`/api/memories/search` -> `/api/search`) and wrong payload field (`limit` -> `n_results`) that caused HTTP 405 errors on all OpenCode memory searches. Closes #847.
+- **Project-scoped searches correctly scoped**: `/api/search` ignores `tags` server-side; plugin now over-fetches and filters client-side by tag intersection so project memory stays isolated.
 
 ---
 
 **Previous Releases**:
+- **v10.49.2** - fix(ontology): register custom base types with empty subtype lists (PR #846)
 - **v10.49.1** - fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844)
 - **v10.49.0** - feat(cli): lazy lifecycle commands and faster startup (PR #841, @creativelaides)
 - **v10.48.0** - feat: include_superseded retrieval filter + auto-mark on contradiction (PR #814, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.49.2"
+version = "10.49.3"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.49.2"
+__version__ = "10.49.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.49.2"
+version = "10.49.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Fix OpenCode plugin API path (`/api/memories/search` -> `/api/search`) and payload field (`limit` -> `n_results`) that caused HTTP 405 on all memory searches (PR #850, closes #847)
- Add client-side tag filter in OpenCode plugin: over-fetch `max(limit * 4, 20)` when tags present, filter by intersection, trim to limit — project-scoped searches now actually scoped (PR #849)
- CI version-drift check skips landing-page assertion for PATCH releases (PR #850)

## Files changed

- `pyproject.toml` — version 10.49.2 -> 10.49.3
- `src/mcp_memory_service/_version.py` — version 10.49.2 -> 10.49.3
- `CHANGELOG.md` — v10.49.3 entry added
- `README.md` — Latest Release updated
- `CLAUDE.md` — version callout updated
- `uv.lock` — regenerated

## Test plan

- [ ] CI passes on this branch
- [ ] Version consistent across `pyproject.toml` and `_version.py`
- [ ] CHANGELOG has no duplicate version entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)