### PR TITLE
feat(sse): Last-Event-ID replay on /api/events reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **feat(sse): Last-Event-ID replay on `/api/events` reconnect**: Bounded ring buffer of recently broadcast events lets SSE clients resume after a transient disconnect per the standard EventSource resume header. Buffer size configurable via `MCP_SSE_REPLAY_BUFFER_SIZE` (default 1000, 0 disables). Replay outcome (`status: resumed` or `status: id_not_in_buffer`) is surfaced in the `connection_established` welcome event so clients can detect overflow and fall back to their own catch-up strategy. Connection-scoped events (welcome, close) and heartbeats are not buffered; filtered broadcasts are excluded to avoid expanding the original audience on replay.
+
 ## [10.59.2] - 2026-05-17
 
 ### Fixed

--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -579,6 +579,10 @@ HTTP_PORT = safe_get_int_env('MCP_HTTP_PORT', 8000, min_value=1024, max_value=65
 HTTP_HOST = os.getenv('MCP_HTTP_HOST', '127.0.0.1')
 CORS_ORIGINS = os.getenv('MCP_CORS_ORIGINS', 'http://localhost:8000,http://127.0.0.1:8000').split(',')
 SSE_HEARTBEAT_INTERVAL = safe_get_int_env('MCP_SSE_HEARTBEAT', 30, min_value=5, max_value=300)  # 5 seconds to 5 minutes
+# Bounded ring buffer of broadcast SSE events kept for Last-Event-ID replay
+# on client reconnect. Defaults to 1000 events (~ a few minutes at typical
+# memory_stored rates). Set to 0 to disable replay entirely.
+SSE_EVENT_REPLAY_BUFFER_SIZE = safe_get_int_env('MCP_SSE_REPLAY_BUFFER_SIZE', 1000, min_value=0, max_value=100000)
 API_KEY = os.getenv('MCP_API_KEY', None)  # Optional authentication
 
 # HTTPS Configuration

--- a/src/mcp_memory_service/web/sse.py
+++ b/src/mcp_memory_service/web/sse.py
@@ -157,30 +157,32 @@ class SSEManager:
         disabled. Otherwise it describes the outcome (resumed vs. overflow)
         so the client can decide whether to trust the resume or do its own
         catch-up (e.g. via search-by-tag).
+
+        Single-pass iteration over the deque — no full-buffer copy — so the
+        memory cost stays proportional to what actually needs replaying,
+        not to MCP_SSE_REPLAY_BUFFER_SIZE.
         """
         if not last_event_id or self._replay_buffer.maxlen == 0:
             return None, []
 
-        buffered: List[SSEEvent] = list(self._replay_buffer)
-        oldest_id = buffered[0].event_id if buffered else None
-        for index, event in enumerate(buffered):
-            if event.event_id == last_event_id:
-                to_replay = buffered[index + 1:]
-                return ({
-                    "requested_last_event_id": last_event_id,
-                    "status": "resumed",
-                    "events_replayed": len(to_replay),
-                    "buffer_size": self._replay_buffer.maxlen,
-                    "buffer_oldest_id": oldest_id,
-                }, to_replay)
+        oldest_id = self._replay_buffer[0].event_id if self._replay_buffer else None
+        to_replay: List[SSEEvent] = []
+        found = False
+        for event in self._replay_buffer:
+            if found:
+                to_replay.append(event)
+            elif event.event_id == last_event_id:
+                found = True
 
-        return ({
+        base_meta = {
             "requested_last_event_id": last_event_id,
-            "status": "id_not_in_buffer",
-            "events_replayed": 0,
+            "events_replayed": len(to_replay),
             "buffer_size": self._replay_buffer.maxlen,
             "buffer_oldest_id": oldest_id,
-        }, [])
+        }
+        if found:
+            return ({**base_meta, "status": "resumed"}, to_replay)
+        return ({**base_meta, "status": "id_not_in_buffer"}, [])
     
     async def _remove_connection(self, connection_id: str):
         """Remove an SSE connection."""
@@ -203,9 +205,18 @@ class SSEManager:
     
     async def broadcast_event(self, event: SSEEvent, connection_filter: Optional[Set[str]] = None):
         """Broadcast an event to all or filtered connections."""
-        # Buffer only globally broadcast events; replaying a filtered event to
-        # a different reconnecting client would expand the original audience.
-        if connection_filter is None and self._replay_buffer.maxlen:
+        # Buffer only globally broadcast, non-heartbeat events:
+        # - Filtered broadcasts targeted specific live connections; replaying
+        #   them to a different reconnecting client would expand the audience.
+        # - Heartbeats are liveness signals; they carry no value to a resuming
+        #   client and would dominate the buffer during quiet periods (every
+        #   SSE_HEARTBEAT_INTERVAL seconds; at 30s a 1000-slot buffer fills
+        #   with heartbeats in ~8h of no real traffic).
+        if (
+            connection_filter is None
+            and event.event_type != "heartbeat"
+            and self._replay_buffer.maxlen
+        ):
             self._replay_buffer.append(event)
 
         if not self.connections:

--- a/src/mcp_memory_service/web/sse.py
+++ b/src/mcp_memory_service/web/sse.py
@@ -23,7 +23,8 @@ import asyncio
 import json
 import time
 import uuid
-from typing import Dict, Any, Optional, Set
+from collections import deque
+from typing import Dict, Any, List, Optional, Set
 from datetime import datetime, timezone
 from dataclasses import dataclass
 
@@ -31,7 +32,7 @@ from fastapi import Request
 from sse_starlette import EventSourceResponse
 import logging
 
-from ..config import SSE_HEARTBEAT_INTERVAL
+from ..config import SSE_HEARTBEAT_INTERVAL, SSE_EVENT_REPLAY_BUFFER_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +56,20 @@ class SSEEvent:
 
 class SSEManager:
     """Manages Server-Sent Event connections and broadcasting."""
-    
-    def __init__(self, heartbeat_interval: int = SSE_HEARTBEAT_INTERVAL):
+
+    def __init__(
+        self,
+        heartbeat_interval: int = SSE_HEARTBEAT_INTERVAL,
+        replay_buffer_size: int = SSE_EVENT_REPLAY_BUFFER_SIZE,
+    ):
         self.connections: Dict[str, Dict[str, Any]] = {}
         self.heartbeat_interval = heartbeat_interval
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._running = False
+        # Bounded ring of recently broadcast events for Last-Event-ID replay.
+        # Connection-scoped events (welcome/close) and heartbeats are excluded;
+        # only events every consumer sees are eligible. maxlen=0 disables replay.
+        self._replay_buffer: deque = deque(maxlen=max(0, replay_buffer_size))
         
     async def start(self):
         """Start the SSE manager and heartbeat task."""
@@ -88,10 +97,23 @@ class SSEManager:
         
         logger.info("SSE Manager stopped")
     
-    async def add_connection(self, connection_id: str, request: Request) -> asyncio.Queue:
-        """Add a new SSE connection."""
+    async def add_connection(
+        self,
+        connection_id: str,
+        request: Request,
+        last_event_id: Optional[str] = None,
+    ) -> asyncio.Queue:
+        """Add a new SSE connection.
+
+        If last_event_id is supplied and is present in the replay buffer, all
+        broadcast events stored after it are pushed into the new queue ahead
+        of any live events, matching EventSource resume semantics from the
+        HTML Living Standard. Buffer overflow (id is too old or unknown) is
+        surfaced in the welcome event so clients can detect it and fall back
+        to their own catch-up strategy.
+        """
         queue = asyncio.Queue()
-        
+
         self.connections[connection_id] = {
             'queue': queue,
             'request': request,
@@ -100,21 +122,65 @@ class SSEManager:
             'user_agent': request.headers.get('User-Agent', 'Unknown'),
             'client_ip': request.client.host if request.client else 'Unknown'
         }
-        
+
         logger.info(f"SSE connection added: {connection_id} from {self.connections[connection_id]['client_ip']}")
-        
-        # Send welcome event
-        welcome_event = SSEEvent(
-            event_type="connection_established",
-            data={
-                "connection_id": connection_id,
-                "message": "Connected to MCP Memory Service SSE stream",
-                "heartbeat_interval": self.heartbeat_interval
-            }
-        )
-        await queue.put(welcome_event)
-        
+
+        # Resolve replay (if requested) before sending the welcome so the
+        # welcome can describe the outcome to the client.
+        replay_meta, events_to_replay = self._resolve_replay(last_event_id)
+
+        welcome_data = {
+            "connection_id": connection_id,
+            "message": "Connected to MCP Memory Service SSE stream",
+            "heartbeat_interval": self.heartbeat_interval,
+        }
+        if replay_meta is not None:
+            welcome_data["replay"] = replay_meta
+        await queue.put(SSEEvent(event_type="connection_established", data=welcome_data))
+
+        # Replay AFTER the welcome so the welcome stays the first event a
+        # client sees (preserves the existing connection-established protocol).
+        for event in events_to_replay:
+            await queue.put(event)
+        if events_to_replay:
+            logger.info(
+                f"SSE replayed {len(events_to_replay)} event(s) to {connection_id} "
+                f"after Last-Event-ID={last_event_id}"
+            )
+
         return queue
+
+    def _resolve_replay(self, last_event_id: Optional[str]):
+        """Walk the replay buffer for last_event_id; return (welcome_meta, events).
+
+        welcome_meta is None when no replay was requested OR the buffer is
+        disabled. Otherwise it describes the outcome (resumed vs. overflow)
+        so the client can decide whether to trust the resume or do its own
+        catch-up (e.g. via search-by-tag).
+        """
+        if not last_event_id or self._replay_buffer.maxlen == 0:
+            return None, []
+
+        buffered: List[SSEEvent] = list(self._replay_buffer)
+        oldest_id = buffered[0].event_id if buffered else None
+        for index, event in enumerate(buffered):
+            if event.event_id == last_event_id:
+                to_replay = buffered[index + 1:]
+                return ({
+                    "requested_last_event_id": last_event_id,
+                    "status": "resumed",
+                    "events_replayed": len(to_replay),
+                    "buffer_size": self._replay_buffer.maxlen,
+                    "buffer_oldest_id": oldest_id,
+                }, to_replay)
+
+        return ({
+            "requested_last_event_id": last_event_id,
+            "status": "id_not_in_buffer",
+            "events_replayed": 0,
+            "buffer_size": self._replay_buffer.maxlen,
+            "buffer_oldest_id": oldest_id,
+        }, [])
     
     async def _remove_connection(self, connection_id: str):
         """Remove an SSE connection."""
@@ -137,6 +203,11 @@ class SSEManager:
     
     async def broadcast_event(self, event: SSEEvent, connection_filter: Optional[Set[str]] = None):
         """Broadcast an event to all or filtered connections."""
+        # Buffer only globally broadcast events; replaying a filtered event to
+        # a different reconnecting client would expand the original audience.
+        if connection_filter is None and self._replay_buffer.maxlen:
+            self._replay_buffer.append(event)
+
         if not self.connections:
             return
         
@@ -226,9 +297,14 @@ sse_manager = SSEManager()
 async def create_event_stream(request: Request):
     """Create an SSE event stream for a client."""
     connection_id = str(uuid.uuid4())
-    
+    # EventSource spec: clients send the id of the last event they processed
+    # in the Last-Event-ID header on reconnect. Honour it for resume; missing
+    # or stale ids fall through to a fresh stream with overflow surfaced in
+    # the welcome event.
+    last_event_id = request.headers.get('Last-Event-ID')
+
     async def event_generator():
-        queue = await sse_manager.add_connection(connection_id, request)
+        queue = await sse_manager.add_connection(connection_id, request, last_event_id)
         
         try:
             while True:

--- a/tests/web/test_sse_replay.py
+++ b/tests/web/test_sse_replay.py
@@ -1,0 +1,168 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SSE Last-Event-ID replay behaviour.
+
+Exercises SSEManager directly with a fake Request so we don't need to
+spin up the full FastAPI app or any storage backend.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from mcp_memory_service.web.sse import SSEEvent, SSEManager
+
+
+@dataclass
+class _FakeClient:
+    host: str = "127.0.0.1"
+
+
+class _FakeRequest:
+    """Minimal fastapi.Request stand-in. Only exposes the attributes the
+    SSEManager actually touches: .headers.get(...) and .client.host."""
+
+    def __init__(self, headers=None, client_host: str = "127.0.0.1"):
+        self.headers = headers or {}
+        self.client = _FakeClient(host=client_host)
+
+
+async def _drain(queue):
+    """Drain a non-empty asyncio.Queue without blocking on the next get."""
+    drained = []
+    while not queue.empty():
+        drained.append(queue.get_nowait())
+    return drained
+
+
+@pytest.mark.asyncio
+async def test_fresh_connect_has_no_replay_metadata():
+    """A connect without Last-Event-ID gets the welcome event only, no replay key."""
+    manager = SSEManager(replay_buffer_size=10)
+    queue = await manager.add_connection("conn-1", _FakeRequest())
+
+    events = await _drain(queue)
+    assert len(events) == 1
+    assert events[0].event_type == "connection_established"
+    assert "replay" not in events[0].data
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_events_after_id():
+    """Reconnect with a known Last-Event-ID replays everything after it."""
+    manager = SSEManager(replay_buffer_size=10)
+
+    # Broadcast three events with no live connections (still buffered).
+    e1 = SSEEvent(event_type="memory_stored", data={"n": 1})
+    e2 = SSEEvent(event_type="memory_stored", data={"n": 2})
+    e3 = SSEEvent(event_type="memory_stored", data={"n": 3})
+    for e in (e1, e2, e3):
+        await manager.broadcast_event(e)
+
+    # Reconnect, claiming we last saw e1.
+    queue = await manager.add_connection(
+        "conn-r",
+        _FakeRequest(headers={"Last-Event-ID": e1.event_id}),
+        last_event_id=e1.event_id,
+    )
+    events = await _drain(queue)
+
+    # Welcome first, then e2, then e3.
+    assert events[0].event_type == "connection_established"
+    assert events[0].data["replay"]["status"] == "resumed"
+    assert events[0].data["replay"]["events_replayed"] == 2
+    assert [e.event_id for e in events[1:]] == [e2.event_id, e3.event_id]
+
+
+@pytest.mark.asyncio
+async def test_resume_with_unknown_id_signals_overflow():
+    """Reconnect with an id not in the buffer reports id_not_in_buffer and replays nothing."""
+    manager = SSEManager(replay_buffer_size=10)
+    await manager.broadcast_event(SSEEvent(event_type="memory_stored", data={"n": 1}))
+
+    queue = await manager.add_connection(
+        "conn-overflow",
+        _FakeRequest(),
+        last_event_id="00000000-0000-0000-0000-000000000000",
+    )
+    events = await _drain(queue)
+
+    assert len(events) == 1  # welcome only
+    replay = events[0].data["replay"]
+    assert replay["status"] == "id_not_in_buffer"
+    assert replay["events_replayed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_filtered_broadcasts_are_not_buffered():
+    """Filtered broadcasts target specific live connections; a reconnecting
+    client must not receive them via replay because it wasn't an original target."""
+    manager = SSEManager(replay_buffer_size=10)
+
+    e_global = SSEEvent(event_type="memory_stored", data={"n": "global"})
+    e_filtered = SSEEvent(event_type="memory_stored", data={"n": "filtered"})
+    await manager.broadcast_event(e_global)
+    await manager.broadcast_event(e_filtered, connection_filter={"some-other-conn"})
+
+    queue = await manager.add_connection(
+        "conn-r",
+        _FakeRequest(),
+        last_event_id=e_global.event_id,
+    )
+    events = await _drain(queue)
+
+    # Welcome only — no replays after e_global, because e_filtered was not buffered.
+    assert len(events) == 1
+    assert events[0].data["replay"]["status"] == "resumed"
+    assert events[0].data["replay"]["events_replayed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_buffer_evicts_oldest_at_capacity():
+    """A small buffer drops the oldest event; resume from an evicted id reports overflow."""
+    manager = SSEManager(replay_buffer_size=2)
+
+    e1 = SSEEvent(event_type="memory_stored", data={"n": 1})
+    e2 = SSEEvent(event_type="memory_stored", data={"n": 2})
+    e3 = SSEEvent(event_type="memory_stored", data={"n": 3})
+    for e in (e1, e2, e3):
+        await manager.broadcast_event(e)
+
+    # e1 should be evicted; resume from e1 = overflow.
+    queue = await manager.add_connection(
+        "conn-evicted",
+        _FakeRequest(),
+        last_event_id=e1.event_id,
+    )
+    events = await _drain(queue)
+    assert events[0].data["replay"]["status"] == "id_not_in_buffer"
+    assert events[0].data["replay"]["buffer_oldest_id"] == e2.event_id
+
+
+@pytest.mark.asyncio
+async def test_replay_disabled_when_buffer_size_zero():
+    """replay_buffer_size=0 disables replay entirely; Last-Event-ID is ignored."""
+    manager = SSEManager(replay_buffer_size=0)
+    await manager.broadcast_event(SSEEvent(event_type="memory_stored", data={"n": 1}))
+
+    queue = await manager.add_connection(
+        "conn-disabled",
+        _FakeRequest(),
+        last_event_id="any-id",
+    )
+    events = await _drain(queue)
+
+    assert len(events) == 1
+    assert "replay" not in events[0].data

--- a/tests/web/test_sse_replay.py
+++ b/tests/web/test_sse_replay.py
@@ -152,6 +152,30 @@ async def test_buffer_evicts_oldest_at_capacity():
 
 
 @pytest.mark.asyncio
+async def test_heartbeats_are_not_buffered():
+    """Heartbeats reach live connections but are excluded from the replay
+    buffer — otherwise a quiet period would fill the buffer with pings."""
+    manager = SSEManager(replay_buffer_size=10)
+
+    real = SSEEvent(event_type="memory_stored", data={"n": 1})
+    beat = SSEEvent(event_type="heartbeat", data={"ping": True})
+    await manager.broadcast_event(real)
+    await manager.broadcast_event(beat)
+
+    queue = await manager.add_connection(
+        "conn-hb",
+        _FakeRequest(),
+        last_event_id=real.event_id,
+    )
+    events = await _drain(queue)
+
+    # Welcome only — heartbeat was filtered, so nothing to replay after `real`.
+    assert len(events) == 1
+    assert events[0].data["replay"]["status"] == "resumed"
+    assert events[0].data["replay"]["events_replayed"] == 0
+
+
+@pytest.mark.asyncio
 async def test_replay_disabled_when_buffer_size_zero():
     """replay_buffer_size=0 disables replay entirely; Last-Event-ID is ignored."""
     manager = SSEManager(replay_buffer_size=0)


### PR DESCRIPTION
## Description

Adds a bounded ring buffer of recently broadcast events to `SSEManager` and uses it to resume new connections that send the standard EventSource `Last-Event-ID` header. The existing connection-establishment protocol is preserved; the only client-visible additions are events replayed after the welcome on resume and a new `replay` field in the welcome describing the outcome.

## Motivation

`/api/events` does not honour `Last-Event-ID` today. Any event broadcast between a client disconnecting and reconnecting is lost. Verified empirically against a running 10.59.2: three back-to-back connects (no header / valid id / fake id) all opened identically with no replay attempt and no acknowledgement of the header — same code path. This makes long-lived consumers behind NAT/firewall idle drops effectively at-most-once across the disconnect window, even though the EventSource spec promises at-least-once via the resume header.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔧 Configuration change (new env var)

## Changes

- New config `MCP_SSE_REPLAY_BUFFER_SIZE` in `config.py` (default 1000, range 0..100000; 0 disables replay entirely).
- `SSEManager._replay_buffer` (bounded `deque`) appended in `broadcast_event` for globally-broadcast events. Filtered broadcasts (those passed a `connection_filter`) are not buffered — replaying a targeted event to a different reconnecting client would expand the original audience.
- `SSEManager.add_connection` accepts a `last_event_id` argument. On resume, events buffered after that id are queued after the welcome event. New `_resolve_replay` helper walks the buffer and returns the events plus a status dict.
- The `connection_established` welcome event carries a new `replay` field (`status: resumed` with replayed count, or `status: id_not_in_buffer` with the buffer's oldest id) so clients can detect overflow and trigger their own catch-up when replay isn't available.
- `create_event_stream` reads `Last-Event-ID` from request headers and forwards it.

Connection-scoped events (welcome, close) and heartbeats are not buffered. No behaviour change when clients omit the header.

## Testing

### How Has This Been Tested?

- [x] Unit tests — `tests/web/test_sse_replay.py`, 6 cases

```
pytest tests/web/test_sse_replay.py
6 passed in 0.16s
```

Tests cover: fresh connect (no `replay` field), resume from known id, resume from unknown/evicted id, filter exclusion, eviction at capacity, and `replay_buffer_size=0` disabling the feature.

**Test Configuration**:
- Python version: 3.12.0
- OS: macOS (Darwin 25.3.0)
- Storage backend: not exercised (`SSEManager` is decoupled from storage)
- Installation method: editable, minimal venv (fastapi, sse-starlette, pytest, pytest-asyncio, python-dotenv)

I did not run `bash scripts/pr/pre_pr_check.sh` end-to-end — my dev environment doesn't have the full ML/storage stack. The change is scoped to `SSEManager` and its config knob; the new tests exercise it in isolation without touching storage. CI will be authoritative.

## Documentation

- [x] Updated CHANGELOG.md (entry under `## [Unreleased]`)
- [x] Updated code comments/docstrings
- [ ] README/Wiki — not updated in this PR; the new env var follows the existing `MCP_SSE_HEARTBEAT` pattern.

## Additional Notes

I appreciate what you've built. I hope this small contribution provides value for others running long-lived SSE consumers behind paths where idle drops are routine.