### PR TITLE
feat(web): populate type dropdowns from /api/types endpoint

### DIFF
--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -502,3 +502,12 @@ async def store_session(
         content_hash=raw_memory.get("content_hash"),
         turn_count=len(lines),
     )
+
+
+@router.get("/types")
+async def get_memory_types(
+    _auth: AuthenticationResult = Depends(require_read_access),
+) -> List[str]:
+    """Return all valid memory types (built-in + custom from MCP_CUSTOM_MEMORY_TYPES)."""
+    from ...models.ontology import get_all_types
+    return sorted(get_all_types())

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 
 from ...storage.base import MemoryStorage
 from ...models.memory import Memory
+from ...models.ontology import get_all_types
 from ...services.memory_service import MemoryService
 from ...config import INCLUDE_HOSTNAME
 # OAuth config no longer needed - auth is always enabled
@@ -509,5 +510,4 @@ async def get_memory_types(
     _auth: AuthenticationResult = Depends(require_read_access),
 ) -> List[str]:
     """Return all valid memory types (built-in + custom from MCP_CUSTOM_MEMORY_TYPES)."""
-    from ...models.ontology import get_all_types
     return sorted(get_all_types())

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -884,33 +884,28 @@ class MemoryDashboard {
             // Populate typeFilter (search filter) - keep "All types" option
             const typeFilter = document.getElementById('typeFilter');
             if (typeFilter) {
-                const allOption = typeFilter.querySelector('option[value=""]');
-                typeFilter.innerHTML = '';
-                if (allOption) typeFilter.appendChild(allOption);
-                else {
-                    const opt = document.createElement('option');
-                    opt.value = '';
-                    opt.textContent = this.t('search.filters.type.all') || 'All types';
-                    typeFilter.appendChild(opt);
-                }
-                types.forEach(t => {
+                const allOpt = document.createElement('option');
+                allOpt.value = '';
+                allOpt.textContent = this.t('search.filters.type.all') || 'All types';
+                const typeOpts = types.map(t => {
                     const opt = document.createElement('option');
                     opt.value = t;
                     opt.textContent = t;
-                    typeFilter.appendChild(opt);
+                    return opt;
                 });
+                typeFilter.replaceChildren(allOpt, ...typeOpts);
             }
 
             // Populate all memoryType selects (document upload + add memory modal)
-            document.querySelectorAll('select#memoryType').forEach(select => {
+            document.querySelectorAll('select.memory-type-select, select#memoryType').forEach(select => {
                 const currentValue = select.value;
-                select.innerHTML = '';
-                types.forEach(t => {
+                const opts = types.map(t => {
                     const opt = document.createElement('option');
                     opt.value = t;
                     opt.textContent = t;
-                    select.appendChild(opt);
+                    return opt;
                 });
+                select.replaceChildren(...opts);
                 if (types.includes(currentValue)) select.value = currentValue;
             });
         } catch (error) {

--- a/src/mcp_memory_service/web/static/app.js
+++ b/src/mcp_memory_service/web/static/app.js
@@ -153,6 +153,7 @@ class MemoryDashboard {
         this.setupSSE();
 
         await this.loadVersion();
+        await this.loadMemoryTypes();
         await this.loadDashboardData();
         this.updateConnectionStatus('connected');
 
@@ -869,6 +870,51 @@ class MemoryDashboard {
             if (versionBadge) {
                 versionBadge.textContent = 'v?.?.?';
             }
+        }
+    }
+
+    /**
+     * Load valid memory types from API and populate type selects/dropdowns
+     */
+    async loadMemoryTypes() {
+        try {
+            const types = await this.apiCall('/types');
+            if (!Array.isArray(types)) return;
+
+            // Populate typeFilter (search filter) - keep "All types" option
+            const typeFilter = document.getElementById('typeFilter');
+            if (typeFilter) {
+                const allOption = typeFilter.querySelector('option[value=""]');
+                typeFilter.innerHTML = '';
+                if (allOption) typeFilter.appendChild(allOption);
+                else {
+                    const opt = document.createElement('option');
+                    opt.value = '';
+                    opt.textContent = this.t('search.filters.type.all') || 'All types';
+                    typeFilter.appendChild(opt);
+                }
+                types.forEach(t => {
+                    const opt = document.createElement('option');
+                    opt.value = t;
+                    opt.textContent = t;
+                    typeFilter.appendChild(opt);
+                });
+            }
+
+            // Populate all memoryType selects (document upload + add memory modal)
+            document.querySelectorAll('select#memoryType').forEach(select => {
+                const currentValue = select.value;
+                select.innerHTML = '';
+                types.forEach(t => {
+                    const opt = document.createElement('option');
+                    opt.value = t;
+                    opt.textContent = t;
+                    select.appendChild(opt);
+                });
+                if (types.includes(currentValue)) select.value = currentValue;
+            });
+        } catch (error) {
+            console.warn('Failed to load memory types:', error);
         }
     }
 


### PR DESCRIPTION
Adds `GET /api/types` endpoint returning all valid memory types (built-in + `MCP_CUSTOM_MEMORY_TYPES`). The Web UI now fetches types dynamically on init, populating the filter dropdown and add-memory/upload type selects.

## Changes

- **`web/api/memories.py`**: New `GET /api/types` endpoint using `get_all_types()` from ontology
- **`web/static/app.js`**: `loadMemoryTypes()` fetches from `/api/types` and populates all type `<select>` elements dynamically

## Testing

- Ontology tests pass (57 tests)
- Endpoint returns sorted list of all types including custom ones registered via env var

Closes #857.