### PR TITLE
fix(milvus): add missing stale_days param to count_all_memories

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1809,6 +1809,7 @@ class MilvusMemoryStorage(MemoryStorage):
         self,
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        stale_days: Optional[int] = None,
     ) -> int:
         if not self._ensure_initialized():
             return 0

--- a/tests/storage/test_milvus.py
+++ b/tests/storage/test_milvus.py
@@ -389,6 +389,9 @@ async def test_get_all_memories_and_count(storage):
     assert await storage.count_all_memories(tags=["g-1"]) == 1
     assert await storage.count_all_memories(memory_type="note") == 3
     assert await storage.count_all_memories(memory_type="reminder") == 0
+    # stale_days is accepted but ignored (Milvus has no last_accessed field)
+    assert await storage.count_all_memories(stale_days=7) == 3
+    assert await storage.count_all_memories(memory_type="note", stale_days=30) == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`MilvusMemoryStorage.count_all_memories()` is missing the `stale_days` parameter that was added to all other backends in PR #784. This causes `memory_list` to crash with a `TypeError` when using the Milvus backend:

```
TypeError: MilvusMemoryStorage.count_all_memories() got an unexpected keyword argument 'stale_days'
```

## Motivation

PR #784 (commit 48d388ba, 2026-04-30) added `stale_days` to `MemoryStorage` base class and all backend implementations, but the Milvus backend's `count_all_memories` was missed — only `get_all_memories` was updated.

The call chain `memory_list` → `MemoryService.list_memories()` → `storage.count_all_memories(stale_days=...)` breaks immediately on Milvus.

## Changes

- **`src/mcp_memory_service/storage/milvus.py`**: Add `stale_days: Optional[int] = None` to `count_all_memories()` signature. The parameter is accepted but ignored since the Milvus collection schema has no `last_accessed` field (same approach as `CloudflareStorage`).
- **`tests/storage/test_milvus.py`**: Add assertions verifying `count_all_memories(stale_days=...)` does not raise and returns correct counts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `test_get_all_memories_and_count` passes with Milvus Lite locally
- All 564 existing tests continue to pass (the one pre-existing failure in `test_conversation_id_bypasses_semantic_dedup` is unrelated)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes