### PR TITLE
chore: release v10.59.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.59.2] - 2026-05-17
+
+### Fixed
+
+- **fix(oauth): use AnyUrl for redirect_uri in AuthorizationRequest and TokenRequest** ([#942](https://github.com/doobidoo/mcp-memory-service/issues/942), reported by @tkislan): `HttpUrl` only accepts `http`/`https` — `cursor://`, `vscode://`, `vscode-insiders://` were silently rejected by Pydantic before reaching the `ALLOWED_SCHEMES` whitelist in `registration.py`, making the scheme addition in v10.59.0 a no-op in practice. Fixed: `redirect_uri` fields in `AuthorizationRequest` and `TokenRequest` changed from `Optional[HttpUrl]` to `Optional[AnyUrl]` in `src/mcp_memory_service/web/oauth/models.py`. `ErrorResponse.error_uri` keeps `HttpUrl`. 8 regression tests added in `tests/unit/test_oauth_native_clients.py`.
+
 ## [10.59.1] - 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.59.1 - fix(oauth): reflect state verbatim per RFC 6749 §4.1.2, fixes Cursor OAuth — ~1,989 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.59.2 - fix(oauth): AnyUrl for redirect_uri so IDE schemes (cursor://, vscode://) pass Pydantic validation — ~1,997 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,16 +496,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.59.1** (May 17, 2026)
+## Latest Release: **v10.59.2** (May 17, 2026)
 
-**OAuth state parameter RFC 6749 compliance fix**
+**OAuth redirect_uri AnyUrl fix — IDE schemes now actually work**
 
 **What's New:**
-- `fix(oauth)`: Reflect OAuth `state` parameter verbatim per RFC 6749 §4.1.2 — previous `_sanitize_state()` stripped base64url padding (`=`), mangled JWTs, and truncated values >128 chars, breaking Cursor OAuth. Fix removes sanitization entirely. 5 regression tests added (PR #944, @tkislan).
+- `fix(oauth)`: `redirect_uri` fields in `AuthorizationRequest` and `TokenRequest` changed from `Optional[HttpUrl]` to `Optional[AnyUrl]` — `HttpUrl` silently rejected `cursor://`, `vscode://`, `vscode-insiders://` before reaching the scheme whitelist, making the v10.59.0 IDE scheme feature a no-op in practice. 8 regression tests added (#942, reported by @tkislan).
 
 ---
 
 **Previous Releases**:
+- **v10.59.1** - fix(oauth): reflect state parameter verbatim per RFC 6749 §4.1.2, fixes Cursor OAuth (#944, @tkislan)
 - **v10.59.0** - feat(oauth): PEM key files + IDE redirect URI schemes; fix(hooks): symmetric project-affinity (PRs #926, #942, #941)
 - **v10.58.0** - feat(insights): configurable exclusion, automated-type heuristic, acknowledgement flow (PR #939); feat(harvest): locale YAML plugins (PR #935, @filhocf); feat(plugin): smart-tagger example (PR #932, @filhocf)
 - **v10.57.3** - feat(milvus): last_accessed tracking via `_access` side-collection (PR #925, @henry201605)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.59.1"
+version = "10.59.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.59.1"
+__version__ = "10.59.2"

--- a/src/mcp_memory_service/web/oauth/models.py
+++ b/src/mcp_memory_service/web/oauth/models.py
@@ -17,7 +17,7 @@ OAuth 2.1 data models and schemas for MCP Memory Service.
 """
 
 from typing import List, Optional
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, HttpUrl
 
 
 class OAuthServerMetadata(BaseModel):
@@ -147,7 +147,7 @@ class AuthorizationRequest(BaseModel):
 
     response_type: str = Field(..., description="OAuth response type")
     client_id: str = Field(..., description="OAuth client identifier")
-    redirect_uri: Optional[HttpUrl] = Field(default=None, description="Redirection URI")
+    redirect_uri: Optional[AnyUrl] = Field(default=None, description="Redirection URI")
     scope: Optional[str] = Field(default=None, description="Requested scope")
     state: Optional[str] = Field(default=None, description="Opaque value for CSRF protection")
 
@@ -157,7 +157,7 @@ class TokenRequest(BaseModel):
 
     grant_type: str = Field(..., description="OAuth grant type")
     code: Optional[str] = Field(default=None, description="Authorization code")
-    redirect_uri: Optional[HttpUrl] = Field(default=None, description="Redirection URI")
+    redirect_uri: Optional[AnyUrl] = Field(default=None, description="Redirection URI")
     client_id: Optional[str] = Field(default=None, description="OAuth client identifier")
     client_secret: Optional[str] = Field(default=None, description="OAuth client secret")
 

--- a/tests/unit/test_oauth_native_clients.py
+++ b/tests/unit/test_oauth_native_clients.py
@@ -192,9 +192,11 @@ def test_authorization_request_accepts_ide_redirect_uri(scheme, uri):
 
 
 @pytest.mark.parametrize("scheme,uri", [
-    ("cursor",  "cursor://callback"),
-    ("vscode",  "vscode://callback"),
-    ("https",   "https://app.example.com/callback"),
+    ("cursor",          "cursor://callback"),
+    ("vscode",          "vscode://callback"),
+    ("vscode-insiders", "vscode-insiders://callback"),
+    ("https",           "https://app.example.com/callback"),
+    ("http",            "http://localhost:8080/callback"),
 ])
 def test_token_request_accepts_ide_redirect_uri(scheme, uri):
     """TokenRequest must accept IDE deep-link schemes (AnyUrl, not HttpUrl)."""

--- a/tests/unit/test_oauth_native_clients.py
+++ b/tests/unit/test_oauth_native_clients.py
@@ -11,7 +11,7 @@ from mcp_memory_service.web.oauth.authorization import (
     authorize_post,
     validate_redirect_uri,
 )
-from mcp_memory_service.web.oauth.models import RegisteredClient
+from mcp_memory_service.web.oauth.models import AuthorizationRequest, RegisteredClient, TokenRequest
 from mcp_memory_service.web.oauth.storage.memory import MemoryOAuthStorage
 
 
@@ -183,13 +183,12 @@ async def test_authorize_post_returns_state_verbatim(client_state):
 ])
 def test_authorization_request_accepts_ide_redirect_uri(scheme, uri):
     """AuthorizationRequest must accept IDE deep-link schemes (AnyUrl, not HttpUrl)."""
-    from mcp_memory_service.web.oauth.models import AuthorizationRequest
     req = AuthorizationRequest(
         response_type="code",
         client_id="test-client",
         redirect_uri=uri,
     )
-    assert str(req.redirect_uri).rstrip("/").startswith(scheme)
+    assert req.redirect_uri.scheme == scheme
 
 
 @pytest.mark.parametrize("scheme,uri", [
@@ -199,10 +198,9 @@ def test_authorization_request_accepts_ide_redirect_uri(scheme, uri):
 ])
 def test_token_request_accepts_ide_redirect_uri(scheme, uri):
     """TokenRequest must accept IDE deep-link schemes (AnyUrl, not HttpUrl)."""
-    from mcp_memory_service.web.oauth.models import TokenRequest
     req = TokenRequest(
         grant_type="authorization_code",
         code="abc123",
         redirect_uri=uri,
     )
-    assert str(req.redirect_uri).rstrip("/").startswith(scheme)
+    assert req.redirect_uri.scheme == scheme

--- a/tests/unit/test_oauth_native_clients.py
+++ b/tests/unit/test_oauth_native_clients.py
@@ -168,3 +168,41 @@ async def test_authorize_post_returns_state_verbatim(client_state):
     qs = parse_qs(urlparse(redirect_url).query)
     assert "code" in qs, f"authorization code missing: {redirect_url}"
     assert qs.get("state")[0] == client_state
+
+
+# ---------------------------------------------------------------------------
+# Regression: AnyUrl — cursor:// and vscode:// must not be rejected by Pydantic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme,uri", [
+    ("cursor",          "cursor://callback"),
+    ("vscode",          "vscode://callback"),
+    ("vscode-insiders", "vscode-insiders://callback"),
+    ("https",           "https://app.example.com/callback"),
+    ("http",            "http://localhost:8080/callback"),
+])
+def test_authorization_request_accepts_ide_redirect_uri(scheme, uri):
+    """AuthorizationRequest must accept IDE deep-link schemes (AnyUrl, not HttpUrl)."""
+    from mcp_memory_service.web.oauth.models import AuthorizationRequest
+    req = AuthorizationRequest(
+        response_type="code",
+        client_id="test-client",
+        redirect_uri=uri,
+    )
+    assert str(req.redirect_uri).rstrip("/").startswith(scheme)
+
+
+@pytest.mark.parametrize("scheme,uri", [
+    ("cursor",  "cursor://callback"),
+    ("vscode",  "vscode://callback"),
+    ("https",   "https://app.example.com/callback"),
+])
+def test_token_request_accepts_ide_redirect_uri(scheme, uri):
+    """TokenRequest must accept IDE deep-link schemes (AnyUrl, not HttpUrl)."""
+    from mcp_memory_service.web.oauth.models import TokenRequest
+    req = TokenRequest(
+        grant_type="authorization_code",
+        code="abc123",
+        redirect_uri=uri,
+    )
+    assert str(req.redirect_uri).rstrip("/").startswith(scheme)

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.59.1"
+version = "10.59.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump version to v10.59.2 (PATCH)
- Update CHANGELOG.md with [10.59.2] entry
- Update README.md Latest Release section
- Update CLAUDE.md version callout
- Update uv.lock

## Changes

**fix(oauth): use AnyUrl for redirect_uri in AuthorizationRequest and TokenRequest**

`HttpUrl` only accepts `http`/`https` — `cursor://`, `vscode://`, `vscode-insiders://` were silently rejected by Pydantic before reaching the `ALLOWED_SCHEMES` whitelist in `registration.py`. This made the IDE scheme feature added in v10.59.0 a no-op in practice.

Fixed: `redirect_uri` fields changed from `Optional[HttpUrl]` to `Optional[AnyUrl]` in `src/mcp_memory_service/web/oauth/models.py`. `ErrorResponse.error_uri` keeps `HttpUrl` (always a docs URL). 8 regression tests added. (#942, reported by @tkislan)

## Files changed (release plumbing)

- `src/mcp_memory_service/_version.py`: 10.59.1 → 10.59.2
- `pyproject.toml`: 10.59.1 → 10.59.2
- `uv.lock`: updated package version
- `CHANGELOG.md`: new [10.59.2] section
- `README.md`: latest release updated
- `CLAUDE.md`: version callout updated

## Test plan

- [ ] CI passes on this PR
- [ ] `uv lock` reflects v10.59.2
- [ ] CHANGELOG has no duplicate version entries
- [ ] PyPI publish triggered automatically after tag push on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)