### PR TITLE
fix(hooks): use protocol-correct default port for standard HTTPS/HTTP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.60.0] - 2026-05-17
+
+### Added
+
+- **feat(consolidation): temporal contradiction detection via embedding similarity band** ([#949](https://github.com/doobidoo/mcp-memory-service/pull/949), @filhocf): New module `src/mcp_memory_service/consolidation/contradictions.py`. Detects contradictions using a similarity band of 0.4–0.75 (too similar to be independent facts, too different to be duplicates). Emits a `CONTRADICTED_BY` graph edge and sets `superseded_by` on the older memory. Opt-in via `MCP_CONTRADICTION_DETECTION_ENABLED=true` and `MCP_CONTRADICTION_ON_STORE=true`. Integrated as Step 7 in `handlers/quality.py` maintain flow. 8 new tests in `tests/consolidation/test_contradictions.py`.
+
+### Fixed
+
+- **fix(milvus): instance-level graph cache + filter superseded in retrieve** ([#948](https://github.com/doobidoo/mcp-memory-service/pull/948), @henry201605): Replaces the class-variable `_graph_storage_cache` with an instance attribute protected by double-checked locking, preventing cross-instance contamination in tests. `retrieve()` now filters out `superseded_by` memories before trimming results to match the sqlite_vec behavior.
+
 ## [10.59.2] - 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.59.2 - fix(oauth): AnyUrl for redirect_uri so IDE schemes (cursor://, vscode://) pass Pydantic validation — ~1,997 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.60.0 - feat(consolidation): temporal contradiction detection + fix(milvus): instance-level graph cache — ~2,005 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,16 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.59.2** (May 17, 2026)
+## Latest Release: **v10.60.0** (May 17, 2026)
 
-**OAuth redirect_uri AnyUrl fix — IDE schemes now actually work**
+**Temporal contradiction detection + Milvus instance-level graph cache fix**
 
 **What's New:**
-- `fix(oauth)`: `redirect_uri` fields in `AuthorizationRequest` and `TokenRequest` changed from `Optional[HttpUrl]` to `Optional[AnyUrl]` — `HttpUrl` silently rejected `cursor://`, `vscode://`, `vscode-insiders://` before reaching the scheme whitelist, making the v10.59.0 IDE scheme feature a no-op in practice. 8 regression tests added (#942, reported by @tkislan).
+- `feat(consolidation)`: New temporal contradiction detection module — detects contradicting facts using embedding similarity band 0.4–0.75, emits `CONTRADICTED_BY` graph edges, marks older memory with `superseded_by`. Opt-in via `MCP_CONTRADICTION_DETECTION_ENABLED=true` and `MCP_CONTRADICTION_ON_STORE=true`. 8 new tests. (#949, @filhocf)
+- `fix(milvus)`: Replace class-variable `_graph_storage_cache` with instance attribute + double-checked locking to prevent cross-instance contamination. `retrieve()` now filters `superseded_by` memories before trimming, matching sqlite_vec behavior. (#948, @henry201605)
 
 ---
 
 **Previous Releases**:
+- **v10.59.2** - fix(oauth): AnyUrl for redirect_uri so IDE schemes (cursor://, vscode://) pass Pydantic validation (#942, @tkislan)
 - **v10.59.1** - fix(oauth): reflect state parameter verbatim per RFC 6749 §4.1.2, fixes Cursor OAuth (#944, @tkislan)
 - **v10.59.0** - feat(oauth): PEM key files + IDE redirect URI schemes; fix(hooks): symmetric project-affinity (PRs #926, #942, #941)
 - **v10.58.0** - feat(insights): configurable exclusion, automated-type heuristic, acknowledgement flow (PR #939); feat(harvest): locale YAML plugins (PR #935, @filhocf); feat(plugin): smart-tagger example (PR #932, @filhocf)

--- a/claude-hooks/core/memory-retrieval.js
+++ b/claude-hooks/core/memory-retrieval.js
@@ -53,7 +53,7 @@ async function queryMemoryService(endpoint, apiKey, query) {
 
         const options = {
             hostname: url.hostname,
-            port: url.port || 8443,
+            port: url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80),
             path: url.pathname,
             method: 'POST',
             headers: {

--- a/claude-hooks/utilities/memory-client.js
+++ b/claude-hooks/utilities/memory-client.js
@@ -167,7 +167,7 @@ class MemoryClient {
 
                 const requestOptions = {
                     hostname: url.hostname,
-                    port: url.port || (url.protocol === 'https:' ? 8443 : 8000),
+                    port: url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80),
                     path: url.pathname,
                     method: 'GET',
                     headers: {
@@ -280,7 +280,7 @@ class MemoryClient {
 
             const options = {
                 hostname: url.hostname,
-                port: url.port || (isHttps ? 8443 : 8000),
+                port: url.port ? Number(url.port) : (isHttps ? 443 : 80),
                 path: url.pathname,
                 method: 'POST',
                 headers: {
@@ -363,7 +363,7 @@ class MemoryClient {
 
             const options = {
                 hostname: url.hostname,
-                port: url.port || (url.protocol === 'https:' ? 8443 : 8000),
+                port: url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80),
                 path: url.pathname,
                 method: 'POST',
                 headers: {

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.59.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.60.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.59.0">
-<meta property="og:description" content="OAuth PEM key files, IDE redirect URI schemes for Cursor/VS Code, and symmetric memory-scorer project-affinity fix. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.60.0">
+<meta property="og:description" content="Temporal contradiction detection, Milvus instance-level graph cache fix, and Kiro CLI harvest support. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.59 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.60 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.59</h2>
-    <p class="section-subtitle">OAuth PEM key files, IDE redirect URI schemes for Cursor/VS Code, and symmetric memory-scorer project-affinity fix. ~1,989 tests.</p>
+    <h2 class="section-title">What's New in v10.60</h2>
+    <p class="section-subtitle">Temporal contradiction detection, Milvus instance-level graph cache fix, and Kiro CLI harvest support. ~2,005 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon privacy">&#128273;</div>
-        <h3>PEM Key Files for OAuth</h3>
-        <p>Load OAuth signing keys from files via <code>MCP_OAUTH_PRIVATE_KEY_PATH</code> / <code>MCP_OAUTH_PUBLIC_KEY_PATH</code> — prevents silent JWT invalidation on restart. Startup fails hard if the file cannot be read, so broken configs are never silently ignored.</p>
+        <div class="feature-icon privacy">&#128260;</div>
+        <h3>Temporal Contradiction Detection</h3>
+        <p>New opt-in module detects contradicting facts using an embedding similarity band (0.4&ndash;0.75). Emits <code>CONTRADICTED_BY</code> graph edges and marks the older memory with <code>superseded_by</code>. Enable via <code>MCP_CONTRADICTION_DETECTION_ENABLED=true</code>.</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#128295;</div>
-        <h3>IDE OAuth Redirect Schemes</h3>
-        <p>OAuth now accepts <code>cursor://</code>, <code>vscode://</code>, and <code>vscode-insiders://</code> redirect URI schemes, enabling deep-link OAuth callbacks for Cursor and VS Code extensions without manual workarounds.</p>
+        <div class="feature-icon consolidation">&#128736;</div>
+        <h3>Milvus Graph Cache Fix</h3>
+        <p>Replaces the class-variable graph storage cache with an instance attribute + double-checked locking, preventing cross-instance contamination in multi-test environments. <code>retrieve()</code> now filters <code>superseded_by</code> memories to match sqlite_vec behavior.</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#128279;</div>
-        <h3>Symmetric Memory-Scorer Affinity</h3>
-        <p>Fixed a bug where short memory tags (e.g. <code>wing:hoi4</code>) were zeroed by the project-affinity filter when the project name was a superset (e.g. <code>hoi4coach</code>). Affinity now checks both directions, so context-relevant memories always surface.</p>
+        <div class="feature-icon http">&#128196;</div>
+        <h3>Kiro CLI Harvest Support</h3>
+        <p>The <code>TranscriptParser</code> now auto-detects Kiro CLI session format (<code>kind</code> key) in addition to Claude Code format (<code>type</code> key), mapping <code>kind: Prompt</code> &rarr; user and <code>kind: Response</code> &rarr; assistant. Fully additive, no breaking changes.</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1989">0</div>
+        <div class="stat-number" data-target="2005">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.59.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.60.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.59.2"
+version = "10.60.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.59.2"
+__version__ = "10.60.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.59.2"
+version = "10.60.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem

`memory-client.js` and `memory-retrieval.js` used `url.port || 8443` (or `|| 8000`) as the port fallback. In Node.js's `URL` API, `url.port` returns an **empty string** for standard ports (443 for HTTPS, 80 for HTTP) — they are never included in the string representation. This means the `||` fallback always triggered for standard-port URLs, forcing connections to 8443/8000 instead of 443/80.

This broke any deployment behind a **Cloudflare Tunnel** (or any reverse proxy listening on standard ports), causing silent connection failures.

## Root cause

```js
// Before — broken for https://memory.example.com/ (url.port === "")
port: url.port || 8443  // always 8443 for standard HTTPS URLs ❌
```

## Fix

```js
// After — correct for all cases
port: url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80)
```

| URL | Before | After |
|-----|--------|-------|
| `https://memory.example.com/` | 8443 ❌ | 443 ✅ |
| `https://memory.example.com:8443/` | 8443 ✅ | 8443 ✅ |
| `http://localhost:8000/` | 8000 ✅ | 8000 ✅ |
| `http://localhost/` | 8000 ❌ | 80 ✅ |

## Affected files

- `claude-hooks/utilities/memory-client.js` — 3 locations (`_attemptHealthCheck`, `storeMemoryHTTP`, `_performApiPost`)
- `claude-hooks/core/memory-retrieval.js` — 1 location (`queryMemoryService`)

Fixes #950