### PR TITLE
chore: release v10.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.57.1] - 2026-05-14
+
+### Fixed
+
+- **fix(sqlite): replace GLOB with LIKE ESCAPE for tag matching** ([#916](https://github.com/doobidoo/mcp-memory-service/pull/916)): Replaced `_escape_glob` with `_escape_like` in `sqlite_vec.py`. All 13 tag-filtering query sites migrated from `GLOB ?` to `LIKE ? ESCAPE '\'`, fixing fragility when tags contain `%`, `_`, or `\` characters. Closes [#914](https://github.com/doobidoo/mcp-memory-service/issues/914).
+- **fix(milvus): compare values in structural change detection for `preserve_timestamps`** ([#918](https://github.com/doobidoo/mcp-memory-service/pull/918), @henry201605): In `_compute_update_timestamps()`, replaced key-presence checks with value comparisons. Prevents consolidation runs from incorrectly bumping `updated_at` for all memories and fixes the Forgetting engine's `access_boost` fallback logic on Milvus.
+
 ## [10.57.0] - 2026-05-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.57.0 - feat(memory_list): tag_match AND/OR filtering + feat(session): automatic chunking at turn boundaries — ~1,960 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.57.1 - fix(sqlite): LIKE ESCAPE tag matching + fix(milvus): preserve_timestamps value comparison — ~1,960 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,20 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.57.0** (May 13, 2026)
+## Latest Release: **v10.57.1** (May 14, 2026)
 
-**Tag-match filtering for `memory_list` + automatic session chunking**
-
-**What's New:**
-- `memory_list` now accepts `tag_match="any"` (OR, default) / `tag_match="all"` (AND) — harmonizes with `memory_search` and `memory_delete` filtering. Implemented across all three backends (sqlite_vec, cloudflare, hybrid) (PR #904, @filhocf).
-- `memory_store_session` automatically splits long sessions at turn boundaries. Configure with `SESSION_CHUNK_SIZE` (default 1500 chars, 0=disabled); chunks are tagged `chunk:N/M` for easy retrieval (PR #912, @filhocf).
+**SQLite tag matching robustness + Milvus preserve_timestamps fix**
 
 **What's Fixed:**
-- CI: `pr-contributor-welcome` workflow now guarded against non-PR event triggers to prevent crash on push events.
+- `sqlite_vec`: replaced `GLOB` with `LIKE ESCAPE '\'` for tag matching — fixes fragility when tags contain `%`, `_`, or `\` characters. All 13 query sites migrated (PR #916, closes #914).
+- `milvus`: `_compute_update_timestamps()` now compares field values instead of checking key presence, preventing spurious `updated_at` bumps during consolidation runs and fixing `access_boost` fallback logic in the Forgetting engine (PR #918, @henry201605).
 
 ---
 
 **Previous Releases**:
+- **v10.57.0** - feat(memory_list): tag_match AND/OR filtering + feat(session): automatic chunking at turn boundaries (PRs #904, #912, @filhocf)
 - **v10.56.3** - feat(milvus): get_memory_connections() via graph collection + fix(quality): MAINTAIN_SCAN_LIMIT fallback hardening
 - **v10.56.2** - fix(milvus): missing `stale_days` param in `count_all_memories` + fix(quality): graceful `MAINTAIN_SCAN_LIMIT` fallback
 - **v10.56.1** - fix(session): pass session_id as conversation_id to bypass semantic dedup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.57.0"
+version = "10.57.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.57.0"
+__version__ = "10.57.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.57.0"
+version = "10.57.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.57.1 — Patch

### Changes

- **fix(sqlite): replace GLOB with LIKE ESCAPE for tag matching** (PR #916, closes #914)
  - Replaced `_escape_glob` with `_escape_like` in `sqlite_vec.py`
  - All 13 tag-filtering query sites migrated from `GLOB ?` to `LIKE ? ESCAPE '\'`
  - Fixes fragility when tags contain `%`, `_`, or `\` characters

- **fix(milvus): compare values in structural change detection for preserve_timestamps** (PR #918, @henry201605)
  - `_compute_update_timestamps()` now compares field values instead of checking key presence
  - Prevents consolidation runs from incorrectly bumping `updated_at` for all memories
  - Fixes Forgetting engine's `access_boost` fallback logic on Milvus

### Files changed
- `src/mcp_memory_service/_version.py` — 10.57.0 → 10.57.1
- `pyproject.toml` — 10.57.0 → 10.57.1
- `CHANGELOG.md` — new [10.57.1] section added
- `README.md` — Latest Release updated, v10.57.0 moved to Previous Releases
- `CLAUDE.md` — Current Version callout updated
- `uv.lock` — updated

### Test plan
- [ ] CI passes on this branch
- [ ] No landing page changes (patch release — docs/index.html not touched)
- [ ] PyPI auto-publishes via "Publish and Test (Tags)" workflow on tag push after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)