### PR TITLE
fix(milvus): compare values in structural change detection for preserve_timestamps

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1588,7 +1588,17 @@ class MilvusMemoryStorage(MemoryStorage):
         """
         now = time.time()
         now_iso = self._iso_from_epoch(now)
-        structural = any(k in updates for k in ("tags", "memory_type", "content"))
+
+        # Detect structural changes by comparing actual values, not just key
+        # presence. This prevents consolidation's metadata-only updates (which
+        # pass tags/memory_type unchanged) from incorrectly bumping updated_at.
+        structural = False
+        if "content" in updates and updates["content"] != existing.content:
+            structural = True
+        elif "tags" in updates and sorted(updates["tags"] or []) != sorted(existing.tags or []):
+            structural = True
+        elif "memory_type" in updates and updates["memory_type"] != existing.memory_type:
+            structural = True
 
         if preserve_timestamps and not structural:
             updated_at = existing.updated_at if existing.updated_at is not None else now

--- a/tests/storage/test_milvus.py
+++ b/tests/storage/test_milvus.py
@@ -499,6 +499,65 @@ async def test_update_rejects_bad_tag_type(storage, sample_memory):
 
 
 @pytest.mark.asyncio
+async def test_metadata_only_update_preserves_updated_at(storage, sample_memory):
+    """Regression: updating only metadata (not tags/type/content) with
+    preserve_timestamps=True must NOT bump updated_at.
+
+    This guards against consolidation's _update_consolidation_timestamps
+    incorrectly refreshing updated_at for all memories, which breaks the
+    Forgetting engine's access_boost fallback logic.
+    """
+    await storage.store(sample_memory)
+    original = await storage.get_by_hash(sample_memory.content_hash)
+    original_updated_at = original.updated_at
+
+    # Simulate what consolidation does: update metadata only, same tags/type
+    import asyncio
+    await asyncio.sleep(0.1)  # ensure time passes
+    ok, _ = await storage.update_memory_metadata(
+        sample_memory.content_hash,
+        updates={
+            "tags": sample_memory.tags,  # same tags, no change
+            "memory_type": sample_memory.memory_type,  # same type
+            "metadata": {"last_consolidated_at": 9999999999.0},
+        },
+        preserve_timestamps=True,
+    )
+    assert ok
+
+    refreshed = await storage.get_by_hash(sample_memory.content_hash)
+    assert refreshed.updated_at == original_updated_at, (
+        f"updated_at was bumped from {original_updated_at} to {refreshed.updated_at} "
+        f"despite preserve_timestamps=True and no structural change"
+    )
+
+
+@pytest.mark.asyncio
+async def test_structural_change_bumps_updated_at(storage, sample_memory):
+    """When tags actually change, updated_at SHOULD be bumped even with preserve_timestamps=True."""
+    await storage.store(sample_memory)
+    original = await storage.get_by_hash(sample_memory.content_hash)
+    original_updated_at = original.updated_at
+
+    import asyncio
+    await asyncio.sleep(0.1)
+    ok, _ = await storage.update_memory_metadata(
+        sample_memory.content_hash,
+        updates={
+            "tags": ["completely", "different", "tags"],
+            "metadata": {"reason": "user edit"},
+        },
+        preserve_timestamps=True,
+    )
+    assert ok
+
+    refreshed = await storage.get_by_hash(sample_memory.content_hash)
+    assert refreshed.updated_at > original_updated_at, (
+        "updated_at should be bumped when tags actually change"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_stats(storage, sample_memory):
     await storage.store(sample_memory)
     stats = await storage.get_stats()


### PR DESCRIPTION
## Description

Fix incorrect `updated_at` timestamp bumping in `MilvusMemoryStorage._compute_update_timestamps()` when `preserve_timestamps=True` is passed with unchanged tags/memory_type.

## Problem

The structural change detection used key-presence checking:

```python
structural = any(k in updates for k in ("tags", "memory_type", "content"))
```

This means if `updates` contains `tags` or `memory_type` keys — even with **identical values** — it's treated as a structural change and `updated_at` gets bumped to `now`.

### Impact on consolidation

`_update_consolidation_timestamps()` calls `update_memories_batch(preserve_timestamps=True)`, which routes through `update_memory()` → `update_memory_metadata()`. The base class `update_memory()` always passes `tags` and `memory_type` in the updates dict (even when unchanged):

```python
updates = {
    'tags': memory.tags,          # same value, but key exists
    'metadata': memory.metadata,  # only this actually changed
    'memory_type': memory.memory_type  # same value, but key exists
}
```

Result: **every consolidation run resets `updated_at` to current time for ALL processed memories**, even though only `metadata.last_consolidated_at` changed.

This breaks the Forgetting engine's `access_boost` fallback logic — when `last_accessed` is unavailable (Milvus has no such field), it falls back to `updated_at`. With all memories showing `updated_at = last consolidation time`, the engine thinks everything was "recently accessed" and never archives anything.

### Evidence from production

All memories in the Milvus collection show identical `updated_at` = `2026-05-13T09:57:44` (the last consolidation run time), regardless of when they were actually created or last modified by the user.

## Fix

Compare actual values instead of checking key presence:

```python
structural = False
if "content" in updates and updates["content"] != existing.content:
    structural = True
elif "tags" in updates and sorted(updates["tags"] or []) != sorted(existing.tags or []):
    structural = True
elif "memory_type" in updates and updates["memory_type"] != existing.memory_type:
    structural = True
```

This aligns with SQLite-vec's `update_memories_batch` which already does value comparison:
```python
structural_change = (new_tags != current_tags or new_type != current_type)
```

## Changes

- **`src/mcp_memory_service/storage/milvus.py`**: Replace key-presence check with value comparison in `_compute_update_timestamps()`
- **`tests/storage/test_milvus.py`**: Add two regression tests:
  - `test_metadata_only_update_preserves_updated_at`: Verifies unchanged tags/type don't bump `updated_at`
  - `test_structural_change_bumps_updated_at`: Verifies actually-changed tags DO bump `updated_at`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Both new tests pass with Milvus Lite locally
- All 45 existing Milvus tests continue to pass


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes