### PR TITLE
chore: release v10.51.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.51.3] - 2026-05-08
+
+### Added
+
+- **Versioned memory update via `memory_update` tool** ([#865](https://github.com/doobidoo/mcp-memory-service/pull/865), @filhocf): Adds `versioned: bool = False` parameter to the `memory_update` MCP tool. When `True`, routes through `update_memory_versioned()` in sqlite_vec, storing `superseded_by` in the replaced memory's metadata for a full audit trail. Returns an explicit error message on backends that do not support versioning.
+- **Transitive inference and relationship suggestions in `memory_graph`** ([#866](https://github.com/doobidoo/mcp-memory-service/pull/866), @filhocf): Wires `infer` and `suggest` actions into the `memory_graph` MCP tool. `infer_transitive` computes the transitive closure of a starting node using a recursive CTE in `GraphStorage` (database-side traversal, no Python BFS), keeping large graph queries fast. `suggest_relationships` proposes new edges based on semantic proximity of existing associations.
+
 ## [10.51.2] - 2026-05-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.51.2 - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.51.3 - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships actions (PRs #865, #866, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -490,17 +490,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.51.2** (May 8, 2026)
+## Latest Release: **v10.51.3** (May 8, 2026)
 
-**fix(oauth) + refactor(milvus): CORS preflight fixes, RFC 9728 resource_metadata, and opt-in embedding hydration on Milvus read paths (PRs #877, #878)**
+**feat(memory_update + memory_graph): versioned update flag and transitive/suggest graph actions (PRs #865, #866, @filhocf)**
 
 **What's New:**
-- **OAuth CORS preflight fix**: Resolves three bugs in the OAuth remote connector flow — CORS on `oauth_app`, OPTIONS handling on `/mcp`, and `resource_metadata` in `WWW-Authenticate` headers per RFC 9728. (PR #877, @ghelleks)
-- **Milvus embedding hydration**: Adds `include_embedding: bool = False` opt-in parameter to Milvus read paths so the consolidation pipeline can access embeddings, fixing consolidation returning 0 clusters/associations on Milvus deployments. (PR #878, @henry201605)
+- **Versioned memory updates**: `memory_update` now accepts a `versioned: bool = False` parameter. When `True`, routes through `update_memory_versioned()` in sqlite_vec, storing `superseded_by` in metadata for full audit trail. Returns an explicit error on unsupported backends. (PR #865, @filhocf)
+- **Transitive inference and relationship suggestions**: `memory_graph` gains `infer` and `suggest` actions. Transitive closure uses a recursive CTE in GraphStorage (database-side, no Python BFS), making large graph traversals fast and efficient. (PR #866, @filhocf)
 
 ---
 
 **Previous Releases**:
+- **v10.51.2** - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878)
 - **v10.51.1** - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)
 - **v10.51.0** - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)
 - **v10.50.0** - feat(plugins): plugin hook scaffolding — on_store, on_delete, on_retrieve, on_consolidate (PR #856, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.51.2"
+version = "10.51.3"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.51.2"
+__version__ = "10.51.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.51.2"
+version = "10.51.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps `_version.py` and `pyproject.toml` to `10.51.3`
- Updates `CHANGELOG.md` with new `[10.51.3]` section (two added features)
- Updates `README.md` Latest Release section and previous releases list
- Updates `CLAUDE.md` current version callout
- Regenerates `uv.lock`

## Changes included

**PR #865** (@filhocf) — `feat: expose update_memory_versioned via memory_update versioned flag`
- Adds `versioned: bool = False` to the `memory_update` MCP tool
- When `True`: routes through `update_memory_versioned()` in sqlite_vec, stores `superseded_by` in replaced memory metadata
- Returns explicit error on unsupported backends

**PR #866** (@filhocf) — `feat(reasoning): implement infer_transitive and suggest_relationships`
- Wires `infer` and `suggest` actions into the `memory_graph` MCP tool
- Transitive closure uses recursive CTE in GraphStorage (database-side, no Python BFS)

## Version bump type

PATCH — new features are additive, backward-compatible, and gated behind new parameters with safe defaults.

## Test plan

- [ ] CI passes on this branch
- [ ] `uv.lock` updated correctly (`mcp-memory-service v10.51.2 -> v10.51.3`)
- [ ] CHANGELOG has no duplicate version entries
- [ ] [Unreleased] section remains empty above `[10.51.3]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)