### PR TITLE
chore: release v10.57.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.57.2] - 2026-05-14
+
+### Fixed
+
+- **fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI** ([#921](https://github.com/doobidoo/mcp-memory-service/pull/921)): Added `<3.0.0` upper bound to the `pymilvus` dependency in `pyproject.toml` and re-locked to `2.6.13` in `uv.lock`. pymilvus 3.0.0 introduced breaking API changes that silently broke the Milvus Docker CI job when the dependency was upgraded. Full pymilvus 3.x migration is tracked in [#922](https://github.com/doobidoo/mcp-memory-service/issues/922).
+
 ## [10.57.1] - 2026-05-14
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.57.1 - fix(sqlite): LIKE ESCAPE tag matching + fix(milvus): preserve_timestamps value comparison — ~1,960 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.57.2 - fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI — ~1,960 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.57.1** (May 14, 2026)
+## Latest Release: **v10.57.2** (May 14, 2026)
 
-**SQLite tag matching robustness + Milvus preserve_timestamps fix**
+**Dependency pin: pymilvus<3.0.0 restores Milvus Docker CI**
 
 **What's Fixed:**
-- `sqlite_vec`: replaced `GLOB` with `LIKE ESCAPE '\'` for tag matching — fixes fragility when tags contain `%`, `_`, or `\` characters. All 13 query sites migrated (PR #916, closes #914).
-- `milvus`: `_compute_update_timestamps()` now compares field values instead of checking key presence, preventing spurious `updated_at` bumps during consolidation runs and fixing `access_boost` fallback logic in the Forgetting engine (PR #918, @henry201605).
+- `deps`: pinned `pymilvus<3.0.0` in `pyproject.toml`; re-locked to `2.6.13` in `uv.lock`. pymilvus 3.0.0 introduced breaking API changes that silently broke the Milvus Docker CI job (PR #921). Full 3.x migration tracked in issue #922.
 
 ---
 
 **Previous Releases**:
+- **v10.57.1** - fix(sqlite): LIKE ESCAPE tag matching + fix(milvus): preserve_timestamps value comparison (PRs #916, #918)
 - **v10.57.0** - feat(memory_list): tag_match AND/OR filtering + feat(session): automatic chunking at turn boundaries (PRs #904, #912, @filhocf)
 - **v10.56.3** - feat(milvus): get_memory_connections() via graph collection + fix(quality): MAINTAIN_SCAN_LIMIT fallback hardening
 - **v10.56.2** - fix(milvus): missing `stale_days` param in `count_all_memories` + fix(quality): graceful `MAINTAIN_SCAN_LIMIT` fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.57.1"
+version = "10.57.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.57.1"
+__version__ = "10.57.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.57.1"
+version = "10.57.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bumps version to `10.57.2` across `_version.py`, `pyproject.toml`, `uv.lock`
- Adds CHANGELOG entry for v10.57.2
- Updates README Latest Release section (v10.57.1 moves to Previous Releases)
- Updates CLAUDE.md version callout

## Changes in this release

**fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI** (PR #921)

pymilvus 3.0.0 introduced breaking API changes. When the dep was bumped from 2.6.12 to 3.0.0 (silently via uv.lock update), the Milvus Docker CI job broke. This patch adds `<3.0.0` upper bound in `pyproject.toml` and re-locks to `2.6.13`. Full pymilvus 3.x migration is tracked in issue #922 (assigned to CODEOWNERS).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: tag v10.57.2, create GitHub release
- [ ] PyPI auto-publishes via "Publish and Test (Tags)" GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)