### PR TITLE
chore: release v10.49.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.49.4] - 2026-05-05
+
+### Fixed
+
+- **[#853] Mistake-notes survive consolidation**: `_is_protected_memory()` in [`consolidation/base.py`](src/mcp_memory_service/consolidation/base.py) now shields memories with `memory_type='mistake'` and `failure_count >= 3` from decay and forgetting passes. High-value error-replay records no longer vanish during scheduled consolidation. 10 new tests in `tests/consolidation/test_mistake_lifecycle.py`. Closes #853. (PR #854, @filhocf)
+
 ## [10.49.3] - 2026-05-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.49.3 - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850) — ~1,803 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.49.4 - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf) — ~1,813 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,17 +490,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.49.3** (May 5, 2026)
+## Latest Release: **v10.49.4** (May 5, 2026)
 
-**fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)**
+**fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)**
 
 **What's New:**
-- **OpenCode plugin works again**: Fixed wrong API path (`/api/memories/search` -> `/api/search`) and wrong payload field (`limit` -> `n_results`) that caused HTTP 405 errors on all OpenCode memory searches. Closes #847.
-- **Project-scoped searches correctly scoped**: `/api/search` ignores `tags` server-side; plugin now over-fetches and filters client-side by tag intersection so project memory stays isolated.
+- **Mistake notes survive consolidation**: `_is_protected_memory()` now shields `memory_type='mistake'` records with `failure_count >= 3` from decay and forgetting passes. Error-replay knowledge is no longer silently erased during scheduled consolidation. Closes #853.
 
 ---
 
 **Previous Releases**:
+- **v10.49.3** - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)
 - **v10.49.2** - fix(ontology): register custom base types with empty subtype lists (PR #846)
 - **v10.49.1** - fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844)
 - **v10.49.0** - feat(cli): lazy lifecycle commands and faster startup (PR #841, @creativelaides)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.49.3"
+version = "10.49.4"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.49.3"
+__version__ = "10.49.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.49.3"
+version = "10.49.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to 10.49.4 (PATCH)
- Add CHANGELOG entry for PR #854: mistake-notes now protected from consolidation decay
- Update README Latest Release section (v10.49.3 -> v10.49.4)
- Update CLAUDE.md version callout
- Run `uv lock`

## Changes

This release ships the consolidation safety fix from @filhocf (PR #854, commit bd1ab86):

- `_is_protected_memory()` in `consolidation/base.py` extended to protect `memory_type='mistake'` memories with `failure_count >= 3` from decay and forgetting passes
- 10 new tests in `tests/consolidation/test_mistake_lifecycle.py`
- Closes #853

No breaking changes. No new user-visible API surface. PATCH bump only.

Landing page (`docs/index.html`) NOT updated per policy (PATCH releases only).

## Test plan

- [ ] CI passes on this branch
- [ ] Version strings consistent across `pyproject.toml`, `_version.py`, CHANGELOG, README, CLAUDE.md
- [ ] `uv.lock` reflects updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)