### PR TITLE
chore: release v10.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.59.0] - 2026-05-16
+
+### Added
+
+- **feat(oauth): file-based PEM key loading via `MCP_OAUTH_PRIVATE_KEY_PATH` / `MCP_OAUTH_PUBLIC_KEY_PATH`** ([#926](https://github.com/doobidoo/mcp-memory-service/pull/926), co-authored by aria-inboxia): New `_load_pem_from_env()` helper in `config.py` reads PEM content from a file path when the corresponding `_PATH` env var is set. Inline env vars continue to take precedence. When a `_PATH` var is set but the file cannot be read, startup aborts with `ValueError` — fail-hard prevents silent JWT invalidation on restart. 6 unit tests added in `tests/test_config.py`.
+- **feat(oauth): allow `cursor`, `vscode`, `vscode-insiders` as OAuth redirect URI schemes** ([#942](https://github.com/doobidoo/mcp-memory-service/pull/942), co-authored by tkislan): `src/mcp_memory_service/web/oauth/registration.py` now accepts IDE deep-link schemes (`cursor://`, `vscode://`, `vscode-insiders://`) as valid OAuth redirect URIs, enabling OAuth callbacks for Cursor and VS Code extensions.
+
+### Fixed
+
+- **fix(hooks): symmetric project-affinity check in `memory-scorer.js`** ([#941](https://github.com/doobidoo/mcp-memory-service/issues/941), reported by minecraft-mattsource): Added `projectName.includes(tag)` as the inverse check so short memory tags (e.g. `wing:hoi4`) are matched when the project name is a superset (e.g. `hoi4coach`). Previously all memories were zeroed by the affinity filter in this case.
+
 ## [10.58.0] - 2026-05-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.58.0 - feat(insights): configurable exclusion, automated-type heuristic, and acknowledgement flow — ~1,983 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.59.0 - feat(oauth): PEM key files + IDE redirect URI schemes; fix(hooks): symmetric project-affinity — ~1,989 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,19 +496,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.58.0** (May 16, 2026)
+## Latest Release: **v10.59.0** (May 16, 2026)
 
-**InsightGenerator: configurable exclusion, automated-type heuristic, and acknowledgement flow**
+**OAuth PEM key files, IDE redirect URI schemes, and memory-scorer affinity fix**
 
 **What's New:**
-- `feat(insights)`: `MCP_INSIGHT_EXCLUDE_TAGS` env var — comma-separated tags to exclude from gap detection (e.g. `MCP_INSIGHT_EXCLUDE_TAGS=ci,radar`). Automated-type heuristic skips gap detection for tags where >90% of memories are session/auto-generated/temporary type. Insight card acknowledgement — tagging a card with `acknowledged` materialises a stable sentinel so the card is never regenerated, even after deletion (PR #939). Closes discussion #897.
-- `fix(milvus)`: deduplicate `_drain_graph_edges` against Milvus Lite double-batch bug; use `consistency_level="Session"` in semantic-dedup ANN search (commit 6f7e1f82).
-- `fix(triage)`: use existing `daily-triage` label; create missing `automated` label (commit 6f7e1f82).
-- `fix(test)`: raise `test_api_search_by_tag_time_filter_performance` threshold to 500ms for CI stability (PR #939).
+- `feat(oauth)`: File-based PEM key loading via `MCP_OAUTH_PRIVATE_KEY_PATH` / `MCP_OAUTH_PUBLIC_KEY_PATH` env vars — prevents silent JWT invalidation on restart; startup aborts with `ValueError` if the file cannot be read (PR #926, co-author aria-inboxia).
+- `feat(oauth)`: Allow `cursor`, `vscode`, `vscode-insiders` as OAuth redirect URI schemes for IDE deep-link OAuth callbacks (PR #942, co-author tkislan).
+- `fix(hooks)`: Symmetric project-affinity check in `memory-scorer.js` — short memory tags (e.g. `wing:hoi4`) no longer zeroed when the project name is a superset (e.g. `hoi4coach`) (#941, reported by minecraft-mattsource).
 
 ---
 
 **Previous Releases**:
+- **v10.58.0** - feat(insights): configurable exclusion, automated-type heuristic, acknowledgement flow (PR #939); feat(harvest): locale YAML plugins (PR #935, @filhocf); feat(plugin): smart-tagger example (PR #932, @filhocf)
 - **v10.57.3** - feat(milvus): last_accessed tracking via `_access` side-collection (PR #925, @henry201605)
 - **v10.57.2** - fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI (PR #921)
 - **v10.57.1** - fix(sqlite): LIKE ESCAPE tag matching + fix(milvus): preserve_timestamps value comparison (PRs #916, #918)

--- a/claude-hooks/utilities/memory-scorer.js
+++ b/claude-hooks/utilities/memory-scorer.js
@@ -471,7 +471,11 @@ function calculateRelevanceScore(memory, projectContext, options = {}) {
 
         // Check for project name in tags OR content
         const hasProjectTag = projectName && (
-            memoryTags.some(tag => tag === projectName || tag.includes(projectName)) ||
+            memoryTags.some(tag =>
+                tag === projectName ||
+                tag.includes(projectName) ||
+                projectName.includes(tag)
+            ) ||
             memoryContent.includes(projectName)
         );
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.58.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.59.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.58.0">
-<meta property="og:description" content="InsightGenerator: configurable tag exclusion, automated-type heuristic, acknowledgement sentinel flow. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.59.0">
+<meta property="og:description" content="OAuth PEM key files, IDE redirect URI schemes for Cursor/VS Code, and symmetric memory-scorer project-affinity fix. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.58 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.59 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.58</h2>
-    <p class="section-subtitle">InsightGenerator: configurable tag exclusion, automated-type heuristic, and acknowledgement sentinel flow. ~1,983 tests.</p>
+    <h2 class="section-title">What's New in v10.59</h2>
+    <p class="section-subtitle">OAuth PEM key files, IDE redirect URI schemes for Cursor/VS Code, and symmetric memory-scorer project-affinity fix. ~1,989 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon privacy">&#127991;</div>
-        <h3>Configurable Tag Exclusion</h3>
-        <p>New <code>MCP_INSIGHT_EXCLUDE_TAGS</code> env var — comma-separated list of tags to exclude from InsightGenerator gap detection, in addition to the built-in set. Example: <code>MCP_INSIGHT_EXCLUDE_TAGS=ci,radar</code>. Prevents noisy system tags from polluting insight results.</p>
+        <div class="feature-icon privacy">&#128273;</div>
+        <h3>PEM Key Files for OAuth</h3>
+        <p>Load OAuth signing keys from files via <code>MCP_OAUTH_PRIVATE_KEY_PATH</code> / <code>MCP_OAUTH_PUBLIC_KEY_PATH</code> — prevents silent JWT invalidation on restart. Startup fails hard if the file cannot be read, so broken configs are never silently ignored.</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#128203;</div>
-        <h3>Automated-Type Heuristic</h3>
-        <p>Gap detection is now skipped for tags where &gt;90% of memories have an automated <code>memory_type</code> (<code>session</code>, <code>auto-generated</code>, <code>temporary</code>). Catches status markers not in the exclusion list without manual configuration.</p>
+        <div class="feature-icon consolidation">&#128295;</div>
+        <h3>IDE OAuth Redirect Schemes</h3>
+        <p>OAuth now accepts <code>cursor://</code>, <code>vscode://</code>, and <code>vscode-insiders://</code> redirect URI schemes, enabling deep-link OAuth callbacks for Cursor and VS Code extensions without manual workarounds.</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon http">&#128279;</div>
-        <h3>Insight Card Acknowledgement</h3>
-        <p>Tagging an insight card with <code>acknowledged</code> materialises a stable sentinel so the card is never regenerated — even after deletion. The sentinel hash is independent of source memories, making acknowledgement permanent across consolidation cycles.</p>
+        <h3>Symmetric Memory-Scorer Affinity</h3>
+        <p>Fixed a bug where short memory tags (e.g. <code>wing:hoi4</code>) were zeroed by the project-affinity filter when the project name was a superset (e.g. <code>hoi4coach</code>). Affinity now checks both directions, so context-relevant memories always surface.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1983">0</div>
+        <div class="stat-number" data-target="1989">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.58.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.59.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.58.0"
+version = "10.59.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.58.0"
+__version__ = "10.59.0"

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -795,11 +795,36 @@ Example:
 if OAUTH_STORAGE_BACKEND == "sqlite":
     pass  # SQLite OAuth storage configured
 
-# RSA key pair configuration for JWT signing (RS256)
-# Private key for signing tokens
-OAUTH_PRIVATE_KEY = os.getenv('MCP_OAUTH_PRIVATE_KEY')
-# Public key for verifying tokens
-OAUTH_PUBLIC_KEY = os.getenv('MCP_OAUTH_PUBLIC_KEY')
+# RSA key pair configuration for JWT signing (RS256).
+# Two ways to provide keys (inline takes precedence):
+#   1. Inline PEM via MCP_OAUTH_PRIVATE_KEY / MCP_OAUTH_PUBLIC_KEY
+#   2. File path via MCP_OAUTH_PRIVATE_KEY_PATH / MCP_OAUTH_PUBLIC_KEY_PATH
+#
+# SECURITY: when a _PATH var is set but the file cannot be read, startup is
+# aborted (ValueError) rather than silently falling through to ephemeral key
+# generation, which would invalidate all active JWTs on every restart.
+
+def _load_pem_from_env(value_var: str, path_var: str) -> "str | None":
+    """Return PEM string from inline env var or file path, or None if neither set."""
+    inline = os.getenv(value_var)
+    if inline:
+        return inline
+    path = os.getenv(path_var)
+    if path:
+        expanded = os.path.expanduser(path)
+        try:
+            with open(expanded) as fh:
+                return fh.read()
+        except OSError as exc:
+            raise ValueError(
+                f"{path_var}={path!r} is set but the file could not be read: {exc}. "
+                "Fix the path / permissions or unset the variable."
+            ) from exc
+    return None
+
+
+OAUTH_PRIVATE_KEY = _load_pem_from_env('MCP_OAUTH_PRIVATE_KEY', 'MCP_OAUTH_PRIVATE_KEY_PATH')
+OAUTH_PUBLIC_KEY = _load_pem_from_env('MCP_OAUTH_PUBLIC_KEY', 'MCP_OAUTH_PUBLIC_KEY_PATH')
 
 # Generate RSA key pair if not provided
 if not OAUTH_PRIVATE_KEY or not OAUTH_PUBLIC_KEY:

--- a/src/mcp_memory_service/web/oauth/registration.py
+++ b/src/mcp_memory_service/web/oauth/registration.py
@@ -58,6 +58,10 @@ def validate_redirect_uris(redirect_uris: Optional[List[str]]) -> None:
     ALLOWED_SCHEMES = {
         'https',    # HTTPS (preferred)
         'http',     # HTTP (localhost only)
+        # IDE deep-link schemes for OAuth callback in editor extensions
+        'cursor',
+        'vscode',
+        'vscode-insiders',
         # Native app custom schemes (common patterns)
         'com.example.app',  # Reverse domain notation
         'myapp',           # Simple custom scheme

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 """Tests for config.py environment variable parsing robustness."""
 import os
+import tempfile
 import pytest
 
 
@@ -140,3 +141,62 @@ def test_validate_config_returns_warning_for_hybrid_weight_normalization():
             os.environ['MCP_HYBRID_SEMANTIC_WEIGHT'] = original_semantic
         else:
             os.environ.pop('MCP_HYBRID_SEMANTIC_WEIGHT', None)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _load_pem_from_env (MCP_OAUTH_*_KEY_PATH support, PR #926)
+# ---------------------------------------------------------------------------
+
+def test_load_pem_from_env_returns_inline_value(monkeypatch):
+    """Inline env var takes precedence over path var."""
+    from mcp_memory_service.config import _load_pem_from_env
+    monkeypatch.setenv('_TEST_PEM_INLINE', 'INLINE_PEM')
+    monkeypatch.delenv('_TEST_PEM_PATH', raising=False)
+    assert _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH') == 'INLINE_PEM'
+
+
+def test_load_pem_from_env_reads_from_file(monkeypatch, tmp_path):
+    """When only path var is set, content is read from the file."""
+    from mcp_memory_service.config import _load_pem_from_env
+    pem_file = tmp_path / "key.pem"
+    pem_file.write_text("FILE_PEM_CONTENT")
+    monkeypatch.delenv('_TEST_PEM_INLINE', raising=False)
+    monkeypatch.setenv('_TEST_PEM_PATH', str(pem_file))
+    assert _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH') == 'FILE_PEM_CONTENT'
+
+
+def test_load_pem_from_env_returns_none_when_unset(monkeypatch):
+    """Returns None when neither var is set (triggers auto-generation)."""
+    from mcp_memory_service.config import _load_pem_from_env
+    monkeypatch.delenv('_TEST_PEM_INLINE', raising=False)
+    monkeypatch.delenv('_TEST_PEM_PATH', raising=False)
+    assert _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH') is None
+
+
+def test_load_pem_from_env_raises_on_missing_file(monkeypatch, tmp_path):
+    """When path var points to a non-existent file, ValueError is raised (fail-hard)."""
+    from mcp_memory_service.config import _load_pem_from_env
+    monkeypatch.delenv('_TEST_PEM_INLINE', raising=False)
+    monkeypatch.setenv('_TEST_PEM_PATH', str(tmp_path / "nonexistent.pem"))
+    with pytest.raises(ValueError, match="_TEST_PEM_PATH"):
+        _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH')
+
+
+def test_load_pem_from_env_inline_takes_precedence_over_path(monkeypatch, tmp_path):
+    """Inline value wins even when path var also points to a valid file."""
+    from mcp_memory_service.config import _load_pem_from_env
+    pem_file = tmp_path / "key.pem"
+    pem_file.write_text("FILE_PEM")
+    monkeypatch.setenv('_TEST_PEM_INLINE', 'INLINE_WINS')
+    monkeypatch.setenv('_TEST_PEM_PATH', str(pem_file))
+    assert _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH') == 'INLINE_WINS'
+
+
+def test_load_pem_from_env_reads_absolute_path(monkeypatch, tmp_path):
+    """Absolute path without tilde is read correctly."""
+    from mcp_memory_service.config import _load_pem_from_env
+    pem_file = tmp_path / "key.pem"
+    pem_file.write_text("ABSOLUTE_PEM")
+    monkeypatch.delenv('_TEST_PEM_INLINE', raising=False)
+    monkeypatch.setenv('_TEST_PEM_PATH', str(pem_file))
+    assert _load_pem_from_env('_TEST_PEM_INLINE', '_TEST_PEM_PATH') == 'ABSOLUTE_PEM'

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.58.0"
+version = "10.59.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- feat(oauth): file-based PEM key loading via `MCP_OAUTH_PRIVATE_KEY_PATH` / `MCP_OAUTH_PUBLIC_KEY_PATH` — fail-hard on missing file (co-author aria-inboxia, #926)
- feat(oauth): allow `cursor`, `vscode`, `vscode-insiders` as OAuth redirect URI schemes (co-author tkislan, #942)
- fix(hooks): symmetric project-affinity check in memory-scorer.js — short tags no longer zeroed by superset project names (#941)

## Version bump

`v10.58.0` → `v10.59.0` (MINOR — two new features + one fix)

## Files changed

- `src/mcp_memory_service/_version.py` — version bump
- `pyproject.toml` — version bump
- `uv.lock` — updated lock file
- `CHANGELOG.md` — new `[10.59.0]` entry
- `README.md` — Latest Release section updated
- `CLAUDE.md` — Current Version updated
- `docs/index.html` — landing page updated (MINOR release)

## Test plan

- [ ] CI green on this branch
- [ ] Version references consistent across all four files
- [ ] CHANGELOG has no duplicate entries
- [ ] Landing page version badge shows v10.59

🤖 Generated with [Claude Code](https://claude.com/claude-code)