### PR TITLE
feat(consolidation): protect high-value mistake notes from decay

### DIFF
--- a/src/mcp_memory_service/consolidation/base.py
+++ b/src/mcp_memory_service/consolidation/base.py
@@ -174,10 +174,14 @@ class ConsolidationBase(ABC):
         # Protect high-value mistake notes (recurring patterns)
         if memory.memory_type == 'mistake':
             metadata = memory.metadata or {}
-            if isinstance(metadata, str):
+            if isinstance(metadata, str) and metadata.strip():
                 import json
-                metadata = json.loads(metadata) if metadata else {}
-            if metadata.get('failure_count', 0) >= 3:
+                try:
+                    metadata = json.loads(metadata)
+                except (json.JSONDecodeError, TypeError):
+                    metadata = {}
+
+            if isinstance(metadata, dict) and metadata.get('failure_count', 0) >= 3:
                 return True
 
         return False

--- a/src/mcp_memory_service/consolidation/base.py
+++ b/src/mcp_memory_service/consolidation/base.py
@@ -161,9 +161,26 @@ class ConsolidationBase(ABC):
         return memory.memory_type or 'standard'
     
     def _is_protected_memory(self, memory: Memory) -> bool:
-        """Check if a memory is protected from consolidation operations."""
+        """Check if a memory is protected from consolidation operations.
+
+        Protected memories include:
+        - Memories with critical/important/reference/permanent tags
+        - Mistake notes with failure_count >= 3 (proven error patterns)
+        """
         protected_tags = {'critical', 'important', 'reference', 'permanent'}
-        return bool(set(memory.tags).intersection(protected_tags))
+        if set(memory.tags).intersection(protected_tags):
+            return True
+
+        # Protect high-value mistake notes (recurring patterns)
+        if memory.memory_type == 'mistake':
+            metadata = memory.metadata or {}
+            if isinstance(metadata, str):
+                import json
+                metadata = json.loads(metadata) if metadata else {}
+            if metadata.get('failure_count', 0) >= 3:
+                return True
+
+        return False
 
 class ConsolidationError(Exception):
     """Base exception for consolidation operations."""

--- a/tests/consolidation/test_mistake_lifecycle.py
+++ b/tests/consolidation/test_mistake_lifecycle.py
@@ -70,3 +70,13 @@ class TestMistakeNoteProtection:
     def test_mistake_note_json_string_low_count(self, consolidation_base):
         mem = _make_memory(memory_type="mistake", metadata='{"failure_count": 2}')
         assert consolidation_base._is_protected_memory(mem) is False
+
+    def test_mistake_note_invalid_json_metadata(self, consolidation_base):
+        """Invalid JSON metadata should not crash — just not protect."""
+        mem = _make_memory(memory_type="mistake", metadata="{invalid json")
+        assert consolidation_base._is_protected_memory(mem) is False
+
+    def test_mistake_note_list_metadata(self, consolidation_base):
+        """Non-dict JSON (e.g. list) should not crash."""
+        mem = _make_memory(memory_type="mistake", metadata='[1, 2, 3]')
+        assert consolidation_base._is_protected_memory(mem) is False

--- a/tests/consolidation/test_mistake_lifecycle.py
+++ b/tests/consolidation/test_mistake_lifecycle.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Claudio Ferreira Filho
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for mistake notes lifecycle integration in consolidation."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from mcp_memory_service.consolidation.decay import ExponentialDecayCalculator
+from mcp_memory_service.consolidation.base import ConsolidationConfig
+from mcp_memory_service.models.memory import Memory
+
+
+@pytest.fixture
+def consolidation_base():
+    """Create a concrete ConsolidationBase subclass for testing."""
+    config = ConsolidationConfig()
+    return ExponentialDecayCalculator(config)
+
+
+def _make_memory(memory_type="note", tags=None, metadata=None):
+    """Helper to create a Memory object for testing."""
+    mem = MagicMock(spec=Memory)
+    mem.memory_type = memory_type
+    mem.tags = tags or []
+    mem.metadata = metadata
+    return mem
+
+
+class TestMistakeNoteProtection:
+    """Test that high-value mistake notes are protected from decay/forgetting."""
+
+    def test_regular_memory_not_protected(self, consolidation_base):
+        mem = _make_memory(memory_type="note", tags=["general"])
+        assert consolidation_base._is_protected_memory(mem) is False
+
+    def test_critical_tag_protected(self, consolidation_base):
+        mem = _make_memory(tags=["critical"])
+        assert consolidation_base._is_protected_memory(mem) is True
+
+    def test_mistake_note_low_count_not_protected(self, consolidation_base):
+        """Mistake notes with failure_count < 3 can still be decayed."""
+        mem = _make_memory(memory_type="mistake", metadata={"failure_count": 1})
+        assert consolidation_base._is_protected_memory(mem) is False
+
+    def test_mistake_note_high_count_protected(self, consolidation_base):
+        """Mistake notes with failure_count >= 3 are protected."""
+        mem = _make_memory(memory_type="mistake", metadata={"failure_count": 3})
+        assert consolidation_base._is_protected_memory(mem) is True
+
+    def test_mistake_note_very_high_count_protected(self, consolidation_base):
+        mem = _make_memory(memory_type="mistake", metadata={"failure_count": 10})
+        assert consolidation_base._is_protected_memory(mem) is True
+
+    def test_mistake_note_no_metadata_not_protected(self, consolidation_base):
+        """Mistake notes without metadata are not protected."""
+        mem = _make_memory(memory_type="mistake", metadata=None)
+        assert consolidation_base._is_protected_memory(mem) is False
+
+    def test_mistake_note_json_string_metadata(self, consolidation_base):
+        """Metadata stored as JSON string should be parsed."""
+        mem = _make_memory(memory_type="mistake", metadata='{"failure_count": 5}')
+        assert consolidation_base._is_protected_memory(mem) is True
+
+    def test_mistake_note_json_string_low_count(self, consolidation_base):
+        mem = _make_memory(memory_type="mistake", metadata='{"failure_count": 2}')
+        assert consolidation_base._is_protected_memory(mem) is False


### PR DESCRIPTION
## Summary

Mistake notes with `failure_count >= 3` are now protected from consolidation decay and forgetting. These represent proven, recurring error patterns that should never be automatically removed.

## Changes

- **`consolidation/base.py`**: Extend `_is_protected_memory()` to check `memory_type='mistake'` with `failure_count >= 3` in metadata
- **`tests/consolidation/test_mistake_lifecycle.py`**: 8 test cases covering all edge cases (low count, high count, no metadata, JSON string metadata)

## Rationale

From #853 and the #732 status update — mistake notes are stored as regular memories with `memory_type='mistake'`, but consolidation/decay didn't know they were special. A mistake note that has been triggered 3+ times is a proven, high-value error pattern that should be preserved indefinitely.

## Design decisions

- **Threshold of 3**: Low enough to protect real patterns, high enough to not protect one-off mistakes
- **Metadata parsing**: Handles both dict and JSON string metadata (both exist in production)
- **Minimal diff**: Only touches `_is_protected_memory()` — the single gate used by both decay and forgetting engines

## Testing

```bash
pytest tests/consolidation/test_mistake_lifecycle.py -v  # 8/8 pass
```

Refs: #853