### PR TITLE
fix(milvus): use query() instead of search() for semantic dedup (#938)

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1328,8 +1328,8 @@ class MilvusMemoryStorage(MemoryStorage):
     def _cosine_similarity(a: List[float], b: List[float]) -> float:
         """Compute cosine similarity between two vectors (pure Python)."""
         dot = sum(x * y for x, y in zip(a, b))
-        norm_a = sum(x * x for x in a) ** 0.5
-        norm_b = sum(x * x for x in b) ** 0.5
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(x * x for x in b))
         if norm_a == 0 or norm_b == 0:
             return 0.0
         return dot / (norm_a * norm_b)
@@ -1378,11 +1378,20 @@ class MilvusMemoryStorage(MemoryStorage):
         if not rows:
             return False, None
 
+        # Pre-compute query embedding norm once — it is constant across all candidates.
+        norm_embedding = math.sqrt(sum(x * x for x in embedding))
+        if norm_embedding == 0:
+            return False, None
+
         for row in rows:
             row_vec = row.get("vector")
             if not row_vec:
                 continue
-            similarity = self._cosine_similarity(embedding, row_vec)
+            norm_row = math.sqrt(sum(x * x for x in row_vec))
+            if norm_row == 0:
+                continue
+            dot = sum(x * y for x, y in zip(embedding, row_vec))
+            similarity = dot / (norm_embedding * norm_row)
             if similarity >= similarity_threshold:
                 return True, row.get("id")
         return False, None

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1324,6 +1324,16 @@ class MilvusMemoryStorage(MemoryStorage):
 
     # -- Semantic dedup ------------------------------------------------------
 
+    @staticmethod
+    def _cosine_similarity(a: List[float], b: List[float]) -> float:
+        """Compute cosine similarity between two vectors (pure Python)."""
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = sum(x * x for x in a) ** 0.5
+        norm_b = sum(x * x for x in b) ** 0.5
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
     async def _check_semantic_duplicate(
         self,
         content: str,
@@ -1332,11 +1342,15 @@ class MilvusMemoryStorage(MemoryStorage):
     ) -> Tuple[bool, Optional[str]]:
         """Look for a recently stored memory that is semantically similar.
 
-        Returns ``(is_duplicate, existing_hash)``. Mirrors the sqlite_vec
-        implementation: search the top-N nearest neighbours without a
-        server-side time filter (some Milvus Lite versions raise
-        ``Method not implemented`` for filtered ANN searches) and applies
-        the time-window cut-off on the client instead.
+        Returns ``(is_duplicate, existing_hash)``.
+
+        Uses ``query()`` (brute-force scan) instead of ``search()`` (ANN) to
+        guarantee visibility of data in growing segments on Milvus Lite.  ANN
+        search may not find freshly inserted records whose segment has not yet
+        been sealed/indexed — see GitHub issue #938.
+
+        The query fetches recent memories with their vectors, then computes
+        cosine similarity on the client side.
         """
         if not self._ensure_initialized():
             return False, None
@@ -1349,32 +1363,28 @@ class MilvusMemoryStorage(MemoryStorage):
             return False, None
 
         try:
-            results = await self._call_client(
-                "search",
+            rows = await self._call_client(
+                "query",
                 collection_name=self.collection_name,
-                data=[embedding],
-                anns_field="vector",
-                limit=10,
-                output_fields=["id", "created_at"],
-                search_params={"metric_type": "COSINE"},
-                consistency_level="Session",
+                filter=f"created_at >= {cutoff}",
+                output_fields=["id", "vector", "created_at"],
+                limit=50,
+                consistency_level="Strong",
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Semantic dedup search failed: %s", exc)
+            logger.warning("Semantic dedup query failed: %s", exc)
             return False, None
 
-        if not results or not results[0]:
+        if not rows:
             return False, None
 
-        for hit in results[0]:
-            entity = hit.get("entity") or hit
-            hit_created = float(entity.get("created_at") or 0.0)
-            if hit_created < cutoff:
+        for row in rows:
+            row_vec = row.get("vector")
+            if not row_vec:
                 continue
-            similarity = float(hit.get("distance", 0.0))
+            similarity = self._cosine_similarity(embedding, row_vec)
             if similarity >= similarity_threshold:
-                hit_id = entity.get("id") or hit.get("id")
-                return True, hit_id
+                return True, row.get("id")
         return False, None
 
     # -- Store ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

ANN `search()` cannot find records in unsealed/unindexed growing segments on Milvus Lite, causing semantic dedup to miss near-duplicates stored moments earlier. `test_semantic_dedup_blocks_near_duplicate` failed with `assert not True`.

## Fix

Based on PR #963 by @henry201605 — thank you for the root-cause analysis and fix.

- Replace `search()` with `query(consistency_level="Strong")` + server-side `created_at >= cutoff` filter — brute-force scan reliably reads growing segment data regardless of index state
- Add `_cosine_similarity()` static method (pure Python) for client-side similarity computation
- **Optimization applied over #963**: pre-compute query embedding norm (`norm_embedding`) once before the candidate loop instead of inside `_cosine_similarity` on every iteration — avoids redundant O(d) work per row (Gemini review feedback)
- Use `math.sqrt()` instead of `** 0.5` (more idiomatic, marginally faster)
- `limit=50` gives 5× wider coverage vs the former `search(limit=10)`; server-side time filter keeps the candidate set bounded to the configured window

## Testing

- `test_semantic_dedup_blocks_near_duplicate`: ✅ PASSED (previously failing)
- Full Milvus test suite: ✅ 53 tests pass, no regression

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)