### PR TITLE
fix(milvus): use instance-level graph cache and filter superseded in retrieve

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -975,23 +975,30 @@ class MilvusMemoryStorage(MemoryStorage):
 
     # Cached graph storage instance for conflict operations. Avoids creating
     # a new MilvusClient + gRPC connection on every store() call.
-    _graph_storage_cache: Optional[Any] = None
+    # Stored as an instance attribute (_graph_storage) via _get_graph_storage().
 
     async def _get_graph_storage(self):
-        """Get or create a cached MilvusGraphStorage instance."""
+        """Get or create a cached MilvusGraphStorage instance (thread-safe)."""
         from .milvus_graph import MilvusGraphStorage
 
-        if self._graph_storage_cache is not None:
-            return self._graph_storage_cache
+        # Fast path: already initialized
+        if getattr(self, "_graph_storage", None) is not None:
+            return self._graph_storage
 
-        graph = MilvusGraphStorage(
-            uri=self.uri,
-            token=self.token,
-            collection_name=self.collection_name,
-        )
-        await graph.initialize()
-        self._graph_storage_cache = graph
-        return graph
+        # Slow path: initialize under lock to prevent concurrent creation
+        async with self._write_lock:
+            # Double-check after acquiring lock
+            if getattr(self, "_graph_storage", None) is not None:
+                return self._graph_storage
+
+            graph = MilvusGraphStorage(
+                uri=self.uri,
+                token=self.token,
+                collection_name=self.collection_name,
+            )
+            await graph.initialize()
+            self._graph_storage = graph
+            return graph
 
     async def _detect_conflicts(
         self, new_hash: str, new_content: str, embedding: List[float]
@@ -1685,7 +1692,15 @@ class MilvusMemoryStorage(MemoryStorage):
             hits = await self._run_hybrid_search(query, query_embedding, tag_filter, fetch_n)
         else:
             hits = await self._run_search(query_embedding, tag_filter, fetch_n)
-        results = self._rank_and_trim(hits, query, n_results, min_confidence)
+
+        # Rank all hits, filter superseded before trimming to preserve result count
+        results = self._rank_and_trim(hits, query, len(hits), min_confidence)
+        if not include_superseded:
+            results = [
+                r for r in results
+                if not r.memory.metadata.get("superseded_by")
+            ]
+        results = results[:n_results]
 
         # Async update last_accessed for hit memories (non-blocking)
         if results:


### PR DESCRIPTION
## Summary

Follow-up fix for PR #931 (conflict detection). Addresses two issues:

1. **Instance-level graph storage cache**: Changed from class variable `_graph_storage_cache` to instance attribute `_graph_storage` (via `getattr` pattern). The class variable caused cross-instance contamination in tests where different storage instances share different collections.

2. **Filter superseded memories in `retrieve()`**: When `include_superseded=False` (default), memories marked with `metadata.superseded_by` are now excluded from search results. This matches sqlite_vec behavior where `AND (m.superseded_by IS NULL OR m.superseded_by = '')` is applied in the SQL query.

## Changes

- `_get_graph_storage()`: Use `getattr(self, "_graph_storage", None)` instead of class-level `_graph_storage_cache`
- `retrieve()`: Add post-filter to exclude memories where `metadata.superseded_by` is set

## Testing

- All 55 Milvus tests pass (50 original + 5 conflict detection tests)