### PR TITLE
chore: release v10.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.56.0] - 2026-05-12
+
+### Added
+
+- **`MCP_MAINTAIN_SCAN_LIMIT` env var** (default: 2000, 0 = unlimited): Controls how many memories are scanned per maintain cycle for entity extraction (Step 5) and insight card generation (Step 6). Previously hardcoded to 500 — large deployments can now tune or remove the cap entirely.
+
+### Fixed
+
+- **InsightGenerator gap detector skips metadata/status tags**: The `_detect_gaps` method now ignores tags that are operational markers rather than knowledge domains (`conflict:unresolved`, `automated`, `__test__`, `temporary`, `processed`, `auto-generated`, `insight-card`), eliminating false-positive "Decision gap" insight cards for these system tags.
+
 ## [10.55.2] - 2026-05-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.55.2 - fix(insights): handle None memory\_type and tags in InsightGenerator sort — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.56.0 - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,16 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.55.2** (May 12, 2026)
+## Latest Release: **v10.56.0** (May 12, 2026)
 
-**fix(insights): handle None memory\_type and tags in InsightGenerator sort**
+**feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter**
 
-**What's Fixed:**
-- **InsightGenerator TypeError** (`insights.py`): Fixed `'<' not supported between instances of 'str' and 'NoneType'` crash when memories have `None` values for `memory_type` or `tags`. The `maintain` cycle Step 6 (Insight Cards) now runs without errors.
+**What's New:**
+- **`MCP_MAINTAIN_SCAN_LIMIT` env var** (default: 2000, 0 = unlimited): Replaces the hardcoded 500-memory cap in the `maintain` cycle. Tune or remove the scan ceiling for entity extraction (Step 5) and insight card generation (Step 6) on large deployments.
+- **InsightGenerator gap filter**: The gap detector now skips operational/metadata tags (`conflict:unresolved`, `automated`, `__test__`, `temporary`, `processed`, `auto-generated`, `insight-card`) that are not knowledge domains, eliminating false-positive "Decision gap" insight cards.
 
 ---
 
 **Previous Releases**:
+- **v10.55.2** - fix(insights): handle None memory\_type and tags in InsightGenerator sort
 - **v10.55.1** - fix(entities): entity links always 0 in `maintain` Step 5 due to wrong graph accessor (PR #895)
 - **v10.55.0** - feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf)
 - **v10.54.0** - feat(search): tag_match parameter for memory_search AND/OR tag filtering (PR #890, @filhocf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.55.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.56.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.55.0">
-<meta property="og:description" content="Entity extraction, memory-entity linking, and Insight Cards. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.56.0">
+<meta property="og:description" content="Configurable maintain scan limit, InsightGenerator gap filter. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.55 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.56 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.55</h2>
-    <p class="section-subtitle">Entity extraction, memory-entity linking, and Insight Cards. ~1,902 tests.</p>
+    <h2 class="section-title">What's New in v10.56</h2>
+    <p class="section-subtitle">Configurable maintain scan limit and smarter Insight Cards. ~1,902 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon privacy">&#128279;</div>
-        <h3>Entity Extraction and Memory-Entity Linking</h3>
-        <p>New <code>EntityExtractor</code> detects @mentions, #tags, URLs, and file paths inside memory content. <code>memory_search</code> gains an <code>entity</code> filter; <code>memory_graph</code> gains <code>action="extract_entities"</code>. Runs as Step 5 in the <code>maintain</code> cycle. (PR #868, @filhocf)</p>
+        <h3>Configurable Maintain Scan Limit</h3>
+        <p>New <code>MCP_MAINTAIN_SCAN_LIMIT</code> env var (default: 2000, set to 0 for unlimited) replaces the hardcoded 500-memory cap in the <code>maintain</code> cycle. Large deployments can now tune or remove the ceiling for entity extraction (Step 5) and insight card generation (Step 6).</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon consolidation">&#128161;</div>
-        <h3>Insight Cards</h3>
-        <p><code>InsightGenerator</code> analyses the memory corpus and surfaces patterns, trends, and gaps automatically. Runs as Step 6 in <code>maintain</code>. Opt-in via <code>MCP_INSIGHT_CARDS_ENABLED=true</code> — default off, no impact on existing deployments. (PR #869, @filhocf)</p>
+        <h3>Smarter Insight Card Gap Detection</h3>
+        <p><code>InsightGenerator._detect_gaps</code> now skips operational metadata tags (<code>conflict:unresolved</code>, <code>automated</code>, <code>__test__</code>, <code>temporary</code>, <code>processed</code>, <code>auto-generated</code>, <code>insight-card</code>) that are not knowledge domains, eliminating false-positive "Decision gap" insight cards.</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#128274;</div>
-        <h3>Dependency Update</h3>
-        <p>urllib3 bumped from 2.6.3 to 2.7.0. Routine maintenance — no behaviour change. (PR #893)</p>
+        <div class="feature-icon http">&#9881;</div>
+        <h3>Entity Extraction and Insight Cards</h3>
+        <p>Built on v10.55: <code>EntityExtractor</code> indexes @mentions, #tags, URLs, and file paths from memory content. <code>InsightGenerator</code> surfaces patterns, trends, and gaps via <code>memory_quality maintain</code>. Opt-in via <code>MCP_INSIGHT_CARDS_ENABLED=true</code>.</p>
       </div>
     </div>
   </div>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.55.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.56.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.55.2"
+version = "10.56.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.55.2"
+__version__ = "10.56.0"

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -1212,6 +1212,10 @@ MAINTAIN_AUTO_RESOLVE_AGE_DAYS = safe_get_int_env('MCP_MAINTAIN_AUTO_RESOLVE_AGE
 # Insight Cards (Phase 3, #732) — opt-in, generates pattern/trend/gap insights during maintain
 MCP_INSIGHT_CARDS_ENABLED = safe_get_bool_env('MCP_INSIGHT_CARDS_ENABLED', False)
 
+# Maximum memories to scan per maintain cycle for entity extraction and insight cards.
+# 0 = unlimited (scans all memories — may be slow on large corpora).
+MAINTAIN_SCAN_LIMIT = safe_get_int_env('MCP_MAINTAIN_SCAN_LIMIT', 2000, min_value=0)
+
 # =============================================================================
 # Configuration Validation
 # =============================================================================

--- a/src/mcp_memory_service/consolidation/insights.py
+++ b/src/mcp_memory_service/consolidation/insights.py
@@ -33,6 +33,12 @@ class InsightGenerator:
     OLD_DAYS = 30
     GAP_MIN_MEMORIES = 5
 
+    # Tags that are status/metadata markers, not knowledge domains — skip gap detection.
+    EXCLUDED_GAP_TAGS: frozenset = frozenset({
+        "conflict:unresolved", "automated", "__test__", "temporary",
+        "processed", "auto-generated", "insight-card",
+    })
+
     def generate_insights(
         self, memories: List[dict], clusters: List[List[dict]]
     ) -> List[InsightCard]:
@@ -147,6 +153,8 @@ class InsightGenerator:
 
         insights = []
         for tag, mems in tag_mems.items():
+            if tag in self.EXCLUDED_GAP_TAGS:
+                continue
             if len(mems) >= self.GAP_MIN_MEMORIES and not tag_has_decision[tag]:
                 hashes = [m["content_hash"] for m in mems]
                 insights.append(InsightCard(

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -495,15 +495,17 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
     try:
         from mcp_memory_service.reasoning.entities import EntityExtractor
         from .graph import get_graph_storage
+        from ...config import MAINTAIN_SCAN_LIMIT
 
         all_mems = await storage.get_all_memories()
+        scan_slice = all_mems if MAINTAIN_SCAN_LIMIT == 0 else all_mems[:MAINTAIN_SCAN_LIMIT]
         extractor = EntityExtractor()
         total_entities = 0
         linked = 0
 
         graph = await get_graph_storage() if not dry_run else None
 
-        for mem in all_mems[:500]:  # Cap to avoid excessive processing
+        for mem in scan_slice:
             content = mem.content if hasattr(mem, 'content') else ""
             metadata = mem.metadata if hasattr(mem, 'metadata') else {}
             if isinstance(metadata, str):
@@ -526,15 +528,16 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
                     except Exception:
                         pass
 
+        scanned = len(scan_slice)
         if dry_run:
             report["steps"]["entities"] = {
                 "skipped_dry_run": True,
-                "memories_scanned": min(len(all_mems), 500),
+                "memories_scanned": scanned,
                 "entities_found": total_entities,
             }
         else:
             report["steps"]["entities"] = {
-                "memories_scanned": min(len(all_mems), 500),
+                "memories_scanned": scanned,
                 "entities_found": total_entities,
                 "links_stored": linked,
             }
@@ -550,8 +553,9 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
 
             # Fetch recent memories for analysis
             all_mems = await storage.get_all_memories()
+            scan_slice = all_mems if MAINTAIN_SCAN_LIMIT == 0 else all_mems[:MAINTAIN_SCAN_LIMIT]
             mem_dicts = []
-            for m in all_mems[:500]:  # Cap to avoid excessive processing
+            for m in scan_slice:
                 mem_dicts.append({
                     "content_hash": m.content_hash,
                     "tags": m.tags if isinstance(m.tags, list) else [t.strip() for t in (m.tags or "").split(",") if t.strip()],

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.55.2"
+version = "10.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **feat**: `MCP_MAINTAIN_SCAN_LIMIT` env var (default: 2000, 0 = unlimited) replaces the hardcoded 500-memory cap in the `maintain` cycle for entity extraction (Step 5) and insight card generation (Step 6)
- **fix**: `InsightGenerator._detect_gaps` now skips metadata/status tags (`conflict:unresolved`, `automated`, `__test__`, `temporary`, `processed`, `auto-generated`, `insight-card`) that are not knowledge domains, eliminating false-positive "Decision gap" insight cards
- **chore**: version bump v10.55.2 → v10.56.0; CHANGELOG, README, CLAUDE.md, docs/index.html, uv.lock updated

## Files Changed

| File | Change |
|------|--------|
| `src/mcp_memory_service/config.py` | Added `MAINTAIN_SCAN_LIMIT` config constant |
| `src/mcp_memory_service/consolidation/insights.py` | Added `EXCLUDED_GAP_TAGS` frozenset; skip in `_detect_gaps` |
| `src/mcp_memory_service/server/handlers/quality.py` | Use `MAINTAIN_SCAN_LIMIT` in Steps 5 & 6 instead of hardcoded 500 |
| `src/mcp_memory_service/_version.py` | `10.55.2` → `10.56.0` |
| `pyproject.toml` | `10.55.2` → `10.56.0` |
| `uv.lock` | Regenerated after version bump |
| `CHANGELOG.md` | Added `[10.56.0]` section under `[Unreleased]` |
| `README.md` | Updated Latest Release section |
| `CLAUDE.md` | Updated Current Version callout |
| `docs/index.html` | Updated version badge, meta tags, "What's New" heading, release notes link |

## Test plan

- [ ] CI passes on this branch
- [ ] `MCP_MAINTAIN_SCAN_LIMIT=0` disables the cap (unlimited scan)
- [ ] `MCP_MAINTAIN_SCAN_LIMIT=100` limits scan to 100 memories
- [ ] Maintain cycle does not generate gap insight cards for `__test__`, `automated`, `insight-card` tags
- [ ] CHANGELOG entry is under the correct `[10.56.0]` heading with no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)