### PR TITLE
fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ sqlite-ml = [
 # Milvus backend — Milvus Lite (single file), self-hosted Milvus, or Zilliz Cloud.
 # Shipped with the ML extras so sentence-transformers embeddings are available.
 milvus = [
-    "pymilvus>=2.5.0",
+    "pymilvus>=2.5.0,<3.0.0",  # 3.x has breaking API changes; migrate separately
     "milvus-lite>=2.4.10",
     # milvus-lite 2.5.x still imports `pkg_resources` from setuptools; that API
     # was removed in setuptools 81. Pin setuptools below 81 on newer Pythons

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "extra == 'sqlite'", specifier = ">=1.14.1" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
-    { name = "pymilvus", marker = "extra == 'milvus'", specifier = ">=2.5.0" },
+    { name = "pymilvus", marker = "extra == 'milvus'", specifier = ">=2.5.0,<3.0.0" },
     { name = "pypdf", specifier = ">=6.9.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -2356,7 +2356,7 @@ crypto = [
 
 [[package]]
 name = "pymilvus"
-version = "3.0.0"
+version = "2.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -2369,8 +2369,9 @@ dependencies = [
     { name = "requests" },
     { name = "setuptools" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/28/78/68e752283ad58891687c2d9e56a09019585a31d03637af9b60bf2d396821/pymilvus-2.6.13.tar.gz", hash = "sha256:d29908d9623967be7be41c518d1fb68fe5816b9ab780af2737fd3059f2d370c0", size = 1579003, upload-time = "2026-05-07T12:08:36.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/c1/01647e61f3a82fd881382746b6dde3401d65b88cd4f75bd059901fb2392b/pymilvus-3.0.0-1-py3-none-any.whl", hash = "sha256:57c8e7c87fbbf579f122b4df893949bc78e50bca2988527864891bd544817b05", size = 344817, upload-time = "2026-05-07T14:57:45.235Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f2/850c023173525ba02701cc0990461a67ef999825b301847ce16db9efee32/pymilvus-2.6.13-py3-none-any.whl", hash = "sha256:3098204172413f6fe7c7928652adba0e1ec70150d6e515b83da4e319b98d9e69", size = 319649, upload-time = "2026-05-07T12:08:34.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds upper bound `<3.0.0` to the `pymilvus` constraint in `pyproject.toml`
- Re-locks to `pymilvus 2.6.13` (latest stable 2.x) via `uv lock --upgrade-package pymilvus`

## Root Cause

The dependency bump (#905 / `chore: bump uv group with 9 updates`, commit `253ba2da`) silently upgraded `pymilvus` from `2.6.12` → `3.0.0`. The `pymilvus 3.0.0` release introduced breaking API changes, causing the **Test Milvus (Docker)** CI job to fail on every push since then.

The uncapped `>=2.5.0` constraint in `pyproject.toml` allowed the 3.0 release to land automatically. Adding `<3.0.0` locks us to the compatible 2.x range.

## What's NOT in this PR

This is a **hotfix** only — no code changes. A follow-up PR will migrate `milvus.py` to be compatible with the pymilvus 3.x API once the breaking changes have been catalogued.

## Test plan

- [ ] CI `Test Milvus (Docker)` job passes (was failing on every commit since `253ba2da`)
- [ ] Other jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)