### PR TITLE
chore(security): bump GitPython 3.1.47 → 3.1.50 (3 high CVEs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Security
+
+- **Bump GitPython 3.1.47 → 3.1.50** ([#886](https://github.com/doobidoo/mcp-memory-service/pull/886)): Resolves 3 high-severity vulnerabilities in transitive dependency (`wandb → GitPython`): path traversal allowing arbitrary file write/delete outside the repository ([GHSA-7545-fcxq-7j24](https://github.com/advisories/GHSA-7545-fcxq-7j24)), newline injection in `config_writer().set_value()` enabling RCE via `core.hooksPath` ([GHSA-v87r-6q3f-2j67](https://github.com/advisories/GHSA-v87r-6q3f-2j67)), and newline injection in `config_writer()` section parameter bypassing the prior CVE patch ([GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w)).
+
 ## [10.52.0] - 2026-05-08
 
 ### Added

--- a/uv.lock
+++ b/uv.lock
@@ -963,14 +963,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps transitive dependency **GitPython** from 3.1.47 to 3.1.50 via `uv.lock`.

GitPython is pulled in by `wandb` (optional ML dependency). All 3 Dependabot alerts are high-severity:

| GHSA | Severity | Description | Fixed in |
|------|----------|-------------|---------|
| [GHSA-7545-fcxq-7j24](https://github.com/advisories/GHSA-7545-fcxq-7j24) | **high** | Path traversal in reference APIs → arbitrary file write/delete | 3.1.48 |
| [GHSA-v87r-6q3f-2j67](https://github.com/advisories/GHSA-v87r-6q3f-2j67) | **high** | Newline injection in `config_writer().set_value()` → RCE via `core.hooksPath` | 3.1.49 |
| [GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w) | **high** | Newline injection in `config_writer()` section → RCE via `core.hooksPath` | 3.1.50 |

Only `uv.lock` is changed — no production code affected.

## Test plan

- [ ] CI passes (no direct usage of GitPython in mcp-memory-service)
- [ ] Dependabot alerts close automatically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)