### PR TITLE
feat(harvest): Kiro CLI session format support in TranscriptParser

### DIFF
--- a/src/mcp_memory_service/harvest/parser.py
+++ b/src/mcp_memory_service/harvest/parser.py
@@ -1,4 +1,4 @@
-"""JSONL transcript parser for Claude Code session files."""
+"""JSONL transcript parser for Claude Code and Kiro CLI session files."""
 
 import json
 import logging
@@ -19,9 +19,16 @@ class ParsedMessage:
 
 
 class TranscriptParser:
-    """Parses Claude Code JSONL session transcripts."""
+    """Parses JSONL session transcripts (Claude Code and Kiro CLI).
+
+    Format is detected from the first message in the file:
+    - If "type" key exists → Claude Code format
+    - If "kind" key exists → Kiro CLI format
+    - Unknown → warning logged, returns empty
+    """
 
     RELEVANT_TYPES = {"user", "assistant"}
+    KIRO_KIND_MAP = {"Prompt": "user", "Response": "assistant"}
 
     def find_sessions(self, project_dir: Path, count: int = 1) -> List[Path]:
         """Find the most recent JSONL session files in a project directory."""
@@ -34,12 +41,17 @@ class TranscriptParser:
         return jsonl_files[:count]
 
     def parse_file(self, filepath: Path) -> List[ParsedMessage]:
-        """Parse a JSONL file and extract user/assistant text messages."""
+        """Parse a JSONL file and extract user/assistant text messages.
+
+        Auto-detects format (Claude Code vs Kiro CLI) from first message.
+        """
         filepath = Path(filepath)
         messages: List[ParsedMessage] = []
 
         if not filepath.exists() or filepath.stat().st_size == 0:
             return messages
+
+        format_detected = None
 
         with open(filepath, 'r', encoding='utf-8') as f:
             for line_num, line in enumerate(f, 1):
@@ -52,26 +64,70 @@ class TranscriptParser:
                     logger.debug(f"Skipping corrupt line {line_num} in {filepath.name}")
                     continue
 
-                msg_type = obj.get("type")
-                if msg_type not in self.RELEVANT_TYPES:
-                    continue
+                # Auto-detect format from first valid JSON line
+                if format_detected is None:
+                    if "type" in obj:
+                        format_detected = "claude"
+                    elif "kind" in obj:
+                        format_detected = "kiro"
+                    else:
+                        logger.warning(f"Unknown session format in {filepath.name}, skipping")
+                        return messages
 
-                message = obj.get("message", {})
-                content = message.get("content", [])
-                timestamp = obj.get("timestamp")
-                uuid = obj.get("uuid")
+                if format_detected == "claude":
+                    msg = self._parse_claude_line(obj)
+                else:
+                    msg = self._parse_kiro_line(obj)
 
-                # Extract text blocks (skip thinking, tool_use, etc.)
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text = block.get("text", "").strip()
-                        if text and not self._is_system_content(text):
-                            messages.append(ParsedMessage(
-                                role=msg_type,
-                                text=text,
-                                timestamp=timestamp,
-                                uuid=uuid
-                            ))
+                if msg:
+                    messages.append(msg)
+
+        return messages
+
+    def _parse_claude_line(self, obj: dict) -> Optional[ParsedMessage]:
+        """Parse a single Claude Code JSONL line."""
+        msg_type = obj.get("type")
+        if msg_type not in self.RELEVANT_TYPES:
+            return None
+
+        message = obj.get("message", {})
+        content = message.get("content", [])
+        timestamp = obj.get("timestamp")
+        uuid = obj.get("uuid")
+
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "").strip()
+                if text and not self._is_system_content(text):
+                    return ParsedMessage(role=msg_type, text=text, timestamp=timestamp, uuid=uuid)
+        return None
+
+    def _parse_kiro_line(self, obj: dict) -> Optional[ParsedMessage]:
+        """Parse a single Kiro CLI JSONL line."""
+        kind = obj.get("kind")
+        role = self.KIRO_KIND_MAP.get(kind)
+        if not role:
+            return None
+
+        data = obj.get("data", {})
+        content = data.get("content", []) if isinstance(data.get("content"), list) else []
+        timestamp = obj.get("timestamp")
+        uuid = obj.get("uuid")
+
+        # Kiro uses content[].data (where kind=="text") for text
+        # Also handle content as plain string
+        if isinstance(data.get("content"), str):
+            text = data["content"].strip()
+            if text and not self._is_system_content(text):
+                return ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid)
+            return None
+
+        for block in content:
+            if isinstance(block, dict) and block.get("kind") == "text":
+                text = block.get("data", "").strip()
+                if text and not self._is_system_content(text):
+                    return ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid)
+        return None
 
         return messages
 

--- a/src/mcp_memory_service/harvest/parser.py
+++ b/src/mcp_memory_service/harvest/parser.py
@@ -75,61 +75,60 @@ class TranscriptParser:
                         return messages
 
                 if format_detected == "claude":
-                    msg = self._parse_claude_line(obj)
+                    msgs = self._parse_claude_line(obj)
                 else:
-                    msg = self._parse_kiro_line(obj)
+                    msgs = self._parse_kiro_line(obj)
 
-                if msg:
-                    messages.append(msg)
+                if msgs:
+                    messages.extend(msgs)
 
         return messages
 
-    def _parse_claude_line(self, obj: dict) -> Optional[ParsedMessage]:
+    def _parse_claude_line(self, obj: dict) -> List[ParsedMessage]:
         """Parse a single Claude Code JSONL line."""
         msg_type = obj.get("type")
         if msg_type not in self.RELEVANT_TYPES:
-            return None
+            return []
 
         message = obj.get("message", {})
         content = message.get("content", [])
         timestamp = obj.get("timestamp")
         uuid = obj.get("uuid")
 
+        results = []
         for block in content:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "").strip()
                 if text and not self._is_system_content(text):
-                    return ParsedMessage(role=msg_type, text=text, timestamp=timestamp, uuid=uuid)
-        return None
+                    results.append(ParsedMessage(role=msg_type, text=text, timestamp=timestamp, uuid=uuid))
+        return results
 
-    def _parse_kiro_line(self, obj: dict) -> Optional[ParsedMessage]:
+    def _parse_kiro_line(self, obj: dict) -> List[ParsedMessage]:
         """Parse a single Kiro CLI JSONL line."""
         kind = obj.get("kind")
         role = self.KIRO_KIND_MAP.get(kind)
         if not role:
-            return None
+            return []
 
         data = obj.get("data", {})
         content = data.get("content", []) if isinstance(data.get("content"), list) else []
         timestamp = obj.get("timestamp")
         uuid = obj.get("uuid")
 
-        # Kiro uses content[].data (where kind=="text") for text
-        # Also handle content as plain string
+        # Handle plain string content
         if isinstance(data.get("content"), str):
             text = data["content"].strip()
             if text and not self._is_system_content(text):
-                return ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid)
-            return None
+                return [ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid)]
+            return []
 
+        results = []
         for block in content:
             if isinstance(block, dict) and block.get("kind") == "text":
                 text = block.get("data", "").strip()
                 if text and not self._is_system_content(text):
-                    return ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid)
-        return None
-
-        return messages
+                    results.append(ParsedMessage(role=role, text=text, timestamp=timestamp, uuid=uuid))
+        return results
 
     @staticmethod
     def _is_system_content(text: str) -> bool:

--- a/tests/harvest/test_kiro_parser.py
+++ b/tests/harvest/test_kiro_parser.py
@@ -1,0 +1,101 @@
+"""Tests for Kiro CLI session format support in TranscriptParser."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_memory_service.harvest.parser import TranscriptParser
+
+
+# Real Kiro CLI JSONL fixture (anonymized)
+KIRO_SESSION_LINES = [
+    {"version": "v1", "kind": "Prompt", "data": {"content": [{"kind": "text", "data": "Implement the login page"}]}, "timestamp": "2026-05-15T10:00:00Z", "uuid": "p1"},
+    {"version": "v1", "kind": "Response", "data": {"content": [{"kind": "text", "data": "I'll create the login component with email and password fields."}]}, "timestamp": "2026-05-15T10:00:05Z", "uuid": "r1"},
+    {"version": "v1", "kind": "Prompt", "data": {"content": [{"kind": "text", "data": "Add validation"}]}, "timestamp": "2026-05-15T10:01:00Z", "uuid": "p2"},
+    {"version": "v1", "kind": "Response", "data": {"content": [{"kind": "text", "data": "Added email format validation and required field checks."}]}, "timestamp": "2026-05-15T10:01:10Z", "uuid": "r2"},
+]
+
+# Kiro with plain string content (alternative format)
+KIRO_STRING_CONTENT = [
+    {"version": "v1", "kind": "Prompt", "data": {"content": "Fix the bug"}, "timestamp": "2026-05-15T11:00:00Z"},
+    {"version": "v1", "kind": "Response", "data": {"content": "Done, the null check was missing."}, "timestamp": "2026-05-15T11:00:05Z"},
+]
+
+# Claude Code format for comparison
+CLAUDE_SESSION_LINES = [
+    {"type": "user", "message": {"content": [{"type": "text", "text": "Hello"}]}, "timestamp": "2026-05-15T09:00:00Z", "uuid": "c1"},
+    {"type": "assistant", "message": {"content": [{"type": "text", "text": "Hi there!"}]}, "timestamp": "2026-05-15T09:00:01Z", "uuid": "c2"},
+]
+
+UNKNOWN_FORMAT_LINES = [
+    {"foo": "bar", "baz": 123},
+]
+
+
+def _write_jsonl(lines, tmpdir, filename="session.jsonl"):
+    path = Path(tmpdir) / filename
+    with open(path, "w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+    return path
+
+
+class TestKiroParser:
+    def setup_method(self):
+        self.parser = TranscriptParser()
+
+    def test_parse_kiro_session(self, tmp_path):
+        path = _write_jsonl(KIRO_SESSION_LINES, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert len(messages) == 4
+        assert messages[0].role == "user"
+        assert messages[0].text == "Implement the login page"
+        assert messages[1].role == "assistant"
+        assert messages[1].text == "I'll create the login component with email and password fields."
+        assert messages[2].role == "user"
+        assert messages[3].role == "assistant"
+
+    def test_parse_kiro_preserves_metadata(self, tmp_path):
+        path = _write_jsonl(KIRO_SESSION_LINES, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert messages[0].timestamp == "2026-05-15T10:00:00Z"
+        assert messages[0].uuid == "p1"
+
+    def test_parse_kiro_string_content(self, tmp_path):
+        path = _write_jsonl(KIRO_STRING_CONTENT, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert len(messages) == 2
+        assert messages[0].role == "user"
+        assert messages[0].text == "Fix the bug"
+        assert messages[1].role == "assistant"
+
+    def test_parse_claude_still_works(self, tmp_path):
+        path = _write_jsonl(CLAUDE_SESSION_LINES, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert len(messages) == 2
+        assert messages[0].role == "user"
+        assert messages[0].text == "Hello"
+        assert messages[1].role == "assistant"
+
+    def test_unknown_format_returns_empty(self, tmp_path):
+        path = _write_jsonl(UNKNOWN_FORMAT_LINES, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert messages == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        path = Path(tmp_path) / "empty.jsonl"
+        path.write_text("")
+        messages = self.parser.parse_file(path)
+        assert messages == []
+
+    def test_kiro_skips_non_prompt_response(self, tmp_path):
+        lines = [
+            {"version": "v1", "kind": "ToolUse", "data": {"content": [{"kind": "text", "data": "internal"}]}},
+            {"version": "v1", "kind": "Prompt", "data": {"content": [{"kind": "text", "data": "real message"}]}},
+        ]
+        path = _write_jsonl(lines, tmp_path)
+        messages = self.parser.parse_file(path)
+        assert len(messages) == 1
+        assert messages[0].text == "real message"


### PR DESCRIPTION
Auto-detect session format from first JSONL line:
- `type` key → Claude Code (existing, unchanged)
- `kind` key → Kiro CLI (new)
- Unknown → warning + graceful empty return

**Kiro format mapping:**
- `kind: Prompt` → role `user`
- `kind: Response` → role `assistant`
- `data.content[].data` (where `kind == "text"`) → text extraction
- Also handles plain string `content` field

**No breaking changes** — existing Claude Code parsing untouched. Pure additive.

**Tests:** 7 new tests covering Kiro parsing, Claude backward compat, unknown format, edge cases.

Design discussion: #927
Closes #934