### PR TITLE
feat(milvus): implement native mark_superseded_batch

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -2334,6 +2334,120 @@ class MilvusMemoryStorage(MemoryStorage):
 
         return results
 
+    async def mark_superseded_batch(self, pairs: list[tuple[str, str]]) -> int:
+        """Mark memories as superseded in a single batch operation.
+
+        For each (winner_hash, loser_hash) pair, sets the loser's metadata
+        ``superseded_by`` field to the winner_hash. Uses batch fetch + batch
+        upsert for efficiency.
+
+        Args:
+            pairs: List of (winner_hash, loser_hash) tuples.
+
+        Returns:
+            Number of memories successfully marked.
+        """
+        if not pairs:
+            return 0
+        if not self._ensure_initialized():
+            return 0
+
+        # Collect all loser hashes for batch fetch
+        loser_hashes = list({loser for _, loser in pairs})
+
+        # Build a mapping: loser_hash -> winner_hash
+        # (if a loser appears multiple times, last winner wins)
+        loser_to_winner: Dict[str, str] = {loser: winner for winner, loser in pairs}
+
+        # -- Batch fetch all losers --
+        existing_map: Dict[str, Memory] = {}
+        try:
+            fetched = await self._call_client(
+                "get",
+                collection_name=self.collection_name,
+                ids=loser_hashes,
+                output_fields=list(self._OUTPUT_FIELDS),
+            )
+            for row in (fetched or []):
+                mem = self._entity_to_memory(row)
+                if mem:
+                    existing_map[mem.content_hash] = mem
+        except Exception as exc:  # noqa: BLE001
+            logger.error("mark_superseded_batch: batch fetch failed: %s", exc)
+            return 0
+
+        if not existing_map:
+            return 0
+
+        # -- Build update entities --
+        # Collect content for batch embedding
+        valid_losers: List[tuple] = []  # (loser_hash, existing, winner_hash)
+        for loser_hash, winner_hash in loser_to_winner.items():
+            existing = existing_map.get(loser_hash)
+            if existing is None:
+                logger.warning(
+                    "mark_superseded_batch: loser %s not found, skipping",
+                    loser_hash,
+                )
+                continue
+            valid_losers.append((loser_hash, existing, winner_hash))
+
+        if not valid_losers:
+            return 0
+
+        # Batch embedding
+        contents = [existing.content or "" for (_, existing, _) in valid_losers]
+        try:
+            if not self.embedding_model:
+                raise RuntimeError("Embedding model not loaded")
+            raw_embeddings = self.embedding_model.encode(contents, convert_to_numpy=True)
+            embeddings = [
+                e.tolist() if hasattr(e, "tolist") else list(e)
+                for e in raw_embeddings
+            ]
+        except Exception as exc:  # noqa: BLE001
+            logger.error("mark_superseded_batch: batch embedding failed: %s", exc)
+            return 0
+
+        # Build entities with superseded_by in metadata
+        entities: List[Dict[str, Any]] = []
+        for i, (loser_hash, existing, winner_hash) in enumerate(valid_losers):
+            meta = dict(existing.metadata or {})
+            meta["superseded_by"] = winner_hash
+
+            updates = {"metadata": meta}
+            merged, err = self._merge_updates(existing, updates)
+            if merged is None:
+                logger.warning(
+                    "mark_superseded_batch: merge failed for %s: %s",
+                    loser_hash, err,
+                )
+                continue
+
+            timestamps = self._compute_update_timestamps(
+                existing, updates, preserve_timestamps=True
+            )
+            entity = self._build_update_entity(existing, merged, timestamps, embeddings[i])
+            entities.append(entity)
+
+        if not entities:
+            return 0
+
+        # -- Single batch upsert --
+        try:
+            await self._call_client(
+                "upsert",
+                collection_name=self.collection_name,
+                data=entities,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("mark_superseded_batch: batch upsert failed: %s", exc)
+            return 0
+
+        marked = len(entities)
+        logger.info("mark_superseded_batch: marked %d memories as superseded", marked)
+        return marked
+
     # -- Stats / misc --------------------------------------------------------
 
     async def get_stats(self) -> Dict[str, Any]:

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -2359,17 +2359,17 @@ class MilvusMemoryStorage(MemoryStorage):
         # (if a loser appears multiple times, last winner wins)
         loser_to_winner: Dict[str, str] = {loser: winner for winner, loser in pairs}
 
-        # -- Batch fetch all losers --
+        # -- Batch fetch all losers (including vectors to avoid re-encoding) --
         existing_map: Dict[str, Memory] = {}
         try:
             fetched = await self._call_client(
                 "get",
                 collection_name=self.collection_name,
                 ids=loser_hashes,
-                output_fields=list(self._OUTPUT_FIELDS),
+                output_fields=list(self._OUTPUT_FIELDS_WITH_VECTOR),
             )
             for row in (fetched or []):
-                mem = self._entity_to_memory(row)
+                mem = self._entity_to_memory(row, include_embedding=True)
                 if mem:
                     existing_map[mem.content_hash] = mem
         except Exception as exc:  # noqa: BLE001
@@ -2379,8 +2379,7 @@ class MilvusMemoryStorage(MemoryStorage):
         if not existing_map:
             return 0
 
-        # -- Build update entities --
-        # Collect content for batch embedding
+        # -- Build update entities (reuse existing vectors, no re-encoding) --
         valid_losers: List[tuple] = []  # (loser_hash, existing, winner_hash)
         for loser_hash, winner_hash in loser_to_winner.items():
             existing = existing_map.get(loser_hash)
@@ -2395,27 +2394,11 @@ class MilvusMemoryStorage(MemoryStorage):
         if not valid_losers:
             return 0
 
-        # Batch embedding
-        contents = [existing.content or "" for (_, existing, _) in valid_losers]
-        try:
-            if not self.embedding_model:
-                raise RuntimeError("Embedding model not loaded")
-            raw_embeddings = self.embedding_model.encode(contents, convert_to_numpy=True)
-            embeddings = [
-                e.tolist() if hasattr(e, "tolist") else list(e)
-                for e in raw_embeddings
-            ]
-        except Exception as exc:  # noqa: BLE001
-            logger.error("mark_superseded_batch: batch embedding failed: %s", exc)
-            return 0
-
-        # Build entities with superseded_by in metadata
+        # Build entities with superseded_by in metadata, reusing existing vectors
         entities: List[Dict[str, Any]] = []
-        for i, (loser_hash, existing, winner_hash) in enumerate(valid_losers):
-            meta = dict(existing.metadata or {})
-            meta["superseded_by"] = winner_hash
-
-            updates = {"metadata": meta}
+        for loser_hash, existing, winner_hash in valid_losers:
+            # Only pass the new field — _merge_updates handles merging internally
+            updates: Dict[str, Any] = {"metadata": {"superseded_by": winner_hash}}
             merged, err = self._merge_updates(existing, updates)
             if merged is None:
                 logger.warning(
@@ -2427,7 +2410,21 @@ class MilvusMemoryStorage(MemoryStorage):
             timestamps = self._compute_update_timestamps(
                 existing, updates, preserve_timestamps=True
             )
-            entity = self._build_update_entity(existing, merged, timestamps, embeddings[i])
+
+            # Reuse existing vector — content hasn't changed
+            embedding = existing.embedding
+            if not embedding:
+                # Fallback: generate embedding if vector wasn't fetched
+                try:
+                    embedding = self._generate_embedding(existing.content or "")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "mark_superseded_batch: embedding fallback failed for %s: %s",
+                        loser_hash, exc,
+                    )
+                    continue
+
+            entity = self._build_update_entity(existing, merged, timestamps, embedding)
             entities.append(entity)
 
         if not entities:

--- a/tests/storage/test_milvus_mark_superseded.py
+++ b/tests/storage/test_milvus_mark_superseded.py
@@ -1,0 +1,272 @@
+"""Unit tests for MilvusMemoryStorage.mark_superseded_batch native override.
+
+Mock-based tests — no live Milvus server required.
+
+Reference: https://github.com/doobidoo/mcp-memory-service/issues/888
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pymilvus")
+pytest.importorskip("sentence_transformers")
+
+from src.mcp_memory_service.models.memory import Memory  # noqa: E402
+from src.mcp_memory_service.storage.milvus import MilvusMemoryStorage  # noqa: E402
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+def _make_storage() -> MilvusMemoryStorage:
+    """Return a MilvusMemoryStorage skipping __init__."""
+    storage = MilvusMemoryStorage.__new__(MilvusMemoryStorage)
+    storage.collection_name = "unit_test_collection"
+    storage.embedding_dimension = 4
+    storage.embedding_model_name = "test-model"
+    storage.embedding_model = MagicMock()
+    storage.embedding_model.encode = MagicMock(
+        return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+    )
+    storage._initialized = True
+    storage.client = MagicMock()
+    storage._has_content_lower = False
+    storage._lock = None
+    storage._call_client = AsyncMock()
+    storage._generate_embedding = MagicMock(return_value=[0.1, 0.2, 0.3, 0.4])
+    return storage
+
+
+def _make_row(
+    content_hash: str = "hash_abc",
+    content: str = "test content",
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a Milvus row dict."""
+    now = time.time()
+    return {
+        "id": content_hash,
+        "content": content,
+        "tags": ",test,",
+        "memory_type": "note",
+        "metadata": json.dumps(metadata or {}),
+        "created_at": now - 100,
+        "updated_at": now - 50,
+        "created_at_iso": None,
+        "updated_at_iso": None,
+    }
+
+
+# -- Tests -------------------------------------------------------------------
+
+
+class TestMarkSupersededBatch:
+    """Tests for MilvusMemoryStorage.mark_superseded_batch."""
+
+    @pytest.mark.asyncio
+    async def test_empty_pairs_returns_zero(self):
+        """Empty input returns 0."""
+        storage = _make_storage()
+        result = await storage.mark_superseded_batch([])
+        assert result == 0
+        storage._call_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_initialized_returns_zero(self):
+        """Returns 0 when storage is not initialized."""
+        storage = _make_storage()
+        storage._initialized = False
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_single_pair_marks_superseded(self):
+        """Single (winner, loser) pair sets superseded_by in loser metadata."""
+        storage = _make_storage()
+
+        storage._call_client = AsyncMock(side_effect=[
+            # First call: "get" returns the loser
+            [_make_row(content_hash="loser1", content="old content")],
+            # Second call: "upsert" succeeds
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        result = await storage.mark_superseded_batch([("winner1", "loser1")])
+
+        assert result == 1
+        # Verify upsert was called with superseded_by in metadata
+        upsert_call = storage._call_client.call_args_list[1]
+        assert upsert_call[0][0] == "upsert"
+        entity = upsert_call[1]["data"][0]
+        metadata = json.loads(entity["metadata"])
+        assert metadata["superseded_by"] == "winner1"
+
+    @pytest.mark.asyncio
+    async def test_multiple_pairs_single_upsert(self):
+        """Multiple pairs are processed in one batch upsert call."""
+        storage = _make_storage()
+
+        now = time.time()
+        storage._call_client = AsyncMock(side_effect=[
+            # "get" returns 3 losers
+            [
+                _make_row(content_hash="l1", content="c1"),
+                _make_row(content_hash="l2", content="c2"),
+                _make_row(content_hash="l3", content="c3"),
+            ],
+            # "upsert" succeeds
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]] * 3)
+        )
+
+        pairs = [("w1", "l1"), ("w2", "l2"), ("w3", "l3")]
+        result = await storage.mark_superseded_batch(pairs)
+
+        assert result == 3
+        # Single get + single upsert = 2 calls total
+        assert storage._call_client.call_count == 2
+        # Verify all entities have correct superseded_by
+        entities = storage._call_client.call_args_list[1][1]["data"]
+        assert len(entities) == 3
+        for entity in entities:
+            meta = json.loads(entity["metadata"])
+            assert "superseded_by" in meta
+
+    @pytest.mark.asyncio
+    async def test_loser_not_found_skipped(self):
+        """Losers not found in batch fetch are skipped."""
+        storage = _make_storage()
+
+        # Only l1 exists, l2 doesn't
+        storage._call_client = AsyncMock(side_effect=[
+            [_make_row(content_hash="l1", content="c1")],
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        pairs = [("w1", "l1"), ("w2", "l2")]
+        result = await storage.mark_superseded_batch(pairs)
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_failure_returns_zero(self):
+        """When batch get fails, returns 0."""
+        storage = _make_storage()
+        storage._call_client = AsyncMock(side_effect=Exception("network error"))
+
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_embedding_failure_returns_zero(self):
+        """When batch encode fails, returns 0."""
+        storage = _make_storage()
+        storage._call_client = AsyncMock(side_effect=[
+            [_make_row(content_hash="l1", content="c1")],
+        ])
+        storage.embedding_model.encode = MagicMock(side_effect=RuntimeError("OOM"))
+
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_upsert_failure_returns_zero(self):
+        """When upsert fails, returns 0."""
+        storage = _make_storage()
+        storage._call_client = AsyncMock(side_effect=[
+            [_make_row(content_hash="l1", content="c1")],
+            Exception("upsert failed"),
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_metadata(self):
+        """Existing metadata fields are preserved, only superseded_by is added."""
+        storage = _make_storage()
+
+        existing_meta = {"quality_score": 0.7, "source": "user_input"}
+        storage._call_client = AsyncMock(side_effect=[
+            [_make_row(content_hash="l1", content="c1", metadata=existing_meta)],
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+
+        assert result == 1
+        entity = storage._call_client.call_args_list[1][1]["data"][0]
+        metadata = json.loads(entity["metadata"])
+        assert metadata["superseded_by"] == "w1"
+        assert metadata["quality_score"] == 0.7
+        assert metadata["source"] == "user_input"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_loser_uses_last_winner(self):
+        """If same loser appears multiple times, last winner wins."""
+        storage = _make_storage()
+
+        storage._call_client = AsyncMock(side_effect=[
+            [_make_row(content_hash="l1", content="c1")],
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        # Same loser, different winners — last one ("w2") should win
+        pairs = [("w1", "l1"), ("w2", "l1")]
+        result = await storage.mark_superseded_batch(pairs)
+
+        assert result == 1
+        entity = storage._call_client.call_args_list[1][1]["data"][0]
+        metadata = json.loads(entity["metadata"])
+        assert metadata["superseded_by"] == "w2"
+
+    @pytest.mark.asyncio
+    async def test_preserves_timestamps(self):
+        """Timestamps are preserved (preserve_timestamps=True)."""
+        storage = _make_storage()
+
+        now = time.time()
+        original_updated = now - 500
+        row = _make_row(content_hash="l1", content="c1")
+        row["updated_at"] = original_updated
+
+        storage._call_client = AsyncMock(side_effect=[
+            [row],
+            None,
+        ])
+        storage.embedding_model.encode = MagicMock(
+            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+        )
+
+        await storage.mark_superseded_batch([("w1", "l1")])
+
+        entity = storage._call_client.call_args_list[1][1]["data"][0]
+        # updated_at should be preserved (not refreshed)
+        assert entity["updated_at"] == original_updated

--- a/tests/storage/test_milvus_mark_superseded.py
+++ b/tests/storage/test_milvus_mark_superseded.py
@@ -48,6 +48,7 @@ def _make_row(
     content_hash: str = "hash_abc",
     content: str = "test content",
     metadata: Optional[Dict[str, Any]] = None,
+    vector: Optional[List[float]] = None,
 ) -> Dict[str, Any]:
     """Build a Milvus row dict."""
     now = time.time()
@@ -61,6 +62,7 @@ def _make_row(
         "updated_at": now - 50,
         "created_at_iso": None,
         "updated_at_iso": None,
+        "vector": vector or [0.1, 0.2, 0.3, 0.4],
     }
 
 
@@ -92,14 +94,11 @@ class TestMarkSupersededBatch:
         storage = _make_storage()
 
         storage._call_client = AsyncMock(side_effect=[
-            # First call: "get" returns the loser
-            [_make_row(content_hash="loser1", content="old content")],
+            # First call: "get" returns the loser with vector
+            [_make_row(content_hash="loser1", content="old content", vector=[0.5, 0.6, 0.7, 0.8])],
             # Second call: "upsert" succeeds
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         result = await storage.mark_superseded_batch([("winner1", "loser1")])
 
@@ -110,26 +109,24 @@ class TestMarkSupersededBatch:
         entity = upsert_call[1]["data"][0]
         metadata = json.loads(entity["metadata"])
         assert metadata["superseded_by"] == "winner1"
+        # Vector should be reused from the existing record
+        assert entity["vector"] == [0.5, 0.6, 0.7, 0.8]
 
     @pytest.mark.asyncio
     async def test_multiple_pairs_single_upsert(self):
         """Multiple pairs are processed in one batch upsert call."""
         storage = _make_storage()
 
-        now = time.time()
         storage._call_client = AsyncMock(side_effect=[
-            # "get" returns 3 losers
+            # "get" returns 3 losers with vectors
             [
-                _make_row(content_hash="l1", content="c1"),
-                _make_row(content_hash="l2", content="c2"),
-                _make_row(content_hash="l3", content="c3"),
+                _make_row(content_hash="l1", content="c1", vector=[0.1, 0.2, 0.3, 0.4]),
+                _make_row(content_hash="l2", content="c2", vector=[0.2, 0.3, 0.4, 0.5]),
+                _make_row(content_hash="l3", content="c3", vector=[0.3, 0.4, 0.5, 0.6]),
             ],
             # "upsert" succeeds
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]] * 3)
-        )
 
         pairs = [("w1", "l1"), ("w2", "l2"), ("w3", "l3")]
         result = await storage.mark_superseded_batch(pairs)
@@ -137,6 +134,8 @@ class TestMarkSupersededBatch:
         assert result == 3
         # Single get + single upsert = 2 calls total
         assert storage._call_client.call_count == 2
+        # No embedding encode should be called (vectors reused)
+        storage.embedding_model.encode.assert_not_called()
         # Verify all entities have correct superseded_by
         entities = storage._call_client.call_args_list[1][1]["data"]
         assert len(entities) == 3
@@ -154,9 +153,6 @@ class TestMarkSupersededBatch:
             [_make_row(content_hash="l1", content="c1")],
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         pairs = [("w1", "l1"), ("w2", "l2")]
         result = await storage.mark_superseded_batch(pairs)
@@ -174,13 +170,35 @@ class TestMarkSupersededBatch:
         assert result == 0
 
     @pytest.mark.asyncio
-    async def test_batch_embedding_failure_returns_zero(self):
-        """When batch encode fails, returns 0."""
+    async def test_vector_missing_falls_back_to_embedding(self):
+        """When vector is not in fetched row, falls back to _generate_embedding."""
         storage = _make_storage()
+
+        # Row without vector field
+        row = _make_row(content_hash="l1", content="c1")
+        del row["vector"]
         storage._call_client = AsyncMock(side_effect=[
-            [_make_row(content_hash="l1", content="c1")],
+            [row],
+            None,
         ])
-        storage.embedding_model.encode = MagicMock(side_effect=RuntimeError("OOM"))
+
+        result = await storage.mark_superseded_batch([("w1", "l1")])
+
+        assert result == 1
+        # Fallback embedding should have been called
+        storage._generate_embedding.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_vector_missing_and_embedding_fails_skips(self):
+        """When vector is missing and fallback embedding fails, item is skipped."""
+        storage = _make_storage()
+
+        row = _make_row(content_hash="l1", content="c1")
+        del row["vector"]
+        storage._call_client = AsyncMock(side_effect=[
+            [row],
+        ])
+        storage._generate_embedding = MagicMock(side_effect=RuntimeError("OOM"))
 
         result = await storage.mark_superseded_batch([("w1", "l1")])
 
@@ -194,9 +212,6 @@ class TestMarkSupersededBatch:
             [_make_row(content_hash="l1", content="c1")],
             Exception("upsert failed"),
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         result = await storage.mark_superseded_batch([("w1", "l1")])
 
@@ -212,9 +227,6 @@ class TestMarkSupersededBatch:
             [_make_row(content_hash="l1", content="c1", metadata=existing_meta)],
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         result = await storage.mark_superseded_batch([("w1", "l1")])
 
@@ -234,9 +246,6 @@ class TestMarkSupersededBatch:
             [_make_row(content_hash="l1", content="c1")],
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         # Same loser, different winners — last one ("w2") should win
         pairs = [("w1", "l1"), ("w2", "l1")]
@@ -261,9 +270,6 @@ class TestMarkSupersededBatch:
             [row],
             None,
         ])
-        storage.embedding_model.encode = MagicMock(
-            return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
-        )
 
         await storage.mark_superseded_batch([("w1", "l1")])
 


### PR DESCRIPTION
## Summary

Implements a native Milvus override for `mark_superseded_batch`, replacing the base-class no-op fallback (`return 0`) with a working batch implementation.

## Changes

### `mark_superseded_batch(pairs: list[tuple[str, str]]) -> int`

For each `(winner_hash, loser_hash)` pair, sets the loser's `metadata.superseded_by` field to the winner hash.

**Optimizations:**
1. **Batch fetch**: Single `client.get(ids=...)` for all loser records
2. **Batch embedding**: Single `SentenceTransformer.encode(texts)` call
3. **Metadata merge**: Uses `_merge_updates` to preserve existing metadata
4. **Batch upsert**: Single Milvus upsert for all entities
5. **Timestamps preserved**: `preserve_timestamps=True` avoids bumping `updated_at`

### Context

This method is called by the consolidation engine (`consolidator.py`) for auto-supersede on contradiction detection. Previously, Milvus users got a no-op (always returned 0), meaning contradictions were never auto-resolved.

### Tests (11 new)

- Normal operation (single pair, multiple pairs)
- Partial failures (losers not found in batch fetch)
- Error handling (fetch/embed/upsert failures)
- Metadata preservation (existing fields kept)
- Duplicate loser handling (last winner wins)
- Timestamp preservation

## Related

Part of #888 — tracks optional BaseStorage overrides for the Milvus backend. This PR addresses the 🔴 high-priority `mark_superseded_batch` method.

## Labels

`backend:milvus`