### PR TITLE
chore: release v10.56.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.56.3] - 2026-05-13
+
+### Fixed
+
+- **feat(milvus): implement `get_memory_connections()` via graph collection** ([#907](https://github.com/doobidoo/mcp-memory-service/pull/907), @henry201605): `MilvusMemoryStorage.get_memory_connections()` was a stub returning `{}`, meaning hub memories had no protection from archival in the Forgetting engine's connection-based retention boost. Implemented using `QueryIterator` + `asyncio.to_thread` to drain all edges from the `{collection_name}_graph` collection. Adds 2 unit tests.
+- **fix(quality): apply Gemini review suggestion for `MAINTAIN_SCAN_LIMIT` fallback**: Replaced `__import__('os')` with a standard `import os`, added `try/except ValueError` guard for invalid `MCP_MAINTAIN_SCAN_LIMIT` env values, and documented the DoS risk of uncapped values in a comment. Addresses a Gemini code-assist review comment on PR #902 that was missed before merge.
+
 ## [10.56.2] - 2026-05-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.56.2 - fix(milvus): missing stale\_days param + fix(quality): graceful MAINTAIN\_SCAN\_LIMIT fallback — ~1,902 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.56.3 - feat(milvus): get\_memory\_connections() via graph collection + fix(quality): MAINTAIN\_SCAN\_LIMIT fallback hardening — ~1,904 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.56.2** (May 12, 2026)
+## Latest Release: **v10.56.3** (May 13, 2026)
 
-**Compatibility fixes for Milvus and stale-process server upgrades**
+**Milvus connection graph + quality handler hardening**
 
 **What's Fixed:**
-- `MilvusMemoryStorage.count_all_memories()` was missing `stale_days` parameter, causing `TypeError` when called with this argument (all other backends accept it). Now accepted and silently ignored (Milvus has no `last_accessed` field).
-- `quality.py` maintain handler now falls back gracefully when `MAINTAIN_SCAN_LIMIT` cannot be imported from a stale `sys.modules` cache after an in-place server upgrade. Falls back to `MCP_MAINTAIN_SCAN_LIMIT` env-var (default 2000).
+- `MilvusMemoryStorage.get_memory_connections()` was a stub returning `{}`, meaning hub memories had no protection from archival in the Forgetting engine's connection-based retention boost. Now fully implemented via `QueryIterator` + `asyncio.to_thread` against the graph collection.
+- `quality.py` `MAINTAIN_SCAN_LIMIT` fallback now uses a clean `import os` (replacing `__import__('os')`), guards against invalid env-var values with `try/except ValueError`, and documents the DoS risk of uncapped scan limits.
 
 ---
 
 **Previous Releases**:
+- **v10.56.2** - fix(milvus): missing `stale_days` param in `count_all_memories` + fix(quality): graceful `MAINTAIN_SCAN_LIMIT` fallback
 - **v10.56.1** - fix(session): pass session_id as conversation_id to bypass semantic dedup
 - **v10.56.0** - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter
 - **v10.55.2** - fix(insights): handle None memory\_type and tags in InsightGenerator sort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.56.2"
+version = "10.56.3"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.56.2"
+__version__ = "10.56.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.56.2"
+version = "10.56.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.56.3

PATCH release — bug fixes and implementation completions, no breaking changes.

### Changes

**feat(milvus): implement `get_memory_connections()` via graph collection** ([#907](https://github.com/doobidoo/mcp-memory-service/pull/907), @henry201605)
- `MilvusMemoryStorage.get_memory_connections()` was a stub returning `{}`, so hub memories had no protection from archival in the Forgetting engine's connection-based retention boost.
- Implemented using `QueryIterator` + `asyncio.to_thread` to drain all edges from the `{collection_name}_graph` collection.
- Adds 2 unit tests.

**fix(quality): `MAINTAIN_SCAN_LIMIT` fallback hardening**
- Replaced `__import__('os')` with a clean `import os`.
- Added `try/except ValueError` guard for invalid `MCP_MAINTAIN_SCAN_LIMIT` env values.
- Documents the DoS risk of uncapped scan limits in a comment.
- Addresses Gemini code-assist review comment on PR #902 that was missed before merge.

### Files Changed
- `src/mcp_memory_service/_version.py` — 10.56.2 → 10.56.3
- `pyproject.toml` — 10.56.2 → 10.56.3
- `CHANGELOG.md` — new [10.56.3] section
- `README.md` — Latest Release updated
- `CLAUDE.md` — version callout updated
- `uv.lock` — regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)