### PR TITLE
refactor(milvus): add opt-in embedding hydration on read paths

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -755,14 +755,36 @@ class MilvusMemoryStorage(MemoryStorage):
             entity["content_lower"] = content.lower()
         return entity
 
-    def _entity_to_memory(self, row: Dict[str, Any]) -> Optional[Memory]:
+    def _entity_to_memory(
+        self,
+        row: Dict[str, Any],
+        include_embedding: bool = False,
+    ) -> Optional[Memory]:
+        """Convert a Milvus row dict into a :class:`Memory`.
+
+        Args:
+            row: The row dict as returned by pymilvus ``query`` or
+                ``query_iterator``.
+            include_embedding: If True **and** the row carries a usable
+                ``vector`` value, populate ``Memory.embedding`` as a
+                ``list[float]``. If False, ``Memory.embedding`` is always
+                ``None``. If True but the vector is missing / empty /
+                malformed, ``Memory.embedding`` is ``None`` — hydration
+                never raises.
+
+        Returns:
+            A :class:`Memory` instance, or ``None`` if the row cannot be
+            parsed at all (e.g. missing mandatory scalar fields).
+        """
         try:
+            embedding = self._coerce_vector(row) if include_embedding else None
             return Memory(
                 content=row.get("content", "") or "",
                 content_hash=row.get("id", "") or "",
                 tags=_string_to_tags(row.get("tags")),
                 memory_type=row.get("memory_type") or None,
                 metadata=_safe_json_loads(row.get("metadata", ""), "milvus_entity"),
+                embedding=embedding,
                 created_at=row.get("created_at"),
                 updated_at=row.get("updated_at"),
                 created_at_iso=row.get("created_at_iso") or None,
@@ -770,6 +792,52 @@ class MilvusMemoryStorage(MemoryStorage):
             )
         except Exception as exc:  # noqa: BLE001 — never kill a batch on one bad row
             logger.warning("Failed to convert Milvus entity to Memory: %s", exc)
+            return None
+
+    def _coerce_vector(self, row: Dict[str, Any]) -> Optional[List[float]]:
+        """Convert ``row['vector']`` into a ``list[float]`` or return ``None``.
+
+        Never raises. The four non-happy paths all map to ``None``:
+
+        * ``vector`` key absent
+        * ``vector is None``
+        * ``vector`` is an empty sequence
+        * ``vector`` is a type we cannot safely convert to a list
+
+        Numpy arrays are converted via ``.tolist()``; other sequences go
+        through ``list(...)``. A successful conversion is **not** validated
+        against ``self.embedding_dimension`` — dimension validation belongs
+        to ``_validate_existing_collection`` at connect time, not the hot
+        loop. Downstream consumers (clustering / associations) already
+        handle mismatched-length embeddings defensively.
+        """
+        if "vector" not in row:
+            return None
+        raw = row["vector"]
+        if raw is None:
+            return None
+        # Fast path: already a list of numbers.
+        if isinstance(raw, list):
+            return raw if raw else None
+        # Numpy array path.
+        to_list = getattr(raw, "tolist", None)
+        if callable(to_list):
+            try:
+                converted = to_list()
+            except Exception:  # noqa: BLE001 — tolist() contract is loose
+                converted = None
+            if isinstance(converted, list):
+                return converted if converted else None
+        # Generic sequence fallback.
+        try:
+            converted = list(raw)
+            return converted if converted else None
+        except TypeError:
+            row_id = row.get("id", "<unknown>")
+            logger.warning(
+                "Unexpected vector type %s for row id=%s; leaving embedding=None",
+                type(raw).__name__, _sanitize_log_value(row_id),
+            )
             return None
 
     @staticmethod
@@ -807,10 +875,24 @@ class MilvusMemoryStorage(MemoryStorage):
             return keep[0]
         return " and ".join(f"({p})" for p in keep)
 
-    _OUTPUT_FIELDS = (
+    # Base output fields for CRUD read paths. Intentionally excludes ``vector``
+    # (roughly ``embedding_dimension * 4`` bytes, ≈ 2 KB per row at 512-dim) so
+    # that high-frequency tool calls like ``retrieve`` / ``search_by_tag`` /
+    # ``get_by_hash`` don't transfer vectors the caller doesn't consume.
+    _OUTPUT_FIELDS_BASE = (
         "id", "content", "tags", "memory_type", "metadata",
         "created_at", "updated_at", "created_at_iso", "updated_at_iso",
     )
+
+    # Extended output fields used by the consolidation read path, which needs
+    # the stored vector to drive DBSCAN clustering and cosine-similarity
+    # associations. Callers opt in via ``include_embeddings=True`` on
+    # ``get_all_memories`` / ``get_memories_by_time_range``.
+    _OUTPUT_FIELDS_WITH_VECTOR = _OUTPUT_FIELDS_BASE + ("vector",)
+
+    # Backward-compat alias. All existing references keep working; new code
+    # should pick one of the two tuples above explicitly.
+    _OUTPUT_FIELDS = _OUTPUT_FIELDS_BASE
 
     # -- Semantic dedup ------------------------------------------------------
 
@@ -1688,6 +1770,7 @@ class MilvusMemoryStorage(MemoryStorage):
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
         stale_days: Optional[int] = None,
+        include_embeddings: bool = False,
     ) -> List[Memory]:
         if not self._ensure_initialized():
             return []
@@ -1708,6 +1791,7 @@ class MilvusMemoryStorage(MemoryStorage):
             limit=limit if limit is not None else _MILVUS_MAX_LIMIT,
             offset=offset,
             sort_desc_key="created_at",
+            include_embeddings=include_embeddings,
         )
 
     async def count_all_memories(
@@ -1744,7 +1828,8 @@ class MilvusMemoryStorage(MemoryStorage):
             return 0
 
     async def get_memories_by_time_range(
-        self, start_time: float, end_time: float
+        self, start_time: float, end_time: float,
+        include_embeddings: bool = False,
     ) -> List[Memory]:
         if not self._ensure_initialized():
             return []
@@ -1753,6 +1838,7 @@ class MilvusMemoryStorage(MemoryStorage):
             filter_expr=filter_expr,
             limit=_MILVUS_MAX_LIMIT,
             sort_desc_key="created_at",
+            include_embeddings=include_embeddings,
         )
 
     async def get_memory_timestamps(self, days: Optional[int] = None) -> List[float]:
@@ -1787,6 +1873,7 @@ class MilvusMemoryStorage(MemoryStorage):
         limit: int,
         offset: int = 0,
         sort_desc_key: Optional[str] = None,
+        include_embeddings: bool = False,
     ) -> List[Memory]:
         """Stream rows via ``QueryIterator`` and return sorted, sliced ``Memory``
         objects.
@@ -1797,13 +1884,21 @@ class MilvusMemoryStorage(MemoryStorage):
         to return an arbitrary window. Sorting is still done client-side
         (Milvus Lite has no server-side ``order_by``), but it is now applied
         to the full matching set rather than to a random subset.
+
+        Args:
+            include_embeddings: If True, request the ``vector`` field from
+                Milvus and populate ``Memory.embedding`` on the returned
+                objects. Used by the consolidation pipeline. Default False
+                keeps the CRUD cost envelope unchanged.
         """
         if limit <= 0:
             return []
-        rows = await self._iterate_all_rows(filter_expr)
+        rows = await self._iterate_all_rows(
+            filter_expr, include_embeddings=include_embeddings,
+        )
         memories: List[Memory] = []
         for row in rows:
-            mem = self._entity_to_memory(row)
+            mem = self._entity_to_memory(row, include_embedding=include_embeddings)
             if mem is not None:
                 memories.append(mem)
 
@@ -1814,24 +1909,44 @@ class MilvusMemoryStorage(MemoryStorage):
             memories = memories[offset:]
         return memories[:limit]
 
-    async def _iterate_all_rows(self, filter_expr: str) -> List[Dict[str, Any]]:
+    async def _iterate_all_rows(
+        self,
+        filter_expr: str,
+        include_embeddings: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Collect every row matching ``filter_expr`` using ``QueryIterator``.
 
         One lock-acquisition covers the full iteration so other coroutines
         can't interleave RPCs on the shared pymilvus channel.
+
+        Args:
+            include_embeddings: If True, request the ``vector`` field in
+                ``output_fields`` so :meth:`_entity_to_memory` can hydrate
+                ``Memory.embedding``.
         """
         async with self._write_lock:
             if self.client is None:
                 raise RuntimeError("MilvusMemoryStorage was not initialized")
-            return await asyncio.to_thread(self._drain_query_iterator, filter_expr)
+            return await asyncio.to_thread(
+                self._drain_query_iterator, filter_expr, include_embeddings,
+            )
 
-    def _drain_query_iterator(self, filter_expr: str) -> List[Dict[str, Any]]:
+    def _drain_query_iterator(
+        self,
+        filter_expr: str,
+        include_embeddings: bool = False,
+    ) -> List[Dict[str, Any]]:
         """Sync helper that drains a ``QueryIterator`` into a plain list."""
         assert self.client is not None
+        fields = (
+            self._OUTPUT_FIELDS_WITH_VECTOR
+            if include_embeddings
+            else self._OUTPUT_FIELDS_BASE
+        )
         iterator = self.client.query_iterator(
             collection_name=self.collection_name,
             filter=filter_expr or "",
-            output_fields=list(self._OUTPUT_FIELDS),
+            output_fields=list(fields),
             batch_size=self._QUERY_ITER_BATCH,
         )
         rows: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary

Preparatory refactor for a Milvus consolidation bug: `MilvusMemoryStorage._entity_to_memory` currently drops the `vector` column on reads, so every `Memory` returned by Milvus has `embedding=None`. This breaks the clustering / association / compression stages of `DreamInspiredConsolidator`.

This PR adds the plumbing (opt-in keyword, split output-fields, defensive vector coercion) **without changing any caller behavior**. Follow-up PRs will switch consumers over and add end-to-end tests.

## Background

Production evidence on a 65-memory Milvus-backed deployment after running `memory_consolidate({"action":"run","time_horizon":"monthly"})`:


And the run report: `clusters_created=0 / associations=0 / compressed=0 / archived=0`.

Compared to `SqliteVecMemoryStorage._row_to_memory` which populates `embedding` via `deserialize_embedding(embedding_blob)`, `MilvusMemoryStorage._entity_to_memory` never requested the `vector` column.

## Changes

1. Split `_OUTPUT_FIELDS` into:
   - `_OUTPUT_FIELDS_BASE` — scalar columns, used by CRUD.
   - `_OUTPUT_FIELDS_WITH_VECTOR` — `_OUTPUT_FIELDS_BASE + ("vector",)`, used when a caller opts in.
   - `_OUTPUT_FIELDS` kept as alias to `_OUTPUT_FIELDS_BASE` for backward compat.
2. New `_coerce_vector(row) -> Optional[List[float]]` helper. Defensive, never raises. Handles missing key, `None`, empty sequence, numpy arrays, generic sequences, and unexpected types (warns with sanitized row id).
3. `_entity_to_memory(row, include_embedding=False)` — when True, hydrate via `_coerce_vector`; when False (default), `embedding=None` as today.
4. Propagate `include_embeddings: bool = False` through `_iterate_all_rows`, `_drain_query_iterator`, `_query_memories`. The flag selects between the two `_OUTPUT_FIELDS_*` tuples.
5. Public `get_all_memories` and `get_memories_by_time_range` accept `include_embeddings: bool = False`.

## No caller opts in (intentional)

Every existing call site — `get_by_hash`, `retrieve`, `search_by_tag`, `get_recent_memories`, `get_by_exact_content`, `cleanup_duplicates`, etc. — does not pass `include_embeddings`, so `_OUTPUT_FIELDS_BASE` is used and `Memory.embedding` stays `None`, identical to current behavior.

## Follow-ups (separate PRs)

- Extend `MemoryStorage` base ABC with the same kwarg so all backends share the contract.
- Switch `DreamInspiredConsolidator._get_memories_for_horizon` to `include_embeddings=True`.
- Add unit + Hypothesis property tests + Milvus-Lite integration tests, including an end-to-end assertion that a seeded consolidator run yields `clusters_created >= 1` — directly disproving the production log.

## Blast radius

- `gitnexus_impact`: LOW, 0 affected processes.
- Purely additive plumbing; no existing call sites change semantics.
- Other storage backends untouched.

## Testing

- Smoke-tested `_coerce_vector` and `_entity_to_memory` against: missing key, `None`, empty list, list, tuple, numpy array, int (→ warn + None). All paths behave per spec.
- Verified `_OUTPUT_FIELDS_BASE` excludes `"vector"` and `_OUTPUT_FIELDS_WITH_VECTOR` includes it.
- Full Milvus-Lite integration tests require the sentence-transformers model cache which is not available locally; expected to pass in CI.
- Existing test suite untouched — no signatures removed, all defaults preserved.

## Spec

Design doc in this repo at `.kiro/specs/milvus-hydrate-embedding-for-consolidation/` covers the 3-PR plan (internal → ABC → consumer+tests).
