### PR TITLE
feat(milvus): implement get_memory_connections via graph collection

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1887,6 +1887,9 @@ class MilvusMemoryStorage(MemoryStorage):
         times each hash appears as either ``source_hash`` or ``target_hash``.
         This enables the Forgetting engine to protect highly-connected
         "hub" memories from premature archival.
+
+        Uses ``query_iterator`` to handle arbitrarily large graph collections
+        without hitting the single-query limit cap.
         """
         graph_collection = f"{self.collection_name}_graph"
 
@@ -1904,15 +1907,14 @@ class MilvusMemoryStorage(MemoryStorage):
         except Exception:  # noqa: BLE001
             return {}
 
-        # Fetch all edges (source_hash, target_hash) from graph collection
+        # Drain all edges via QueryIterator (handles large graphs)
         try:
-            rows = await self._call_client(
-                "query",
-                collection_name=graph_collection,
-                filter="",
-                output_fields=["source_hash", "target_hash"],
-                limit=_MILVUS_MAX_LIMIT,
-            )
+            async with self._write_lock:
+                if self.client is None:
+                    return {}
+                rows = await asyncio.to_thread(
+                    self._drain_graph_edges, graph_collection,
+                )
         except Exception as exc:  # noqa: BLE001
             logger.warning("get_memory_connections: failed to query graph collection: %s", exc)
             return {}
@@ -1928,6 +1930,29 @@ class MilvusMemoryStorage(MemoryStorage):
                 connections[tgt] = connections.get(tgt, 0) + 1
 
         return connections
+
+    def _drain_graph_edges(self, graph_collection: str) -> List[Dict[str, Any]]:
+        """Sync helper that drains all edges from the graph collection."""
+        assert self.client is not None
+        iterator = self.client.query_iterator(
+            collection_name=graph_collection,
+            filter="",
+            output_fields=["source_hash", "target_hash"],
+            batch_size=self._QUERY_ITER_BATCH,
+        )
+        rows: List[Dict[str, Any]] = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                rows.extend(batch)
+        finally:
+            try:
+                iterator.close()
+            except Exception:  # noqa: BLE001
+                pass
+        return rows
 
     _QUERY_ITER_BATCH = 1000
 

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1876,6 +1876,59 @@ class MilvusMemoryStorage(MemoryStorage):
         timestamps = [row["created_at"] for row in rows if row.get("created_at") is not None]
         return sorted(timestamps, reverse=True)
 
+    # ------------------------------------------------------------------
+    # Connection tracking (graph-based)
+    # ------------------------------------------------------------------
+
+    async def get_memory_connections(self) -> Dict[str, int]:
+        """Return connection counts per memory hash from the graph collection.
+
+        Queries ``{collection_name}_graph`` for all edges and counts how many
+        times each hash appears as either ``source_hash`` or ``target_hash``.
+        This enables the Forgetting engine to protect highly-connected
+        "hub" memories from premature archival.
+        """
+        graph_collection = f"{self.collection_name}_graph"
+
+        if not self._ensure_initialized():
+            return {}
+
+        # Check if graph collection exists
+        try:
+            has_graph = await self._call_client(
+                "has_collection",
+                collection_name=graph_collection,
+            )
+            if not has_graph:
+                return {}
+        except Exception:  # noqa: BLE001
+            return {}
+
+        # Fetch all edges (source_hash, target_hash) from graph collection
+        try:
+            rows = await self._call_client(
+                "query",
+                collection_name=graph_collection,
+                filter="",
+                output_fields=["source_hash", "target_hash"],
+                limit=_MILVUS_MAX_LIMIT,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_memory_connections: failed to query graph collection: %s", exc)
+            return {}
+
+        # Count occurrences of each hash (as source or target)
+        connections: Dict[str, int] = {}
+        for row in rows:
+            src = row.get("source_hash")
+            tgt = row.get("target_hash")
+            if src:
+                connections[src] = connections.get(src, 0) + 1
+            if tgt:
+                connections[tgt] = connections.get(tgt, 0) + 1
+
+        return connections
+
     _QUERY_ITER_BATCH = 1000
 
     async def _query_memories(

--- a/tests/storage/test_milvus.py
+++ b/tests/storage/test_milvus.py
@@ -401,6 +401,65 @@ async def test_get_all_tags_deduplicates(storage):
     assert set(tags) == {"x", "y", "z"}
 
 
+# -- Connection tracking -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_memory_connections_empty(storage):
+    """get_memory_connections returns empty dict when no graph collection exists."""
+    connections = await storage.get_memory_connections()
+    assert connections == {}
+
+
+@pytest.mark.asyncio
+async def test_get_memory_connections_with_graph_data(storage):
+    """get_memory_connections counts edges from graph collection."""
+    from pymilvus import DataType
+
+    graph_collection = f"{storage.collection_name}_graph"
+    client = storage.client
+
+    # Create graph collection if not exists (mimics MilvusGraphStorage)
+    if not client.has_collection(collection_name=graph_collection):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.VARCHAR, is_primary=True, max_length=64)
+        schema.add_field(field_name="source_hash", datatype=DataType.VARCHAR, max_length=64)
+        schema.add_field(field_name="target_hash", datatype=DataType.VARCHAR, max_length=64)
+        schema.add_field(field_name="similarity", datatype=DataType.FLOAT)
+        schema.add_field(field_name="connection_types", datatype=DataType.VARCHAR, max_length=65535)
+        schema.add_field(field_name="metadata", datatype=DataType.VARCHAR, max_length=65535)
+        schema.add_field(field_name="relationship_type", datatype=DataType.VARCHAR, max_length=32)
+        schema.add_field(field_name="created_at", datatype=DataType.DOUBLE)
+        schema.add_field(field_name="_dummy_vec", datatype=DataType.FLOAT_VECTOR, dim=2)
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="_dummy_vec", index_type="AUTOINDEX", metric_type="L2")
+        client.create_collection(collection_name=graph_collection, schema=schema, index_params=index_params)
+
+    # Insert test edges: A->B, A->C, B->C
+    import hashlib, time
+    edges = [
+        {"id": hashlib.sha256(b"a:b").hexdigest()[:64], "source_hash": "aaaa1111", "target_hash": "bbbb2222",
+         "similarity": 0.8, "connection_types": "shared_tags", "metadata": "{}",
+         "relationship_type": "related", "created_at": time.time(), "_dummy_vec": [0.0, 0.0]},
+        {"id": hashlib.sha256(b"a:c").hexdigest()[:64], "source_hash": "aaaa1111", "target_hash": "cccc3333",
+         "similarity": 0.7, "connection_types": "temporal_proximity", "metadata": "{}",
+         "relationship_type": "related", "created_at": time.time(), "_dummy_vec": [0.0, 0.0]},
+        {"id": hashlib.sha256(b"b:c").hexdigest()[:64], "source_hash": "bbbb2222", "target_hash": "cccc3333",
+         "similarity": 0.6, "connection_types": "shared_concepts", "metadata": "{}",
+         "relationship_type": "related", "created_at": time.time(), "_dummy_vec": [0.0, 0.0]},
+    ]
+    client.insert(collection_name=graph_collection, data=edges)
+
+    # Verify counts
+    connections = await storage.get_memory_connections()
+    assert connections["aaaa1111"] == 2  # source twice
+    assert connections["bbbb2222"] == 2  # source once + target once
+    assert connections["cccc3333"] == 2  # target twice
+
+    # Cleanup
+    client.drop_collection(collection_name=graph_collection)
+
+
 # -- Update / stats ---------------------------------------------------------
 
 


### PR DESCRIPTION
## Description

Implement `get_memory_connections()` for `MilvusMemoryStorage` by querying the `mcp_memory_graph` collection to count how many edges reference each memory hash.

## Motivation

The Milvus backend currently falls through to the base class default (`return {}`), which means the **Forgetting engine's connection-based retention boost is completely inactive**. Highly connected "hub" memories — those referenced by many associations — receive no protection from archival.

The consolidation pipeline calls `storage.get_memory_connections()` during `_update_relevance_scores()` to boost the relevance of well-connected memories. Without this implementation, the Milvus backend's forgetting decisions are based solely on time decay, ignoring graph topology entirely.

### Call chain (verified via GitNexus impact analysis):
```
consolidate() → _update_relevance_scores() → _get_memory_connections() → storage.get_memory_connections()
```

Impact: **LOW risk** — no existing callers break; the method simply returns richer data instead of `{}`.

## Changes

- **`src/mcp_memory_service/storage/milvus.py`**: Add `get_memory_connections()` method that:
  - Checks if `{collection_name}_graph` collection exists
  - Queries all edges for `source_hash` and `target_hash` fields
  - Counts occurrences of each hash (as source or target)
  - Returns `Dict[str, int]` mapping `content_hash → connection_count`
  - Gracefully returns `{}` if graph collection doesn't exist or query fails

- **`tests/storage/test_milvus.py`**: Add two tests:
  - `test_get_memory_connections_empty`: Verifies empty dict when no graph collection exists
  - `test_get_memory_connections_with_graph_data`: Creates a graph collection with 3 edges (A→B, A→C, B→C), verifies correct counts (A=2, B=2, C=2)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Both new tests pass with Milvus Lite locally
- All 43 existing Milvus tests continue to pass
- No schema changes required — reads from existing `mcp_memory_graph` collection created by `MilvusGraphStorage`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes