### PR TITLE
chore: release v10.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [10.60.0] - 2026-05-17
+## [10.60.0] - 2026-05-18
 
 ### Added
 
 - **feat(consolidation): temporal contradiction detection via embedding similarity band** ([#949](https://github.com/doobidoo/mcp-memory-service/pull/949), @filhocf): New module `src/mcp_memory_service/consolidation/contradictions.py`. Detects contradictions using a similarity band of 0.4–0.75 (too similar to be independent facts, too different to be duplicates). Emits a `CONTRADICTED_BY` graph edge and sets `superseded_by` on the older memory. Opt-in via `MCP_CONTRADICTION_DETECTION_ENABLED=true` and `MCP_CONTRADICTION_ON_STORE=true`. Integrated as Step 7 in `handlers/quality.py` maintain flow. 8 new tests in `tests/consolidation/test_contradictions.py`.
+- **feat(benchmarks): mem0 adapter — tested end-to-end with cloud API** ([#954](https://github.com/doobidoo/mcp-memory-service/pull/954), @filhocf): Adds `scripts/benchmarks/adapters/` with an abstract `BenchmarkAdapter` base class and a concrete `Mem0Adapter` implementation that wraps the mem0 cloud API. Validated end-to-end with the mem0 cloud service. Provides a foundation for systematic latency/quality comparisons between mcp-memory-service and alternative memory backends.
 
 ### Fixed
 
 - **fix(milvus): instance-level graph cache + filter superseded in retrieve** ([#948](https://github.com/doobidoo/mcp-memory-service/pull/948), @henry201605): Replaces the class-variable `_graph_storage_cache` with an instance attribute protected by double-checked locking, preventing cross-instance contamination in tests. `retrieve()` now filters out `superseded_by` memories before trimming results to match the sqlite_vec behavior.
+- **fix(hooks): use protocol-correct default port for standard HTTPS/HTTP URLs** ([#952](https://github.com/doobidoo/mcp-memory-service/pull/952), fixes [#950](https://github.com/doobidoo/mcp-memory-service/issues/950)): `memory-client.js` and `memory-retrieval.js` used `url.port || 8443` (or `|| 8080`) as the default port. For standard `https://` URLs (e.g. Cloudflare Tunnel, reverse proxy) `url.port` is empty string — causing the fallback to always trigger and producing `https://host:8443/...` instead of the correct portless URL. Fix: use the protocol's default port (`443` for https, `80` for http) when `url.port` is absent, and omit the port from the constructed URL if it matches the protocol default. Resolves broken hook connectivity for all Cloudflare Tunnel and reverse proxy deployments.
 
 ## [10.59.2] - 2026-05-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.60.0 - feat(consolidation): temporal contradiction detection + fix(milvus): instance-level graph cache — ~2,005 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.60.0 - feat(consolidation): temporal contradiction detection + fix(milvus): instance-level graph cache + fix(hooks): tunnel/reverse-proxy port fix + feat(benchmarks): mem0 adapter — ~2,005 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,13 +496,15 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.60.0** (May 17, 2026)
+## Latest Release: **v10.60.0** (May 18, 2026)
 
-**Temporal contradiction detection + Milvus instance-level graph cache fix**
+**Temporal contradiction detection + Milvus fixes + Hooks tunnel fix + Benchmark adapters**
 
 **What's New:**
 - `feat(consolidation)`: New temporal contradiction detection module — detects contradicting facts using embedding similarity band 0.4–0.75, emits `CONTRADICTED_BY` graph edges, marks older memory with `superseded_by`. Opt-in via `MCP_CONTRADICTION_DETECTION_ENABLED=true` and `MCP_CONTRADICTION_ON_STORE=true`. 8 new tests. (#949, @filhocf)
+- `feat(benchmarks)`: Adds `scripts/benchmarks/adapters/` with abstract `BenchmarkAdapter` base + concrete `Mem0Adapter` for end-to-end mem0 cloud API comparison. (#954, @filhocf)
 - `fix(milvus)`: Replace class-variable `_graph_storage_cache` with instance attribute + double-checked locking to prevent cross-instance contamination. `retrieve()` now filters `superseded_by` memories before trimming, matching sqlite_vec behavior. (#948, @henry201605)
+- `fix(hooks)`: Use protocol-correct default port for standard HTTPS/HTTP URLs — fixes broken hook connectivity for Cloudflare Tunnel and reverse proxy deployments. (#952, fixes #950)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR releases **v10.60.0** (MINOR bump from v10.59.2) by completing the CHANGELOG and README with all four changes included in this release.

### Changes in this release (all already merged to main)

**Added:**
- `feat(consolidation)`: Temporal contradiction detection via embedding similarity band (#949, @filhocf) — new `contradictions.py` module, CONTRADICTED_BY graph edges, superseded_by marker, opt-in via env vars, 8 new tests
- `feat(benchmarks)`: mem0 adapter tested end-to-end with cloud API (#954, @filhocf) — adds `scripts/benchmarks/adapters/` with abstract base + Mem0Adapter

**Fixed:**
- `fix(milvus)`: Instance-level graph cache + filter superseded in retrieve (#948, @henry201605) — replaces class-variable cache with instance attribute + double-checked locking
- `fix(hooks)`: Use protocol-correct default port for standard HTTPS/HTTP URLs (#952, fixes #950) — resolves broken hook connectivity for Cloudflare Tunnel and reverse proxy deployments

### This PR contains

- `CHANGELOG.md`: Adds the two missing entries (fix/hooks #952 + feat/benchmarks #954) to the [10.60.0] section. Corrects the release date to 2026-05-18.
- `README.md`: Updates "What's New" bullets to list all four changes. Updates release date.
- `CLAUDE.md`: Updates version callout to reflect all four changes.

### Version files

All version files (`_version.py`, `pyproject.toml`) are already at `10.60.0` on main — no further changes needed.

### Landing page

`docs/index.html` is already at v10.60.0 with `data-target="2005"` and the correct release notes link — no changes needed.

### Post-merge steps

- [ ] Create annotated tag `v10.60.0` on main
- [ ] Publish GitHub release with CHANGELOG entry
- [ ] Re-publish here.now landing page (slug `merry-realm-j835`)
- [ ] Close related issues (#950 — hooks tunnel fix)
- [ ] Thank @filhocf (PRs #949, #954) and @henry201605 (PR #948)

### Special Thanks

- @filhocf for temporal contradiction detection (#949) and the mem0 benchmark adapter (#954)
- @henry201605 for the Milvus instance-level graph cache fix (#948)

Note: This is a fresh PR replacing the closed #951 — do not re-open that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)