### PR TITLE
chore: release v10.56.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.56.2] - 2026-05-12
+
+### Fixed
+
+- **fix(milvus): add missing `stale_days` param to `count_all_memories`** ([#901](https://github.com/doobidoo/mcp-memory-service/pull/901), @henry201605): `MilvusMemoryStorage.count_all_memories()` was missing the `stale_days: Optional[int] = None` parameter present on all other backends, causing a `TypeError` when callers passed this argument. The parameter is now accepted and silently ignored (Milvus has no `last_accessed` field).
+- **fix(quality): graceful fallback for `MAINTAIN_SCAN_LIMIT` on stale server process**: Wrapped the `from ...config import MAINTAIN_SCAN_LIMIT, MCP_INSIGHT_CARDS_ENABLED` import in a `try/except ImportError` block. On in-place upgrades where the server process has a stale `sys.modules` cache, the import can fail; the handler now falls back to reading `MCP_MAINTAIN_SCAN_LIMIT` from the environment (default: 2000) so maintain cycles continue working without a full server restart.
+
 ## [10.56.1] - 2026-05-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.56.1 - fix(session): pass session\_id as conversation\_id to bypass semantic dedup — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.56.2 - fix(milvus): missing stale\_days param + fix(quality): graceful MAINTAIN\_SCAN\_LIMIT fallback — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,16 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.56.1** (May 12, 2026)
+## Latest Release: **v10.56.2** (May 12, 2026)
 
-**fix(session): pass session_id as conversation_id to bypass semantic dedup**
+**Compatibility fixes for Milvus and stale-process server upgrades**
 
 **What's Fixed:**
-- `memory_store_session` was incorrectly blocked by semantic deduplication against topically-similar atomic memories — a category error (session logs vs atomic facts). Fixed by setting `skip_dedup = bool(conversation_id) or (memory_type == "session")` in `store_memory()`.
+- `MilvusMemoryStorage.count_all_memories()` was missing `stale_days` parameter, causing `TypeError` when called with this argument (all other backends accept it). Now accepted and silently ignored (Milvus has no `last_accessed` field).
+- `quality.py` maintain handler now falls back gracefully when `MAINTAIN_SCAN_LIMIT` cannot be imported from a stale `sys.modules` cache after an in-place server upgrade. Falls back to `MCP_MAINTAIN_SCAN_LIMIT` env-var (default 2000).
 
 ---
 
 **Previous Releases**:
+- **v10.56.1** - fix(session): pass session_id as conversation_id to bypass semantic dedup
 - **v10.56.0** - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter
 - **v10.55.2** - fix(insights): handle None memory\_type and tags in InsightGenerator sort
 - **v10.55.1** - fix(entities): entity links always 0 in `maintain` Step 5 due to wrong graph accessor (PR #895)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.56.1"
+version = "10.56.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.56.1"
+__version__ = "10.56.2"

--- a/src/mcp_memory_service/server/handlers/quality.py
+++ b/src/mcp_memory_service/server/handlers/quality.py
@@ -492,7 +492,12 @@ async def handle_maintain(server, arguments: dict) -> List[types.TextContent]:
         report["steps"]["quality"] = {"error": str(e)}
 
     # Pre-fetch memories once; shared by Steps 5 and 6 to avoid duplicate DB calls.
-    from ...config import MAINTAIN_SCAN_LIMIT, MCP_INSIGHT_CARDS_ENABLED
+    # Fallback guards against stale sys.modules cache when server runs across upgrades.
+    try:
+        from ...config import MAINTAIN_SCAN_LIMIT, MCP_INSIGHT_CARDS_ENABLED
+    except ImportError:
+        MAINTAIN_SCAN_LIMIT = int(__import__('os').environ.get('MCP_MAINTAIN_SCAN_LIMIT', '2000') or '2000')
+        MCP_INSIGHT_CARDS_ENABLED = __import__('os').environ.get('MCP_INSIGHT_CARDS_ENABLED', '').lower() in ('1', 'true', 'yes')
     _all_mems = await storage.get_all_memories()
     _scan_slice = _all_mems if MAINTAIN_SCAN_LIMIT == 0 else _all_mems[:MAINTAIN_SCAN_LIMIT]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.56.1"
+version = "10.56.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.56.2

PATCH release — two compatibility fixes.

### Changes

**fix(milvus): add missing `stale_days` param to `count_all_memories`** (PR #901, @henry201605)
- `MilvusMemoryStorage.count_all_memories()` was missing the `stale_days: Optional[int] = None` parameter present on all other backends
- Callers passing this argument got a `TypeError`; parameter is now accepted and silently ignored (Milvus has no `last_accessed` field)

**fix(quality): graceful fallback for `MAINTAIN_SCAN_LIMIT` on stale server process**
- Wrapped `from ...config import MAINTAIN_SCAN_LIMIT` in `try/except ImportError`
- Prevents maintain cycle failures on in-place upgrades where `sys.modules` cache is stale
- Falls back to `MCP_MAINTAIN_SCAN_LIMIT` env-var (default 2000)

### Files changed
- `src/mcp_memory_service/storage/milvus.py` — stale_days param
- `src/mcp_memory_service/server/handlers/quality.py` — ImportError fallback
- `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `pyproject.toml`, `_version.py`, `uv.lock` — version bump to 10.56.2

### Checklist
- [x] Version bump: 10.56.1 → 10.56.2 (PATCH)
- [x] CHANGELOG.md updated (new section, [Unreleased] empty)
- [x] README.md Latest Release updated
- [x] CLAUDE.md version updated
- [x] `uv lock` run
- [x] No `docs/index.html` changes (patch release)
- [x] No here.now re-publish (patch release)