### PR TITLE
chore: release v10.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.54.0] - 2026-05-10
+
+### Added
+
+- **`tag_match` parameter for `memory_search` MCP tool** ([#890](https://github.com/doobidoo/mcp-memory-service/pull/890), @filhocf, closes [#889](https://github.com/doobidoo/mcp-memory-service/issues/889)): Extends the AND/OR tag filtering already present in `memory_delete` to the `memory_search` tool. Accepts `tag_match: "any"` (OR, default — existing behavior unchanged) or `tag_match: "all"` (AND — only memories matching every supplied tag are returned). Implemented across `server_impl.py`, `server/handlers/memory.py`, and `storage/base.py`.
+
 ## [10.53.0] - 2026-05-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.53.0 - feat(milvus): consolidation embedding hydration end-to-end (PR #885, @henry201605); security: GitPython 3.1.50 (PR #886) — ~1,838 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.54.0 - feat(search): tag_match parameter for memory_search AND/OR tag filtering (PR #890, @filhocf) — ~1,875 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -493,17 +493,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.53.0** (May 9, 2026)
+## Latest Release: **v10.54.0** (May 10, 2026)
 
-**feat(milvus): activate consolidation embedding hydration end-to-end (PR #885, @henry201605)**
+**feat(search): add `tag_match` parameter to `memory_search` for AND/OR tag filtering (PR #890, @filhocf)**
 
 **What's New:**
-- **Milvus consolidation embedding hydration**: Completes a 4-PR series that fixes a production failure where consolidation produced 0 clusters/associations on Milvus deployments. `consolidator._get_memories_for_horizon` now passes `include_embeddings=True` to bulk-read methods, ensuring embeddings are hydrated before clustering. All backends updated: sqlite_vec gains conditional LEFT JOIN, hybrid forwards the kwarg, cloudflare accepts it (vectors live in Vectorize), milvus gets stricter `_coerce_vector` type rejection. Covered by 29 new tests. (PR #885, @henry201605)
-- **GitPython security bump**: Upgraded 3.1.47 to 3.1.50, resolving 3 high-severity CVEs (path traversal, newline injection / RCE, CVE patch bypass). (PR #886)
+- **AND/OR tag filtering in `memory_search`**: Extends the `tag_match: "any" | "all"` parameter (already available in `memory_delete`) to the `memory_search` MCP tool. Use `"all"` to require every supplied tag to match (AND); `"any"` (default) preserves existing OR behavior. No breaking change. (PR #890, @filhocf, closes #889)
 
 ---
 
 **Previous Releases**:
+- **v10.53.0** - feat(milvus): activate consolidation embedding hydration end-to-end; security: GitPython 3.1.50 (PRs #885, #886, @henry201605)
 - **v10.52.0** - feat(search): cascading fallback when semantic results are sparse; refactor(storage): include_embeddings on bulk-read ABC methods (PRs #883, #881, @filhocf, @henry201605)
 - **v10.51.3** - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships (PRs #865, #866, @filhocf)
 - **v10.51.2** - fix(oauth): CORS preflight failures and missing resource_metadata; refactor(milvus): opt-in embedding hydration on read paths (PRs #877, #878)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.53.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.54.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.53.0">
-<meta property="og:description" content="Plugin hooks now live in MemoryService. Dynamic /api/types dropdowns. Audit-log example. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.54.0">
+<meta property="og:description" content="AND/OR tag filtering for memory_search. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.53 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.54 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.53</h2>
-    <p class="section-subtitle">Milvus consolidation fully operational — embedding hydration end-to-end. ~1,838 tests.</p>
+    <h2 class="section-title">What's New in v10.54</h2>
+    <p class="section-subtitle">AND/OR tag filtering for memory_search. ~1,875 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon consolidation">&#9889;</div>
-        <h3>Milvus Consolidation Fixed</h3>
-        <p>End-to-end embedding hydration for Milvus deployments — consolidation no longer produces 0 clusters/associations. <code>consolidator._get_memories_for_horizon</code> now passes <code>include_embeddings=True</code> to bulk-read methods, ensuring clustering receives real vectors. Completes a 4-PR series (#872, #878, #881, #885). (PR #885, @henry201605)</p>
+        <div class="feature-icon privacy">&#127991;</div>
+        <h3>AND/OR Tag Filtering in memory_search</h3>
+        <p>The <code>tag_match</code> parameter (already in <code>memory_delete</code>) is now available in <code>memory_search</code>. Use <code>"all"</code> to require every tag to match (AND), or <code>"any"</code> (default) for OR — existing callers are unaffected. (PR #890, @filhocf, closes #889)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon http">&#128274;</div>
-        <h3>GitPython Security Bump</h3>
-        <p>Upgraded GitPython to the latest secure release, resolving 3 high-severity CVEs in the transitive <code>wandb</code> dependency: path traversal (arbitrary file write/delete), newline injection enabling RCE via <code>core.hooksPath</code>, and a bypass of the prior CVE patch. (PR #886)</p>
+        <div class="feature-icon consolidation">&#9889;</div>
+        <h3>Milvus Consolidation Fixed</h3>
+        <p>Completes a 4-PR series that fixes a production failure on Milvus deployments where consolidation produced 0 clusters/associations. All backends now pass <code>include_embeddings=True</code> on bulk reads. (PR #885, @henry201605)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon privacy">&#9881;</div>
+        <div class="feature-icon http">&#127313;</div>
         <h3>Cascading Search Fallback</h3>
-        <p>Opt-in two-tier fallback in <code>retrieve_memories</code> (<code>fallback=True</code>) for sparse semantic results: BM25 exact-match, then tag-intersection, merged and de-duplicated up to <code>n_results</code>. Default off — existing callers unaffected. (PR #883, @filhocf)</p>
+        <p>Opt-in BM25 + tag-intersection fallback in <code>retrieve_memories</code> for sparse semantic results. Merged and de-duplicated up to <code>n_results</code>. Default off — no breaking change. (PR #883, @filhocf)</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1838">0</div>
+        <div class="stat-number" data-target="1875">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.53.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.54.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -150,7 +150,7 @@ footer a{color:var(--cyan)}
         <p>Completes a 4-PR series that fixes a production failure on Milvus deployments where consolidation produced 0 clusters/associations. All backends now pass <code>include_embeddings=True</code> on bulk reads. (PR #885, @henry201605)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#127313;</div>
+        <div class="feature-icon http">&#128269;</div>
         <h3>Cascading Search Fallback</h3>
         <p>Opt-in BM25 + tag-intersection fallback in <code>retrieve_memories</code> for sparse semantic results. Merged and de-duplicated up to <code>n_results</code>. Default off — no breaking change. (PR #883, @filhocf)</p>
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.53.0"
+version = "10.54.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.53.0"
+__version__ = "10.54.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.53.0"
+version = "10.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.54.0

### What's included

- **feat(search): add `tag_match` parameter to `memory_search` MCP tool** (PR #890, @filhocf, closes #889)
  - Extends AND/OR tag filtering (already in `memory_delete`) to `memory_search`
  - `tag_match: "any"` (OR) is default — no breaking change
  - `tag_match: "all"` (AND) requires every supplied tag to match
  - 3 files changed: `server_impl.py`, `server/handlers/memory.py`, `storage/base.py`

### Files updated

| File | Change |
|------|--------|
| `src/mcp_memory_service/_version.py` | `10.53.0` → `10.54.0` |
| `pyproject.toml` | `10.53.0` → `10.54.0` |
| `uv.lock` | regenerated |
| `CHANGELOG.md` | added `[10.54.0]` entry |
| `README.md` | updated Latest Release section |
| `CLAUDE.md` | updated Current Version line |
| `docs/index.html` | updated title, meta, badge, features, test count (1875), release link |

### Version bump rationale

New optional parameter added to MCP tool schema — additive, non-breaking → MINOR (v10.53.0 → v10.54.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)