### PR TITLE
feat(milvus): add last_accessed tracking via _access side-collection

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1937,18 +1937,20 @@ class MilvusMemoryStorage(MemoryStorage):
         Cross-references the ``_access`` side-collection to determine which
         memories are stale. Memories without an access record fall back to
         ``created_at`` for staleness determination.
+
+        Uses QueryIterator for both queries to handle arbitrarily large
+        collections without hitting the single-query limit cap.
         """
         threshold = time.time() - stale_days * 86400
 
-        # Get all memory hashes + created_at from main collection
+        # Get all memory hashes + created_at from main collection via iterator
         try:
-            all_rows = await self._call_client(
-                "query",
-                collection_name=self.collection_name,
-                filter=base_filter,
-                output_fields=["id", "created_at"],
-                limit=_MILVUS_MAX_LIMIT,
-            )
+            async with self._write_lock:
+                if self.client is None:
+                    return 0
+                all_rows = await asyncio.to_thread(
+                    self._drain_main_ids_and_created_at, base_filter,
+                )
         except Exception as exc:  # noqa: BLE001
             logger.warning("_count_stale_memories: main query failed: %s", exc)
             return 0
@@ -1971,7 +1973,7 @@ class MilvusMemoryStorage(MemoryStorage):
             except Exception as exc:  # noqa: BLE001
                 logger.warning("_count_stale_memories: access query failed: %s", exc)
 
-        # Count stale: not in active set AND (has access record with old ts OR created_at < threshold)
+        # Count stale: not in active set AND created_at < threshold
         stale_count = 0
         for row in all_rows:
             rid = row.get("id")
@@ -2089,6 +2091,29 @@ class MilvusMemoryStorage(MemoryStorage):
             collection_name=self._access_collection,
             filter="",
             output_fields=["id", "last_accessed"],
+            batch_size=self._QUERY_ITER_BATCH,
+        )
+        rows: List[Dict[str, Any]] = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                rows.extend(batch)
+        finally:
+            try:
+                iterator.close()
+            except Exception:  # noqa: BLE001
+                pass
+        return rows
+
+    def _drain_main_ids_and_created_at(self, filter_expr: str) -> List[Dict[str, Any]]:
+        """Sync helper that drains id + created_at from the main collection."""
+        assert self.client is not None
+        iterator = self.client.query_iterator(
+            collection_name=self.collection_name,
+            filter=filter_expr or "",
+            output_fields=["id", "created_at"],
             batch_size=self._QUERY_ITER_BATCH,
         )
         rows: List[Dict[str, Any]] = []

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -274,6 +274,11 @@ class MilvusMemoryStorage(MemoryStorage):
         # without the ``sparse_vector`` field fall back to vector-only search.
         self._has_bm25 = False
 
+        # Whether the access-tracking side-collection exists. Set during
+        # initialize() by _ensure_access_collection().
+        self._has_access_collection = False
+        self._access_collection: str = f"{self.collection_name}_access"
+
         # Whether this storage is backed by Milvus Lite (embedded daemon) as
         # opposed to a remote Milvus server or Zilliz Cloud endpoint. We
         # mirror pymilvus's own heuristic (``uri.endswith('.db')``) — see
@@ -323,6 +328,7 @@ class MilvusMemoryStorage(MemoryStorage):
         await self._initialize_embedding_model()
         await asyncio.to_thread(self._connect_client)
         await asyncio.to_thread(self._ensure_collection)
+        await asyncio.to_thread(self._ensure_access_collection)
 
         self._initialized = True
         logger.info(
@@ -512,6 +518,61 @@ class MilvusMemoryStorage(MemoryStorage):
                 "using vector-only search",
                 self.collection_name,
             )
+
+    def _ensure_access_collection(self) -> None:
+        """Create the access-tracking side-collection if it does not exist.
+
+        Schema mirrors the ``_graph`` collection pattern: a lightweight
+        scalar collection with a dummy vector field for Zilliz Cloud
+        compatibility.
+        """
+        assert self.client is not None
+
+        if self.client.has_collection(collection_name=self._access_collection):
+            self._has_access_collection = True
+            logger.info(
+                "Reusing existing access collection '%s'",
+                self._access_collection,
+            )
+            return
+
+        schema = self.client.create_schema(
+            auto_id=False,
+            enable_dynamic_field=False,
+        )
+        schema.add_field(
+            field_name="id",
+            datatype=DataType.VARCHAR,
+            is_primary=True,
+            max_length=_ID_MAX_LEN,
+        )
+        schema.add_field(
+            field_name="last_accessed",
+            datatype=DataType.DOUBLE,
+        )
+        schema.add_field(
+            field_name="_dummy_vec",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=2,
+        )
+
+        index_params = self.client.prepare_index_params()
+        index_params.add_index(
+            field_name="_dummy_vec",
+            index_type="AUTOINDEX",
+            metric_type="L2",
+        )
+
+        self.client.create_collection(
+            collection_name=self._access_collection,
+            schema=schema,
+            index_params=index_params,
+        )
+        self._has_access_collection = True
+        logger.info(
+            "Created access-tracking collection '%s'",
+            self._access_collection,
+        )
 
     async def _initialize_embedding_model(self) -> None:
         """Load the sentence-transformers model (or cached instance)."""
@@ -1252,7 +1313,14 @@ class MilvusMemoryStorage(MemoryStorage):
             hits = await self._run_hybrid_search(query, query_embedding, tag_filter, fetch_n)
         else:
             hits = await self._run_search(query_embedding, tag_filter, fetch_n)
-        return self._rank_and_trim(hits, query, n_results, min_confidence)
+        results = self._rank_and_trim(hits, query, n_results, min_confidence)
+
+        # Async update last_accessed for hit memories (non-blocking)
+        if results:
+            hit_hashes = [r.memory.content_hash for r in results]
+            asyncio.create_task(self._touch_access(hit_hashes))
+
+        return results
 
     # -- Tag-based search ----------------------------------------------------
 
@@ -1342,6 +1410,16 @@ class MilvusMemoryStorage(MemoryStorage):
             return False, f"Failed to delete memory: {exc}"
 
         logger.info("Deleted memory %s", content_hash)
+        # Clean up access tracking record
+        if self._has_access_collection:
+            try:
+                await self._call_client(
+                    "delete",
+                    collection_name=self._access_collection,
+                    ids=[content_hash],
+                )
+            except Exception:  # noqa: BLE001
+                pass  # non-fatal
         return True, f"Successfully deleted memory {content_hash}"
 
     async def delete_memory(self, content_hash: str) -> bool:
@@ -1837,6 +1915,10 @@ class MilvusMemoryStorage(MemoryStorage):
 
         filter_expr = self._combine_filter(*filters)
 
+        # When stale_days is set, perform cross-collection filtering
+        if stale_days is not None and stale_days > 0:
+            return await self._count_stale_memories(filter_expr, stale_days)
+
         try:
             rows = await self._call_client(
                 "query",
@@ -1848,6 +1930,58 @@ class MilvusMemoryStorage(MemoryStorage):
         except Exception as exc:  # noqa: BLE001
             logger.warning("count_all_memories failed: %s", exc)
             return 0
+
+    async def _count_stale_memories(self, base_filter: str, stale_days: int) -> int:
+        """Count memories not accessed in the last ``stale_days`` days.
+
+        Cross-references the ``_access`` side-collection to determine which
+        memories are stale. Memories without an access record fall back to
+        ``created_at`` for staleness determination.
+        """
+        threshold = time.time() - stale_days * 86400
+
+        # Get all memory hashes + created_at from main collection
+        try:
+            all_rows = await self._call_client(
+                "query",
+                collection_name=self.collection_name,
+                filter=base_filter,
+                output_fields=["id", "created_at"],
+                limit=_MILVUS_MAX_LIMIT,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("_count_stale_memories: main query failed: %s", exc)
+            return 0
+
+        if not all_rows:
+            return 0
+
+        # Get active hashes from _access collection (last_accessed >= threshold)
+        active_hashes: set = set()
+        if self._has_access_collection:
+            try:
+                active_rows = await self._call_client(
+                    "query",
+                    collection_name=self._access_collection,
+                    filter=f"last_accessed >= {threshold}",
+                    output_fields=["id"],
+                    limit=_MILVUS_MAX_LIMIT,
+                )
+                active_hashes = {row.get("id") for row in active_rows if row.get("id")}
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("_count_stale_memories: access query failed: %s", exc)
+
+        # Count stale: not in active set AND (has access record with old ts OR created_at < threshold)
+        stale_count = 0
+        for row in all_rows:
+            rid = row.get("id")
+            if rid and rid not in active_hashes:
+                # Not recently accessed — check created_at as fallback
+                created_at = row.get("created_at", 0)
+                if created_at < threshold:
+                    stale_count += 1
+
+        return stale_count
 
     async def get_memories_by_time_range(
         self, start_time: float, end_time: float,
@@ -1890,6 +2024,86 @@ class MilvusMemoryStorage(MemoryStorage):
     # ------------------------------------------------------------------
     # Connection tracking (graph-based)
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Access tracking (_access side-collection)
+    # ------------------------------------------------------------------
+
+    async def _touch_access(self, hashes: List[str]) -> None:
+        """Batch-upsert last_accessed timestamps for retrieved memories.
+
+        Called asynchronously after retrieve() returns results. Failures are
+        logged but never propagate — access tracking is best-effort.
+        """
+        if not self._has_access_collection or not hashes:
+            return
+
+        now = time.time()
+        rows = [
+            {"id": h, "last_accessed": now, "_dummy_vec": [0.0, 0.0]}
+            for h in hashes
+        ]
+
+        try:
+            await self._call_client(
+                "upsert",
+                collection_name=self._access_collection,
+                data=rows,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("_touch_access failed (non-fatal): %s", exc)
+
+    async def get_access_patterns(self) -> Dict[str, datetime]:
+        """Return last-accessed timestamps from the _access side-collection.
+
+        Used by the Forgetting engine's decay calculator to compute
+        access_boost. Returns ``{content_hash: datetime}`` for all memories
+        that have been accessed at least once.
+        """
+        if not self._has_access_collection:
+            return {}
+
+        try:
+            async with self._write_lock:
+                if self.client is None:
+                    return {}
+                rows = await asyncio.to_thread(
+                    self._drain_access_records,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_access_patterns failed: %s", exc)
+            return {}
+
+        patterns: Dict[str, datetime] = {}
+        for row in rows:
+            ts = row.get("last_accessed")
+            rid = row.get("id")
+            if rid and ts:
+                patterns[rid] = datetime.fromtimestamp(ts, tz=timezone.utc)
+        return patterns
+
+    def _drain_access_records(self) -> List[Dict[str, Any]]:
+        """Sync helper that drains all rows from the _access collection."""
+        assert self.client is not None
+        iterator = self.client.query_iterator(
+            collection_name=self._access_collection,
+            filter="",
+            output_fields=["id", "last_accessed"],
+            batch_size=self._QUERY_ITER_BATCH,
+        )
+        rows: List[Dict[str, Any]] = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                rows.extend(batch)
+        finally:
+            try:
+                iterator.close()
+            except Exception:  # noqa: BLE001
+                pass
+        return rows
 
     async def get_memory_connections(self) -> Dict[str, int]:
         """Return connection counts per memory hash from the graph collection.

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1943,7 +1943,7 @@ class MilvusMemoryStorage(MemoryStorage):
         """
         threshold = time.time() - stale_days * 86400
 
-        # Get all memory hashes + created_at from main collection via iterator
+        # Drain both collections under a single lock acquisition to avoid deadlock
         try:
             async with self._write_lock:
                 if self.client is None:
@@ -1951,27 +1951,20 @@ class MilvusMemoryStorage(MemoryStorage):
                 all_rows = await asyncio.to_thread(
                     self._drain_main_ids_and_created_at, base_filter,
                 )
+                active_rows: List[Dict[str, Any]] = []
+                if self._has_access_collection:
+                    active_rows = await asyncio.to_thread(
+                        self._drain_active_hashes, threshold,
+                    )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("_count_stale_memories: main query failed: %s", exc)
+            logger.warning("_count_stale_memories failed: %s", exc)
             return 0
 
         if not all_rows:
             return 0
 
-        # Get active hashes from _access collection (last_accessed >= threshold)
-        active_hashes: set = set()
-        if self._has_access_collection:
-            try:
-                active_rows = await self._call_client(
-                    "query",
-                    collection_name=self._access_collection,
-                    filter=f"last_accessed >= {threshold}",
-                    output_fields=["id"],
-                    limit=_MILVUS_MAX_LIMIT,
-                )
-                active_hashes = {row.get("id") for row in active_rows if row.get("id")}
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("_count_stale_memories: access query failed: %s", exc)
+        # Build active hash set
+        active_hashes = {row.get("id") for row in active_rows if row.get("id")}
 
         # Count stale: not in active set AND created_at < threshold
         stale_count = 0
@@ -2114,6 +2107,29 @@ class MilvusMemoryStorage(MemoryStorage):
             collection_name=self.collection_name,
             filter=filter_expr or "",
             output_fields=["id", "created_at"],
+            batch_size=self._QUERY_ITER_BATCH,
+        )
+        rows: List[Dict[str, Any]] = []
+        try:
+            while True:
+                batch = iterator.next()
+                if not batch:
+                    break
+                rows.extend(batch)
+        finally:
+            try:
+                iterator.close()
+            except Exception:  # noqa: BLE001
+                pass
+        return rows
+
+    def _drain_active_hashes(self, threshold: float) -> List[Dict[str, Any]]:
+        """Sync helper that drains active (recently accessed) hashes from _access collection."""
+        assert self.client is not None
+        iterator = self.client.query_iterator(
+            collection_name=self._access_collection,
+            filter=f"last_accessed >= {threshold}",
+            output_fields=["id"],
             batch_size=self._QUERY_ITER_BATCH,
         )
         rows: List[Dict[str, Any]] = []

--- a/tests/storage/test_milvus.py
+++ b/tests/storage/test_milvus.py
@@ -389,9 +389,9 @@ async def test_get_all_memories_and_count(storage):
     assert await storage.count_all_memories(tags=["g-1"]) == 1
     assert await storage.count_all_memories(memory_type="note") == 3
     assert await storage.count_all_memories(memory_type="reminder") == 0
-    # stale_days is accepted but ignored (Milvus has no last_accessed field)
-    assert await storage.count_all_memories(stale_days=7) == 3
-    assert await storage.count_all_memories(memory_type="note", stale_days=30) == 3
+    # stale_days filtering: memories just created are NOT stale
+    assert await storage.count_all_memories(stale_days=7) == 0
+    assert await storage.count_all_memories(memory_type="note", stale_days=30) == 0
 
 
 @pytest.mark.asyncio
@@ -461,6 +461,87 @@ async def test_get_memory_connections_with_graph_data(storage):
 
     # Cleanup
     client.drop_collection(collection_name=graph_collection)
+
+
+# -- Access tracking ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_collection_created_on_init(storage):
+    """_access collection is created during initialize()."""
+    assert storage._has_access_collection is True
+    assert storage.client.has_collection(collection_name=storage._access_collection)
+
+
+@pytest.mark.asyncio
+async def test_touch_access_creates_record(storage, sample_memory):
+    """retrieve() triggers _touch_access which creates a record in _access."""
+    await storage.store(sample_memory)
+    # Trigger retrieve to update last_accessed
+    await storage.retrieve("fastapi", n_results=1)
+    import asyncio
+    await asyncio.sleep(0.2)  # let async task complete
+
+    patterns = await storage.get_access_patterns()
+    assert sample_memory.content_hash in patterns
+
+
+@pytest.mark.asyncio
+async def test_touch_access_updates_timestamp(storage, sample_memory):
+    """Multiple retrieves update the timestamp."""
+    await storage.store(sample_memory)
+
+    await storage.retrieve("fastapi", n_results=1)
+    import asyncio
+    await asyncio.sleep(0.2)
+    patterns1 = await storage.get_access_patterns()
+    ts1 = patterns1.get(sample_memory.content_hash)
+    assert ts1 is not None
+
+    await asyncio.sleep(0.1)
+    await storage.retrieve("fastapi", n_results=1)
+    await asyncio.sleep(0.2)
+    patterns2 = await storage.get_access_patterns()
+    ts2 = patterns2.get(sample_memory.content_hash)
+    assert ts2 is not None
+    assert ts2 >= ts1
+
+
+@pytest.mark.asyncio
+async def test_get_access_patterns_returns_correct_format(storage, sample_memory):
+    """get_access_patterns returns Dict[str, datetime]."""
+    from datetime import datetime as dt
+    await storage.store(sample_memory)
+    await storage.retrieve("fastapi", n_results=1)
+    import asyncio
+    await asyncio.sleep(0.2)
+
+    patterns = await storage.get_access_patterns()
+    assert isinstance(patterns, dict)
+    for k, v in patterns.items():
+        assert isinstance(k, str)
+        assert isinstance(v, dt)
+
+
+@pytest.mark.asyncio
+async def test_delete_cleans_access_record(storage, sample_memory):
+    """Deleting a memory also removes its _access record."""
+    await storage.store(sample_memory)
+    await storage.retrieve("fastapi", n_results=1)
+    import asyncio
+    await asyncio.sleep(0.2)
+
+    # Verify access record exists
+    patterns = await storage.get_access_patterns()
+    assert sample_memory.content_hash in patterns
+
+    # Delete the memory
+    ok, _ = await storage.delete(sample_memory.content_hash)
+    assert ok
+
+    # Access record should be gone
+    patterns_after = await storage.get_access_patterns()
+    assert sample_memory.content_hash not in patterns_after
 
 
 # -- Update / stats ---------------------------------------------------------


### PR DESCRIPTION
## Description

Implement access-time tracking for the Milvus backend using a separate lightweight collection (`{collection_name}_access`), enabling the Forgetting engine and stale detection to work correctly.

Closes #923 (Option B as discussed with maintainer).

## Problem

The Milvus backend had no `last_accessed` tracking, causing:
1. Forgetting engine's `access_boost` always fell back to `updated_at` — no distinction between frequently-accessed and never-queried memories
2. `count_all_memories(stale_days=N)` ignored the parameter, returning total count instead of stale count
3. `memory_quality(action="maintain")` reported all memories as "stale"

## Solution

Create a side-collection `{collection_name}_access` (same pattern as `_graph`) with schema:
- `id`: VARCHAR PK (content_hash)
- `last_accessed`: DOUBLE (epoch seconds)
- `_dummy_vec`: FLOAT_VECTOR(dim=2) (Zilliz Cloud compatibility)

### Key behaviors:
- **On retrieve()**: Async `_touch_access()` upserts hit memory hashes with current timestamp (non-blocking, best-effort)
- **get_access_patterns()**: Reads all records via QueryIterator, returns `Dict[str, datetime]` for Forgetting engine
- **count_all_memories(stale_days=N)**: Cross-references `_access` table — memories with `last_accessed >= threshold` are active; others fall back to `created_at`
- **delete()**: Cleans up corresponding `_access` record
- **Graceful degradation**: If `_access` collection doesn't exist, all methods fall back to previous behavior (no crash)

## Changes

- **`src/mcp_memory_service/storage/milvus.py`**:
  - Add `_ensure_access_collection()` called during `initialize()`
  - Add `_touch_access(hashes)` — async batch upsert to `_access` collection
  - Add `get_access_patterns()` — QueryIterator-based read from `_access`
  - Add `_count_stale_memories()` — cross-collection stale filtering
  - Modify `retrieve()` to trigger `_touch_access` via `asyncio.create_task`
  - Modify `count_all_memories(stale_days=N)` to use real filtering
  - Modify `delete()` to clean up `_access` records

- **`tests/storage/test_milvus.py`**:
  - `test_access_collection_created_on_init`
  - `test_touch_access_creates_record`
  - `test_touch_access_updates_timestamp`
  - `test_get_access_patterns_returns_correct_format`
  - `test_delete_cleans_access_record`
  - Updated `stale_days` assertions (now correctly returns 0 for fresh memories)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- All 50 Milvus tests pass (45 existing + 5 new)
- Tested with Milvus Lite locally
- Non-blocking: `_touch_access` failures are logged but never propagate

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes