### PR TITLE
chore: release v10.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.53.0] - 2026-05-09
+
+### Added
+
+- **Milvus consolidation embedding hydration end-to-end** ([#885](https://github.com/doobidoo/mcp-memory-service/pull/885), @henry201605): Completes a 4-PR series (#872, #878, #881, #885) that fixes a production failure on Milvus-backed deployments where consolidation produced 0 clusters and 0 associations. Root cause: the `vector` column was dropped during bulk reads, leaving every `Memory` with `embedding=None`. `consolidator._get_memories_for_horizon` now passes `include_embeddings=True` to both `get_all_memories` and `get_memories_by_time_range`. Supporting changes: `sqlite_vec.get_memories_by_time_range` gains a conditional LEFT JOIN on `memory_embeddings`; `hybrid.py` forwards the kwarg to the primary backend; `cloudflare.py` accepts the kwarg on both methods (ignores it — vectors live in Vectorize); `milvus._coerce_vector` now explicitly rejects `str`/`bytes`/`dict` types and `_log_hydration_stats` receives a pre-computed count for O(n) efficiency. Covered by 24 unit tests (`test_milvus_hydration.py`) and 5 Milvus Lite integration tests (`test_milvus_consolidation.py`).
+
 ### Security
 
 - **Bump GitPython 3.1.47 → 3.1.50** ([#886](https://github.com/doobidoo/mcp-memory-service/pull/886)): Resolves 3 high-severity vulnerabilities in transitive dependency (`wandb → GitPython`): path traversal allowing arbitrary file write/delete outside the repository ([GHSA-7545-fcxq-7j24](https://github.com/advisories/GHSA-7545-fcxq-7j24)), newline injection in `config_writer().set_value()` enabling RCE via `core.hooksPath` ([GHSA-v87r-6q3f-2j67](https://github.com/advisories/GHSA-v87r-6q3f-2j67)), and newline injection in `config_writer()` section parameter bypassing the prior CVE patch ([GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-mv93-w799-cj2w)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.52.0 - feat(search): cascading fallback (PR #883, @filhocf); refactor(storage): include_embeddings on bulk-read methods (PR #881, @henry201605) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.53.0 - feat(milvus): consolidation embedding hydration end-to-end (PR #885, @henry201605); security: GitPython 3.1.50 (PR #886) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -493,18 +493,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.52.0** (May 8, 2026)
+## Latest Release: **v10.53.0** (May 9, 2026)
 
-**feat(search): cascading fallback + refactor(storage): include_embeddings on bulk-read methods (PRs #883, #881, @filhocf, @henry201605)**
+**feat(milvus): activate consolidation embedding hydration end-to-end (PR #885, @henry201605)**
 
 **What's New:**
-- **Cascading search fallback**: `retrieve_memories` now supports opt-in two-tier fallback (`fallback=True`) when semantic similarity returns sparse results. Falls back to BM25 exact-match then tag-intersection, merging de-duplicated results up to `n_results`. Closes [#873](https://github.com/doobidoo/mcp-memory-service/issues/873). (PR #883, @filhocf)
-- **`include_embeddings` on bulk-read methods**: `get_all_memories` and `get_memories_by_time_range` on the `MemoryStorage` ABC and all backends now accept `include_embeddings: bool = False`, enabling consolidation pipelines to hydrate embeddings without a separate fetch. (PR #881, @henry201605)
-- **CI fork-PR automation fix**: Workflow triggers now use `pull_request_target` to resolve 403 failures for fork-originated PRs.
+- **Milvus consolidation embedding hydration**: Completes a 4-PR series that fixes a production failure where consolidation produced 0 clusters/associations on Milvus deployments. `consolidator._get_memories_for_horizon` now passes `include_embeddings=True` to bulk-read methods, ensuring embeddings are hydrated before clustering. All backends updated: sqlite_vec gains conditional LEFT JOIN, hybrid forwards the kwarg, cloudflare accepts it (vectors live in Vectorize), milvus gets stricter `_coerce_vector` type rejection. Covered by 29 new tests. (PR #885, @henry201605)
+- **GitPython security bump**: Upgraded 3.1.47 to 3.1.50, resolving 3 high-severity CVEs (path traversal, newline injection / RCE, CVE patch bypass). (PR #886)
 
 ---
 
 **Previous Releases**:
+- **v10.52.0** - feat(search): cascading fallback when semantic results are sparse; refactor(storage): include_embeddings on bulk-read ABC methods (PRs #883, #881, @filhocf, @henry201605)
 - **v10.51.3** - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships (PRs #865, #866, @filhocf)
 - **v10.51.2** - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878)
 - **v10.51.1** - fix(milvus): add delete_memory proxy for consolidation protocol (PR #872, @henry201605)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.52.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.53.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.52.0">
+<meta property="og:title" content="MCP Memory Service v10.53.0">
 <meta property="og:description" content="Plugin hooks now live in MemoryService. Dynamic /api/types dropdowns. Audit-log example. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.51 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.53 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.51</h2>
-    <p class="section-subtitle">Plugin hooks live — wire your logic into every memory event. ~1,838 tests.</p>
+    <h2 class="section-title">What's New in v10.53</h2>
+    <p class="section-subtitle">Milvus consolidation fully operational — embedding hydration end-to-end. ~1,838 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon http">&#9881;</div>
-        <h3>Plugin Hooks Are Live</h3>
-        <p>Fire points wired into <code>MemoryService</code> — <code>on_store</code>, <code>on_delete</code>, <code>on_retrieve</code>, <code>on_consolidate</code> now called at actual lifecycle events. Install a plugin package and it receives live events automatically. (PR #864, @filhocf)</p>
+        <div class="feature-icon consolidation">&#9889;</div>
+        <h3>Milvus Consolidation Fixed</h3>
+        <p>End-to-end embedding hydration for Milvus deployments — consolidation no longer produces 0 clusters/associations. <code>consolidator._get_memories_for_horizon</code> now passes <code>include_embeddings=True</code> to bulk-read methods, ensuring clustering receives real vectors. Completes a 4-PR series (#872, #878, #881, #885). (PR #885, @henry201605)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#9889;</div>
-        <h3>Dynamic Type Dropdowns</h3>
-        <p>New <code>GET /api/types</code> endpoint returns all valid memory types — built-in and custom (<code>MCP_CUSTOM_MEMORY_TYPES</code>). Dashboard filter and store-form dropdowns now populate dynamically, so custom ontology entries appear in the UI automatically. (PR #863, @filhocf)</p>
+        <div class="feature-icon http">&#128274;</div>
+        <h3>GitPython Security Bump</h3>
+        <p>Upgraded GitPython 3.1.47 to 3.1.50, resolving 3 high-severity CVEs in the transitive <code>wandb</code> dependency: path traversal (arbitrary file write/delete), newline injection enabling RCE via <code>core.hooksPath</code>, and a bypass of the prior CVE patch. (PR #886)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon privacy">&#128196;</div>
-        <h3>Audit-Log Example Plugin</h3>
-        <p>Reference implementation in <code>examples/plugins/audit_log/</code> demonstrating all four hooks with standard <code>entry_points</code> packaging. A complete, working plugin you can fork as a starting point. Living documentation for the plugin API. (PR #867, @filhocf)</p>
+        <div class="feature-icon privacy">&#9881;</div>
+        <h3>Cascading Search Fallback</h3>
+        <p>Opt-in two-tier fallback in <code>retrieve_memories</code> (<code>fallback=True</code>) for sparse semantic results: BM25 exact-match, then tag-intersection, merged and de-duplicated up to <code>n_results</code>. Default off — existing callers unaffected. (PR #883, @filhocf)</p>
       </div>
     </div>
   </div>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.52.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.53.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -147,7 +147,7 @@ footer a{color:var(--cyan)}
       <div class="feature-card" data-delay="150">
         <div class="feature-icon http">&#128274;</div>
         <h3>GitPython Security Bump</h3>
-        <p>Upgraded GitPython 3.1.47 to 3.1.50, resolving 3 high-severity CVEs in the transitive <code>wandb</code> dependency: path traversal (arbitrary file write/delete), newline injection enabling RCE via <code>core.hooksPath</code>, and a bypass of the prior CVE patch. (PR #886)</p>
+        <p>Upgraded GitPython to the latest secure release, resolving 3 high-severity CVEs in the transitive <code>wandb</code> dependency: path traversal (arbitrary file write/delete), newline injection enabling RCE via <code>core.hooksPath</code>, and a bypass of the prior CVE patch. (PR #886)</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon privacy">&#9881;</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.52.0"
+version = "10.53.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.52.0"
+__version__ = "10.53.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.52.0"
+version = "10.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **Version bump**: 10.52.0 → 10.53.0 (MINOR)
- **`_version.py`**, **`pyproject.toml`**, **`uv.lock`** updated
- **CHANGELOG.md**: v10.53.0 entry added (feat + security), empty `[Unreleased]` at top
- **README.md**: Latest Release section updated, v10.52.0 moved to Previous Releases
- **CLAUDE.md**: Current Version callout updated

## What's in this release

### feat(milvus): activate consolidation embedding hydration end-to-end (PR #885, @henry201605)

Completes the 4-PR series (#872 → #878 → #881 → #885) fixing a production failure on Milvus-backed deployments where consolidation produced 0 clusters/associations because the `vector` column was dropped during bulk reads, leaving every `Memory` with `embedding=None`.

Key change: `consolidator._get_memories_for_horizon` now passes `include_embeddings=True` to both storage bulk-read methods. All backends updated to handle the kwarg. 29 new tests added.

### security: GitPython 3.1.47 → 3.1.50 (PR #886)

Resolves 3 high-severity CVEs in the `wandb → GitPython` transitive dependency.

## Test plan

- [ ] CI passes on this branch
- [ ] No version duplicates in CHANGELOG.md
- [ ] PyPI publishes automatically via CI on tag push after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)