### PR TITLE
chore: release v10.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.51.1] - 2026-05-07
+
+### Fixed
+
+- **Milvus consolidation failure** ([#872](https://github.com/doobidoo/mcp-memory-service/pull/872), @henry201605): Adds `delete_memory(hash) -> bool` alias to `MilvusMemoryStorage`. Without this method, `memory_consolidate` silently failed on the Milvus backend during Compression (stage 4) and Controlled Forgetting (stage 5) with `AttributeError`. No behaviour change for other backends.
+
 ## [10.51.0] - 2026-05-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.51.0 - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.51.1 - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,18 +490,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.51.0** (May 7, 2026)
+## Latest Release: **v10.51.1** (May 7, 2026)
 
-**feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)**
+**fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)**
 
 **What's New:**
-- **Plugin hooks are now live**: Fire points wired into `MemoryService` — `on_store`, `on_delete`, `on_retrieve`, `on_consolidate` called at actual lifecycle events. Third-party plugins receive live events. (PR #864)
-- **Dynamic type dropdowns**: New `GET /api/types` endpoint returns all valid memory types (built-in + custom). Dashboard filter and store-form dropdowns now populate from this endpoint automatically. (PR #863)
-- **Audit-log example plugin**: Reference implementation in `examples/plugins/audit_log/` demonstrating all four hooks with `entry_points` packaging. Living documentation for the plugin API. (PR #867)
+- **Milvus consolidation fix**: Adds `delete_memory(hash) -> bool` alias to `MilvusMemoryStorage`. Without this method, `memory_consolidate` silently failed on the Milvus backend during Compression (stage 4) and Controlled Forgetting (stage 5) with `AttributeError`. (PR #872)
 
 ---
 
 **Previous Releases**:
+- **v10.51.0** - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)
 - **v10.50.0** - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)
 - **v10.49.4** - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)
 - **v10.49.3** - fix(opencode): correct API path, payload field, and client-side tag filter (PRs #849, #850)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.51.0"
+version = "10.51.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.51.0"
+__version__ = "10.51.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.51.0"
+version = "10.51.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version from v10.51.0 to v10.51.1
- Adds CHANGELOG entry for PR #872 (fix(milvus): delete_memory proxy for consolidation protocol)
- Updates README Latest Release section
- Updates CLAUDE.md version callout
- Updates uv.lock

## Change

**fix(milvus): add delete_memory proxy for consolidation protocol** ([#872](https://github.com/doobidoo/mcp-memory-service/pull/872), @henry201605)

Adds `delete_memory(hash) -> bool` alias to `MilvusMemoryStorage`. Without this method, `memory_consolidate` silently failed on the Milvus backend during Compression (stage 4) and Controlled Forgetting (stage 5) with `AttributeError`. 31 additions across `milvus.py` + `test_milvus.py`, no breaking changes.

## Test plan

- [x] Patch release — no new features, no landing page update needed
- [x] uv.lock updated via `uv lock`
- [x] CHANGELOG follows reverse-chronological order, no duplicates
- [x] PyPI will auto-publish via GitHub Actions on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)