### PR TITLE
chore: release v10.60.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **feat(sse): Last-Event-ID replay on `/api/events` reconnect**: Bounded ring buffer of recently broadcast events lets SSE clients resume after a transient disconnect per the standard EventSource resume header. Buffer size configurable via `MCP_SSE_REPLAY_BUFFER_SIZE` (default 1000, 0 disables). Replay outcome (`status: resumed` or `status: id_not_in_buffer`) is surfaced in the `connection_established` welcome event so clients can detect overflow and fall back to their own catch-up strategy. Connection-scoped events (welcome, close) and heartbeats are not buffered; filtered broadcasts are excluded to avoid expanding the original audience on replay.
 
+## [10.60.2] - 2026-05-19
+
+### Fixed
+
+- **fix(milvus): replace ANN `search()` with brute-force `query()` in semantic dedup to fix growing-segment visibility on Milvus Lite** ([#964](https://github.com/doobidoo/mcp-memory-service/pull/964), closes [#938](https://github.com/doobidoo/mcp-memory-service/issues/938), @henry201605): Milvus Lite's ANN `search()` cannot find freshly inserted records in unsealed (growing) segments, causing the semantic deduplication check to silently miss near-duplicates. The fix replaces `search()` with `query(consistency_level="Strong")` + client-side cosine similarity computed from the pre-stored normalized embedding and a pre-computed query norm, restoring correct deduplication behaviour on Milvus Lite.
+
 ## [10.60.1] - 2026-05-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.60.1 - fix(milvus): tag_match param in get_all_memories/count_all_memories + fix(hooks): session-end port fallback + fix(consolidation): repair contradiction detection — ~2,005 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.60.2 - fix(milvus): replace ANN search() with brute-force query() in semantic dedup to fix growing-segment visibility on Milvus Lite — ~2,005 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,18 +496,17 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.60.1** (May 19, 2026)
+## Latest Release: **v10.60.2** (May 19, 2026)
 
-**Patch: Milvus tag_match fix + Session-end port fallback + Contradiction detection repair**
+**Patch: Milvus Lite growing-segment visibility fix for semantic dedup**
 
 **What's New:**
-- `fix(milvus)`: Add missing `tag_match` param to `get_all_memories`/`count_all_memories` (#958, @henry201605)
-- `fix(hooks)`: Apply protocol-correct port fallback to `session-end.js` `triggerQualityEvaluation` (#960, fixes #957)
-- `fix(consolidation)`: Repair broken contradiction detection — `list_memories`→`get_all_memories`, dataclass attribute access, `search_memories` param/return type (#961, fixes #959)
+- `fix(milvus)`: Replace ANN `search()` with brute-force `query(consistency_level="Strong")` + client-side cosine similarity in semantic dedup — fixes Milvus Lite growing-segment visibility bug (#964, closes #938, @henry201605)
 
 ---
 
 **Previous Releases**:
+- **v10.60.1** - fix(milvus): tag_match param in get_all_memories/count_all_memories + fix(hooks): session-end port fallback + fix(consolidation): repair contradiction detection (PRs #958, #960, #961)
 - **v10.60.0** - feat(consolidation): temporal contradiction detection + fix(milvus): instance-level graph cache + fix(hooks): tunnel/reverse-proxy port fix + feat(benchmarks): mem0 adapter (PRs #949, #954, #948, #952)
 - **v10.59.2** - fix(oauth): AnyUrl for redirect_uri so IDE schemes (cursor://, vscode://) pass Pydantic validation (#942, @tkislan)
 - **v10.59.1** - fix(oauth): reflect state parameter verbatim per RFC 6749 §4.1.2, fixes Cursor OAuth (#944, @tkislan)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.60.1"
+version = "10.60.2"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.60.1"
+__version__ = "10.60.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.60.1"
+version = "10.60.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Patch release v10.60.2.

- Version bump: `10.60.1` → `10.60.2` in `_version.py`, `pyproject.toml`, `uv.lock`
- CHANGELOG: new `[10.60.2]` section added under `[Unreleased]`
- README: Latest Release updated to v10.60.2; v10.60.1 moved to Previous Releases
- CLAUDE.md: Current Version callout updated

## Change included

**fix(milvus): replace ANN `search()` with brute-force `query()` in semantic dedup** ([#964](https://github.com/doobidoo/mcp-memory-service/pull/964), closes [#938](https://github.com/doobidoo/mcp-memory-service/issues/938), @henry201605)

Milvus Lite's ANN `search()` cannot find freshly inserted records in unsealed (growing) segments. The fix uses `query(consistency_level="Strong")` + client-side cosine similarity with a pre-computed query norm, restoring correct deduplication behaviour.

## Notes

- PATCH release — `docs/index.html` NOT updated (no landing page changes)
- PyPI publishes automatically via GitHub Actions on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)