### PR TITLE
fix(oauth): reflect state parameter back to client verbatim (RFC 6749)

### DIFF
--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -55,12 +55,6 @@ def _sanitize_log_value(value: object) -> str:
     return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\x1b", "\\x1b")
 
 
-def _sanitize_state(state: str) -> str:
-    """Sanitize the OAuth state parameter to prevent log injection and open redirect abuse."""
-    # Allow only alphanumeric, hyphen, underscore, and dot characters (RFC 6749 opaque value)
-    import re as _re
-
-    return _re.sub(r"[^A-Za-z0-9\-_.]", "", state)[:128]
 
 
 def _is_loopback_http_redirect(parsed: ParseResult) -> bool:
@@ -425,7 +419,7 @@ async def authorize_post(
         # Redirect with authorization code
         redirect_params = {"code": auth_code}
         if state:
-            redirect_params["state"] = _sanitize_state(state)
+            redirect_params["state"] = state
 
         redirect_url = _build_redirect_url(validated_redirect_uri, redirect_params)
         logger.info(f"Authorization granted, redirecting to callback")
@@ -459,7 +453,7 @@ async def authorize_post(
             "error_description": "Internal server error",
         }
         if state:
-            error_params["state"] = _sanitize_state(state)
+            error_params["state"] = state
         if validated_redirect_uri:
             return RedirectResponse(
                 url=_build_redirect_url(validated_redirect_uri, error_params)

--- a/tests/unit/test_oauth_native_clients.py
+++ b/tests/unit/test_oauth_native_clients.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 from unittest.mock import patch
 
@@ -5,6 +8,7 @@ from fastapi import HTTPException
 
 from mcp_memory_service.web.oauth.authorization import (
     _handle_authorization_code_grant,
+    authorize_post,
     validate_redirect_uri,
 )
 from mcp_memory_service.web.oauth.models import RegisteredClient
@@ -107,3 +111,60 @@ async def test_public_pkce_client_can_exchange_code_without_secret():
 
     assert response.token_type == "Bearer"
     assert response.access_token
+
+
+@pytest.mark.parametrize(
+    "client_state",
+    [
+        "plain_state_123",
+        "eyJ0Ijp7ImEiOjF9fQ==",                       # base64url with '=' padding
+        "abc+def/ghi==",                              # standard base64 (+ / =)
+        "hdr.eyJzdWIiOiJ4In0.c2ln",                   # JWT-shaped
+        "S" * 200,                                    # > 128 chars
+    ],
+)
+@pytest.mark.asyncio
+async def test_authorize_post_returns_state_verbatim(client_state):
+    """RFC 6749 §4.1.2: state MUST be reflected back to the client unchanged.
+    """
+    storage = MemoryOAuthStorage()
+    await storage.store_client(
+        RegisteredClient(
+            client_id="cursor-native",
+            client_secret="unused",
+            redirect_uris=["cursor://127.0.0.1:51234/callback"],
+            grant_types=["authorization_code"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            client_name="Cursor",
+            created_at=0,
+        )
+    )
+
+    with patch(
+        "mcp_memory_service.web.oauth.authorization.get_oauth_storage",
+        return_value=storage,
+    ), patch(
+        "mcp_memory_service.web.oauth.authorization.API_KEY", "test-api-key"
+    ) as api_key:
+        response = await authorize_post(
+            request=None,  # unused on the success path
+            response_type="code",
+            client_id="cursor-native",
+            redirect_uri="cursor://127.0.0.1:51234/callback",
+            scope="read write",
+            state=client_state,
+            code_challenge="E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            code_challenge_method="S256",
+            api_key=api_key,
+        )
+
+    # Success body embeds the callback URL as a JS string literal:
+    #   <script>window.location.href = "<redirect_url>";</script>
+    body = response.body.decode()
+    js_literal = body.split("window.location.href = ", 1)[1].split(";</script>", 1)[0]
+    redirect_url = json.loads(js_literal.replace("<\\/", "</"))
+
+    qs = parse_qs(urlparse(redirect_url).query)
+    assert "code" in qs, f"authorization code missing: {redirect_url}"
+    assert qs.get("state")[0] == client_state


### PR DESCRIPTION
# Pull Request

## Description

_sanitize_state() stripped every character outside [A-Za-z0-9-_.] and truncated to 128 chars before reflecting `state` back to the client. RFC 6749 §4.1.2 requires returning `state` to the client exactly as received, so this corrupted base64url ('=' padding), standard base64 (+ / =), percent-encoded JSON, JWTs, and values >128 chars. Cursor failed with "OAuth callback received with invalid state parameter undefined" because the mangled value no longer matched its pending request map.

## Motivation

<!-- Explain why these changes are needed and what problem they solve -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧪 Test improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## Changes

<!-- List the specific changes made in this PR -->

-
-
-

**Breaking Changes** (if any):
<!-- Describe any breaking changes and migration steps -->

-

## Testing

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

Tested manually in Cursor, now is able to authenticate

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] MCP Inspector validation

**Test Configuration**:
- Python version:
- OS:
- Storage backend:
- Installation method:

### Test Coverage

<!-- Describe the test coverage added or modified -->

- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Test coverage maintained/improved

## Regression Prevention (required for Bug fix PRs)

<!--
Goal: prevent the same bug from recurring. Skip ONLY for new-feature PRs that
have no failure mode to lock in.
-->

**What test prevents reintroduction of this bug?**
<!-- File path + test name. e.g. tests/storage/test_sqlite_vec.py::test_deleted_at_guard -->

-

**If no regression test was added, why?**
<!-- Valid reasons: bug is in deprecated code being removed, untestable infra issue,
test infra doesn't yet exist (file follow-up issue and link it). -->

-

## Captured Learnings (recommended)

<!--
Did this PR teach you something non-obvious about the codebase, a library, CI,
or a workflow? Capture it here so the project's memory layer can index it. The
maintainer will save anything useful to the MCP Memory Service with the
appropriate tags. One-line per learning is fine.

Examples (good):
  - SQLite WAL mode requires explicit busy_timeout to survive concurrent writes
    under HTTP+MCP server load (closes the "database is locked" class)
  - peter-evans/create-pull-request must be pinned to SHA, not version tag —
    supply chain finding from PR #578

Skip if there's nothing non-obvious — don't manufacture content.
-->

-

## Related Issues

<!-- Link related issues using keywords: Fixes #123, Closes #456, Relates to #789 -->

Fixes #
Closes #
Relates to #

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Documentation

<!-- Check all that apply -->

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [ ] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [ ] Updated code comments/docstrings
- [ ] Added API documentation
- [ ] No documentation needed

## Pre-submission Checklist

<!-- Check all boxes before submitting -->

- [ ] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [ ] ✅ I have performed a self-review of my code
- [ ] ✅ I have commented my code, particularly in hard-to-understand areas
- [ ] ✅ I have made corresponding changes to the documentation
- [ ] ✅ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works
- [ ] ✅ New and existing unit tests pass locally with my changes
- [ ] ✅ Any dependent changes have been merged and published
- [ ] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [ ] ✅ I have verified this works with all supported storage backends (if applicable)

## Additional Notes

<!-- Any additional information, context, or notes for reviewers -->

---

**For Reviewers**:
- Review checklist: See [Development Reference](https://github.com/doobidoo/mcp-memory-service/wiki/06-Development-Reference)
- Consider testing with Gemini Code Assist for comprehensive review
- Verify CHANGELOG.md entry is present and correctly formatted
- Check documentation accuracy and completeness
