### PR TITLE
feat(plugins): add plugin hook scaffolding

### DIFF
--- a/src/mcp_memory_service/plugins/__init__.py
+++ b/src/mcp_memory_service/plugins/__init__.py
@@ -1,0 +1,15 @@
+"""Plugin system for mcp-memory-service.
+
+Plugins register via Python entry_points:
+
+    [project.entry-points."mcp_memory_service.plugins"]
+    my_plugin = "my_package:register"
+
+Each plugin's `register(ctx: PluginContext)` is called once at startup,
+after storage initialization completes.
+"""
+
+from .context import PluginContext
+from .registry import PluginRegistry
+
+__all__ = ["PluginContext", "PluginRegistry"]

--- a/src/mcp_memory_service/plugins/context.py
+++ b/src/mcp_memory_service/plugins/context.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
 
 if TYPE_CHECKING:
-    from ..services.memory_service import MemoryService
-    from ..storage.sqlite_vec import SqliteVecMemoryStorage
+    from ..services.memory_service import MemoryService  # noqa: F401
+    from ..storage.sqlite_vec import SqliteVecMemoryStorage  # noqa: F401
 
 HookName = Literal["on_store", "on_delete", "on_retrieve", "on_consolidate"]
 

--- a/src/mcp_memory_service/plugins/context.py
+++ b/src/mcp_memory_service/plugins/context.py
@@ -3,11 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
-
-if TYPE_CHECKING:
-    from ..services.memory_service import MemoryService  # noqa: F401
-    from ..storage.sqlite_vec import SqliteVecMemoryStorage  # noqa: F401
+from typing import Any, Awaitable, Callable, Literal
 
 HookName = Literal["on_store", "on_delete", "on_retrieve", "on_consolidate"]
 

--- a/src/mcp_memory_service/plugins/context.py
+++ b/src/mcp_memory_service/plugins/context.py
@@ -1,0 +1,40 @@
+"""Plugin context — what a plugin receives at registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
+
+if TYPE_CHECKING:
+    from ..services.memory_service import MemoryService
+    from ..storage.sqlite_vec import SqliteVecMemoryStorage
+
+HookName = Literal["on_store", "on_delete", "on_retrieve", "on_consolidate"]
+
+# Hook signatures
+# on_store(memory_dict: dict) -> None
+# on_delete(content_hash: str) -> None
+# on_retrieve(query: str, results: list[dict]) -> list[dict]  (can rerank)
+# on_consolidate(report: dict) -> None
+HookFn = Callable[..., Awaitable[Any]]
+
+
+@dataclass
+class PluginContext:
+    """Context passed to plugin register() functions.
+
+    Provides access to storage and service, plus a method to subscribe to hooks.
+    """
+
+    storage: Any  # SqliteVecMemoryStorage (avoid import cycle)
+    service: Any  # MemoryService (avoid import cycle)
+    _hooks: dict[HookName, list[HookFn]] = field(default_factory=dict)
+
+    def on(self, hook: HookName, fn: HookFn) -> None:
+        """Subscribe to a lifecycle hook.
+
+        Args:
+            hook: One of on_store, on_delete, on_retrieve, on_consolidate
+            fn: Async callable to invoke when the hook fires
+        """
+        self._hooks.setdefault(hook, []).append(fn)

--- a/src/mcp_memory_service/plugins/registry.py
+++ b/src/mcp_memory_service/plugins/registry.py
@@ -46,25 +46,36 @@ class PluginRegistry:
     async def fire(self, hook: HookName, *args: Any, **kwargs: Any) -> Any:
         """Fire a hook, calling all registered handlers in order.
 
-        For on_retrieve: handlers can modify and return the results list.
+        For on_retrieve: handlers receive (query, results) and can return
+        modified results. Chaining passes updated results to next handler.
         For other hooks: handlers are called for side effects only.
         """
         handlers = self.ctx._hooks.get(hook, [])
         if not handlers:
+            # on_retrieve: return results (2nd arg), others: return 1st arg
+            if hook == "on_retrieve":
+                return args[1] if len(args) > 1 else args[0] if args else None
             return args[0] if args else None
 
-        result = args[0] if args else None
+        if hook == "on_retrieve":
+            query = args[0] if args else None
+            results = args[1] if len(args) > 1 else args[0] if args else None
+            for fn in handlers:
+                try:
+                    modified = await fn(query, results, **kwargs)
+                    if modified is not None:
+                        results = modified
+                except Exception:
+                    logger.exception(
+                        "Error in plugin hook '%s' handler %s", hook, fn.__qualname__
+                    )
+            return results
 
         for fn in handlers:
             try:
-                if hook == "on_retrieve":
-                    # on_retrieve can rerank/filter results
-                    result = await fn(*args, **kwargs) or result
-                else:
-                    await fn(*args, **kwargs)
+                await fn(*args, **kwargs)
             except Exception:
                 logger.exception(
                     "Error in plugin hook '%s' handler %s", hook, fn.__qualname__
                 )
-
-        return result
+        return args[0] if args else None

--- a/src/mcp_memory_service/plugins/registry.py
+++ b/src/mcp_memory_service/plugins/registry.py
@@ -1,0 +1,70 @@
+"""Plugin registry — discovery via entry_points and hook firing."""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+from typing import Any
+
+from .context import HookName, PluginContext
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "mcp_memory_service.plugins"
+
+
+class PluginRegistry:
+    """Discovers and manages plugins."""
+
+    def __init__(self, ctx: PluginContext) -> None:
+        self.ctx = ctx
+        self._loaded: list[str] = []
+
+    def discover_and_register(self) -> None:
+        """Load all plugins from entry_points and call their register()."""
+        eps = entry_points()
+        # Python 3.12+ returns SelectableGroups, 3.9-3.11 returns dict
+        if hasattr(eps, "select"):
+            plugin_eps = eps.select(group=ENTRY_POINT_GROUP)
+        else:
+            plugin_eps = eps.get(ENTRY_POINT_GROUP, [])
+
+        for ep in plugin_eps:
+            try:
+                register_fn = ep.load()
+                register_fn(self.ctx)
+                self._loaded.append(ep.name)
+                logger.info("Plugin '%s' registered successfully", ep.name)
+            except Exception:
+                logger.exception("Failed to load plugin '%s'", ep.name)
+
+    @property
+    def loaded_plugins(self) -> list[str]:
+        """Names of successfully loaded plugins."""
+        return list(self._loaded)
+
+    async def fire(self, hook: HookName, *args: Any, **kwargs: Any) -> Any:
+        """Fire a hook, calling all registered handlers in order.
+
+        For on_retrieve: handlers can modify and return the results list.
+        For other hooks: handlers are called for side effects only.
+        """
+        handlers = self.ctx._hooks.get(hook, [])
+        if not handlers:
+            return args[0] if args else None
+
+        result = args[0] if args else None
+
+        for fn in handlers:
+            try:
+                if hook == "on_retrieve":
+                    # on_retrieve can rerank/filter results
+                    result = await fn(*args, **kwargs) or result
+                else:
+                    await fn(*args, **kwargs)
+            except Exception:
+                logger.exception(
+                    "Error in plugin hook '%s' handler %s", hook, fn.__qualname__
+                )
+
+        return result

--- a/tests/plugins/test_plugin_hooks.py
+++ b/tests/plugins/test_plugin_hooks.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Claudio Ferreira Filho
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+"""Tests for plugin hook system."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_memory_service.plugins.context import PluginContext
+from mcp_memory_service.plugins.registry import PluginRegistry
+
+
+@pytest.fixture
+def ctx():
+    """Create a PluginContext with mock storage/service."""
+    return PluginContext(storage=MagicMock(), service=MagicMock())
+
+
+@pytest.fixture
+def registry(ctx):
+    return PluginRegistry(ctx)
+
+
+class TestPluginContext:
+    def test_subscribe_hook(self, ctx):
+        fn = AsyncMock()
+        ctx.on("on_store", fn)
+        assert "on_store" in ctx._hooks
+        assert fn in ctx._hooks["on_store"]
+
+    def test_multiple_hooks(self, ctx):
+        fn1 = AsyncMock()
+        fn2 = AsyncMock()
+        ctx.on("on_store", fn1)
+        ctx.on("on_store", fn2)
+        assert len(ctx._hooks["on_store"]) == 2
+
+    def test_different_hook_types(self, ctx):
+        fn1 = AsyncMock()
+        fn2 = AsyncMock()
+        ctx.on("on_store", fn1)
+        ctx.on("on_delete", fn2)
+        assert len(ctx._hooks["on_store"]) == 1
+        assert len(ctx._hooks["on_delete"]) == 1
+
+
+class TestPluginRegistry:
+    @pytest.mark.asyncio
+    async def test_fire_no_handlers(self, registry):
+        result = await registry.fire("on_store", {"content": "test"})
+        assert result == {"content": "test"}
+
+    @pytest.mark.asyncio
+    async def test_fire_on_store(self, registry):
+        handler = AsyncMock()
+        registry.ctx.on("on_store", handler)
+        await registry.fire("on_store", {"content": "test"})
+        handler.assert_called_once_with({"content": "test"})
+
+    @pytest.mark.asyncio
+    async def test_fire_on_retrieve_reranks(self, registry):
+        async def reranker(results):
+            return list(reversed(results))
+
+        registry.ctx.on("on_retrieve", reranker)
+        result = await registry.fire("on_retrieve", [1, 2, 3])
+        assert result == [3, 2, 1]
+
+    @pytest.mark.asyncio
+    async def test_fire_handler_error_doesnt_crash(self, registry):
+        async def bad_handler(*args):
+            raise ValueError("boom")
+
+        good_handler = AsyncMock()
+        registry.ctx.on("on_store", bad_handler)
+        registry.ctx.on("on_store", good_handler)
+
+        await registry.fire("on_store", {"content": "test"})
+        good_handler.assert_called_once()
+
+    def test_discover_no_plugins(self, registry):
+        with patch("mcp_memory_service.plugins.registry.entry_points") as mock_eps:
+            mock_eps.return_value.select.return_value = []
+            registry.discover_and_register()
+        assert registry.loaded_plugins == []
+
+    def test_discover_with_plugin(self, registry):
+        mock_register = MagicMock()
+        mock_ep = MagicMock()
+        mock_ep.name = "test_plugin"
+        mock_ep.load.return_value = mock_register
+
+        with patch("mcp_memory_service.plugins.registry.entry_points") as mock_eps:
+            mock_eps.return_value.select.return_value = [mock_ep]
+            registry.discover_and_register()
+
+        mock_register.assert_called_once_with(registry.ctx)
+        assert registry.loaded_plugins == ["test_plugin"]
+
+    def test_discover_plugin_error_doesnt_crash(self, registry):
+        mock_ep = MagicMock()
+        mock_ep.name = "bad_plugin"
+        mock_ep.load.side_effect = ImportError("no module")
+
+        with patch("mcp_memory_service.plugins.registry.entry_points") as mock_eps:
+            mock_eps.return_value.select.return_value = [mock_ep]
+            registry.discover_and_register()
+
+        assert registry.loaded_plugins == []

--- a/tests/plugins/test_plugin_hooks.py
+++ b/tests/plugins/test_plugin_hooks.py
@@ -60,12 +60,27 @@ class TestPluginRegistry:
 
     @pytest.mark.asyncio
     async def test_fire_on_retrieve_reranks(self, registry):
-        async def reranker(results):
+        async def reranker(query, results):
             return list(reversed(results))
 
         registry.ctx.on("on_retrieve", reranker)
-        result = await registry.fire("on_retrieve", [1, 2, 3])
+        result = await registry.fire("on_retrieve", "test query", [1, 2, 3])
         assert result == [3, 2, 1]
+
+    @pytest.mark.asyncio
+    async def test_fire_on_retrieve_chaining(self, registry):
+        """Subsequent handlers receive modified results from previous."""
+
+        async def add_item(query, results):
+            return results + [99]
+
+        async def reverse_it(query, results):
+            return list(reversed(results))
+
+        registry.ctx.on("on_retrieve", add_item)
+        registry.ctx.on("on_retrieve", reverse_it)
+        result = await registry.fire("on_retrieve", "q", [1, 2, 3])
+        assert result == [99, 3, 2, 1]
 
     @pytest.mark.asyncio
     async def test_fire_handler_error_doesnt_crash(self, registry):


### PR DESCRIPTION
## Summary

Plugin system with entry_points discovery and lifecycle hooks, per the [Apr 20 spec](https://github.com/doobidoo/mcp-memory-service/issues/732#issuecomment-4283375806).

## Changes

- `src/mcp_memory_service/plugins/` — new module
  - `context.py`: PluginContext with storage/service access + `ctx.on(hook, fn)` subscription
  - `registry.py`: entry_points discovery + `fire()` with error isolation
- `tests/plugins/test_plugin_hooks.py`: 10 tests

## Hooks

- `on_store(memory_dict)` — after successful store
- `on_delete(content_hash)` — after soft-delete
- `on_retrieve(query, results) -> results` — can rerank/filter
- `on_consolidate(report)` — end of consolidation run

## Plugin registration

```toml
[project.entry-points."mcp_memory_service.plugins"]
my_plugin = "my_package:register"
```

## Design decisions

- Error in one plugin doesn't crash others or the server
- on_retrieve is the only hook that can modify return values (reranking)
- No new dependencies
- Not wired into MemoryService yet — that's the follow-up PR (fire points)

Refs: #853