### PR TITLE
docs(plugins): add audit-log example plugin

### DIFF
--- a/examples/plugin-audit-log/README.md
+++ b/examples/plugin-audit-log/README.md
@@ -23,10 +23,10 @@ Restart mcp-memory-service — the plugin loads automatically via `entry_points`
 Each line in the audit log is a JSON object:
 
 ```json
-{"timestamp": 1715000000.0, "type": "store", "hash": "abc123...", "type": "note", "tags": ["project"], "content_length": 150}
-{"timestamp": 1715000001.0, "type": "retrieve", "query": "how to deploy", "result_count": 5}
-{"timestamp": 1715000002.0, "type": "delete", "hash": "def456..."}
-{"timestamp": 1715000003.0, "type": "consolidate", "memories_processed": 42, "time_horizon": "7d"}
+{"timestamp": 1715000000.0, "event": "store", "hash": "abc123...", "memory_type": "note", "tags": ["project"], "content_length": 150}
+{"timestamp": 1715000001.0, "event": "retrieve", "query": "how to deploy", "result_count": 5}
+{"timestamp": 1715000002.0, "event": "delete", "hash": "def456..."}
+{"timestamp": 1715000003.0, "event": "consolidate", "memories_processed": 42, "time_horizon": "7d"}
 ```
 
 ## Hooks Used

--- a/examples/plugin-audit-log/README.md
+++ b/examples/plugin-audit-log/README.md
@@ -1,0 +1,58 @@
+# Audit Log Plugin — Example
+
+Demonstrates all 4 lifecycle hooks by writing events to a JSON Lines file.
+
+## Install
+
+```bash
+pip install -e examples/plugin-audit-log/
+# or
+uv pip install -e examples/plugin-audit-log/
+```
+
+Restart mcp-memory-service — the plugin loads automatically via `entry_points` discovery.
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `MCP_PLUGIN_AUDIT_LOG_PATH` | `/tmp/mcp-memory-audit.jsonl` | Path to the audit log file |
+
+## Events
+
+Each line in the audit log is a JSON object:
+
+```json
+{"timestamp": 1715000000.0, "type": "store", "hash": "abc123...", "type": "note", "tags": ["project"], "content_length": 150}
+{"timestamp": 1715000001.0, "type": "retrieve", "query": "how to deploy", "result_count": 5}
+{"timestamp": 1715000002.0, "type": "delete", "hash": "def456..."}
+{"timestamp": 1715000003.0, "type": "consolidate", "memories_processed": 42, "time_horizon": "7d"}
+```
+
+## Hooks Used
+
+| Hook | Purpose |
+|------|---------|
+| `on_store` | Log hash, type, tags, content length |
+| `on_delete` | Log deleted hash |
+| `on_retrieve` | Log query and result count (returns results unchanged) |
+| `on_consolidate` | Log consolidation stats |
+
+## Writing Your Own Plugin
+
+1. Create a Python package with an `entry_points` declaration:
+
+```toml
+[project.entry-points."mcp_memory_service.plugins"]
+my_plugin = "my_package:register"
+```
+
+2. Implement `register(ctx)` that subscribes to hooks:
+
+```python
+def register(ctx):
+    ctx.on("on_store", my_store_handler)
+    ctx.on("on_retrieve", my_retrieve_handler)
+```
+
+3. Install alongside mcp-memory-service and restart.

--- a/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
+++ b/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
@@ -1,0 +1,81 @@
+"""Example plugin: Audit Log.
+
+Demonstrates all 4 lifecycle hooks by logging events to a JSON Lines file.
+Install alongside mcp-memory-service and hooks activate automatically.
+
+Usage:
+    pip install -e examples/plugin-audit-log/
+    # Restart mcp-memory-service — plugin loads via entry_points discovery
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Audit log file path (configurable via env var)
+AUDIT_LOG_PATH = Path(os.getenv(
+    "MCP_PLUGIN_AUDIT_LOG_PATH",
+    "/tmp/mcp-memory-audit.jsonl"
+))
+
+
+def register(ctx: Any) -> None:
+    """Entry point called by PluginRegistry at startup."""
+    logger.info("audit-log plugin: registered (log=%s)", AUDIT_LOG_PATH)
+    ctx.on("on_store", on_store)
+    ctx.on("on_delete", on_delete)
+    ctx.on("on_retrieve", on_retrieve)
+    ctx.on("on_consolidate", on_consolidate)
+
+
+def _write_event(event_type: str, data: dict) -> None:
+    """Append a JSON event to the audit log."""
+    event = {
+        "timestamp": time.time(),
+        "type": event_type,
+        **data,
+    }
+    try:
+        with AUDIT_LOG_PATH.open("a") as f:
+            f.write(json.dumps(event) + "\n")
+    except OSError as e:
+        logger.warning("audit-log: failed to write event: %s", e)
+
+
+async def on_store(memory_dict: dict) -> None:
+    """Log every memory store event."""
+    _write_event("store", {
+        "hash": memory_dict.get("content_hash", "unknown"),
+        "type": memory_dict.get("memory_type", ""),
+        "tags": memory_dict.get("tags", []),
+        "content_length": len(memory_dict.get("content", "")),
+    })
+
+
+async def on_delete(content_hash: str) -> None:
+    """Log every memory deletion."""
+    _write_event("delete", {"hash": content_hash})
+
+
+async def on_retrieve(query: str, results: list[dict]) -> list[dict]:
+    """Log retrieval queries and result count. Returns results unchanged."""
+    _write_event("retrieve", {
+        "query": query[:100],
+        "result_count": len(results),
+    })
+    return results  # Pass through unmodified
+
+
+async def on_consolidate(report: dict) -> None:
+    """Log consolidation events."""
+    _write_event("consolidate", {
+        "memories_processed": report.get("memories_processed", 0),
+        "time_horizon": report.get("time_horizon", ""),
+    })

--- a/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
+++ b/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
@@ -10,6 +10,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -35,11 +36,11 @@ def register(ctx: Any) -> None:
     ctx.on("on_consolidate", on_consolidate)
 
 
-def _write_event(event_type: str, data: dict) -> None:
-    """Append a JSON event to the audit log."""
+def _write_event_sync(event_type: str, data: dict) -> None:
+    """Synchronous file write — called via asyncio.to_thread."""
     event = {
         "timestamp": time.time(),
-        "type": event_type,
+        "event": event_type,
         **data,
     }
     try:
@@ -49,11 +50,16 @@ def _write_event(event_type: str, data: dict) -> None:
         logger.warning("audit-log: failed to write event: %s", e)
 
 
+async def _write_event(event_type: str, data: dict) -> None:
+    """Offload blocking file I/O to a thread."""
+    await asyncio.to_thread(_write_event_sync, event_type, data)
+
+
 async def on_store(memory_dict: dict) -> None:
     """Log every memory store event."""
-    _write_event("store", {
+    await _write_event("store", {
         "hash": memory_dict.get("content_hash", "unknown"),
-        "type": memory_dict.get("memory_type", ""),
+        "memory_type": memory_dict.get("memory_type", ""),
         "tags": memory_dict.get("tags", []),
         "content_length": len(memory_dict.get("content", "")),
     })
@@ -61,12 +67,12 @@ async def on_store(memory_dict: dict) -> None:
 
 async def on_delete(content_hash: str) -> None:
     """Log every memory deletion."""
-    _write_event("delete", {"hash": content_hash})
+    await _write_event("delete", {"hash": content_hash})
 
 
 async def on_retrieve(query: str, results: list[dict]) -> list[dict]:
     """Log retrieval queries and result count. Returns results unchanged."""
-    _write_event("retrieve", {
+    await _write_event("retrieve", {
         "query": query[:100],
         "result_count": len(results),
     })
@@ -75,7 +81,7 @@ async def on_retrieve(query: str, results: list[dict]) -> list[dict]:
 
 async def on_consolidate(report: dict) -> None:
     """Log consolidation events."""
-    _write_event("consolidate", {
+    await _write_event("consolidate", {
         "memories_processed": report.get("memories_processed", 0),
         "time_horizon": report.get("time_horizon", ""),
     })

--- a/examples/plugin-audit-log/pyproject.toml
+++ b/examples/plugin-audit-log/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp-memory-plugin-audit-log"
+version = "0.1.0"
+description = "Example plugin for mcp-memory-service — demonstrates all 4 lifecycle hooks with an audit log"
+requires-python = ">=3.10"
+license = "MIT"
+
+[project.entry-points."mcp_memory_service.plugins"]
+audit_log = "mcp_memory_plugin_audit_log:register"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mcp_memory_plugin_audit_log"]


### PR DESCRIPTION
Reference implementation demonstrating all 4 lifecycle hooks from the plugin system (v10.50.0).

## What's included

`examples/plugin-audit-log/` — a complete, installable plugin package:

- `pyproject.toml` with `entry_points` declaration
- Implementation of all 4 hooks (`on_store`, `on_delete`, `on_retrieve`, `on_consolidate`)
- `README.md` with usage guide and "Writing Your Own Plugin" section

## Purpose

Lowers the barrier for community plugin development. Users can copy this example as a starting point.

## Usage

```bash
pip install -e examples/plugin-audit-log/
# Restart mcp-memory-service — plugin auto-discovers via entry_points
```

Events are written to `/tmp/mcp-memory-audit.jsonl` (configurable via `MCP_PLUGIN_AUDIT_LOG_PATH`).

Refs #732 (ecosystem extensibility).