### PR TITLE
chore: release v10.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.50.0] - 2026-05-06
+
+### Added
+
+- **Plugin hook scaffolding** ([#856](https://github.com/doobidoo/mcp-memory-service/pull/856), @filhocf, refs [#732](https://github.com/doobidoo/mcp-memory-service/issues/732)): Introduces the plugin extension API for `mcp-memory-service`. Four lifecycle hooks are defined — `on_store`, `on_delete`, `on_retrieve`, and `on_consolidate` — with `entry_points` discovery so third-party packages can register hooks without modifying core. This is pure scaffolding; fire points will be wired into `MemoryService` in a follow-up PR. Enables the ecosystem extensibility roadmap item from canonical issue #732.
+
+### Changed
+
+- **Dependency bumps** (PRs [#858](https://github.com/doobidoo/mcp-memory-service/pull/858), [#859](https://github.com/doobidoo/mcp-memory-service/pull/859), [#860](https://github.com/doobidoo/mcp-memory-service/pull/860), [#861](https://github.com/doobidoo/mcp-memory-service/pull/861)):
+  - `actions/attest-build-provenance` 1 → 4
+  - `github/codeql-action` 3 → 4
+  - `hadolint/hadolint-action` 3.1.0 → 3.3.0
+  - `authlib` 1.7.0 → 1.7.1, `cryptography` 47 → 48, `torch` 2.10 → 2.11, `setuptools` 82 → 81 (uv group bump, 905 tests validated)
+
 ## [10.49.4] - 2026-05-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.49.4 - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf) — ~1,813 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.50.0 - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,16 +490,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.49.4** (May 5, 2026)
+## Latest Release: **v10.50.0** (May 6, 2026)
 
-**fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)**
+**feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)**
 
 **What's New:**
-- **Mistake notes survive consolidation**: `_is_protected_memory()` now shields `memory_type='mistake'` records with `failure_count >= 3` from decay and forgetting passes. Error-replay knowledge is no longer silently erased during scheduled consolidation. Closes #853.
+- **Plugin extension API**: Four lifecycle hooks (`on_store`, `on_delete`, `on_retrieve`, `on_consolidate`) with `entry_points` discovery let third-party packages register hooks without modifying core. Pure scaffolding — fire points wired in follow-up PR. Refs #732.
+- **Dependency updates**: `authlib` 1.7.1, `cryptography` 48, `torch` 2.11; CI actions bumped (`attest-build-provenance` 1→4, `codeql-action` 3→4, `hadolint-action` 3.3.0).
 
 ---
 
 **Previous Releases**:
+- **v10.49.4** - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)
 - **v10.49.3** - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)
 - **v10.49.2** - fix(ontology): register custom base types with empty subtype lists (PR #846)
 - **v10.49.1** - fix: surface memory_type ontology coercion warnings + uvx CI flake fix (PR #844)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.49.2</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.50.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.49.2">
-<meta property="og:description" content="CLI lifecycle commands (launch/stop/restart/info/health/logs) + lazy imports for &lt;3s startup. Security fixes: command injection, FD leak, anonymous-access pass-through. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.50.0">
+<meta property="og:description" content="Plugin hook scaffolding (on_store, on_delete, on_retrieve, on_consolidate) with entry_points discovery. Ecosystem extensibility without forking core. CLI lifecycle commands + lazy imports for &lt;3s startup. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.49 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.50 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.49</h2>
-    <p class="section-subtitle">CLI lifecycle commands + lazy imports for &lt;3s startup. Security fixes. ~1,803 tests.</p>
+    <h2 class="section-title">What's New in v10.50</h2>
+    <p class="section-subtitle">Plugin hook scaffolding — extend memory without forking core. ~1,838 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon http">&#9881;</div>
-        <h3>CLI Lifecycle Commands</h3>
-        <p>New <code>memory launch|stop|restart|info|health|logs</code> commands manage the background HTTP server with cross-platform PID tracking and health polling. <code>restart</code> threads <code>--storage-backend</code> and <code>--debug</code> flags from the running process automatically. (PR #841, @creativelaides)</p>
+        <h3>Plugin Extension API</h3>
+        <p>Four lifecycle hooks — <code>on_store</code>, <code>on_delete</code>, <code>on_retrieve</code>, <code>on_consolidate</code> — let third-party packages inject logic at key points using <code>entry_points</code> discovery. No core fork required. (PR #856, @filhocf, refs #732)</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon consolidation">&#9889;</div>
-        <h3>22s &rarr; &lt;3s CLI Startup</h3>
-        <p>Heavy ML dependencies (torch, transformers, sentence-transformers) are now lazy-loaded — imported only when actually invoked. <code>memory --help</code> and lifecycle commands start instantly without waiting for model initialization. (PR #841, @creativelaides)</p>
+        <h3>entry_points Discovery</h3>
+        <p>Plugins register via standard Python packaging (<code>entry_points</code> group <code>mcp_memory_service.plugins</code>). Install a plugin package and hooks activate automatically — no config changes needed. Enables the ecosystem extensibility milestone.</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon oauth">&#128274;</div>
-        <h3>Security Hardening</h3>
-        <p>Command injection in <code>launch</code> patched (safe arg list replaces <code>-c</code> string interpolation); file-descriptor leak after <code>Popen</code> closed; <code>MCP_ALLOW_ANONYMOUS_ACCESS</code> pass-through restored; PID-reuse detection via <code>create_time</code> + <code>cmdline_hint</code>. (PR #841)</p>
+        <h3>Dependency Refresh</h3>
+        <p><code>authlib</code> 1.7.1, <code>cryptography</code> 48, <code>torch</code> 2.11. CI actions updated: <code>attest-build-provenance</code> 1→4, <code>codeql-action</code> 3→4, <code>hadolint-action</code> 3.3.0. All 905 integration tests pass. (PRs #858–#861)</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1803">0</div>
+        <div class="stat-number" data-target="1838">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.49.2" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.50.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,7 @@ footer a{color:var(--cyan)}
       <div class="feature-card" data-delay="300">
         <div class="feature-icon oauth">&#128274;</div>
         <h3>Dependency Refresh</h3>
-        <p><code>authlib</code> 1.7.1, <code>cryptography</code> 48, <code>torch</code> 2.11. CI actions updated: <code>attest-build-provenance</code> 1→4, <code>codeql-action</code> 3→4, <code>hadolint-action</code> 3.3.0. All 905 integration tests pass. (PRs #858–#861)</p>
+        <p>Latest <code>authlib</code>, <code>cryptography</code>, and <code>torch</code> releases. CI actions updated: <code>attest-build-provenance</code>, <code>codeql-action</code>, and <code>hadolint-action</code> all bumped to current majors. All 905 integration tests pass. (PRs #858–#861)</p>
       </div>
     </div>
   </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.49.4"
+version = "10.50.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.49.4"
+__version__ = "10.50.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.49.4"
+version = "10.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.50.0

**MINOR** bump: new plugin extension API (backward-compatible, no breaking changes).

### What's in this release

**Added**
- Plugin hook scaffolding (PR #856, @filhocf, refs #732): four lifecycle hooks (`on_store`, `on_delete`, `on_retrieve`, `on_consolidate`) with `entry_points` discovery. Pure scaffolding — fire points wired in follow-up PR.

**Changed (deps)**
- `actions/attest-build-provenance` 1 → 4 (PR #858)
- `github/codeql-action` 3 → 4 (PR #859)
- `hadolint/hadolint-action` 3.1.0 → 3.3.0 (PR #860)
- `authlib` 1.7.0 → 1.7.1, `cryptography` 47 → 48, `torch` 2.10 → 2.11, `setuptools` 82 → 81 (PR #861)

### Files changed
- `pyproject.toml` + `src/mcp_memory_service/_version.py` + `uv.lock`: 10.49.4 → 10.50.0
- `CHANGELOG.md`: new `[10.50.0]` section
- `README.md`: Latest Release rotated
- `CLAUDE.md`: version callout updated, test count updated (1,813 → 1,838)
- `docs/index.html`: hero badge, What's New section, test count (1803 → 1838), Release Notes link

### Special Thanks
@filhocf for delivering the plugin scaffolding that unblocks the ecosystem extensibility roadmap.

### Checklist
- [x] Version follows semver (MINOR, backward-compatible new feature)
- [x] CHANGELOG: [Unreleased] section empty, [10.50.0] entry added
- [x] README: Latest Release updated, previous rotated
- [x] CLAUDE.md: version callout + test count updated
- [x] docs/index.html: badge, features, test count, release link updated
- [x] `uv lock` run — lockfile updated
- [x] Tag will be created on main after merge