### PR TITLE
chore: release v10.51.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.51.2] - 2026-05-08
+
+### Fixed
+
+- **OAuth CORS preflight failures and missing resource_metadata** ([#877](https://github.com/doobidoo/mcp-memory-service/pull/877), @ghelleks): Resolves three bugs in the OAuth remote connector flow. CORS headers were missing on the `oauth_app` sub-application; `OPTIONS` requests to `/mcp` were not handled, blocking browser-based preflight checks; and `WWW-Authenticate` headers lacked the `resource_metadata` field required by RFC 9728, causing Remote MCP clients to fail authentication discovery. Fixes issue [#876](https://github.com/doobidoo/mcp-memory-service/issues/876).
+
+### Refactored
+
+- **Milvus opt-in embedding hydration on read paths** ([#878](https://github.com/doobidoo/mcp-memory-service/pull/878), @henry201605): Adds `include_embedding: bool = False` parameter to Milvus read paths (`retrieve_memory`, `list_memories`). When `True`, raw embedding vectors are returned alongside memory data, enabling the consolidation pipeline to access embeddings during clustering and association discovery. Fixes consolidation silently returning 0 clusters and 0 associations on Milvus deployments.
+
 ## [10.51.1] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - **OAuth CORS preflight failures and missing resource_metadata** ([#877](https://github.com/doobidoo/mcp-memory-service/pull/877), @ghelleks): Resolves three bugs in the OAuth remote connector flow. CORS headers were missing on the `oauth_app` sub-application; `OPTIONS` requests to `/mcp` were not handled, blocking browser-based preflight checks; and `WWW-Authenticate` headers lacked the `resource_metadata` field required by RFC 9728, causing Remote MCP clients to fail authentication discovery. Fixes issue [#876](https://github.com/doobidoo/mcp-memory-service/issues/876).
-
-### Refactored
-
-- **Milvus opt-in embedding hydration on read paths** ([#878](https://github.com/doobidoo/mcp-memory-service/pull/878), @henry201605): Adds `include_embedding: bool = False` parameter to Milvus read paths (`retrieve_memory`, `list_memories`). When `True`, raw embedding vectors are returned alongside memory data, enabling the consolidation pipeline to access embeddings during clustering and association discovery. Fixes consolidation silently returning 0 clusters and 0 associations on Milvus deployments.
+- **Milvus consolidation returning 0 clusters/associations** ([#878](https://github.com/doobidoo/mcp-memory-service/pull/878), @henry201605): Adds `include_embedding: bool = False` opt-in parameter to Milvus read paths (`retrieve_memory`, `list_memories`). When `True`, raw embedding vectors are returned alongside memory data, enabling the consolidation pipeline to access embeddings during clustering and association discovery. Fixes consolidation silently returning 0 clusters and 0 associations on Milvus deployments.
 
 ## [10.51.1] - 2026-05-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.51.1 - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.51.2 - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,16 +490,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.51.1** (May 7, 2026)
+## Latest Release: **v10.51.2** (May 8, 2026)
 
-**fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)**
+**fix(oauth) + refactor(milvus): CORS preflight fixes, RFC 9728 resource_metadata, and opt-in embedding hydration on Milvus read paths (PRs #877, #878)**
 
 **What's New:**
-- **Milvus consolidation fix**: Adds `delete_memory(hash) -> bool` alias to `MilvusMemoryStorage`. Without this method, `memory_consolidate` silently failed on the Milvus backend during Compression (stage 4) and Controlled Forgetting (stage 5) with `AttributeError`. (PR #872)
+- **OAuth CORS preflight fix**: Resolves three bugs in the OAuth remote connector flow — CORS on `oauth_app`, OPTIONS handling on `/mcp`, and `resource_metadata` in `WWW-Authenticate` headers per RFC 9728. (PR #877, @ghelleks)
+- **Milvus embedding hydration**: Adds `include_embedding: bool = False` opt-in parameter to Milvus read paths so the consolidation pipeline can access embeddings, fixing consolidation returning 0 clusters/associations on Milvus deployments. (PR #878, @henry201605)
 
 ---
 
 **Previous Releases**:
+- **v10.51.1** - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)
 - **v10.51.0** - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)
 - **v10.50.0** - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)
 - **v10.49.4** - fix(consolidation): protect high-value mistake notes from decay/forgetting (PR #854, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.51.1"
+version = "10.51.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.51.1"
+__version__ = "10.51.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.51.1"
+version = "10.51.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Patch release v10.51.2 bundling two fixes merged to main:

- **fix(oauth)** (PR #877, @ghelleks): CORS preflight failures and missing `resource_metadata` field in `WWW-Authenticate` per RFC 9728 — fixes Remote MCP authentication discovery for browser-based clients.
- **refactor(milvus)** (PR #878, @henry201605): Opt-in `include_embedding: bool = False` parameter on Milvus read paths — fixes consolidation pipeline returning 0 clusters/associations on Milvus deployments.

## Files changed

| File | Change |
|------|--------|
| `src/mcp_memory_service/_version.py` | `10.51.1` → `10.51.2` |
| `pyproject.toml` | `10.51.1` → `10.51.2` |
| `CHANGELOG.md` | New `[10.51.2]` section |
| `README.md` | Latest Release section updated |
| `CLAUDE.md` | Current Version callout updated |
| `uv.lock` | Package version bumped |

## Test plan

- [ ] CI passes on this branch
- [ ] Version strings consistent across `_version.py`, `pyproject.toml`, `uv.lock`
- [ ] CHANGELOG `[Unreleased]` section is empty, `[10.51.2]` entry is correct
- [ ] No landing page changes (PATCH release — docs/index.html untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)