### PR TITLE
fix(hooks): apply protocol-correct port fallback to session-end.js (#952 follow-up)

### DIFF
--- a/claude-hooks/core/session-end.js
+++ b/claude-hooks/core/session-end.js
@@ -223,7 +223,7 @@ function triggerQualityEvaluation(endpoint, apiKey, contentHash) {
 
         const options = {
             hostname: url.hostname,
-            port: url.port || (isHttps ? 8443 : 8000),
+            port: url.port ? Number(url.port) : (isHttps ? 443 : 80),
             path: url.pathname,
             method: 'POST',
             headers: {


### PR DESCRIPTION
## Problem

PR #952 (v10.60.0) fixed the Cloudflare Tunnel / reverse-proxy port-fallback bug in `memory-client.js` and `memory-retrieval.js`, but the same bug remained in `session-end.js` at line 226 inside `triggerQualityEvaluation()`.

```javascript
// Before (broken)
port: url.port || (isHttps ? 8443 : 8000),
```

For standard `https://` URLs without an explicit port (e.g. `https://memory.example.com`), `url.port` is the empty string `""` (falsy), so the `||` fallback always fires — producing port **8443** instead of **443**. Quality evaluation at session-end silently fails on all tunnel/reverse-proxy deployments even after upgrading to v10.60.0.

## Fix

Same one-line pattern PR #952 used in the other two files:

```javascript
// After (correct)
port: url.port ? Number(url.port) : (isHttps ? 443 : 80),
```

## Files

| File | Before | After |
|------|--------|-------|
| `memory-client.js` | Fixed by #952 | ✅ |
| `memory-retrieval.js` | Fixed by #952 | ✅ |
| `session-end-harvest.js` | Already correct (443:80 defaults) | ✅ |
| `session-end.js` line 226 | **Still broken** | ✅ Fixed here |

Closes #957

## Test plan
- [ ] Deploy against an HTTPS endpoint without an explicit port (e.g. Cloudflare Tunnel)
- [ ] Confirm `triggerQualityEvaluation` reaches the server (no silent 8443 connection failure)
- [ ] Confirm standard `http://localhost:8000` deployments unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)