### PR TITLE
feat(oauth): support MCP_OAUTH_{PRIVATE,PUBLIC}_KEY_PATH for file-based PEM keys

### DIFF
--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -795,11 +795,32 @@ Example:
 if OAUTH_STORAGE_BACKEND == "sqlite":
     pass  # SQLite OAuth storage configured
 
-# RSA key pair configuration for JWT signing (RS256)
-# Private key for signing tokens
-OAUTH_PRIVATE_KEY = os.getenv('MCP_OAUTH_PRIVATE_KEY')
-# Public key for verifying tokens
-OAUTH_PUBLIC_KEY = os.getenv('MCP_OAUTH_PUBLIC_KEY')
+# RSA key pair configuration for JWT signing (RS256).
+# Two ways to provide keys:
+#   1. Inline PEM via MCP_OAUTH_PRIVATE_KEY / MCP_OAUTH_PUBLIC_KEY (newline-
+#      preserving env, possible with quoted multi-line values in .env)
+#   2. File path via MCP_OAUTH_PRIVATE_KEY_PATH / MCP_OAUTH_PUBLIC_KEY_PATH
+#      (preferred for production — keeps PEM bytes off the process env and
+#      out of `printenv` / launchd EnvironmentVariables).
+
+
+def _load_pem_from_env(value_var: str, path_var: str) -> Optional[str]:
+    """Return PEM contents from either an inline env var or a file path."""
+    inline = os.getenv(value_var)
+    if inline:
+        return inline
+    path = os.getenv(path_var)
+    if path:
+        try:
+            with open(os.path.expanduser(path), 'r') as f:
+                return f.read()
+        except OSError as e:
+            logger.error(f"Failed to read PEM from {path_var}={path}: {e}")
+    return None
+
+
+OAUTH_PRIVATE_KEY = _load_pem_from_env('MCP_OAUTH_PRIVATE_KEY', 'MCP_OAUTH_PRIVATE_KEY_PATH')
+OAUTH_PUBLIC_KEY = _load_pem_from_env('MCP_OAUTH_PUBLIC_KEY', 'MCP_OAUTH_PUBLIC_KEY_PATH')
 
 # Generate RSA key pair if not provided
 if not OAUTH_PRIVATE_KEY or not OAUTH_PUBLIC_KEY:


### PR DESCRIPTION
## Summary
- Adds `MCP_OAUTH_PRIVATE_KEY_PATH` / `MCP_OAUTH_PUBLIC_KEY_PATH` env vars as an alternative to the existing inline PEM env vars.
- Tiny additive change in `config.py` — uses a `_load_pem_from_env(value_var, path_var)` helper that prefers the inline value when set, then falls back to reading from the file path; finally falls back to in-memory generation (existing behavior).
- No behavior change when the new vars are unset.

## Why
Inline PEM in env vars is awkward in `launchd` plists, systemd service files, and Docker `--env` flags because the PEM block contains newlines. Most operators end up base64-wrapping the value or writing a shell wrapper. Path-based loading lets operators keep the key on disk with `chmod 0600` and reference it from any process-manager that struggles with multi-line env values, without exposing the key bytes via `printenv` or `ps` snapshots.

## Compatibility
- 100% backward compatible. Existing `MCP_OAUTH_PRIVATE_KEY` / `MCP_OAUTH_PUBLIC_KEY` continue to take precedence.
- `~` is expanded via `os.path.expanduser` so `~/keys/oauth.pem`-style paths work.
- File-read failures are logged at `ERROR` and fall through to the next source (inline → path → auto-generate), so a typo doesn't crash startup.

## Test plan
- [x] `MCP_OAUTH_PRIVATE_KEY_PATH` + `MCP_OAUTH_PUBLIC_KEY_PATH` pointing to 2048-bit RSA PEMs → server boots, RS256 selected, JWTs sign/verify against the persistent key (verified locally against `memory.scalarly.org` deployment, RFC 7636 PKCE + RFC 6749 refresh flow + JWT decode all green).
- [x] Same env vars unset, `MCP_OAUTH_PRIVATE_KEY` set inline → falls back to inline path (unchanged behavior).
- [x] Both unset → in-memory RSA generation runs (unchanged behavior).
- [x] Path that doesn't exist → `ERROR` log, falls through to in-memory generation (no crash).