### PR TITLE
feat(consolidation): Insight Cards — automated pattern/trend/gap detection (Phase 3, #732)

### DIFF
--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -1209,6 +1209,9 @@ except (ValueError, TypeError):
 # AND their age difference exceeds this threshold (prevents resolving recent updates)
 MAINTAIN_AUTO_RESOLVE_AGE_DAYS = safe_get_int_env('MCP_MAINTAIN_AUTO_RESOLVE_AGE_DAYS', 7, min_value=0, max_value=365)
 
+# Insight Cards (Phase 3, #732) — opt-in, generates pattern/trend/gap insights during maintain
+MCP_INSIGHT_CARDS_ENABLED = safe_get_bool_env('MCP_INSIGHT_CARDS_ENABLED', False)
+
 # =============================================================================
 # Configuration Validation
 # =============================================================================

--- a/src/mcp_memory_service/consolidation/insights.py
+++ b/src/mcp_memory_service/consolidation/insights.py
@@ -53,7 +53,7 @@ class InsightGenerator:
 
     def _detect_patterns(self, memories: List[dict]) -> List[InsightCard]:
         """Pattern: >=3 memories share 2+ tags → insight about the pattern."""
-        # Group memories by tag pairs
+        # Group memories by tag pairs, then consolidate by source set
         pair_memories: Dict[tuple, List[dict]] = defaultdict(list)
         for mem in memories:
             tags = sorted(set(mem.get("tags", [])))
@@ -61,21 +61,34 @@ class InsightGenerator:
                 for j in range(i + 1, len(tags)):
                     pair_memories[(tags[i], tags[j])].append(mem)
 
+        # Consolidate: group by source memory set to avoid redundant insights
+        seen_source_sets: set = set()
         insights = []
-        for tag_pair, mems in pair_memories.items():
-            if len(mems) >= self.MIN_PATTERN_MEMORIES:
-                hashes = [m["content_hash"] for m in mems]
-                confidence = min(1.0, len(mems) / 10.0)
-                insights.append(InsightCard(
-                    title=f"Recurring pattern: {tag_pair[0]} + {tag_pair[1]}",
-                    content=(
-                        f"{len(mems)} memories share tags '{tag_pair[0]}' and "
-                        f"'{tag_pair[1]}', indicating a recurring theme."
-                    ),
-                    source_hashes=hashes,
-                    insight_type="pattern",
-                    confidence=confidence,
-                ))
+        for tag_pair, mems in sorted(pair_memories.items(), key=lambda x: -len(x[1])):
+            if len(mems) < self.MIN_PATTERN_MEMORIES:
+                continue
+            hashes = tuple(sorted(set(m["content_hash"] for m in mems)))
+            if hashes in seen_source_sets:
+                continue
+            seen_source_sets.add(hashes)
+
+            # Find all shared tags for this memory set
+            shared_tags = set(mems[0].get("tags", []))
+            for m in mems[1:]:
+                shared_tags &= set(m.get("tags", []))
+            tag_label = " + ".join(sorted(shared_tags)) if shared_tags else f"{tag_pair[0]} + {tag_pair[1]}"
+
+            confidence = min(1.0, len(mems) / 10.0)
+            insights.append(InsightCard(
+                title=f"Recurring pattern: {tag_label}",
+                content=(
+                    f"{len(mems)} memories share tags {sorted(shared_tags) if shared_tags else list(tag_pair)}, "
+                    f"indicating a recurring theme."
+                ),
+                source_hashes=list(hashes),
+                insight_type="pattern",
+                confidence=confidence,
+            ))
         return insights
 
     def _detect_trends(self, memories: List[dict]) -> List[InsightCard]:
@@ -162,16 +175,13 @@ async def store_insights(insights: List[InsightCard], storage) -> List[str]:
     for card in insights:
         content_hash = _insight_hash(card)
 
-        # Check deduplication — skip if already stored
-        existing = getattr(storage, "memories", {})
-        if hasattr(storage, "get_memory_by_hash"):
+        # Check deduplication via public API
+        if hasattr(storage, "get_by_hash"):
             try:
-                if await storage.get_memory_by_hash(content_hash):
+                if await storage.get_by_hash(content_hash):
                     continue
             except Exception:
                 pass
-        elif content_hash in existing:
-            continue
 
         memory = Memory(
             content=f"[{card.insight_type.upper()}] {card.title}\n\n{card.content}",
@@ -192,7 +202,7 @@ async def store_insights(insights: List[InsightCard], storage) -> List[str]:
             continue
         stored_hashes.append(content_hash)
 
-        # Create derived_from edges
+        # Create derived_from edges (best-effort — non-critical if some fail)
         if hasattr(storage, "store_association"):
             for src_hash in card.source_hashes:
                 try:
@@ -204,12 +214,12 @@ async def store_insights(insights: List[InsightCard], storage) -> List[str]:
                         relationship_type="derived_from",
                     )
                 except Exception:
-                    pass  # Best-effort edge creation
+                    pass
 
     return stored_hashes
 
 
 def _insight_hash(card: InsightCard) -> str:
     """Deterministic hash for deduplication."""
-    key = f"{card.insight_type}:{card.title}:{sorted(card.source_hashes)}"
+    key = f"{card.insight_type}:{card.title}:{','.join(sorted(card.source_hashes))}"
     return f"insight_{hashlib.sha256(key.encode()).hexdigest()[:16]}"

--- a/src/mcp_memory_service/consolidation/insights.py
+++ b/src/mcp_memory_service/consolidation/insights.py
@@ -1,0 +1,215 @@
+"""Insight Cards generator for memory consolidation (Phase 3, #732).
+
+Generates pattern/trend/gap insights from memory clusters using heuristics only.
+Not integrated into the consolidator yet — standalone module for PR #864 hook.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from typing import List, Dict, Optional, Tuple
+import hashlib
+
+from ..models.memory import Memory
+
+
+@dataclass
+class InsightCard:
+    """A generated insight derived from memory patterns."""
+    title: str
+    content: str
+    source_hashes: List[str]
+    insight_type: str  # 'pattern', 'trend', 'gap'
+    confidence: float  # 0.0 - 1.0
+
+
+class InsightGenerator:
+    """Generates Insight Cards from memories using heuristics."""
+
+    MIN_PATTERN_MEMORIES = 3
+    MIN_SHARED_TAGS = 2
+    RECENT_DAYS = 7
+    OLD_DAYS = 30
+    GAP_MIN_MEMORIES = 5
+
+    def generate_insights(
+        self, memories: List[dict], clusters: List[List[dict]]
+    ) -> List[InsightCard]:
+        """Generate insights from memories and their clusters.
+
+        Args:
+            memories: List of memory dicts (must have 'content_hash', 'tags',
+                      'memory_type', 'created_at').
+            clusters: List of clusters (each cluster is a list of memory dicts).
+
+        Returns:
+            List of InsightCard objects.
+        """
+        insights: List[InsightCard] = []
+        insights.extend(self._detect_patterns(memories))
+        insights.extend(self._detect_trends(memories))
+        insights.extend(self._detect_gaps(memories))
+        return insights
+
+    def _detect_patterns(self, memories: List[dict]) -> List[InsightCard]:
+        """Pattern: >=3 memories share 2+ tags → insight about the pattern."""
+        # Group memories by tag pairs
+        pair_memories: Dict[tuple, List[dict]] = defaultdict(list)
+        for mem in memories:
+            tags = sorted(set(mem.get("tags", [])))
+            for i in range(len(tags)):
+                for j in range(i + 1, len(tags)):
+                    pair_memories[(tags[i], tags[j])].append(mem)
+
+        insights = []
+        for tag_pair, mems in pair_memories.items():
+            if len(mems) >= self.MIN_PATTERN_MEMORIES:
+                hashes = [m["content_hash"] for m in mems]
+                confidence = min(1.0, len(mems) / 10.0)
+                insights.append(InsightCard(
+                    title=f"Recurring pattern: {tag_pair[0]} + {tag_pair[1]}",
+                    content=(
+                        f"{len(mems)} memories share tags '{tag_pair[0]}' and "
+                        f"'{tag_pair[1]}', indicating a recurring theme."
+                    ),
+                    source_hashes=hashes,
+                    insight_type="pattern",
+                    confidence=confidence,
+                ))
+        return insights
+
+    def _detect_trends(self, memories: List[dict]) -> List[InsightCard]:
+        """Trend: recent memories (7d) diverge from older (30d) on same tag."""
+        now = datetime.now(timezone.utc).timestamp()
+        recent_cutoff = now - (self.RECENT_DAYS * 86400)
+        old_cutoff = now - (self.OLD_DAYS * 86400)
+
+        recent_tags: Dict[str, List[dict]] = defaultdict(list)
+        old_tags: Dict[str, List[dict]] = defaultdict(list)
+
+        for mem in memories:
+            created = mem.get("created_at")
+            if created is None:
+                continue
+            for tag in mem.get("tags", []):
+                if created >= recent_cutoff:
+                    recent_tags[tag].append(mem)
+                elif created <= old_cutoff:
+                    old_tags[tag].append(mem)
+
+        insights = []
+        for tag in recent_tags:
+            if tag not in old_tags:
+                continue
+            recent_types = set(m.get("memory_type", "") for m in recent_tags[tag])
+            old_types = set(m.get("memory_type", "") for m in old_tags[tag])
+            if recent_types != old_types and len(recent_tags[tag]) >= 2:
+                hashes = (
+                    [m["content_hash"] for m in recent_tags[tag]] +
+                    [m["content_hash"] for m in old_tags[tag]]
+                )
+                insights.append(InsightCard(
+                    title=f"Trend shift in '{tag}'",
+                    content=(
+                        f"Recent memories tagged '{tag}' show different type distribution "
+                        f"({sorted(recent_types)}) vs older ones ({sorted(old_types)})."
+                    ),
+                    source_hashes=hashes,
+                    insight_type="trend",
+                    confidence=0.6,
+                ))
+        return insights
+
+    def _detect_gaps(self, memories: List[dict]) -> List[InsightCard]:
+        """Gap: tag has many memories but none of type 'decision'."""
+        tag_mems: Dict[str, List[dict]] = defaultdict(list)
+        tag_has_decision: Dict[str, bool] = defaultdict(bool)
+
+        for mem in memories:
+            for tag in mem.get("tags", []):
+                tag_mems[tag].append(mem)
+                if mem.get("memory_type") == "decision":
+                    tag_has_decision[tag] = True
+
+        insights = []
+        for tag, mems in tag_mems.items():
+            if len(mems) >= self.GAP_MIN_MEMORIES and not tag_has_decision[tag]:
+                hashes = [m["content_hash"] for m in mems]
+                insights.append(InsightCard(
+                    title=f"Decision gap: '{tag}'",
+                    content=(
+                        f"Tag '{tag}' has {len(mems)} memories but no decisions recorded. "
+                        f"Consider documenting key decisions for this area."
+                    ),
+                    source_hashes=hashes,
+                    insight_type="gap",
+                    confidence=0.5,
+                ))
+        return insights
+
+
+async def store_insights(insights: List[InsightCard], storage) -> List[str]:
+    """Store InsightCards as memories and create derived_from edges.
+
+    Args:
+        insights: List of InsightCard to persist.
+        storage: Storage backend with store() and store_association() methods.
+
+    Returns:
+        List of content hashes for stored insight memories.
+    """
+    stored_hashes = []
+    for card in insights:
+        content_hash = _insight_hash(card)
+
+        # Check deduplication — skip if already stored
+        existing = getattr(storage, "memories", {})
+        if hasattr(storage, "get_memory_by_hash"):
+            try:
+                if await storage.get_memory_by_hash(content_hash):
+                    continue
+            except Exception:
+                pass
+        elif content_hash in existing:
+            continue
+
+        memory = Memory(
+            content=f"[{card.insight_type.upper()}] {card.title}\n\n{card.content}",
+            content_hash=content_hash,
+            tags=["auto-generated", "insight-card", card.insight_type],
+            memory_type="insight",
+            metadata={
+                "source_hashes": card.source_hashes,
+                "insight_type": card.insight_type,
+                "confidence": card.confidence,
+            },
+            created_at=datetime.now(timezone.utc).timestamp(),
+            created_at_iso=datetime.now(timezone.utc).isoformat(),
+        )
+
+        success, _ = await storage.store(memory)
+        if not success:
+            continue
+        stored_hashes.append(content_hash)
+
+        # Create derived_from edges
+        if hasattr(storage, "store_association"):
+            for src_hash in card.source_hashes:
+                try:
+                    await storage.store_association(
+                        source_hash=src_hash,
+                        target_hash=content_hash,
+                        similarity=card.confidence,
+                        connection_types=["derived_from"],
+                        relationship_type="derived_from",
+                    )
+                except Exception:
+                    pass  # Best-effort edge creation
+
+    return stored_hashes
+
+
+def _insight_hash(card: InsightCard) -> str:
+    """Deterministic hash for deduplication."""
+    key = f"{card.insight_type}:{card.title}:{sorted(card.source_hashes)}"
+    return f"insight_{hashlib.sha256(key.encode()).hexdigest()[:16]}"

--- a/src/mcp_memory_service/consolidation/insights.py
+++ b/src/mcp_memory_service/consolidation/insights.py
@@ -1,7 +1,8 @@
 """Insight Cards generator for memory consolidation (Phase 3, #732).
 
 Generates pattern/trend/gap insights from memory clusters using heuristics only.
-Not integrated into the consolidator yet — standalone module for PR #864 hook.
+Integrated into the maintain cycle (memory_quality action='maintain') as Step 5.
+Opt-in via MCP_INSIGHT_CARDS_ENABLED=true environment variable.
 """
 
 from collections import defaultdict
@@ -26,8 +27,8 @@ class InsightCard:
 class InsightGenerator:
     """Generates Insight Cards from memories using heuristics."""
 
-    MIN_PATTERN_MEMORIES = 3
-    MIN_SHARED_TAGS = 2
+    MIN_PATTERN_MEMORIES = 5
+    MIN_SHARED_TAGS = 3
     RECENT_DAYS = 7
     OLD_DAYS = 30
     GAP_MIN_MEMORIES = 5

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -491,6 +491,45 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["errors"].append(f"quality: {e}")
         report["steps"]["quality"] = {"error": str(e)}
 
+    # Step 5: Insight Cards generation (opt-in)
+    from ..config import MCP_INSIGHT_CARDS_ENABLED
+    if MCP_INSIGHT_CARDS_ENABLED:
+        try:
+            from ..consolidation.insights import InsightGenerator, store_insights
+
+            # Fetch recent memories for analysis
+            all_mems = await storage.get_all_memories()
+            mem_dicts = []
+            for m in all_mems[:500]:  # Cap to avoid excessive processing
+                mem_dicts.append({
+                    "content_hash": m.content_hash,
+                    "tags": m.tags if isinstance(m.tags, list) else [t.strip() for t in (m.tags or "").split(",") if t.strip()],
+                    "memory_type": m.memory_type,
+                    "created_at": m.created_at,
+                })
+
+            generator = InsightGenerator()
+            insights = generator.generate_insights(mem_dicts, [])
+
+            if dry_run:
+                report["steps"]["insights"] = {
+                    "skipped_dry_run": True,
+                    "candidates": len(insights),
+                    "types": {t: sum(1 for i in insights if i.insight_type == t) for t in ("pattern", "trend", "gap")},
+                }
+            else:
+                stored = await store_insights(insights, storage)
+                report["steps"]["insights"] = {
+                    "generated": len(insights),
+                    "stored": len(stored),
+                    "types": {t: sum(1 for i in insights if i.insight_type == t) for t in ("pattern", "trend", "gap")},
+                }
+        except Exception as e:
+            report["errors"].append(f"insights: {e}")
+            report["steps"]["insights"] = {"error": str(e)}
+    else:
+        report["steps"]["insights"] = {"skipped": True, "reason": "MCP_INSIGHT_CARDS_ENABLED=false"}
+
     elapsed = round(time.time() - start, 2)
     report["elapsed_seconds"] = elapsed
     report["completed_at"] = datetime.now(timezone.utc).isoformat()

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -492,10 +492,10 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["steps"]["quality"] = {"error": str(e)}
 
     # Step 5: Insight Cards generation (opt-in)
-    from ..config import MCP_INSIGHT_CARDS_ENABLED
+    from ...config import MCP_INSIGHT_CARDS_ENABLED
     if MCP_INSIGHT_CARDS_ENABLED:
         try:
-            from ..consolidation.insights import InsightGenerator, store_insights
+            from ...consolidation.insights import InsightGenerator, store_insights
 
             # Fetch recent memories for analysis
             all_mems = await storage.get_all_memories()

--- a/tests/test_insight_cards.py
+++ b/tests/test_insight_cards.py
@@ -34,16 +34,20 @@ class TestPatternDetection:
             _mem("h1", ["python", "testing"]),
             _mem("h2", ["python", "testing"]),
             _mem("h3", ["python", "testing"]),
+            _mem("h4", ["python", "testing"]),
+            _mem("h5", ["python", "testing"]),
         ]
         insights = generator.generate_insights(memories, [])
         patterns = [i for i in insights if i.insight_type == "pattern"]
         assert len(patterns) >= 1
         assert any("python" in p.title and "testing" in p.title for p in patterns)
 
-    def test_no_pattern_with_fewer_than_3(self, generator):
+    def test_no_pattern_with_fewer_than_5(self, generator):
         memories = [
             _mem("h1", ["python", "testing"]),
             _mem("h2", ["python", "testing"]),
+            _mem("h3", ["python", "testing"]),
+            _mem("h4", ["python", "testing"]),
         ]
         insights = generator.generate_insights(memories, [])
         patterns = [i for i in insights if i.insight_type == "pattern"]
@@ -60,10 +64,12 @@ class TestPatternDetection:
             _mem("a1", ["docker", "deploy"]),
             _mem("a2", ["docker", "deploy"]),
             _mem("a3", ["docker", "deploy"]),
+            _mem("a4", ["docker", "deploy"]),
+            _mem("a5", ["docker", "deploy"]),
         ]
         insights = generator.generate_insights(memories, [])
         patterns = [i for i in insights if i.insight_type == "pattern"]
-        assert set(patterns[0].source_hashes) == {"a1", "a2", "a3"}
+        assert set(patterns[0].source_hashes) == {"a1", "a2", "a3", "a4", "a5"}
 
 
 class TestTrendDetection:

--- a/tests/test_insight_cards.py
+++ b/tests/test_insight_cards.py
@@ -1,0 +1,202 @@
+"""Tests for Insight Cards generation (Phase 3, #732)."""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock
+
+from mcp_memory_service.consolidation.insights import (
+    InsightCard,
+    InsightGenerator,
+    store_insights,
+    _insight_hash,
+)
+
+
+@pytest.fixture
+def generator():
+    return InsightGenerator()
+
+
+def _mem(hash, tags, memory_type="observation", days_ago=1):
+    """Helper to create a memory dict."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).timestamp()
+    return {
+        "content_hash": hash,
+        "tags": tags,
+        "memory_type": memory_type,
+        "created_at": ts,
+    }
+
+
+class TestPatternDetection:
+    def test_pattern_detected_with_3_shared_tag_pair(self, generator):
+        memories = [
+            _mem("h1", ["python", "testing"]),
+            _mem("h2", ["python", "testing"]),
+            _mem("h3", ["python", "testing"]),
+        ]
+        insights = generator.generate_insights(memories, [])
+        patterns = [i for i in insights if i.insight_type == "pattern"]
+        assert len(patterns) >= 1
+        assert any("python" in p.title and "testing" in p.title for p in patterns)
+
+    def test_no_pattern_with_fewer_than_3(self, generator):
+        memories = [
+            _mem("h1", ["python", "testing"]),
+            _mem("h2", ["python", "testing"]),
+        ]
+        insights = generator.generate_insights(memories, [])
+        patterns = [i for i in insights if i.insight_type == "pattern"]
+        assert len(patterns) == 0
+
+    def test_pattern_confidence_scales_with_count(self, generator):
+        memories = [_mem(f"h{i}", ["api", "rest"]) for i in range(10)]
+        insights = generator.generate_insights(memories, [])
+        patterns = [i for i in insights if i.insight_type == "pattern"]
+        assert patterns[0].confidence == 1.0
+
+    def test_pattern_source_hashes_correct(self, generator):
+        memories = [
+            _mem("a1", ["docker", "deploy"]),
+            _mem("a2", ["docker", "deploy"]),
+            _mem("a3", ["docker", "deploy"]),
+        ]
+        insights = generator.generate_insights(memories, [])
+        patterns = [i for i in insights if i.insight_type == "pattern"]
+        assert set(patterns[0].source_hashes) == {"a1", "a2", "a3"}
+
+
+class TestTrendDetection:
+    def test_trend_detected_when_types_diverge(self, generator):
+        memories = [
+            # Recent (within 7 days) — errors
+            _mem("r1", ["database"], "error", days_ago=1),
+            _mem("r2", ["database"], "error", days_ago=2),
+            # Old (>30 days) — observations
+            _mem("o1", ["database"], "observation", days_ago=35),
+            _mem("o2", ["database"], "observation", days_ago=40),
+        ]
+        insights = generator.generate_insights(memories, [])
+        trends = [i for i in insights if i.insight_type == "trend"]
+        assert len(trends) >= 1
+        assert any("database" in t.title for t in trends)
+
+    def test_no_trend_when_types_same(self, generator):
+        memories = [
+            _mem("r1", ["infra"], "observation", days_ago=1),
+            _mem("r2", ["infra"], "observation", days_ago=2),
+            _mem("o1", ["infra"], "observation", days_ago=35),
+        ]
+        insights = generator.generate_insights(memories, [])
+        trends = [i for i in insights if i.insight_type == "trend"]
+        assert len(trends) == 0
+
+
+class TestGapDetection:
+    def test_gap_detected_when_no_decisions(self, generator):
+        memories = [_mem(f"g{i}", ["kubernetes"], "observation") for i in range(5)]
+        insights = generator.generate_insights(memories, [])
+        gaps = [i for i in insights if i.insight_type == "gap"]
+        assert len(gaps) >= 1
+        assert any("kubernetes" in g.title for g in gaps)
+
+    def test_no_gap_when_decision_exists(self, generator):
+        memories = [_mem(f"g{i}", ["kubernetes"], "observation") for i in range(5)]
+        memories.append(_mem("d1", ["kubernetes"], "decision"))
+        insights = generator.generate_insights(memories, [])
+        gaps = [i for i in insights if i.insight_type == "gap"]
+        k8s_gaps = [g for g in gaps if "kubernetes" in g.title]
+        assert len(k8s_gaps) == 0
+
+    def test_no_gap_when_too_few_memories(self, generator):
+        memories = [_mem(f"g{i}", ["rare-tag"], "observation") for i in range(3)]
+        insights = generator.generate_insights(memories, [])
+        gaps = [i for i in insights if i.insight_type == "gap" and "rare-tag" in g.title for g in [i]]
+        # Simpler check
+        gap_titles = [g.title for g in insights if g.insight_type == "gap"]
+        assert not any("rare-tag" in t for t in gap_titles)
+
+
+class TestStoreInsights:
+    @pytest.mark.asyncio
+    async def test_insights_stored_as_memories(self):
+        storage = AsyncMock()
+        storage.store = AsyncMock(return_value=(True, "hash"))
+        storage.store_association = AsyncMock(return_value=True)
+        storage.get_memory_by_hash = AsyncMock(return_value=None)
+
+        cards = [
+            InsightCard(
+                title="Test pattern",
+                content="A test insight",
+                source_hashes=["src1", "src2"],
+                insight_type="pattern",
+                confidence=0.8,
+            )
+        ]
+
+        hashes = await store_insights(cards, storage)
+        assert len(hashes) == 1
+        storage.store.assert_called_once()
+        stored_mem = storage.store.call_args[0][0]
+        assert stored_mem.memory_type == "insight"
+        assert "auto-generated" in stored_mem.tags
+        assert "insight-card" in stored_mem.tags
+
+    @pytest.mark.asyncio
+    async def test_derived_from_edges_created(self):
+        storage = AsyncMock()
+        storage.store = AsyncMock(return_value=(True, "hash"))
+        storage.store_association = AsyncMock(return_value=True)
+        storage.get_memory_by_hash = AsyncMock(return_value=None)
+
+        cards = [
+            InsightCard(
+                title="Edge test",
+                content="Content",
+                source_hashes=["s1", "s2", "s3"],
+                insight_type="pattern",
+                confidence=0.7,
+            )
+        ]
+
+        await store_insights(cards, storage)
+        assert storage.store_association.call_count == 3
+        # Verify relationship_type
+        for call in storage.store_association.call_args_list:
+            assert call[1]["relationship_type"] == "derived_from"
+
+    @pytest.mark.asyncio
+    async def test_deduplication_skips_existing(self):
+        storage = AsyncMock()
+        storage.store = AsyncMock(return_value=(True, "hash"))
+        storage.store_association = AsyncMock(return_value=True)
+        storage.get_memory_by_hash = AsyncMock(return_value={"exists": True})
+
+        cards = [
+            InsightCard(
+                title="Dup test",
+                content="Content",
+                source_hashes=["s1"],
+                insight_type="gap",
+                confidence=0.5,
+            )
+        ]
+
+        hashes = await store_insights(cards, storage)
+        assert len(hashes) == 0
+        storage.store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deterministic_hash(self):
+        card = InsightCard(
+            title="Same title",
+            content="Same content",
+            source_hashes=["a", "b"],
+            insight_type="pattern",
+            confidence=0.9,
+        )
+        h1 = _insight_hash(card)
+        h2 = _insight_hash(card)
+        assert h1 == h2
+        assert h1.startswith("insight_")

--- a/tests/test_insight_cards.py
+++ b/tests/test_insight_cards.py
@@ -123,7 +123,7 @@ class TestStoreInsights:
         storage = AsyncMock()
         storage.store = AsyncMock(return_value=(True, "hash"))
         storage.store_association = AsyncMock(return_value=True)
-        storage.get_memory_by_hash = AsyncMock(return_value=None)
+        storage.get_by_hash = AsyncMock(return_value=None)
 
         cards = [
             InsightCard(
@@ -148,7 +148,7 @@ class TestStoreInsights:
         storage = AsyncMock()
         storage.store = AsyncMock(return_value=(True, "hash"))
         storage.store_association = AsyncMock(return_value=True)
-        storage.get_memory_by_hash = AsyncMock(return_value=None)
+        storage.get_by_hash = AsyncMock(return_value=None)
 
         cards = [
             InsightCard(


### PR DESCRIPTION
Phase 3 of the #732 roadmap — automated latent insight extraction.

## What it does

After consolidation, generates "Insight Cards" that summarize latent patterns in the memory graph. These insights become new memories themselves, creating recursive memory depth.

## InsightGenerator (`consolidation/insights.py`)

Three heuristic detectors (no LLM required):

### Pattern Detection
If ≥3 memories share 2+ tags → generates an insight about the recurring pattern.
Confidence scales with memory count.

### Trend Detection
Compares memory types between recent (7d) and older (30d) windows for the same tag.
If distribution shifts significantly → flags as trend.

### Gap Detection
If a tag has ≥5 memories but none of type 'decision' → flags as decision gap.
Useful for identifying areas where knowledge exists but no action was taken.

## InsightCard dataclass

```python
@dataclass
class InsightCard:
    title: str
    content: str
    source_hashes: List[str]
    insight_type: str  # pattern, trend, gap
    confidence: float  # 0.0-1.0
```

## Storage

- Each insight stored as memory with `memory_type='insight'`, tags `['auto-generated', 'insight-card']`
- Creates `derived_from` edges to source memories
- Deterministic hash prevents duplicate insights across runs

## Testing

13 tests covering all three detectors + storage + deduplication.

## Integration Note

This module is standalone. Integration with the consolidator will happen after PR #864 (wire plugin hooks) is merged — the `on_consolidate` hook is the natural trigger point.

Refs #732 (Phase 3: Automated insight generation during consolidate).