### PR TITLE
chore: release v10.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.51.0] - 2026-05-07
+
+### Added
+
+- **Plugin fire points wired into MemoryService lifecycle** ([#864](https://github.com/doobidoo/mcp-memory-service/pull/864), @filhocf): Connects the plugin hook scaffolding (introduced in v10.50.0, PR #856) to actual lifecycle events in `MemoryService`. The four hooks — `on_store`, `on_delete`, `on_retrieve`, and `on_consolidate` — are now invoked at the appropriate call sites. Third-party plugins registered via `entry_points` will receive live events from this release onward.
+- **`GET /api/types` endpoint + dynamic type dropdowns in dashboard** ([#863](https://github.com/doobidoo/mcp-memory-service/pull/863), @filhocf): New REST endpoint returns all valid memory types (built-in + custom types from `MCP_CUSTOM_MEMORY_TYPES`). The web dashboard type filter and store-form dropdowns are now populated dynamically from this endpoint instead of being hardcoded, so custom ontology entries appear automatically in the UI.
+- **Audit-log example plugin** ([#867](https://github.com/doobidoo/mcp-memory-service/pull/867), @filhocf): Reference implementation in `examples/plugins/audit_log/` demonstrating all four lifecycle hooks. Shows how to write, package, and install a plugin using `entry_points` discovery. Serves as living documentation for the plugin API.
+
 ## [10.50.0] - 2026-05-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.50.0 - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.51.0 - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,17 +490,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.50.0** (May 6, 2026)
+## Latest Release: **v10.51.0** (May 7, 2026)
 
-**feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)**
+**feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)**
 
 **What's New:**
-- **Plugin extension API**: Four lifecycle hooks (`on_store`, `on_delete`, `on_retrieve`, `on_consolidate`) with `entry_points` discovery let third-party packages register hooks without modifying core. Pure scaffolding — fire points wired in follow-up PR. Refs #732.
-- **Dependency updates**: `authlib` 1.7.1, `cryptography` 48, `torch` 2.11; CI actions bumped (`attest-build-provenance` 1→4, `codeql-action` 3→4, `hadolint-action` 3.3.0).
+- **Plugin hooks are now live**: Fire points wired into `MemoryService` — `on_store`, `on_delete`, `on_retrieve`, `on_consolidate` called at actual lifecycle events. Third-party plugins receive live events. (PR #864)
+- **Dynamic type dropdowns**: New `GET /api/types` endpoint returns all valid memory types (built-in + custom). Dashboard filter and store-form dropdowns now populate from this endpoint automatically. (PR #863)
+- **Audit-log example plugin**: Reference implementation in `examples/plugins/audit_log/` demonstrating all four hooks with `entry_points` packaging. Living documentation for the plugin API. (PR #867)
 
 ---
 
 **Previous Releases**:
+- **v10.50.0** - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)
 - **v10.49.4** - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)
 - **v10.49.3** - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)
 - **v10.49.2** - fix(ontology): register custom base types with empty subtype lists (PR #846)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.50.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.51.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.50.0">
-<meta property="og:description" content="Plugin hook scaffolding (on_store, on_delete, on_retrieve, on_consolidate) with entry_points discovery. Ecosystem extensibility without forking core. CLI lifecycle commands + lazy imports for &lt;3s startup. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.51.0">
+<meta property="og:description" content="Plugin hooks live in MemoryService lifecycle (on_store, on_delete, on_retrieve, on_consolidate). Dynamic type dropdowns via /api/types. Audit-log example plugin. Ecosystem extensibility without forking core. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.50 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.51 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.50</h2>
-    <p class="section-subtitle">Plugin hook scaffolding — extend memory without forking core. ~1,838 tests.</p>
+    <h2 class="section-title">What's New in v10.51</h2>
+    <p class="section-subtitle">Plugin hooks live — wire your logic into every memory event. ~1,838 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon http">&#9881;</div>
-        <h3>Plugin Extension API</h3>
-        <p>Four lifecycle hooks — <code>on_store</code>, <code>on_delete</code>, <code>on_retrieve</code>, <code>on_consolidate</code> — let third-party packages inject logic at key points using <code>entry_points</code> discovery. No core fork required. (PR #856, @filhocf, refs #732)</p>
+        <h3>Plugin Hooks Are Live</h3>
+        <p>Fire points wired into <code>MemoryService</code> — <code>on_store</code>, <code>on_delete</code>, <code>on_retrieve</code>, <code>on_consolidate</code> now called at actual lifecycle events. Install a plugin package and it receives live events automatically. (PR #864, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon consolidation">&#9889;</div>
-        <h3>entry_points Discovery</h3>
-        <p>Plugins register via standard Python packaging (<code>entry_points</code> group <code>mcp_memory_service.plugins</code>). Install a plugin package and hooks activate automatically — no config changes needed. Enables the ecosystem extensibility milestone.</p>
+        <h3>Dynamic Type Dropdowns</h3>
+        <p>New <code>GET /api/types</code> endpoint returns all valid memory types — built-in and custom (<code>MCP_CUSTOM_MEMORY_TYPES</code>). Dashboard filter and store-form dropdowns now populate dynamically, so custom ontology entries appear in the UI automatically. (PR #863, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon oauth">&#128274;</div>
-        <h3>Dependency Refresh</h3>
-        <p>Latest <code>authlib</code>, <code>cryptography</code>, and <code>torch</code> releases. CI actions updated: <code>attest-build-provenance</code>, <code>codeql-action</code>, and <code>hadolint-action</code> all bumped to current majors. All 905 integration tests pass. (PRs #858–#861)</p>
+        <div class="feature-icon oauth">&#128196;</div>
+        <h3>Audit-Log Example Plugin</h3>
+        <p>Reference implementation in <code>examples/plugins/audit_log/</code> demonstrating all four hooks with standard <code>entry_points</code> packaging. A complete, working plugin you can fork as a starting point. Living documentation for the plugin API. (PR #867, @filhocf)</p>
       </div>
     </div>
   </div>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.50.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.51.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.51.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
 <meta property="og:title" content="MCP Memory Service v10.51.0">
-<meta property="og:description" content="Plugin hooks live in MemoryService lifecycle (on_store, on_delete, on_retrieve, on_consolidate). Dynamic type dropdowns via /api/types. Audit-log example plugin. Ecosystem extensibility without forking core. Streamable HTTP + OAuth 2.1 + PKCE. LongMemEval R@5 86%.">
+<meta property="og:description" content="Plugin hooks now live in MemoryService. Dynamic /api/types dropdowns. Audit-log example. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -150,7 +150,7 @@ footer a{color:var(--cyan)}
         <p>New <code>GET /api/types</code> endpoint returns all valid memory types — built-in and custom (<code>MCP_CUSTOM_MEMORY_TYPES</code>). Dashboard filter and store-form dropdowns now populate dynamically, so custom ontology entries appear in the UI automatically. (PR #863, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon oauth">&#128196;</div>
+        <div class="feature-icon privacy">&#128196;</div>
         <h3>Audit-Log Example Plugin</h3>
         <p>Reference implementation in <code>examples/plugins/audit_log/</code> demonstrating all four hooks with standard <code>entry_points</code> packaging. A complete, working plugin you can fork as a starting point. Living documentation for the plugin API. (PR #867, @filhocf)</p>
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.50.0"
+version = "10.51.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.50.0"
+__version__ = "10.51.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.50.0"
+version = "10.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.51.0

MINOR release — plugin hooks live, dynamic type dropdowns, audit-log example plugin.

### Changes included

- **feat(plugins): wire fire points into MemoryService lifecycle** ([#864](https://github.com/doobidoo/mcp-memory-service/pull/864), @filhocf) — `on_store`, `on_delete`, `on_retrieve`, `on_consolidate` are now invoked at actual lifecycle call sites in `MemoryService`. Third-party plugins registered via `entry_points` receive live events from this release.
- **feat(web): populate type dropdowns from /api/types endpoint** ([#863](https://github.com/doobidoo/mcp-memory-service/pull/863), @filhocf) — New `GET /api/types` endpoint returns all valid memory types (built-in + custom). Dashboard filter and store-form dropdowns now populate dynamically.
- **docs(plugins): add audit-log example plugin** ([#867](https://github.com/doobidoo/mcp-memory-service/pull/867), @filhocf) — Reference implementation in `examples/plugins/audit_log/` with all four hooks and `entry_points` packaging.

### Files updated

- `src/mcp_memory_service/_version.py` — 10.50.0 → 10.51.0
- `pyproject.toml` — 10.50.0 → 10.51.0
- `uv.lock` — regenerated
- `CHANGELOG.md` — [Unreleased] moved to [10.51.0] section
- `README.md` — Latest Release updated
- `CLAUDE.md` — version callout updated
- `docs/index.html` — badge, title, feature cards, release notes link updated (MINOR release)

### Special Thanks

Huge thanks to @filhocf for all three PRs in this release — the plugin system is now fully operational end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)