### PR TITLE
fix(consolidation): repair broken contradiction detection API calls

### DIFF
--- a/src/mcp_memory_service/consolidation/contradictions.py
+++ b/src/mcp_memory_service/consolidation/contradictions.py
@@ -9,7 +9,6 @@ Integration: maintain Step 7 + opt-in MCP_CONTRADICTION_ON_STORE=true.
 
 import logging
 import os
-from typing import List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -38,16 +37,8 @@ async def detect_contradictions(storage, dry_run: bool = True) -> dict:
     }
 
     try:
-        # Get all memories with pagination
-        memories = []
-        page = 1
-        while True:
-            chunk = await storage.list_memories(page=page, page_size=500)
-            batch = (chunk or {}).get("memories", [])
-            if not batch:
-                break
-            memories.extend(batch)
-            page += 1
+        # Get all memories — returns List[Memory] dataclass instances
+        memories = await storage.get_all_memories()
 
         if not memories:
             return {**results, "message": "No memories to scan"}
@@ -55,24 +46,24 @@ async def detect_contradictions(storage, dry_run: bool = True) -> dict:
 
         # For each memory, find KNN neighbors in the similarity band
         for memory in memories:
-            content_hash = memory.get("content_hash")
-            memory_type = memory.get("memory_type")
-            content = memory.get("content", "")
+            content_hash = memory.content_hash
+            memory_type = memory.memory_type
+            content = memory.content
 
             if not content or not content_hash:
                 continue
 
-            # Skip if already superseded
-            metadata = memory.get("metadata", {}) or {}
-            if metadata.get("superseded_by"):
+            # Skip if already superseded (superseded_by lives in metadata dict)
+            if (memory.metadata or {}).get("superseded_by"):
                 continue
 
-            # Search for similar memories
+            # Search for similar memories — returns {"memories": [dict, ...], ...}
             try:
-                similar = await storage.search_memories(
+                search_result = await storage.search_memories(
                     query=content,
-                    n_results=KNN_K,
+                    limit=KNN_K,
                 )
+                similar = search_result.get("memories", []) if isinstance(search_result, dict) else []
             except Exception:
                 continue
 
@@ -80,8 +71,9 @@ async def detect_contradictions(storage, dry_run: bool = True) -> dict:
                 continue
 
             for candidate in similar:
+                # candidates are plain dicts (from Memory.to_dict() + similarity_score key)
                 cand_hash = candidate.get("content_hash")
-                similarity = candidate.get("similarity", 0)
+                similarity = candidate.get("similarity_score", 0)
 
                 # Skip self
                 if cand_hash == content_hash:
@@ -91,14 +83,14 @@ async def detect_contradictions(storage, dry_run: bool = True) -> dict:
                 if similarity < SIMILARITY_MIN or similarity > SIMILARITY_MAX:
                     continue
 
-                # Skip if same memory_type=None is wildcard (matches any)
-                cand_type = candidate.get("memory_type")
+                # Skip if types differ (None is wildcard — matches any)
+                cand_type = candidate.get("type")  # to_dict() uses "type", not "memory_type"
                 if memory_type and cand_type and memory_type != cand_type:
                     continue
 
-                # Determine which is older (by created_at)
-                mem_created = memory.get("created_at", "")
-                cand_created = candidate.get("created_at", "")
+                # Determine which is older (by created_at float timestamp)
+                mem_created = memory.created_at or 0
+                cand_created = candidate.get("created_at") or 0
 
                 if mem_created < cand_created:
                     older_hash, newer_hash = content_hash, cand_hash
@@ -153,13 +145,14 @@ async def check_contradiction_on_store(storage, content: str, content_hash: str)
         return None
 
     try:
-        similar = await storage.search_memories(query=content, n_results=KNN_K)
+        search_result = await storage.search_memories(query=content, limit=KNN_K)
+        similar = search_result.get("memories", []) if isinstance(search_result, dict) else []
         if not similar:
             return None
 
         for candidate in similar:
             cand_hash = candidate.get("content_hash")
-            similarity = candidate.get("similarity", 0)
+            similarity = candidate.get("similarity_score", 0)
 
             if cand_hash == content_hash:
                 continue


### PR DESCRIPTION
## Problem

Temporal contradiction detection (shipped as _feat(consolidation): temporal contradiction detection_ in v10.60.0) has **never worked**. Three bugs cause it to crash on every run; the exception is swallowed by a `try/except`, so `memory_quality maintain` still reports `success: true` — a completely silent failure.

Symptom (with `MCP_CONTRADICTION_DETECTION_ENABLED=true`):
```json
"contradictions": {
  "pairs_detected": 0,
  "error": "'HybridMemoryStorage' object has no attribute 'list_memories'"
}
```

## Root causes (all in `contradictions.py`)

### Bug 1 — `list_memories` does not exist
```python
# broken
chunk = await storage.list_memories(page=page, page_size=500)
```
No backend exposes `list_memories`. All backends expose `get_all_memories()` which returns `List[Memory]` directly.

### Bug 2 — dict-style access on Memory dataclasses
```python
# broken — Memory is a dataclass, not a dict
content_hash = memory.get("content_hash")
content = memory.get("content", "")
```
Exactly the documented anti-pattern from CLAUDE.md (caused PRs #466/#467/#469). Fields are top-level attributes: `memory.content_hash`, `memory.content`, `memory.memory_type`, `memory.created_at`, `memory.metadata`.

### Bug 3 — wrong `search_memories` signature and return type
```python
# broken — param is `limit`, not `n_results`; returns a dict, not a list
similar = await storage.search_memories(query=content, n_results=KNN_K)
for candidate in similar:
    similarity = candidate.get("similarity", 0)   # key is "similarity_score"
    cand_type = candidate.get("memory_type")       # to_dict() uses "type"
```

## Fix

- Replace `list_memories` pagination loop with `await storage.get_all_memories()`
- Switch all `memory.get(...)` to attribute access (`memory.content_hash`, etc.)
- Fix `search_memories` call: `limit=KNN_K`, unwrap `result.get("memories", [])`
- Fix candidate key names: `similarity_score`, `type`
- Fix `created_at` comparison: `memory.created_at or 0` vs `candidate.get("created_at") or 0`
- Same fixes applied to `check_contradiction_on_store()`
- Remove now-unused `typing` imports

Closes #959

## Test plan
- [ ] Set `MCP_CONTRADICTION_DETECTION_ENABLED=true`, run `memory_quality` with `action=maintain`
- [ ] Confirm `contradictions.error` is absent from response
- [ ] Confirm `pairs_detected` reflects actual near-duplicate pairs in the database
- [ ] Confirm `MCP_CONTRADICTION_ON_STORE=true` path no longer raises on store

🤖 Generated with [Claude Code](https://claude.com/claude-code)