### PR TITLE
chore: release v10.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.59.1] - 2026-05-17
+
+### Fixed
+
+- **fix(oauth): reflect OAuth state parameter verbatim per RFC 6749 §4.1.2** ([#944](https://github.com/doobidoo/mcp-memory-service/pull/944), @tkislan): `_sanitize_state()` stripped non-`[A-Za-z0-9-_.]` characters and truncated to 128 chars before reflecting `state` back to the client. RFC 6749 §4.1.2 requires returning `state` exactly as received. This broke Cursor OAuth (base64url padding `=`, JWTs, values >128 chars all got mangled). Fix: remove `_sanitize_state()` entirely and reflect `state` verbatim. 5 parametrized regression tests added in `tests/unit/test_oauth_native_clients.py`.
+
 ## [10.59.0] - 2026-05-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.59.0 - feat(oauth): PEM key files + IDE redirect URI schemes; fix(hooks): symmetric project-affinity — ~1,989 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.59.1 - fix(oauth): reflect state verbatim per RFC 6749 §4.1.2, fixes Cursor OAuth — ~1,989 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,18 +496,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.59.0** (May 16, 2026)
+## Latest Release: **v10.59.1** (May 17, 2026)
 
-**OAuth PEM key files, IDE redirect URI schemes, and memory-scorer affinity fix**
+**OAuth state parameter RFC 6749 compliance fix**
 
 **What's New:**
-- `feat(oauth)`: File-based PEM key loading via `MCP_OAUTH_PRIVATE_KEY_PATH` / `MCP_OAUTH_PUBLIC_KEY_PATH` env vars — prevents silent JWT invalidation on restart; startup aborts with `ValueError` if the file cannot be read (PR #926, co-author aria-inboxia).
-- `feat(oauth)`: Allow `cursor`, `vscode`, `vscode-insiders` as OAuth redirect URI schemes for IDE deep-link OAuth callbacks (PR #942, co-author tkislan).
-- `fix(hooks)`: Symmetric project-affinity check in `memory-scorer.js` — short memory tags (e.g. `wing:hoi4`) no longer zeroed when the project name is a superset (e.g. `hoi4coach`) (#941, reported by minecraft-mattsource).
+- `fix(oauth)`: Reflect OAuth `state` parameter verbatim per RFC 6749 §4.1.2 — previous `_sanitize_state()` stripped base64url padding (`=`), mangled JWTs, and truncated values >128 chars, breaking Cursor OAuth. Fix removes sanitization entirely. 5 regression tests added (PR #944, @tkislan).
 
 ---
 
 **Previous Releases**:
+- **v10.59.0** - feat(oauth): PEM key files + IDE redirect URI schemes; fix(hooks): symmetric project-affinity (PRs #926, #942, #941)
 - **v10.58.0** - feat(insights): configurable exclusion, automated-type heuristic, acknowledgement flow (PR #939); feat(harvest): locale YAML plugins (PR #935, @filhocf); feat(plugin): smart-tagger example (PR #932, @filhocf)
 - **v10.57.3** - feat(milvus): last_accessed tracking via `_access` side-collection (PR #925, @henry201605)
 - **v10.57.2** - fix(deps): pin pymilvus<3.0.0 to restore Milvus Docker CI (PR #921)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.59.0"
+version = "10.59.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.59.0"
+__version__ = "10.59.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.59.0"
+version = "10.59.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Patch release v10.59.1
- Bumps version in `_version.py`, `pyproject.toml`, updates `uv.lock`
- Adds CHANGELOG entry for v10.59.1
- Updates README "Latest Release" and "Previous Releases" sections
- Updates CLAUDE.md version callout

## Changes included

**fix(oauth): reflect OAuth `state` parameter verbatim per RFC 6749 §4.1.2** ([#944](https://github.com/doobidoo/mcp-memory-service/pull/944), @tkislan)

`_sanitize_state()` stripped non-`[A-Za-z0-9-_.]` characters and truncated to 128 chars before reflecting `state` back to the client. RFC 6749 §4.1.2 requires returning `state` exactly as received. This broke Cursor OAuth (base64url padding `=`, JWTs, values >128 chars all got mangled). Fix removes `_sanitize_state()` entirely. 5 parametrized regression tests added.

## Type

PATCH — bug fix only. No landing page update required.

## Test plan

- [ ] CI green on this branch
- [ ] PyPI publishes automatically on tag push via "Publish and Test (Tags)" workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)