### PR TITLE
fix(oauth): CORS preflight failures and missing resource_metadata (#876)

### DIFF
--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -317,7 +317,17 @@ class ServerRunManager:
             from ..web.oauth.authorization import router as authorization_router
             from ..config import OAUTH_ISSUER
 
+            from fastapi.middleware.cors import CORSMiddleware
+
             oauth_app = FastAPI(title="MCP Memory OAuth", docs_url=None, redoc_url=None)
+            _cors_origins = [o.strip() for o in os.environ.get("MCP_CORS_ORIGINS", "").split(",") if o.strip()]
+            oauth_app.add_middleware(
+                CORSMiddleware,
+                allow_origins=_cors_origins or ["*"],
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
             oauth_app.include_router(discovery_router)
             oauth_app.include_router(registration_router, prefix="/oauth")
             oauth_app.include_router(authorization_router, prefix="/oauth")
@@ -354,6 +364,24 @@ class ServerRunManager:
 
             path = scope.get("path", "")
             if path == "/mcp" or path == "/mcp/":
+                # Handle CORS preflight for /mcp
+                if scope.get("method") == "OPTIONS":
+                    req_hdrs = dict(scope.get("headers", []))
+                    origin = req_hdrs.get(b"origin", b"").decode("latin-1")
+                    cors_origins = [o.strip() for o in os.environ.get("MCP_CORS_ORIGINS", "").split(",") if o.strip()]
+                    allow_origin = origin if (not cors_origins or origin in cors_origins) else (cors_origins[0] if cors_origins else "*")
+                    response = StarletteResponse(
+                        "",
+                        status_code=204,
+                        headers={
+                            "Access-Control-Allow-Origin": allow_origin,
+                            "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+                            "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key",
+                            "Access-Control-Max-Age": "86400",
+                        },
+                    )
+                    await response(scope, receive, send)
+                    return
                 # Auth check on /mcp
                 if OAUTH_ENABLED or API_KEY:
                     if not await _check_auth_from_scope(scope, receive, send):
@@ -406,11 +434,14 @@ class ServerRunManager:
                     return True
 
             # Auth failed - send 401
+            from ..config import OAUTH_ISSUER as _issuer
+            _resource_metadata_url = f"{_issuer}/.well-known/oauth-protected-resource"
+            _www_auth = f'Bearer resource_metadata="{_resource_metadata_url}"' if OAUTH_ENABLED and _issuer else "Bearer"
             response = StarletteResponse(
                 '{"error":"unauthorized","error_description":"Valid Bearer token or API key required"}',
                 status_code=401,
                 headers={
-                    "WWW-Authenticate": "Bearer",
+                    "WWW-Authenticate": _www_auth,
                     "Content-Type": "application/json",
                 },
             )

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -324,7 +324,9 @@ class ServerRunManager:
             oauth_app.add_middleware(
                 CORSMiddleware,
                 allow_origins=_cors_origins or ["*"],
-                allow_credentials=True,
+                # allow_credentials requires explicit origins; wildcard + credentials
+                # is rejected by browsers (CORS spec §3.2.2).
+                allow_credentials=bool(_cors_origins),
                 allow_methods=["*"],
                 allow_headers=["*"],
             )
@@ -368,15 +370,19 @@ class ServerRunManager:
                 if scope.get("method") == "OPTIONS":
                     req_hdrs = dict(scope.get("headers", []))
                     origin = req_hdrs.get(b"origin", b"").decode("latin-1")
-                    cors_origins = [o.strip() for o in os.environ.get("MCP_CORS_ORIGINS", "").split(",") if o.strip()]
-                    allow_origin = origin if (not cors_origins or origin in cors_origins) else (cors_origins[0] if cors_origins else "*")
+                    # Reuse _cors_origins parsed at startup (set when OAUTH_ENABLED);
+                    # fall back to re-parsing if OAuth is off but CORS origins are set.
+                    _mcp_cors = _cors_origins if OAUTH_ENABLED else [
+                        o.strip() for o in os.environ.get("MCP_CORS_ORIGINS", "").split(",") if o.strip()
+                    ]
+                    allow_origin = "*" if not _mcp_cors else (origin if origin in _mcp_cors else _mcp_cors[0])
                     response = StarletteResponse(
                         "",
                         status_code=204,
                         headers={
                             "Access-Control-Allow-Origin": allow_origin,
                             "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-                            "Access-Control-Allow-Headers": "Content-Type, Authorization, X-API-Key",
+                            "Access-Control-Allow-Headers": "*",
                             "Access-Control-Max-Age": "86400",
                         },
                     )
@@ -435,7 +441,7 @@ class ServerRunManager:
 
             # Auth failed - send 401
             from ..config import OAUTH_ISSUER as _issuer
-            _resource_metadata_url = f"{_issuer}/.well-known/oauth-protected-resource"
+            _resource_metadata_url = f"{_issuer.rstrip('/')}/.well-known/oauth-protected-resource"
             _www_auth = f'Bearer resource_metadata="{_resource_metadata_url}"' if OAUTH_ENABLED and _issuer else "Bearer"
             response = StarletteResponse(
                 '{"error":"unauthorized","error_description":"Valid Bearer token or API key required"}',

--- a/src/mcp_memory_service/web/oauth/middleware.py
+++ b/src/mcp_memory_service/web/oauth/middleware.py
@@ -37,8 +37,10 @@ from ...config import (
 
 def _www_authenticate_header() -> str:
     """Build WWW-Authenticate header with resource_metadata for RFC 9728 compliance."""
-    resource_metadata = f"{OAUTH_ISSUER}/.well-known/oauth-protected-resource"
+    resource_metadata = f"{OAUTH_ISSUER.rstrip('/')}/.well-known/oauth-protected-resource"
     return f'Bearer resource_metadata="{resource_metadata}"'
+
+
 from .storage import get_oauth_storage
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/web/oauth/middleware.py
+++ b/src/mcp_memory_service/web/oauth/middleware.py
@@ -34,6 +34,11 @@ from ...config import (
     get_jwt_algorithm,
     get_jwt_verification_key
 )
+
+def _www_authenticate_header() -> str:
+    """Build WWW-Authenticate header with resource_metadata for RFC 9728 compliance."""
+    resource_metadata = f"{OAUTH_ISSUER}/.well-known/oauth-protected-resource"
+    return f'Bearer resource_metadata="{resource_metadata}"'
 from .storage import get_oauth_storage
 
 logger = logging.getLogger(__name__)
@@ -338,7 +343,7 @@ async def get_current_user(
                 "error": "invalid_token",
                 "error_description": error_msg
             },
-            headers={"WWW-Authenticate": "Bearer"}
+            headers={"WWW-Authenticate": _www_authenticate_header()}
         )
 
     # Check for API key authentication without Bearer token
@@ -397,7 +402,7 @@ async def get_current_user(
             "error": "authorization_required",
             "error_description": error_msg
         },
-        headers={"WWW-Authenticate": "Bearer"}
+        headers={"WWW-Authenticate": _www_authenticate_header()}
     )
 
 


### PR DESCRIPTION
## Summary

Fixes three bugs in the OAuth remote connector flow reported in #876. All changes are in `startup_orchestrator.py` and `web/oauth/middleware.py`.

- **CORS on oauth_app**: Adds `CORSMiddleware` to the `oauth_app` FastAPI sub-app so browser preflight requests to `/.well-known/*` and `/oauth/*` return `200` with proper CORS headers instead of `405 Method Not Allowed`.
- **OPTIONS handling on /mcp**: The raw ASGI handler for `/mcp` now checks for `OPTIONS` before running the auth check, returning `204` with CORS headers instead of `401`.
- **`resource_metadata` in `WWW-Authenticate`**: All `401` responses from both `startup_orchestrator.py` and `oauth/middleware.py` now include `resource_metadata="<issuer>/.well-known/oauth-protected-resource"` per RFC 9728 / MCP spec §Authorization.

`MCP_CORS_ORIGINS` (already an accepted env var) controls allowed origins; defaults to `*`.

## Test plan

- [ ] `curl -si -X OPTIONS <host>/oauth/register -H "Origin: https://claude.ai" ...` returns `200` with `Access-Control-Allow-Origin`
- [ ] `curl -si -X OPTIONS <host>/mcp -H "Origin: https://claude.ai" ...` returns `204` with CORS headers
- [ ] `curl -si -X POST <host>/mcp -H "Content-Type: application/json" -d '{}'` returns `401` with `WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource"`
- [ ] End-to-end: Claude Desktop / claude.ai remote connector opens the authorization page and authenticates successfully

Closes #876