### PR TITLE
chore: release v10.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.56.1] - 2026-05-12
+
+### Fixed
+
+- **fix(session): pass `session_id` as `conversation_id` to bypass semantic dedup** ([#898](https://github.com/doobidoo/mcp-memory-service/pull/898), @henry201605): `memory_store_session` calls were incorrectly blocked by semantic deduplication against topically-similar atomic memories — a category error (session logs vs atomic facts). Fixed by setting `skip_dedup = bool(conversation_id) or (memory_type == "session")` in `memory_service.store_memory()`.
+- **fix(maintain): hoist `get_all_memories()` and `scan_slice` before Steps 5 & 6** (addresses code review on [#899](https://github.com/doobidoo/mcp-memory-service/pull/899)): Eliminates a duplicate DB call and a latent `NameError` where `MAINTAIN_SCAN_LIMIT` was only defined inside Step 5's try block and would have raised `NameError` in Step 6 if Step 5 failed before reaching the import.
+
 ## [10.56.0] - 2026-05-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.56.0 - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.56.1 - fix(session): pass session\_id as conversation\_id to bypass semantic dedup — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.56.0** (May 12, 2026)
+## Latest Release: **v10.56.1** (May 12, 2026)
 
-**feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter**
+**fix(session): pass session_id as conversation_id to bypass semantic dedup**
 
-**What's New:**
-- **`MCP_MAINTAIN_SCAN_LIMIT` env var** (default: 2000, 0 = unlimited): Replaces the hardcoded 500-memory cap in the `maintain` cycle. Tune or remove the scan ceiling for entity extraction (Step 5) and insight card generation (Step 6) on large deployments.
-- **InsightGenerator gap filter**: The gap detector now skips operational/metadata tags (`conflict:unresolved`, `automated`, `__test__`, `temporary`, `processed`, `auto-generated`, `insight-card`) that are not knowledge domains, eliminating false-positive "Decision gap" insight cards.
+**What's Fixed:**
+- `memory_store_session` was incorrectly blocked by semantic deduplication against topically-similar atomic memories — a category error (session logs vs atomic facts). Fixed by setting `skip_dedup = bool(conversation_id) or (memory_type == "session")` in `store_memory()`.
 
 ---
 
 **Previous Releases**:
+- **v10.56.0** - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter
 - **v10.55.2** - fix(insights): handle None memory\_type and tags in InsightGenerator sort
 - **v10.55.1** - fix(entities): entity links always 0 in `maintain` Step 5 due to wrong graph accessor (PR #895)
 - **v10.55.0** - feat(reasoning+consolidation): entity extraction, memory-entity linking, and Insight Cards (PRs #868, #869, @filhocf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.56.0"
+version = "10.56.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.56.0"
+__version__ = "10.56.1"

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -491,21 +491,23 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["errors"].append(f"quality: {e}")
         report["steps"]["quality"] = {"error": str(e)}
 
+    # Pre-fetch memories once; shared by Steps 5 and 6 to avoid duplicate DB calls.
+    from ...config import MAINTAIN_SCAN_LIMIT, MCP_INSIGHT_CARDS_ENABLED
+    _all_mems = await storage.get_all_memories()
+    _scan_slice = _all_mems if MAINTAIN_SCAN_LIMIT == 0 else _all_mems[:MAINTAIN_SCAN_LIMIT]
+
     # Step 5: Batch entity extraction
     try:
         from mcp_memory_service.reasoning.entities import EntityExtractor
         from .graph import get_graph_storage
-        from ...config import MAINTAIN_SCAN_LIMIT
 
-        all_mems = await storage.get_all_memories()
-        scan_slice = all_mems if MAINTAIN_SCAN_LIMIT == 0 else all_mems[:MAINTAIN_SCAN_LIMIT]
         extractor = EntityExtractor()
         total_entities = 0
         linked = 0
 
         graph = await get_graph_storage() if not dry_run else None
 
-        for mem in scan_slice:
+        for mem in _scan_slice:
             content = mem.content if hasattr(mem, 'content') else ""
             metadata = mem.metadata if hasattr(mem, 'metadata') else {}
             if isinstance(metadata, str):
@@ -528,7 +530,7 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
                     except Exception:
                         pass
 
-        scanned = len(scan_slice)
+        scanned = len(_scan_slice)
         if dry_run:
             report["steps"]["entities"] = {
                 "skipped_dry_run": True,
@@ -546,16 +548,12 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["steps"]["entities"] = {"error": str(e)}
 
     # Step 6: Insight Cards generation (opt-in)
-    from ...config import MCP_INSIGHT_CARDS_ENABLED
     if MCP_INSIGHT_CARDS_ENABLED:
         try:
             from ...consolidation.insights import InsightGenerator, store_insights
 
-            # Fetch recent memories for analysis
-            all_mems = await storage.get_all_memories()
-            scan_slice = all_mems if MAINTAIN_SCAN_LIMIT == 0 else all_mems[:MAINTAIN_SCAN_LIMIT]
             mem_dicts = []
-            for m in scan_slice:
+            for m in _scan_slice:
                 mem_dicts.append({
                     "content_hash": m.content_hash,
                     "tags": m.tags if isinstance(m.tags, list) else [t.strip() for t in (m.tags or "").split(",") if t.strip()],

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.56.0"
+version = "10.56.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version from v10.56.0 → v10.56.1
- Hoists `get_all_memories()` and `scan_slice` computation before Steps 5 & 6 in the `maintain` cycle handler, eliminating a duplicate DB call and a latent `NameError` (addresses code review on #899)
- Also includes fix from #898: `memory_store_session` bypass of semantic dedup for session-type memories

## Changes

### Fixed
- **fix(maintain): hoist `get_all_memories()` and `scan_slice` before Steps 5 & 6** (`quality.py`): Previously the shared setup was duplicated inside each step. If Step 5 failed before its import, Step 6 would raise `NameError: MAINTAIN_SCAN_LIMIT`. Now fetched once before both steps.
- **fix(session): pass `session_id` as `conversation_id` to bypass semantic dedup** (#898): `memory_store_session` calls were incorrectly blocked by semantic deduplication against topically-similar atomic memories.

## Test plan
- [ ] CI passes on this branch
- [ ] `maintain` cycle runs without duplicate DB calls
- [ ] Step 6 runs correctly even when Step 5 raises an exception early

🤖 Generated with [Claude Code](https://claude.com/claude-code)