### PR TITLE
feat(search): cascading fallback when semantic results are sparse

### DIFF
--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -811,7 +811,7 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             # Check if existing results have low scores
             high_score_count = sum(
                 1 for m in memories
-                if m.get("relevance_score", 0) >= _FALLBACK_SCORE_THRESHOLD
+                if m.get("similarity_score", 0) >= _FALLBACK_SCORE_THRESHOLD
             )
 
             if high_score_count < _FALLBACK_MIN_RESULTS:
@@ -833,7 +833,7 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
 
                 # Tier 2: Tag intersection (extract potential tags from query tokens)
                 if len(memories) < limit:
-                    query_tokens = [t.strip().lower() for t in query.split() if len(t.strip()) > 2]
+                    query_tokens = [t.strip().lower().strip(".,;:!?\"'()[]{}") for t in query.split() if len(t.strip()) > 2]
                     if query_tokens:
                         tag_result = await storage.search_memories(
                             query=None,

--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -775,15 +775,17 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
         max_response_chars = _get_max_response_chars(arguments)
 
         # Call unified search_memories method
+        query = arguments.get("query")
+        limit = arguments.get("limit", 10)
         result = await storage.search_memories(
-            query=arguments.get("query"),
+            query=query,
             mode=arguments.get("mode", "semantic"),
             time_expr=arguments.get("time_expr"),
             after=arguments.get("after"),
             before=arguments.get("before"),
             tags=tags,
             quality_boost=arguments.get("quality_boost", 0.0),
-            limit=arguments.get("limit", 10),
+            limit=limit,
             include_debug=arguments.get("include_debug", False),
             include_superseded=arguments.get("include_superseded", False)
         )
@@ -793,6 +795,70 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             return [types.TextContent(type="text", text=f"Error: {result['error']}")]
 
         memories = result["memories"]
+        fallback_used = None
+
+        # Cascading fallback: when enabled and semantic results are sparse
+        fallback_enabled = arguments.get("fallback", False)
+        _FALLBACK_MIN_RESULTS = 3
+        _FALLBACK_SCORE_THRESHOLD = 0.4
+
+        if (
+            fallback_enabled
+            and query
+            and arguments.get("mode", "semantic") in ("semantic", "hybrid")
+            and len(memories) < _FALLBACK_MIN_RESULTS
+        ):
+            # Check if existing results have low scores
+            high_score_count = sum(
+                1 for m in memories
+                if m.get("relevance_score", 0) >= _FALLBACK_SCORE_THRESHOLD
+            )
+
+            if high_score_count < _FALLBACK_MIN_RESULTS:
+                seen_hashes = {m.get("content_hash") for m in memories}
+
+                # Tier 1: BM25/exact keyword match
+                exact_result = await storage.search_memories(
+                    query=query,
+                    mode="exact",
+                    limit=limit,
+                    include_superseded=arguments.get("include_superseded", False)
+                )
+                if "error" not in exact_result:
+                    for m in exact_result.get("memories", []):
+                        if m.get("content_hash") not in seen_hashes:
+                            m["match_method"] = "exact_fallback"
+                            memories.append(m)
+                            seen_hashes.add(m.get("content_hash"))
+
+                # Tier 2: Tag intersection (extract potential tags from query tokens)
+                if len(memories) < limit:
+                    query_tokens = [t.strip().lower() for t in query.split() if len(t.strip()) > 2]
+                    if query_tokens:
+                        tag_result = await storage.search_memories(
+                            query=None,
+                            mode="semantic",
+                            tags=query_tokens,
+                            limit=limit,
+                            include_superseded=arguments.get("include_superseded", False)
+                        )
+                        if "error" not in tag_result:
+                            for m in tag_result.get("memories", []):
+                                if m.get("content_hash") not in seen_hashes:
+                                    m["match_method"] = "tag_fallback"
+                                    memories.append(m)
+                                    seen_hashes.add(m.get("content_hash"))
+
+                # Mark original results
+                for m in memories:
+                    if "match_method" not in m:
+                        m["match_method"] = "semantic"
+
+                # Trim to limit
+                memories = memories[:limit]
+                result["memories"] = memories
+                result["total"] = len(memories)
+                fallback_used = True
         total = result["total"]
 
         # Apply truncation if needed
@@ -816,6 +882,8 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             header = f"Found {total} memories"
             if result.get("mode"):
                 header += f" (mode: {result['mode']})"
+            if fallback_used:
+                header += " [fallback: exact+tag]"
             if result.get("query"):
                 header += f" for query: '{result['query']}'"
             header += "\n\n"
@@ -838,15 +906,21 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             tags_display = f" [{', '.join(tags)}]" if tags else ""
             content_hash = memory.get('content_hash', '')
 
+            match_info = ""
+            if fallback_used and memory.get("match_method"):
+                match_info = f" (via {memory['match_method']})"
+
             formatted_results.append(
                 f"{idx}. {memory.get('content', '')}\n"
                 f"   Hash: {content_hash}\n"
-                f"   Created: {created_at}{tags_display}"
+                f"   Created: {created_at}{tags_display}{match_info}"
             )
 
         header = f"Found {total} memories"
         if result.get("mode"):
             header += f" (mode: {result['mode']})"
+        if fallback_used:
+            header += " [fallback: exact+tag]"
         if result.get("query"):
             header += f" for query: '{result['query']}'"
 

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1515,6 +1515,11 @@ Examples:
                                     "type": "boolean",
                                     "default": False,
                                     "description": "Include memories that have been superseded by newer contradicting memories. Default: false (superseded memories are hidden)."
+                                },
+                                "fallback": {
+                                    "type": "boolean",
+                                    "default": False,
+                                    "description": "Enable cascading fallback when semantic results are sparse. When true and fewer than 3 results are found with scores below 0.4, automatically attempts BM25 keyword match and tag intersection. Each result includes match_method field. Default: false."
                                 }
                             }
                         },

--- a/tests/test_cascading_fallback.py
+++ b/tests/test_cascading_fallback.py
@@ -47,7 +47,7 @@ async def test_fallback_triggers_on_sparse_results(mock_server, mock_storage):
     # First call (semantic): returns 1 low-score result
     semantic_result = {
         "memories": [
-            {"content": "partial match", "content_hash": "aaa", "relevance_score": 0.2,
+            {"content": "partial match", "content_hash": "aaa", "similarity_score": 0.2,
              "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
         ],
         "total": 1,
@@ -92,7 +92,7 @@ async def test_fallback_not_triggered_when_results_sufficient(mock_server, mock_
     """When semantic returns enough high-score results, no fallback."""
     mock_storage.search_memories.return_value = {
         "memories": [
-            {"content": f"result {i}", "content_hash": f"hash{i}", "relevance_score": 0.8,
+            {"content": f"result {i}", "content_hash": f"hash{i}", "similarity_score": 0.8,
              "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
             for i in range(5)
         ],
@@ -116,7 +116,7 @@ async def test_fallback_deduplicates_results(mock_server, mock_storage):
     """Fallback doesn't return duplicate memories."""
     shared_memory = {
         "content": "found in both", "content_hash": "same_hash",
-        "relevance_score": 0.3, "tags": ["test"],
+        "similarity_score": 0.3, "tags": ["test"],
         "created_at_iso": "2026-01-01T00:00:00Z"
     }
 
@@ -140,7 +140,7 @@ async def test_fallback_marks_match_method(mock_server, mock_storage):
     """Each result is tagged with its match_method."""
     mock_storage.search_memories.side_effect = [
         {"memories": [
-            {"content": "semantic hit", "content_hash": "s1", "relevance_score": 0.3,
+            {"content": "semantic hit", "content_hash": "s1", "similarity_score": 0.3,
              "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
         ], "total": 1, "query": "test", "mode": "semantic"},
         {"memories": [

--- a/tests/test_cascading_fallback.py
+++ b/tests/test_cascading_fallback.py
@@ -1,0 +1,180 @@
+"""Tests for cascading search fallback (issue #873)."""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from mcp import types
+
+from mcp_memory_service.server.handlers.memory import handle_memory_search
+
+
+@pytest.fixture
+def mock_server():
+    """Create a mock server with storage."""
+    server = MagicMock()
+    server._ensure_storage_initialized = AsyncMock()
+    return server
+
+
+@pytest.fixture
+def mock_storage(mock_server):
+    """Create mock storage with configurable search results."""
+    storage = AsyncMock()
+    mock_server._ensure_storage_initialized.return_value = storage
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_fallback_disabled_by_default(mock_server, mock_storage):
+    """When fallback=False (default), no fallback is attempted."""
+    mock_storage.search_memories.return_value = {
+        "memories": [],
+        "total": 0,
+        "query": "socrates session",
+        "mode": "semantic",
+    }
+
+    result = await handle_memory_search(mock_server, {
+        "query": "socrates session",
+    })
+
+    # Only one call to search_memories (no fallback)
+    assert mock_storage.search_memories.call_count == 1
+    assert "No memories found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_fallback_triggers_on_sparse_results(mock_server, mock_storage):
+    """When fallback=True and results are sparse, BM25 and tag fallback are tried."""
+    # First call (semantic): returns 1 low-score result
+    semantic_result = {
+        "memories": [
+            {"content": "partial match", "content_hash": "aaa", "relevance_score": 0.2,
+             "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
+        ],
+        "total": 1,
+        "query": "socrates session",
+        "mode": "semantic",
+    }
+    # Second call (exact fallback): returns 1 new result
+    exact_result = {
+        "memories": [
+            {"content": "session on socrates machine", "content_hash": "bbb",
+             "tags": ["session", "socrates"], "created_at_iso": "2026-01-02T00:00:00Z"}
+        ],
+        "total": 1,
+        "query": "socrates session",
+        "mode": "exact",
+    }
+    # Third call (tag fallback): returns 1 more
+    tag_result = {
+        "memories": [
+            {"content": "socrates hardware info", "content_hash": "ccc",
+             "tags": ["socrates", "hardware"], "created_at_iso": "2026-01-03T00:00:00Z"}
+        ],
+        "total": 1,
+        "mode": "semantic",
+    }
+
+    mock_storage.search_memories.side_effect = [semantic_result, exact_result, tag_result]
+
+    result = await handle_memory_search(mock_server, {
+        "query": "socrates session",
+        "fallback": True,
+    })
+
+    # Three calls: semantic + exact + tag
+    assert mock_storage.search_memories.call_count == 3
+    assert "fallback: exact+tag" in result[0].text
+    assert "3 memories" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_fallback_not_triggered_when_results_sufficient(mock_server, mock_storage):
+    """When semantic returns enough high-score results, no fallback."""
+    mock_storage.search_memories.return_value = {
+        "memories": [
+            {"content": f"result {i}", "content_hash": f"hash{i}", "relevance_score": 0.8,
+             "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
+            for i in range(5)
+        ],
+        "total": 5,
+        "query": "python patterns",
+        "mode": "semantic",
+    }
+
+    result = await handle_memory_search(mock_server, {
+        "query": "python patterns",
+        "fallback": True,
+    })
+
+    # Only one call — no fallback needed
+    assert mock_storage.search_memories.call_count == 1
+    assert "fallback" not in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_fallback_deduplicates_results(mock_server, mock_storage):
+    """Fallback doesn't return duplicate memories."""
+    shared_memory = {
+        "content": "found in both", "content_hash": "same_hash",
+        "relevance_score": 0.3, "tags": ["test"],
+        "created_at_iso": "2026-01-01T00:00:00Z"
+    }
+
+    mock_storage.search_memories.side_effect = [
+        {"memories": [shared_memory], "total": 1, "query": "test", "mode": "semantic"},
+        {"memories": [shared_memory], "total": 1, "query": "test", "mode": "exact"},
+        {"memories": [], "total": 0, "mode": "semantic"},
+    ]
+
+    result = await handle_memory_search(mock_server, {
+        "query": "test query",
+        "fallback": True,
+    })
+
+    # Should only have 1 result (deduplicated)
+    assert "1 memories" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_fallback_marks_match_method(mock_server, mock_storage):
+    """Each result is tagged with its match_method."""
+    mock_storage.search_memories.side_effect = [
+        {"memories": [
+            {"content": "semantic hit", "content_hash": "s1", "relevance_score": 0.3,
+             "tags": [], "created_at_iso": "2026-01-01T00:00:00Z"}
+        ], "total": 1, "query": "test", "mode": "semantic"},
+        {"memories": [
+            {"content": "exact hit", "content_hash": "e1",
+             "tags": [], "created_at_iso": "2026-01-02T00:00:00Z"}
+        ], "total": 1, "query": "test", "mode": "exact"},
+        {"memories": [], "total": 0, "mode": "semantic"},
+    ]
+
+    result = await handle_memory_search(mock_server, {
+        "query": "test query",
+        "fallback": True,
+    })
+
+    text = result[0].text
+    assert "via semantic" in text
+    assert "via exact_fallback" in text
+
+
+@pytest.mark.asyncio
+async def test_fallback_only_for_semantic_hybrid_modes(mock_server, mock_storage):
+    """Fallback is not triggered for exact mode searches."""
+    mock_storage.search_memories.return_value = {
+        "memories": [],
+        "total": 0,
+        "query": "test",
+        "mode": "exact",
+    }
+
+    result = await handle_memory_search(mock_server, {
+        "query": "test",
+        "mode": "exact",
+        "fallback": True,
+    })
+
+    # Only one call — fallback doesn't apply to exact mode
+    assert mock_storage.search_memories.call_count == 1


### PR DESCRIPTION
Closes #873

When `fallback=True` and semantic/hybrid search returns fewer than 3 results with scores below 0.4, automatically attempts:
1. **BM25/exact keyword match** on query terms
2. **Tag intersection** (query tokens extracted as potential tags)

**Design decisions:**
- Opt-in via `fallback: bool = False` parameter — no change to default behavior
- Each result tagged with `match_method` field (`semantic` | `exact_fallback` | `tag_fallback`)
- Deduplication by content_hash across tiers
- Guard: skips fallback when semantic returns ≥3 results with score ≥0.4
- Latency: only adds overhead when semantic fails (sparse results trigger)

**Tests:** 6 new tests covering semantic-only path, fallback-triggered path, empty results, deduplication, match_method marking, and mode restriction.