### PR TITLE
chore: release v10.55.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.55.1] - 2026-05-11
+
+### Fixed
+
+- **`maintain` Step 5: entity links always 0 due to wrong graph accessor** ([#895](https://github.com/doobidoo/mcp-memory-service/pull/895)): `quality.py` Step 5 checked `storage.graph`, which is never set on storage objects, so `links_stored` was always `0` even when `entities_found > 0`. Fixed by using `get_graph_storage()` — the same accessor pattern used by all other graph handlers.
+
 ## [10.55.0] - 2026-05-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.55.0 - feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf) — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.55.1 - fix(entities): entity links always 0 in `maintain` Step 5 due to wrong graph accessor (PR #895) — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -493,18 +493,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.55.0** (May 11, 2026)
+## Latest Release: **v10.55.1** (May 11, 2026)
 
-**feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf)**
+**fix(entities): entity links always 0 in `maintain` Step 5 due to wrong graph accessor**
 
-**What's New:**
-- **Entity extraction and memory-entity linking** (PR #868): New `EntityExtractor` detects @mentions, #tags, URLs, and paths in memory content. `memory_search` gains an `entity` filter; `memory_graph` gains `action="extract_entities"`. Runs as Step 5 in the `maintain` consolidation cycle.
-- **Insight Cards** (PR #869): `InsightGenerator` analyses the memory corpus and surfaces patterns, trends, and gaps. Runs as Step 6 in `maintain`. Opt-in via `MCP_INSIGHT_CARDS_ENABLED=true` (default: off).
-- **Bump urllib3 2.6.3 → 2.7.0** (PR #893): routine dependency update.
+**What's Fixed:**
+- **`maintain` Step 5 entity links** (PR #895): `quality.py` checked `storage.graph` (never set on storage objects), causing `links_stored` to always be `0` even when `entities_found > 0`. Fixed by using `get_graph_storage()`, the same accessor pattern used by all other graph handlers.
 
 ---
 
 **Previous Releases**:
+- **v10.55.0** - feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf)
 - **v10.54.0** - feat(search): tag_match parameter for memory_search AND/OR tag filtering (PR #890, @filhocf)
 - **v10.53.0** - feat(milvus): activate consolidation embedding hydration end-to-end; security: GitPython 3.1.50 (PRs #885, #886, @henry201605)
 - **v10.52.0** - feat(search): cascading fallback when semantic results are sparse; refactor(storage): include_embeddings on bulk-read ABC methods (PRs #883, #881, @filhocf, @henry201605)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.55.0"
+version = "10.55.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.55.0"
+__version__ = "10.55.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.55.0"
+version = "10.55.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- fix(entities): use `get_graph_storage()` instead of `storage.graph` in maintain Step 5 — entity links were always 0 despite entities being found

## Test plan
- [x] Ran maintain live: `links_stored: 1248` confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)