### PR TITLE
chore: release v10.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.57.0] - 2026-05-13
+
+### Added
+
+- **`tag_match` parameter for `memory_list` MCP tool** ([#904](https://github.com/doobidoo/mcp-memory-service/pull/904), @filhocf): Extends AND/OR tag filtering to `memory_list`, harmonizing it with `memory_search` and `memory_delete`. Accepts `tag_match: "any"` (OR, default — existing behavior unchanged) or `tag_match: "all"` (AND — only memories matching every supplied tag are returned). Implemented across `server_impl.py`, `server/handlers/memory.py`, REST API, and all three storage backends (sqlite_vec, cloudflare, hybrid).
+- **Automatic chunking for `memory_store_session`** ([#912](https://github.com/doobidoo/mcp-memory-service/pull/912), @filhocf): Long sessions stored via `memory_store_session` are now automatically split at turn boundaries (lines starting with `User:`, `Assistant:`, `Human:`, `AI:`, `You:`, `Bot:`). Configure with `SESSION_CHUNK_SIZE` env var (default: 1500 chars, set to 0 to disable). Each chunk is tagged `chunk:N/M` for sequential retrieval. Fully backward compatible — short sessions are stored as a single memory with no change in behavior.
+
+### Fixed
+
+- **CI: guard `pr-contributor-welcome` against non-PR event triggers** (commit b42cf004): Added `github.event_name == 'pull_request_target'` guard to the contributor-welcome workflow to prevent crashes when triggered by push events.
+
 ## [10.56.3] - 2026-05-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.56.3 - feat(milvus): get\_memory\_connections() via graph collection + fix(quality): MAINTAIN\_SCAN\_LIMIT fallback hardening — ~1,904 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.57.0 - feat(memory_list): tag_match AND/OR filtering + feat(session): automatic chunking at turn boundaries — ~1,960 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,21 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.56.3** (May 13, 2026)
+## Latest Release: **v10.57.0** (May 13, 2026)
 
-**Milvus connection graph + quality handler hardening**
+**Tag-match filtering for `memory_list` + automatic session chunking**
+
+**What's New:**
+- `memory_list` now accepts `tag_match="any"` (OR, default) / `tag_match="all"` (AND) — harmonizes with `memory_search` and `memory_delete` filtering. Implemented across all three backends (sqlite_vec, cloudflare, hybrid) (PR #904, @filhocf).
+- `memory_store_session` automatically splits long sessions at turn boundaries. Configure with `SESSION_CHUNK_SIZE` (default 1500 chars, 0=disabled); chunks are tagged `chunk:N/M` for easy retrieval (PR #912, @filhocf).
 
 **What's Fixed:**
-- `MilvusMemoryStorage.get_memory_connections()` was a stub returning `{}`, meaning hub memories had no protection from archival in the Forgetting engine's connection-based retention boost. Now fully implemented via `QueryIterator` + `asyncio.to_thread` against the graph collection.
-- `quality.py` `MAINTAIN_SCAN_LIMIT` fallback now uses a clean `import os` (replacing `__import__('os')`), guards against invalid env-var values with `try/except ValueError`, and documents the DoS risk of uncapped scan limits.
+- CI: `pr-contributor-welcome` workflow now guarded against non-PR event triggers to prevent crash on push events.
 
 ---
 
 **Previous Releases**:
+- **v10.56.3** - feat(milvus): get_memory_connections() via graph collection + fix(quality): MAINTAIN_SCAN_LIMIT fallback hardening
 - **v10.56.2** - fix(milvus): missing `stale_days` param in `count_all_memories` + fix(quality): graceful `MAINTAIN_SCAN_LIMIT` fallback
 - **v10.56.1** - fix(session): pass session_id as conversation_id to bypass semantic dedup
 - **v10.56.0** - feat(consolidation): configurable maintain scan limit + InsightGenerator gap filter

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.56.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.57.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.56.0">
-<meta property="og:description" content="Configurable maintain scan limit, InsightGenerator gap filter. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.57.0">
+<meta property="og:description" content="Tag-match AND/OR filtering for memory_list, automatic session chunking. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.56 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.57 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.56</h2>
-    <p class="section-subtitle">Configurable maintain scan limit and smarter Insight Cards. ~1,902 tests.</p>
+    <h2 class="section-title">What's New in v10.57</h2>
+    <p class="section-subtitle">Tag-match AND/OR filtering for memory_list and automatic session chunking. ~1,960 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon privacy">&#128279;</div>
-        <h3>Configurable Maintain Scan Limit</h3>
-        <p>New <code>MCP_MAINTAIN_SCAN_LIMIT</code> env var (default: 2000, set to 0 for unlimited) replaces the hardcoded 500-memory cap in the <code>maintain</code> cycle. Large deployments can now tune or remove the ceiling for entity extraction (Step 5) and insight card generation (Step 6).</p>
+        <div class="feature-icon privacy">&#127991;</div>
+        <h3>AND/OR Tag Filtering for memory_list</h3>
+        <p>New <code>tag_match</code> parameter for the <code>memory_list</code> MCP tool and REST API: <code>"any"</code> (OR, default) returns memories matching at least one tag; <code>"all"</code> (AND) returns only memories matching every supplied tag. Implemented across sqlite_vec, cloudflare, and hybrid backends.</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#128161;</div>
-        <h3>Smarter Insight Card Gap Detection</h3>
-        <p><code>InsightGenerator._detect_gaps</code> now skips operational metadata tags (<code>conflict:unresolved</code>, <code>automated</code>, <code>__test__</code>, <code>temporary</code>, <code>processed</code>, <code>auto-generated</code>, <code>insight-card</code>) that are not knowledge domains, eliminating false-positive "Decision gap" insight cards.</p>
+        <div class="feature-icon consolidation">&#128203;</div>
+        <h3>Automatic Session Chunking</h3>
+        <p><code>memory_store_session</code> now auto-splits long sessions at turn boundaries (<code>User:</code>, <code>Assistant:</code>, <code>Human:</code>, etc.). Configure with <code>SESSION_CHUNK_SIZE</code> env var (default: 1500 chars, 0=disabled). Chunks tagged <code>chunk:N/M</code> for sequential retrieval. Fully backward compatible.</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#9881;</div>
-        <h3>Entity Extraction and Insight Cards</h3>
-        <p>Built on v10.55: <code>EntityExtractor</code> indexes @mentions, #tags, URLs, and file paths from memory content. <code>InsightGenerator</code> surfaces patterns, trends, and gaps via <code>memory_quality maintain</code>. Opt-in via <code>MCP_INSIGHT_CARDS_ENABLED=true</code>.</p>
+        <div class="feature-icon http">&#128279;</div>
+        <h3>Built on v10.55-10.56 Foundation</h3>
+        <p>Extends the entity extraction, insight cards, and configurable maintain scan limit capabilities introduced in recent releases. Complete AND/OR tag filtering now unified across <code>memory_search</code>, <code>memory_delete</code>, and <code>memory_list</code>.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1902">0</div>
+        <div class="stat-number" data-target="1960">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.56.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.57.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.56.3"
+version = "10.57.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.56.3"
+__version__ = "10.57.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.56.3"
+version = "10.57.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.57.0 — MINOR

### Changes in this release

**New Features (from main since v10.56.3):**

- **feat: `tag_match` parameter for `memory_list`** ([#904](https://github.com/doobidoo/mcp-memory-service/pull/904), @filhocf): Adds `tag_match="any"` (OR, default) / `tag_match="all"` (AND) to `memory_list` MCP tool and REST API. Harmonizes with `memory_search` and `memory_delete`. Implemented across sqlite_vec, cloudflare, and hybrid backends.

- **feat: automatic chunking for `memory_store_session`** ([#912](https://github.com/doobidoo/mcp-memory-service/pull/912), @filhocf): Long sessions are auto-split at turn boundaries. Configure with `SESSION_CHUNK_SIZE` env var (default 1500, 0=disabled). Chunks tagged `chunk:N/M`. Fully backward compatible.

- **fix(ci): guard `pr-contributor-welcome` against non-PR event triggers** (b42cf004): Prevents workflow crash on push events.

### Files changed
- `src/mcp_memory_service/_version.py` — 10.56.3 → 10.57.0
- `pyproject.toml` — 10.56.3 → 10.57.0
- `uv.lock` — updated
- `CHANGELOG.md` — new v10.57.0 entry
- `README.md` — Latest Release section updated
- `CLAUDE.md` — version callout updated
- `docs/index.html` — v10.57 badge, What's New section, test count 1902 → 1960, release notes link

### Notes on Gemini review comments
PRs #904 and #912 were merged with open Gemini review comments flagging potential issues:
- PR #904: `query_params` uninitialized variable in cloudflare.py when `tag_match="all"`
- PR #912: Failed chunk store should abort the entire operation (fail-fast)

These will be tracked and addressed in follow-up patch releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)