### PR TITLE
feat: add tag_match parameter to memory_list

### DIFF
--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -489,23 +489,20 @@ async def handle_memory_list(server, arguments: dict) -> List[types.TextContent]
         page = arguments.get("page", 1)
         page_size = arguments.get("page_size", 20)
         tags = arguments.get("tags")
+        tag_match = arguments.get("tag_match", "any")
         memory_type = arguments.get("memory_type")
         stale_days = arguments.get("stale_days")
 
         # Normalize tags if provided
         if tags:
             tags = normalize_tags(tags)
-            # For list_memories, we need a single tag (legacy API)
-            # Use the first tag if multiple provided
-            tag = tags[0] if tags else None
-        else:
-            tag = None
 
         # Call memory service list_memories
         result = await server.memory_service.list_memories(
             page=page,
             page_size=page_size,
-            tag=tag,
+            tags=tags,
+            tag_match=tag_match,
             memory_type=memory_type,
             stale_days=stale_days,
         )

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1555,7 +1555,8 @@ PAGINATION:
 - page_size: Results per page (default: 20, max: 100)
 
 FILTERS (combine with AND logic):
-- tags: Filter to memories with ANY of these tags
+- tags: Filter to memories with matching tags
+- tag_match: "any" (OR, default) or "all" (AND) — controls how multiple tags are matched
 - memory_type: Filter by type (note, reference, decision, etc.)
 - stale_days: Filter to memories not accessed in the last N days
 
@@ -1563,6 +1564,7 @@ Examples:
 {}  // List first 20 memories
 {"page": 2, "page_size": 50}
 {"tags": ["python", "reference"]}
+{"tags": ["python", "reference"], "tag_match": "all"}
 {"memory_type": "decision", "page_size": 10}
 {"tags": ["important"], "memory_type": "note"}
 {"stale_days": 30}  // Memories not accessed in 30 days
@@ -1587,7 +1589,13 @@ Examples:
                                 "tags": {
                                     "type": "array",
                                     "items": {"type": "string"},
-                                    "description": "Filter by tags (returns memories with ANY of these tags)"
+                                    "description": "Filter by tags (returns memories with ANY of these tags by default, use tag_match to control)"
+                                },
+                                "tag_match": {
+                                    "type": "string",
+                                    "default": "any",
+                                    "enum": ["any", "all"],
+                                    "description": "Match ANY tag (OR, default) or ALL tags (AND)"
                                 },
                                 "memory_type": {
                                     "type": "string",

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -276,6 +276,8 @@ class MemoryService:
         page: int = 1,
         page_size: int = 10,
         tag: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         memory_type: Optional[str] = None,
         stale_days: Optional[int] = None,
     ) -> Union[ListMemoriesSuccess, ListMemoriesError]:
@@ -288,7 +290,9 @@ class MemoryService:
         Args:
             page: Page number (1-based)
             page_size: Number of memories per page
-            tag: Filter by specific tag
+            tag: Filter by specific tag (legacy, use tags instead)
+            tags: Filter by list of tags
+            tag_match: "any" to match ANY tag (OR), "all" to match ALL tags (AND)
             memory_type: Filter by memory type
             stale_days: Filter to memories not accessed in the last N days.
                 Uses COALESCE(last_accessed, created_at) for memories never read.
@@ -301,12 +305,14 @@ class MemoryService:
             offset = (page - 1) * page_size
 
             # Use database-level filtering for optimal performance
-            tags_list = [tag] if tag else None
+            # Support both legacy single tag and new tags list
+            tags_list = tags if tags else ([tag] if tag else None)
             memories = await self.storage.get_all_memories(
                 limit=page_size,
                 offset=offset,
                 memory_type=memory_type,
                 tags=tags_list,
+                tag_match=tag_match,
                 stale_days=stale_days,
             )
 
@@ -314,6 +320,7 @@ class MemoryService:
             total = await self.storage.count_all_memories(
                 memory_type=memory_type,
                 tags=tags_list,
+                tag_match=tag_match,
                 stale_days=stale_days,
             )
 

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -826,6 +826,7 @@ class MemoryStorage(ABC):
         offset: int = 0,
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         stale_days: Optional[int] = None,
         include_embeddings: bool = False,
     ) -> List[Memory]:
@@ -836,7 +837,8 @@ class MemoryStorage(ABC):
             limit: Maximum number of memories to return (None for all)
             offset: Number of memories to skip (for pagination)
             memory_type: Optional filter by memory type
-            tags: Optional filter by tags (matches ANY of the provided tags)
+            tags: Optional filter by tags
+            tag_match: "any" to match ANY tag (OR), "all" to match ALL tags (AND)
             stale_days: Optional filter to memories not accessed in the last N days
             include_embeddings: If True and the backend stores embeddings
                 locally, populate ``Memory.embedding`` on the returned
@@ -851,7 +853,7 @@ class MemoryStorage(ABC):
         """
         return []
     
-    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, stale_days: Optional[int] = None) -> int:
+    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, tag_match: str = "any", stale_days: Optional[int] = None) -> int:
         """
         Get total count of memories in storage.
 

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -1793,6 +1793,7 @@ class CloudflareStorage(MemoryStorage):
         offset: int = 0,
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         stale_days: Optional[int] = None,
         include_embeddings: bool = False,
     ) -> List[Memory]:
@@ -1839,14 +1840,16 @@ class CloudflareStorage(MemoryStorage):
             if where_conditions:
                 sql += " WHERE " + " AND ".join(where_conditions)
 
+            query_params = params.copy()
+
             if tags:
-                sql += " GROUP BY m.id HAVING COUNT(DISTINCT t.name) = ?"
+                if tag_match == "all":
+                    sql += " GROUP BY m.id HAVING COUNT(DISTINCT t.name) = ?"
+                    query_params.append(tag_count)
+                else:
+                    sql += " GROUP BY m.id"
 
             sql += " ORDER BY m.created_at DESC"
-
-            query_params = params.copy()
-            if tags:
-                query_params.append(tag_count)
 
             if limit is not None:
                 sql += " LIMIT ?"
@@ -2125,13 +2128,13 @@ class CloudflareStorage(MemoryStorage):
             logger.error(f"Error getting memories by time range: {str(e)}")
             return []
 
-    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, stale_days: Optional[int] = None) -> int:
+    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, tag_match: str = "any", stale_days: Optional[int] = None) -> int:
         """
         Get total count of memories in storage.
 
         Args:
             memory_type: Optional filter by memory type
-            tags: Optional filter by tags (memories matching ANY of the tags)
+            tags: Optional filter by tags (tag_match controls AND/OR logic)
 
         Returns:
             Total number of memories, optionally filtered by type and/or tags
@@ -2163,12 +2166,15 @@ class CloudflareStorage(MemoryStorage):
                 sql += ' WHERE ' + ' AND '.join(conditions)
 
             if tags:
-                sql += ' GROUP BY m.id HAVING COUNT(DISTINCT t.name) = ?'
+                if tag_match == "all":
+                    sql += ' GROUP BY m.id HAVING COUNT(DISTINCT t.name) = ?'
+                else:
+                    sql += ' GROUP BY m.id'
 
             count_sql = f'SELECT COUNT(*) as count FROM ({sql}) AS subquery'
 
             count_params = params.copy()
-            if tags:
+            if tags and tag_match == "all":
                 count_params.append(tag_count)
 
             payload = {"sql": count_sql, "params": count_params}

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -1706,6 +1706,7 @@ class HybridMemoryStorage(MemoryStorage):
         offset: int = 0,
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         stale_days: Optional[int] = None,
         include_embeddings: bool = False,
     ) -> List[Memory]:
@@ -1719,6 +1720,7 @@ class HybridMemoryStorage(MemoryStorage):
             offset=offset,
             memory_type=memory_type,
             tags=tags,
+            tag_match=tag_match,
             stale_days=stale_days,
             include_embeddings=include_embeddings,
         )
@@ -1727,9 +1729,9 @@ class HybridMemoryStorage(MemoryStorage):
         """Get a memory by its content hash from primary storage."""
         return await self.primary.get_by_hash(content_hash)
 
-    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, stale_days: Optional[int] = None) -> int:
+    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, tag_match: str = "any", stale_days: Optional[int] = None) -> int:
         """Get total count of memories from primary storage."""
-        return await self.primary.count_all_memories(memory_type=memory_type, tags=tags, stale_days=stale_days)
+        return await self.primary.count_all_memories(memory_type=memory_type, tags=tags, tag_match=tag_match, stale_days=stale_days)
 
     async def get_memories_by_time_range(
         self,

--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -3530,6 +3530,7 @@ SOLUTIONS:
         offset: int = 0,
         memory_type: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        tag_match: str = "any",
         stale_days: Optional[int] = None,
         include_embeddings: bool = False,
     ) -> List[Memory]:
@@ -3540,7 +3541,8 @@ SOLUTIONS:
             limit: Maximum number of memories to return (None for all)
             offset: Number of memories to skip (for pagination)
             memory_type: Optional filter by memory type
-            tags: Optional filter by tags (matches ANY of the provided tags)
+            tags: Optional filter by tags
+            tag_match: "any" to match ANY tag (OR), "all" to match ALL tags (AND)
             include_embeddings: Accepted for signature compatibility with the
                 base ABC. SqliteVecMemoryStorage already LEFT-JOINs the
                 embeddings table unconditionally (``_row_to_memory`` decodes
@@ -3576,7 +3578,8 @@ SOLUTIONS:
             # Add tags filter if specified (GLOB for exact tag matching in CSV column)
             if tags and len(tags) > 0:
                 stripped_tags = [tag.strip() for tag in tags]
-                tag_conditions = " OR ".join(
+                joiner = " AND " if tag_match == "all" else " OR "
+                tag_conditions = joiner.join(
                     [
                         "(',' || REPLACE(m.tags, ' ', '') || ',') GLOB ?"
                         for _ in stripped_tags
@@ -3729,13 +3732,14 @@ SOLUTIONS:
             logger.error(f"Error getting memory timestamps: {e}")
             return []
 
-    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, stale_days: Optional[int] = None) -> int:
+    async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, tag_match: str = "any", stale_days: Optional[int] = None) -> int:
         """
         Get total count of memories in storage.
 
         Args:
             memory_type: Optional filter by memory type
-            tags: Optional filter by tags (memories matching ANY of the tags)
+            tags: Optional filter by tags
+            tag_match: "any" to match ANY tag (OR), "all" to match ALL tags (AND)
 
         Returns:
             Total number of memories, optionally filtered by type and/or tags
@@ -3752,9 +3756,10 @@ SOLUTIONS:
                 params.append(memory_type)
 
             if tags:
-                # Filter by tags - match ANY tag (OR logic, GLOB for exact match in CSV)
+                # Filter by tags using tag_match mode
                 stripped_tags = [tag.strip() for tag in tags]
-                tag_conditions = " OR ".join(
+                joiner = " AND " if tag_match == "all" else " OR "
+                tag_conditions = joiner.join(
                     [
                         "(',' || REPLACE(tags, ' ', '') || ',') GLOB ?"
                         for _ in stripped_tags

--- a/src/mcp_memory_service/web/api/memories.py
+++ b/src/mcp_memory_service/web/api/memories.py
@@ -257,6 +257,7 @@ async def list_memories(
     page_size: int = Query(10, ge=1, le=100, description="Number of memories per page"),
     tag: Optional[str] = Query(None, description="Filter by tag"),
     memory_type: Optional[str] = Query(None, description="Filter by memory type"),
+    tag_match: Optional[str] = Query("any", description="Tag matching mode: 'any' (OR) or 'all' (AND)"),
     memory_service: MemoryService = Depends(get_memory_service),
     user: AuthenticationResult = Depends(require_read_access)
 ):
@@ -266,12 +267,16 @@ async def list_memories(
     Uses the MemoryService for consistent business logic and optimal database-level filtering.
     """
     try:
+        # Split comma-separated tags into list for proper multi-tag filtering
+        tags_list = [t.strip() for t in tag.split(",") if t.strip()] if tag else None
+
         # Use the injected service for consistent, performant memory listing
         result = await memory_service.list_memories(
             page=page,
             page_size=page_size,
-            tag=tag,
-            memory_type=memory_type
+            tags=tags_list,
+            memory_type=memory_type,
+            tag_match=tag_match
         )
 
         return MemoryListResponse(

--- a/tests/unit/test_cloudflare_storage.py
+++ b/tests/unit/test_cloudflare_storage.py
@@ -430,8 +430,8 @@ class TestCloudflareStorage:
             assert len(memories) == 1
             sql_payload = mock_request.call_args_list[0].kwargs["json"]
             sql_text = sql_payload["sql"].upper()
-            assert "JOIN MEMORY_TAGS" in sql_text and "HAVING COUNT(DISTINCT T.NAME) = ?" in sql_text
-            assert sql_payload["params"] == ["status:initialized", 1, 10]
+            assert "JOIN MEMORY_TAGS" in sql_text and "GROUP BY M.ID" in sql_text
+            assert sql_payload["params"] == ["status:initialized", 10]
 
     @pytest.mark.asyncio
     async def test_count_all_memories_with_tag_filter(self, cloudflare_storage):
@@ -448,8 +448,8 @@ class TestCloudflareStorage:
             assert count == 3
             sql_payload = mock_request.call_args.kwargs["json"]
             sql_text = sql_payload["sql"].upper()
-            assert "COUNT(*) AS COUNT FROM" in sql_text and "HAVING COUNT(DISTINCT T.NAME) = ?" in sql_text
-            assert sql_payload["params"] == ["alpha", "beta", 2]
+            assert "COUNT(*) AS COUNT FROM" in sql_text and "GROUP BY M.ID" in sql_text
+            assert sql_payload["params"] == ["alpha", "beta"]
 
     @pytest.mark.asyncio
     async def test_delete_memory(self, cloudflare_storage):

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -96,6 +96,7 @@ async def test_list_memories_basic_pagination(memory_service, mock_storage, samp
         offset=0,
         memory_type=None,
         tags=None,
+        tag_match='any',
         stale_days=None
     )
 

--- a/tests/web/api/test_memories_api.py
+++ b/tests/web/api/test_memories_api.py
@@ -148,3 +148,86 @@ def test_store_memory_agent_id_not_duplicated_if_already_in_tags(test_app):
     data = response.json()
     stored_tags = data["memory"]["tags"]
     assert stored_tags.count("agent:researcher") == 1
+
+
+@pytest.mark.integration
+def test_list_memories_tag_match_any_returns_union(test_app):
+    """tag_match=any should return memories with ANY of the specified tags (OR logic)."""
+    # Store memory with tag "python"
+    test_app.post("/api/memories", json={
+        "content": "Python is great for scripting",
+        "tags": ["python", "scripting"]
+    })
+    # Store memory with tag "reference"
+    test_app.post("/api/memories", json={
+        "content": "Reference guide for Docker commands",
+        "tags": ["reference", "docker"]
+    })
+    # Store memory with neither tag
+    test_app.post("/api/memories", json={
+        "content": "Unrelated memory about lunch",
+        "tags": ["personal"]
+    })
+
+    # Query with tag_match=any for "python" — should find the first
+    response = test_app.get("/api/memories", params={"tag": "python", "tag_match": "any"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    # All returned memories should have "python" tag
+    for mem in data["memories"]:
+        assert "python" in mem["tags"]
+
+
+@pytest.mark.integration
+def test_list_memories_tag_match_all_returns_intersection(test_app):
+    """tag_match=all should return only memories with ALL specified tags (AND logic)."""
+    # Store memory with both tags
+    test_app.post("/api/memories", json={
+        "content": "Python reference for async patterns",
+        "tags": ["python", "reference"]
+    })
+    # Store memory with only "python"
+    test_app.post("/api/memories", json={
+        "content": "Python basics tutorial",
+        "tags": ["python", "tutorial"]
+    })
+
+    # Query with tag_match=all for "python,reference" — should find only the first
+    response = test_app.get("/api/memories", params={"tag": "python,reference", "tag_match": "all"})
+    assert response.status_code == 200
+    data = response.json()
+    # Only memories with BOTH tags should be returned
+    for mem in data["memories"]:
+        assert "python" in mem["tags"]
+        assert "reference" in mem["tags"]
+
+
+@pytest.mark.integration
+def test_list_memories_tag_match_any_vs_all_different_results(test_app):
+    """ANY and ALL modes should produce different result sets for the same tags."""
+    # Store memory with both tags
+    test_app.post("/api/memories", json={
+        "content": "Has both alpha and beta tags",
+        "tags": ["alpha", "beta"]
+    })
+    # Store memory with only alpha
+    test_app.post("/api/memories", json={
+        "content": "Has only alpha tag",
+        "tags": ["alpha", "gamma"]
+    })
+
+    # ANY should return both (either alpha OR beta)
+    resp_any = test_app.get("/api/memories", params={"tag": "alpha,beta", "tag_match": "any"})
+    # ALL should return only the first (both alpha AND beta)
+    resp_all = test_app.get("/api/memories", params={"tag": "alpha,beta", "tag_match": "all"})
+
+    assert resp_any.status_code == 200
+    assert resp_all.status_code == 200
+
+    any_total = resp_any.json()["total"]
+    all_total = resp_all.json()["total"]
+
+    # ANY should return more results than ALL
+    assert any_total > all_total
+    assert all_total >= 1


### PR DESCRIPTION
## Summary

Adds `tag_match` parameter to `memory_list`, harmonizing filtering behavior with `memory_search` and `memory_delete`.

Closes #896. Supersedes #903 (rebased onto clean main, no harvest commits).

## Changes

- `tag_match='any'` (default): match memories with ANY of the provided tags (existing behavior)
- `tag_match='all'`: match memories with ALL of the provided tags

### All backends updated

| File | Change |
|------|--------|
| `base.py` | ABC signature updated with `tag_match` param |
| `sqlite_vec.py` | AND/OR joiner in `get_all_memories` and `count_all_memories` |
| `cloudflare.py` | `HAVING COUNT` for 'all', `GROUP BY` only for 'any' |
| `hybrid.py` | Forwards `tag_match` to primary backend |
| `server_impl.py` | Tool schema + description updated |
| `handlers/memory.py` | Pass full tags list + tag_match to service |
| `services/memory_service.py` | Accept `tags` list + `tag_match`, backward-compatible |
| `tests/` | Updated mock assertions + cloudflare SQL assertions |

## Addresses review feedback from #903

1. ✅ `tag_match` propagated to Cloudflare and Hybrid backends
2. ✅ Rebased on clean main (no harvest commits from #892)
3. ⚠️ CI 'Test uvx compatibility' — pre-existing failure unrelated to this PR (env leak injects hostname into tags)