### PR TITLE
feat: add tag_match parameter to memory_search

### DIFF
--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -784,6 +784,7 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             after=arguments.get("after"),
             before=arguments.get("before"),
             tags=tags,
+            tag_match=arguments.get("tag_match", "any"),
             quality_boost=arguments.get("quality_boost", 0.0),
             limit=limit,
             include_debug=arguments.get("include_debug", False),

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1488,6 +1488,12 @@ Examples:
                                     ],
                                     "description": "Filter to memories with any of these tags"
                                 },
+                                "tag_match": {
+                                    "type": "string",
+                                    "enum": ["any", "all"],
+                                    "default": "any",
+                                    "description": "Match ANY tag (OR, default) or ALL tags (AND)"
+                                },
                                 "quality_boost": {
                                     "type": "number",
                                     "minimum": 0,

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -994,6 +994,7 @@ class MemoryStorage(ABC):
         after: Optional[str] = None,
         before: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         quality_boost: float = 0.0,
         limit: int = 10,
         include_debug: bool = False,
@@ -1274,9 +1275,14 @@ class MemoryStorage(ABC):
             if tags:
                 filtered_results = []
                 for result in results:
-                    # Match ANY tag
-                    if any(tag in result.memory.tags for tag in tags):
-                        filtered_results.append(result)
+                    if tag_match == "all":
+                        # Match ALL tags (AND)
+                        if all(tag in result.memory.tags for tag in tags):
+                            filtered_results.append(result)
+                    else:
+                        # Match ANY tag (OR) — default
+                        if any(tag in result.memory.tags for tag in tags):
+                            filtered_results.append(result)
                 results = filtered_results
 
             # Limit results


### PR DESCRIPTION
## Summary

Extends `tag_match` (AND/OR) filtering from `memory_delete` to `memory_search`.

Closes #889

## Changes

- `storage/base.py`: `search_memories()` accepts `tag_match` parameter (`"any"` | `"all"`, default `"any"`)
- `server/handlers/memory.py`: passes `tag_match` from tool arguments to storage
- `server_impl.py`: adds `tag_match` to `memory_search` tool schema

## Behavior

- `tag_match="any"` (default): match memories with ANY of the specified tags (OR) — **no behavior change**
- `tag_match="all"`: match memories with ALL specified tags (AND) — **new capability**

## Example

```json
{"query": "project status", "tags": ["open", "private"], "tag_match": "all"}
```

Returns only memories tagged with BOTH "open" AND "private".

## Notes

- Backward compatible — default is `"any"`, same as current behavior
- Same pattern already used in `memory_delete` (line 722 of handlers/memory.py)
- `memory_list` still uses single-tag filtering (separate scope, could be a follow-up)