### PR TITLE
chore: release v10.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.55.0] - 2026-05-11
+
+### Added
+
+- **Entity extraction and memory-entity linking** ([#868](https://github.com/doobidoo/mcp-memory-service/pull/868), @filhocf): Phase 2 of the #732 reasoning roadmap. Introduces `EntityExtractor` that detects @mentions, #tags, URLs, and file paths inside memory content. `memory_search` gains an `entity` filter parameter for targeted retrieval; `memory_graph` gains `action="extract_entities"` to surface entities from a memory. Entity extraction also runs as Step 5 in the `maintain` consolidation cycle, continuously indexing entities from new memories.
+
+- **Insight Cards — automated pattern/trend/gap detection** ([#869](https://github.com/doobidoo/mcp-memory-service/pull/869), @filhocf): Phase 3 of the #732 reasoning roadmap. Adds `InsightGenerator` that analyses the memory corpus and produces three insight types: patterns (recurring knowledge clusters), trends (frequency changes over time), and gaps (under-represented topic areas). Runs as Step 6 in the `maintain` consolidation cycle. Opt-in via `MCP_INSIGHT_CARDS_ENABLED` (default: `false`) to avoid performance impact on existing deployments.
+
+### Changed
+
+- **Bump urllib3 2.6.3 → 2.7.0** ([#893](https://github.com/doobidoo/mcp-memory-service/pull/893)): Routine dependency update.
+
 ## [10.54.0] - 2026-05-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.54.0 - feat(search): tag_match parameter for memory_search AND/OR tag filtering (PR #890, @filhocf) — ~1,875 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.55.0 - feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf) — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -493,16 +493,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.54.0** (May 10, 2026)
+## Latest Release: **v10.55.0** (May 11, 2026)
 
-**feat(search): add `tag_match` parameter to `memory_search` for AND/OR tag filtering (PR #890, @filhocf)**
+**feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf)**
 
 **What's New:**
-- **AND/OR tag filtering in `memory_search`**: Extends the `tag_match: "any" | "all"` parameter (already available in `memory_delete`) to the `memory_search` MCP tool. Use `"all"` to require every supplied tag to match (AND); `"any"` (default) preserves existing OR behavior. No breaking change. (PR #890, @filhocf, closes #889)
+- **Entity extraction and memory-entity linking** (PR #868): New `EntityExtractor` detects @mentions, #tags, URLs, and paths in memory content. `memory_search` gains an `entity` filter; `memory_graph` gains `action="extract_entities"`. Runs as Step 5 in the `maintain` consolidation cycle.
+- **Insight Cards** (PR #869): `InsightGenerator` analyses the memory corpus and surfaces patterns, trends, and gaps. Runs as Step 6 in `maintain`. Opt-in via `MCP_INSIGHT_CARDS_ENABLED=true` (default: off).
+- **Bump urllib3 2.6.3 → 2.7.0** (PR #893): routine dependency update.
 
 ---
 
 **Previous Releases**:
+- **v10.54.0** - feat(search): tag_match parameter for memory_search AND/OR tag filtering (PR #890, @filhocf)
 - **v10.53.0** - feat(milvus): activate consolidation embedding hydration end-to-end; security: GitPython 3.1.50 (PRs #885, #886, @henry201605)
 - **v10.52.0** - feat(search): cascading fallback when semantic results are sparse; refactor(storage): include_embeddings on bulk-read ABC methods (PRs #883, #881, @filhocf, @henry201605)
 - **v10.51.3** - feat(memory_update): versioned flag; feat(memory_graph): infer_transitive and suggest_relationships (PRs #865, #866, @filhocf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.54.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.55.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.54.0">
-<meta property="og:description" content="AND/OR tag filtering for memory_search. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.55.0">
+<meta property="og:description" content="Entity extraction, memory-entity linking, and Insight Cards. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.54 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.55 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.54</h2>
-    <p class="section-subtitle">AND/OR tag filtering for memory_search. ~1,875 tests.</p>
+    <h2 class="section-title">What's New in v10.55</h2>
+    <p class="section-subtitle">Entity extraction, memory-entity linking, and Insight Cards. ~1,902 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon privacy">&#127991;</div>
-        <h3>AND/OR Tag Filtering in memory_search</h3>
-        <p>The <code>tag_match</code> parameter (already in <code>memory_delete</code>) is now available in <code>memory_search</code>. Use <code>"all"</code> to require every tag to match (AND), or <code>"any"</code> (default) for OR — existing callers are unaffected. (PR #890, @filhocf, closes #889)</p>
+        <div class="feature-icon privacy">&#128279;</div>
+        <h3>Entity Extraction and Memory-Entity Linking</h3>
+        <p>New <code>EntityExtractor</code> detects @mentions, #tags, URLs, and file paths inside memory content. <code>memory_search</code> gains an <code>entity</code> filter; <code>memory_graph</code> gains <code>action="extract_entities"</code>. Runs as Step 5 in the <code>maintain</code> cycle. (PR #868, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#9889;</div>
-        <h3>Milvus Consolidation Fixed</h3>
-        <p>Completes a 4-PR series that fixes a production failure on Milvus deployments where consolidation produced 0 clusters/associations. All backends now pass <code>include_embeddings=True</code> on bulk reads. (PR #885, @henry201605)</p>
+        <div class="feature-icon consolidation">&#128161;</div>
+        <h3>Insight Cards</h3>
+        <p><code>InsightGenerator</code> analyses the memory corpus and surfaces patterns, trends, and gaps automatically. Runs as Step 6 in <code>maintain</code>. Opt-in via <code>MCP_INSIGHT_CARDS_ENABLED=true</code> — default off, no impact on existing deployments. (PR #869, @filhocf)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#128269;</div>
-        <h3>Cascading Search Fallback</h3>
-        <p>Opt-in BM25 + tag-intersection fallback in <code>retrieve_memories</code> for sparse semantic results. Merged and de-duplicated up to <code>n_results</code>. Default off — no breaking change. (PR #883, @filhocf)</p>
+        <div class="feature-icon http">&#128274;</div>
+        <h3>Dependency Update</h3>
+        <p>urllib3 bumped from 2.6.3 to 2.7.0. Routine maintenance — no behaviour change. (PR #893)</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1875">0</div>
+        <div class="stat-number" data-target="1902">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.54.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.55.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.54.0"
+version = "10.55.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.54.0"
+__version__ = "10.55.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.54.0"
+version = "10.55.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.55.0 — Entity Extraction, Insight Cards, urllib3 bump

### What's included

- **feat(reasoning): entity extraction and memory-entity linking** (PR #868, @filhocf) — Phase 2 of the #732 reasoning roadmap. New `EntityExtractor` detects @mentions, #tags, URLs, and file paths. `memory_search` gains `entity` filter; `memory_graph` gains `action="extract_entities"`. Runs as Step 5 in the `maintain` consolidation cycle.

- **feat(consolidation): Insight Cards** (PR #869, @filhocf) — Phase 3 of the #732 reasoning roadmap. `InsightGenerator` produces pattern/trend/gap insights from the memory corpus. Runs as Step 6 in `maintain`. Opt-in via `MCP_INSIGHT_CARDS_ENABLED=true` (default: off).

- **chore(deps): bump urllib3 2.6.3 -> 2.7.0** (PR #893) — routine dependency update.

### Files changed

| File | Change |
|------|--------|
| `src/mcp_memory_service/_version.py` | 10.54.0 -> 10.55.0 |
| `pyproject.toml` | 10.54.0 -> 10.55.0 |
| `CHANGELOG.md` | Added v10.55.0 section |
| `README.md` | Updated Latest Release, moved v10.54.0 to Previous |
| `CLAUDE.md` | Updated version callout and test count |
| `docs/index.html` | Updated version badge, test count (1902), What's New section |
| `uv.lock` | Regenerated |

### Release type: MINOR (two new features, backward compatible)