### PR TITLE
chore: release v10.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.52.0] - 2026-05-08
+
+### Added
+
+- **Cascading search fallback when semantic results are sparse** ([#883](https://github.com/doobidoo/mcp-memory-service/pull/883), @filhocf, closes [#873](https://github.com/doobidoo/mcp-memory-service/issues/873)): Adds a two-tier fallback to `retrieve_memories` for deployments where vector similarity produces fewer results than requested. When enabled (`fallback=True`, opt-in), the system first attempts a BM25 exact-match pass over stored content, then a tag-intersection pass, and merges de-duplicated results up to `n_results`. Default is `fallback=False` so existing callers are unaffected.
+
+### Changed
+
+- **`MemoryStorage` ABC — `include_embeddings` parameter on bulk-read methods** ([#881](https://github.com/doobidoo/mcp-memory-service/pull/881), @henry201605): `get_all_memories` and `get_memories_by_time_range` in the base class (and all concrete backends) now accept `include_embeddings: bool = False`. When `True`, raw embedding vectors are hydrated into the returned `Memory` objects, enabling consolidation pipelines that need embedding data without a separate fetch. Default preserves existing behaviour for all callers.
+
+### Fixed
+
+- **CI fork-PR label/comment automation** ([fix/ci](https://github.com/doobidoo/mcp-memory-service/commit/main)): Workflow triggers that write labels or post comments now use `pull_request_target` instead of `pull_request`, resolving `403` read-only-token failures that broke automation for all fork-originated PRs.
+
 ## [10.51.3] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- **CI fork-PR label/comment automation** ([fix/ci](https://github.com/doobidoo/mcp-memory-service/commit/main)): Workflow triggers that write labels or post comments now use `pull_request_target` instead of `pull_request`, resolving `403` read-only-token failures that broke automation for all fork-originated PRs.
+- **CI fork-PR label/comment automation** ([#882](https://github.com/doobidoo/mcp-memory-service/pull/882)): Workflow triggers that write labels or post comments now use `pull_request_target` instead of `pull_request`, resolving `403` read-only-token failures that broke automation for all fork-originated PRs.
 
 ## [10.51.3] - 2026-05-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.51.3 - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships actions (PRs #865, #866, @filhocf) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.52.0 - feat(search): cascading fallback (PR #883, @filhocf); refactor(storage): include_embeddings on bulk-read methods (PR #881, @henry201605) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 
 ## Latest Release: **v10.52.0** (May 8, 2026)
 
-**feat(search): cascading fallback + refactor(storage): include_embeddings on bulk-read methods (PRs #881, #883, @henry201605, @filhocf)**
+**feat(search): cascading fallback + refactor(storage): include_embeddings on bulk-read methods (PRs #883, #881, @filhocf, @henry201605)**
 
 **What's New:**
 - **Cascading search fallback**: `retrieve_memories` now supports opt-in two-tier fallback (`fallback=True`) when semantic similarity returns sparse results. Falls back to BM25 exact-match then tag-intersection, merging de-duplicated results up to `n_results`. Closes [#873](https://github.com/doobidoo/mcp-memory-service/issues/873). (PR #883, @filhocf)

--- a/README.md
+++ b/README.md
@@ -493,17 +493,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.51.3** (May 8, 2026)
+## Latest Release: **v10.52.0** (May 8, 2026)
 
-**feat(memory_update + memory_graph): versioned update flag and transitive/suggest graph actions (PRs #865, #866, @filhocf)**
+**feat(search): cascading fallback + refactor(storage): include_embeddings on bulk-read methods (PRs #881, #883, @henry201605, @filhocf)**
 
 **What's New:**
-- **Versioned memory updates**: `memory_update` now accepts a `versioned: bool = False` parameter. When `True`, routes through `update_memory_versioned()` in sqlite_vec, storing `superseded_by` in metadata for full audit trail. Returns an explicit error on unsupported backends. (PR #865, @filhocf)
-- **Transitive inference and relationship suggestions**: `memory_graph` gains `infer` and `suggest` actions. Transitive closure uses a recursive CTE in GraphStorage (database-side, no Python BFS), making large graph traversals fast and efficient. (PR #866, @filhocf)
+- **Cascading search fallback**: `retrieve_memories` now supports opt-in two-tier fallback (`fallback=True`) when semantic similarity returns sparse results. Falls back to BM25 exact-match then tag-intersection, merging de-duplicated results up to `n_results`. Closes [#873](https://github.com/doobidoo/mcp-memory-service/issues/873). (PR #883, @filhocf)
+- **`include_embeddings` on bulk-read methods**: `get_all_memories` and `get_memories_by_time_range` on the `MemoryStorage` ABC and all backends now accept `include_embeddings: bool = False`, enabling consolidation pipelines to hydrate embeddings without a separate fetch. (PR #881, @henry201605)
+- **CI fork-PR automation fix**: Workflow triggers now use `pull_request_target` to resolve 403 failures for fork-originated PRs.
 
 ---
 
 **Previous Releases**:
+- **v10.51.3** - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships (PRs #865, #866, @filhocf)
 - **v10.51.2** - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878)
 - **v10.51.1** - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)
 - **v10.51.0** - feat(plugins): live plugin hooks + dynamic type dropdowns + audit-log example (PRs #863, #864, #867, @filhocf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.51.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.52.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.51.0">
+<meta property="og:title" content="MCP Memory Service v10.52.0">
 <meta property="og:description" content="Plugin hooks now live in MemoryService. Dynamic /api/types dropdowns. Audit-log example. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.51.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.52.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.51.3"
+version = "10.52.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.51.3"
+__version__ = "10.52.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.51.3"
+version = "10.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **feat(search)**: Cascading search fallback (BM25 + tag-intersection tiers) when semantic results are sparse — opt-in via `fallback=True` (PR #883, @filhocf, closes #873)
- **refactor(storage)**: `include_embeddings: bool = False` added to `get_all_memories` and `get_memories_by_time_range` on the `MemoryStorage` ABC and all concrete backends (PR #881, @henry201605)
- **fix(ci)**: `pull_request_target` for fork PR workflows — resolves 403 read-only-token failures for label/comment automation on fork PRs

## Version bump

`10.51.3` → `10.52.0` (MINOR — new `feat:` in #883, new parameter on ABC in #881)

## Files changed

- `pyproject.toml` — version bump
- `src/mcp_memory_service/_version.py` — version bump
- `CHANGELOG.md` — new `[10.52.0]` section
- `README.md` — Latest Release updated, v10.51.3 moved to Previous Releases
- `CLAUDE.md` — Current Version callout updated
- `uv.lock` — regenerated

## Test plan

- [ ] CI passes on this branch
- [ ] `pyproject.toml` and `_version.py` both read `10.52.0`
- [ ] CHANGELOG `[Unreleased]` section is empty, `[10.52.0]` appears once
- [ ] README "Latest Release" reads v10.52.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)