### PR TITLE
docs: modernize server commands to memory CLI

### DIFF
--- a/.claude/directives/storage-backends.md
+++ b/.claude/directives/storage-backends.md
@@ -59,8 +59,7 @@ export CLOUDFLARE_VECTORIZE_INDEX="mcp-memory-index"
 MCP_MEMORY_SQLITE_PRAGMAS=busy_timeout=15000,cache_size=20000
 
 # Restart HTTP server
-kill <PID>
-uv run python scripts/server/run_http_server.py
+memory restart
 
 # Restart MCP servers
 # Use /mcp in Claude Code to reconnect, or restart Claude Desktop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Documentation
+
+- **docs: modernize server commands to `memory` CLI** ([#969](https://github.com/doobidoo/mcp-memory-service/pull/969)): Sweep across 23 docs files replacing outdated/dead startup commands with the modern `memory` lifecycle CLI (`launch`, `server`, `restart`). Fixes broken refs (`python scripts/run_http_server.py` — wrong path; `./start_all_servers.sh`, `./stop_all_servers.sh`, `./status_servers.sh`, `python run_server.py` — no longer exist; `python -m src.mcp_memory_service.server` — invalid module path). Modernizes legacy patterns (`uv run memory server` → `memory launch` for HTTP or `memory server` for MCP stdio/Inspector; `python scripts/server/run_http_server.py` → `memory launch`; `./scripts/update_and_restart.sh` → `memory restart`). systemd `ExecStart=` paths, the `claude-hooks/PLUGIN.md` spawn fallback chain, and `python -m mcp_memory_service.server` for MCP stdio are intentionally preserved.
+
 ## [10.61.0] - 2026-05-19
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,16 @@ Answer questions in Issues, Discussions, or help other users.
 
 5. **Run the service**:
    ```bash
-   uv run memory server
+   # HTTP server (background, dashboard + REST API, recommended)
+   memory launch
+
+   # OR MCP stdio server (for Claude Desktop integration)
+   memory server
    ```
 
-6. **Test with MCP Inspector** (optional):
+6. **Test with MCP Inspector** (optional, stdio child process):
    ```bash
-   npx @modelcontextprotocol/inspector uv run memory server
+   npx @modelcontextprotocol/inspector memory server
    ```
 
 ### Alternative: Docker Setup

--- a/docs/assets/images/README.md
+++ b/docs/assets/images/README.md
@@ -33,7 +33,7 @@ The modern dashboard includes:
 
 To capture the dashboard for documentation:
 
-1. Ensure the HTTP server is running: `python scripts/run_http_server.py`
+1. Ensure the HTTP server is running: `memory launch`
 2. Wait for stats to load (shows actual memory count)
 3. Take full-page screenshot at 1920x1080 resolution
 4. Save as `dashboard-v3.3.0.png` in this directory

--- a/docs/cloudflare-setup.md
+++ b/docs/cloudflare-setup.md
@@ -43,11 +43,11 @@ export CLOUDFLARE_D1_DATABASE_ID="your-d1-database-id"
 export CLOUDFLARE_R2_BUCKET="mcp-memory-content"  # Optional
 
 # 4. Test and start
-python -m src.mcp_memory_service.server
+memory launch                   # HTTP server (background, recommended)
 
 # Alternative startup methods:
-# uv run memory server          # Modern CLI (recommended)
-# python scripts/run_memory_server.py  # Direct script execution
+# memory server                 # MCP stdio (for Claude Desktop)
+# python -m mcp_memory_service.server  # MCP stdio (module form)
 ```
 
 > **⚠️ Important**: Cloudflare backend uses Workers AI for embedding generation, so do NOT use `scripts/memory_offline.py` which sets offline mode. Use the standard startup methods above instead.

--- a/docs/development/ai-agent-instructions.md
+++ b/docs/development/ai-agent-instructions.md
@@ -25,14 +25,14 @@ pip show mcp-memory-service | grep Location
 # Verify version consistency (detects stale venv)
 python scripts/validation/check_dev_setup.py
 
-# Start development server
-uv run memory server
+# Start MCP stdio server (for Claude Desktop)
+memory server
 
-# Run with inspector for debugging
-npx @modelcontextprotocol/inspector uv run memory server
+# Run with inspector for debugging (stdio child process)
+npx @modelcontextprotocol/inspector memory server
 
-# Start HTTP API server (dashboard at http://localhost:8000)
-uv run python scripts/server/run_http_server.py
+# Start HTTP API server (dashboard at http://localhost:8000, background)
+memory launch
 ```
 
 **Why `-e` flag matters**: MCP servers load from `site-packages`, not source files. Without editable install, source code changes won't take effect until you reinstall. System restart won't help - it just relaunches with the same stale package.
@@ -105,7 +105,7 @@ src/mcp_memory_service/
 ### Modifying MCP Tools
 1. Edit tool definitions in `src/mcp_memory_service/mcp_server.py`
 2. Update tool handlers in the same file
-3. Test with MCP inspector: `npx @modelcontextprotocol/inspector uv run memory server`
+3. Test with MCP inspector: `npx @modelcontextprotocol/inspector memory server`
 4. Update documentation in `docs/api/tools.md`
 
 ### Adding Environment Variables
@@ -157,7 +157,7 @@ curl http://localhost:8000/api/health
 tail -f ~/.mcp-memory-service/logs/service.log
 
 # Inspect MCP communication
-npx @modelcontextprotocol/inspector uv run memory server
+npx @modelcontextprotocol/inspector memory server
 
 # Database debugging
 sqlite3 ~/.mcp-memory-service/sqlite_vec.db ".tables"

--- a/docs/features/knowledge-graph-dashboard.md
+++ b/docs/features/knowledge-graph-dashboard.md
@@ -129,11 +129,8 @@ Memories are color-coded by type in the graph:
 The Knowledge Graph Dashboard is part of the HTTP dashboard server:
 
 ```bash
-# Start both MCP and HTTP servers
-./start_all_servers.sh
-
-# Or start HTTP server only
-python scripts/server/run_http_server.py
+# Start the HTTP dashboard server (background)
+memory launch
 ```
 
 **Default URL:** http://localhost:8000
@@ -295,7 +292,7 @@ curl -H "X-API-Key: your-api-key" \
    ```
 2. **Verify backend**: Graph is SQLite-only in v9.2.0, ensure you're using `sqlite_vec` or `hybrid` backend
 3. **Check migrations**: Run `python scripts/migration/add_relationship_type_column.py` to add `relationship_type` column
-4. **Restart server**: `./scripts/update_and_restart.sh`
+4. **Restart server**: `memory restart`
 
 ### Slow Performance
 

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -178,8 +178,8 @@ source venv/bin/activate
 # Install the service
 pip install mcp-memory-service
 
-# Start the service
-uv run memory server
+# Start the service (HTTP server, background)
+memory launch
 ```
 
 ## 🔧 Troubleshooting First-Time Issues
@@ -206,7 +206,7 @@ sudo chown -R $USER:$USER ~/.mcp_memory_service/
 
 ### Issue: Service Doesn't Start After Download
 **Solution:**
-1. Check logs: `uv run memory server --debug`
+1. Check logs: `memory logs` or start in foreground: `memory launch --foreground --debug`
 2. Verify installation: `memory server --help`
 3. Restart with clean state:
    ```bash

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -25,16 +25,17 @@
 - **Run single test**: `pytest tests/test_filename.py::test_function_name -v`
 - **Run specific test class**: `pytest tests/test_filename.py::TestClass -v`
 - **Run with markers**: `pytest -m "unit or integration"`
-- **MCP Server startup**: `uv run memory server`
-- **HTTP Dashboard startup**: `python run_server.py` or `./start_all_servers.sh`
+- **MCP Server startup (stdio)**: `memory server` (for Claude Desktop)
+- **HTTP Dashboard startup**: `memory launch` (background, PID tracking, health check)
 - **Install dependencies**: `python scripts/installation/install.py`
 
 ## Server Management Commands
-- **Start all servers**: `./start_all_servers.sh` (both MCP + HTTP Dashboard)
-- **Stop all servers**: `./stop_all_servers.sh`
-- **Check server status**: `./status_servers.sh`
-- **View HTTP logs**: `tail -f http_server.log`
-- **View MCP logs**: `tail -f mcp_server.log`
+- **Start HTTP server**: `memory launch` (background, default)
+- **Foreground mode**: `memory launch --foreground`
+- **Stop server**: `memory stop`
+- **Restart**: `memory restart`
+- **Check server status**: `memory info`
+- **View logs**: `memory logs` or `memory logs -n 50`
 
 ## Memory Cleanup & Auto-Tagging Commands
 

--- a/docs/guides/mdns-service-discovery.md
+++ b/docs/guides/mdns-service-discovery.md
@@ -16,15 +16,15 @@ mDNS service discovery allows MCP Memory Service instances to:
 
 ```bash
 # Basic setup (mDNS enabled by default)
-python scripts/run_http_server.py
+memory launch
 
 # With HTTPS (auto-generates certificates)
 export MCP_HTTPS_ENABLED=true
-python scripts/run_http_server.py
+memory launch
 
 # Custom service name
 export MCP_MDNS_SERVICE_NAME="Team Memory Service"
-python scripts/run_http_server.py
+memory launch
 ```
 
 ### 2. Configure Client for Auto-Discovery
@@ -77,7 +77,7 @@ The server can automatically generate self-signed certificates for development:
 
 ```bash
 export MCP_HTTPS_ENABLED=true
-python scripts/run_http_server.py
+memory launch
 ```
 
 Output:
@@ -97,7 +97,7 @@ For production deployments:
 export MCP_HTTPS_ENABLED=true
 export MCP_SSL_CERT_FILE="/path/to/your/cert.pem"
 export MCP_SSL_KEY_FILE="/path/to/your/key.pem"
-python scripts/run_http_server.py
+memory launch
 ```
 
 ## Service Discovery Process
@@ -220,7 +220,7 @@ Enable detailed logging:
 **Server:**
 ```bash
 export LOG_LEVEL=DEBUG
-python scripts/run_http_server.py
+memory launch
 ```
 
 **Client:**
@@ -261,12 +261,12 @@ Deploy multiple services with different names:
 # Development server
 export MCP_MDNS_SERVICE_NAME="Dev Memory Service"
 export MCP_HTTP_PORT=8000
-python scripts/run_http_server.py &
+memory launch &
 
 # Staging server
 export MCP_MDNS_SERVICE_NAME="Staging Memory Service"
 export MCP_HTTP_PORT=8001
-python scripts/run_http_server.py &
+memory launch &
 ```
 
 Clients will discover both and can select based on preferences.

--- a/docs/guides/mdns-service-discovery.md
+++ b/docs/guides/mdns-service-discovery.md
@@ -261,12 +261,12 @@ Deploy multiple services with different names:
 # Development server
 export MCP_MDNS_SERVICE_NAME="Dev Memory Service"
 export MCP_HTTP_PORT=8000
-memory launch &
+memory launch
 
 # Staging server
 export MCP_MDNS_SERVICE_NAME="Staging Memory Service"
 export MCP_HTTP_PORT=8001
-memory launch &
+memory launch
 ```
 
 Clients will discover both and can select based on preferences.

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -140,7 +140,7 @@ export MCP_HTTP_ENABLED=true
 export MCP_HTTP_PORT=8000
 
 # Start HTTP server
-python scripts/run_http_server.py
+memory launch
 
 # Open browser to http://localhost:8000
 ```

--- a/docs/http-server-management.md
+++ b/docs/http-server-management.md
@@ -34,10 +34,10 @@ uv run python scripts/server/check_http_server.py -q
 [ERROR] HTTP server is NOT running
 
 To start the HTTP server, run:
-   uv run python scripts/server/run_http_server.py
+   memory launch
 
    Or for HTTPS:
-   MCP_HTTPS_ENABLED=true uv run python scripts/server/run_http_server.py
+   MCP_HTTPS_ENABLED=true memory launch
 
 Error: [WinError 10061] No connection could be made...
 ```
@@ -47,11 +47,14 @@ Error: [WinError 10061] No connection could be made...
 ### Manual Start
 
 ```bash
-# HTTP mode (default, port 8000)
-uv run python scripts/server/run_http_server.py
+# HTTP mode (default, port 8000) — background with PID tracking
+memory launch
 
 # HTTPS mode (same port 8000, TLS enabled)
-MCP_HTTPS_ENABLED=true uv run python scripts/server/run_http_server.py
+MCP_HTTPS_ENABLED=true memory launch
+
+# Foreground mode (logs to stdout)
+memory launch --foreground
 ```
 
 ### Auto-Start Scripts
@@ -88,7 +91,7 @@ scripts\server\start_http_server.bat
 
 2. If not running, start it:
    ```bash
-   uv run python scripts/server/run_http_server.py
+   memory launch
    ```
 
 3. Restart Claude Code to trigger session-start hook

--- a/docs/integration/homebrew.md
+++ b/docs/integration/homebrew.md
@@ -359,7 +359,7 @@ pip install -e ".[sqlite]"
 export MCP_MEMORY_SQLITE_PATH="/shared/mcp_memory/memory.db"
 export MCP_HTTP_ENABLED=true
 export MCP_HTTP_PORT=8000
-python scripts/server/run_http_server.py
+memory launch
 ```
 
 ## Development and Contributions

--- a/docs/integration/multi-client.md
+++ b/docs/integration/multi-client.md
@@ -25,10 +25,10 @@ pip install "mcp-memory-service[full]"    # user install
 export MCP_HTTP_ENABLED=true
 export MCP_HTTP_PORT=8000
 export MCP_MEMORY_STORAGE_BACKEND=hybrid   # or sqlite_vec
-memory server --http
+memory launch
 ```
 
-> **Note:** `memory server --http` is the pip-installable CLI entry point. If you cloned the repo, `python scripts/server/run_http_server.py` works equivalently.
+> **Note:** `memory launch` is the recommended lifecycle CLI (background, PID tracking, health check). Equivalent foreground command: `memory server --http`.
 
 **Benefits of the HTTP-based setup:**
 - ✅ One server process serves Claude Desktop, VS Code, Continue, Cursor, and any HTTP/MCP client
@@ -161,7 +161,7 @@ For Claude Desktop on each client machine:
 
 3. **Start the HTTP server:**
    ```bash
-   python scripts/run_http_server.py
+   memory launch
    ```
 
 ### Client Configuration (HTTP Mode)
@@ -417,7 +417,7 @@ netstat -an | grep :8000
    export MCP_HTTP_ENABLED=true
    export MCP_HTTP_PORT=8000
    export MCP_MEMORY_STORAGE_BACKEND=hybrid   # or sqlite_vec
-   python scripts/server/run_http_server.py
+   memory launch
    ```
 
 3. **Update client configurations** to point at `http://<host>:8000` as needed.

--- a/docs/mastery/local-setup-and-run.md
+++ b/docs/mastery/local-setup-and-run.md
@@ -59,13 +59,13 @@ export MCP_HYBRID_SYNC_OWNER=http   # only the HTTP server syncs when running al
 Stdio MCP server (integrates with Claude Desktop):
 
 ```
-uv run memory server
+memory server
 ```
 
-FastMCP HTTP server (for Claude Code / remote):
+HTTP server (background, recommended for Claude Code / remote / dashboard):
 
 ```
-uv run mcp-memory-server
+memory launch
 ```
 
 Configure Claude Desktop example (~/.claude/config.json):

--- a/docs/mastery/testing-guide.md
+++ b/docs/mastery/testing-guide.md
@@ -74,16 +74,16 @@ uv run pytest -q
 
 ## Local MCP/Service Tests
 
-Run stdio server:
+Run stdio MCP server:
 
 ```
-uv run memory server
+memory server
 ```
 
-Run FastMCP HTTP server:
+Run HTTP server (background, dashboard + REST API):
 
 ```
-uv run mcp-memory-server
+memory launch
 ```
 
 Use any MCP client (Claude Desktop/Code) and exercise tools: store, retrieve, search_by_tag, delete, health.

--- a/docs/natural-memory-triggers/cli-reference.md
+++ b/docs/natural-memory-triggers/cli-reference.md
@@ -504,8 +504,8 @@ node memory-mode-controller.js reset --force
 # Check memory service status
 curl http://localhost:8000/api/health
 
-# Start memory service
-uv run memory server
+# Start memory service (HTTP, default port 8000)
+memory launch
 
 # Check configuration
 node memory-mode-controller.js config get memoryService.endpoint

--- a/docs/natural-memory-triggers/installation-guide.md
+++ b/docs/natural-memory-triggers/installation-guide.md
@@ -340,7 +340,7 @@ cat ~/.claude/hooks/config.json | grep -A 5 "memoryService"
 ```
 
 **Solutions**:
-1. **Start Memory Service**: `uv run memory server`
+1. **Start Memory Service**: `memory launch` (HTTP, default port 8000)
 2. **Check API Key**: Ensure valid API key in configuration
 3. **Firewall Settings**: Verify port 8000 is accessible
 4. **SSL Issues**: Self-signed certificates may need special handling

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -25,13 +25,13 @@ export MCP_OAUTH_ENABLED=true
 
 ```bash
 # Start with OAuth enabled
-uv run python scripts/server/run_http_server.py
+memory launch
 
 # Or with HTTPS (recommended for production)
 export MCP_HTTPS_ENABLED=true
 export MCP_SSL_CERT_FILE=/path/to/cert.pem
 export MCP_SSL_KEY_FILE=/path/to/key.pem
-uv run python scripts/server/run_http_server.py
+memory launch
 ```
 
 ### 3. Test OAuth Endpoints
@@ -193,7 +193,7 @@ export MCP_OAUTH_ENABLED=false  # OAuth not required
 export MCP_ALLOW_ANONYMOUS_ACCESS=false  # Require authentication
 
 # Start server
-python scripts/server/run_http_server.py
+memory launch
 
 # Option 1: X-API-Key header (recommended, more secure)
 curl -H "X-API-Key: your-secret-key" \

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -148,10 +148,10 @@ Start OpenCode inside a project that already has stored memories, then ask a pro
 > ```
 
 ```bash
-python scripts/server/run_http_server.py
+memory launch
 ```
 
-The server starts on port 8000 by default.
+The server starts on port 8000 by default (in the background with PID tracking).
 
 ### 2. Open the dashboard
 
@@ -222,7 +222,7 @@ CLOUDFLARE_VECTORIZE_INDEX=mcp-memory-index
 ### 3. Restart servers
 
 ```bash
-./scripts/update_and_restart.sh
+memory restart
 ```
 
 ### 4. Verify
@@ -291,7 +291,7 @@ python scripts/validation/validate_configuration_complete.py
 |---------|-----|
 | Memory tools don't appear in Claude | Restart the client after config change |
 | `command not found: memory` | Run `pip install mcp-memory-service` again, check your PATH |
-| Dashboard not loading | Check `python scripts/server/run_http_server.py` is running, default port 8000 |
+| Dashboard not loading | Check `memory info` (server should be running, default port 8000) |
 | "database is locked" errors | Add `journal_mode=WAL` to `MCP_MEMORY_SQLITE_PRAGMAS` in `.env` |
 | Cloudflare 401 on startup | Set `MCP_HYBRID_SYNC_OWNER=http` — MCP server then skips Cloudflare entirely |
 | Slow first start (30–60s) | Normal — ONNX model loads on first run, cached afterwards |

--- a/docs/sqlite-vec-backend.md
+++ b/docs/sqlite-vec-backend.md
@@ -243,7 +243,7 @@ export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
    # Always connect to existing server (fails if none running)
    export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
    export MCP_HTTP_ENABLED=false
-   # Requires running: python scripts/run_http_server.py
+   # Requires running: memory launch
    ```
 
 3. **Direct WAL Mode Only**
@@ -287,7 +287,7 @@ export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
   }
 }
 ```
-*Note: Requires manually running `python scripts/run_http_server.py` first*
+*Note: Requires manually running `memory launch` first*
 
 **Option 3: WAL Mode Only (Simple)**
 ```json
@@ -431,7 +431,7 @@ print(asyncio.run(detect_server_coordination_mode()))
 **Manual HTTP Server Setup:**
 ```bash
 # Start HTTP server manually in separate terminal
-python scripts/run_http_server.py
+memory launch
 
 # Then start MCP clients (they'll auto-detect the running server)
 ```
@@ -552,7 +552,7 @@ For production with multi-device sync, use the **Hybrid** backend instead (local
 3. **HTTP Server Management**
    ```bash
    # Manual server control
-   python scripts/run_http_server.py  # Start manually
+   memory launch  # Start manually
    
    # Check server health
    curl http://localhost:8000/health

--- a/docs/testing/regression-tests.md
+++ b/docs/testing/regression-tests.md
@@ -209,8 +209,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
 1. **SQLite-vec phase:**
    ```bash
    export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
-   memory launch &
-   SERVER_PID=$!
+   memory launch
 
    # Store 20 memories
    for i in {1..20}; do
@@ -219,7 +218,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
        -d "{\"content\":\"Backend switch test $i\",\"tags\":[\"switch-test\"]}"
    done
 
-   kill $SERVER_PID
+   memory stop
    ```
 
 2. **Switch to hybrid:**
@@ -227,8 +226,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
    export MCP_MEMORY_STORAGE_BACKEND=hybrid
    export MCP_HYBRID_SYNC_INTERVAL=10
    # Set Cloudflare credentials...
-   memory launch &
-   SERVER_PID=$!
+   memory launch
 
    # Wait for startup
    sleep 5

--- a/docs/testing/regression-tests.md
+++ b/docs/testing/regression-tests.md
@@ -74,7 +74,7 @@ sqlite3 ~/Library/Application\ Support/mcp-memory/sqlite_vec.db "PRAGMA journal_
 **Context:** Test simultaneous read/write operations from multiple clients
 
 **Setup:**
-1. Start HTTP server: `uv run python scripts/server/run_http_server.py`
+1. Start HTTP server: `memory launch`
 2. Verify server is healthy: `curl http://127.0.0.1:8000/api/health`
 
 **Execution:**
@@ -148,7 +148,7 @@ tail -100 ~/Library/Logs/Claude/mcp-server-memory.log | grep -i error
    CLOUDFLARE_VECTORIZE_INDEX=mcp-memory-index
    ```
 2. Clear Cloudflare backend: `python scripts/database/clear_cloudflare.py --confirm`
-3. Start server: `uv run python scripts/server/run_http_server.py`
+3. Start server: `memory launch`
 
 **Execution:**
 1. Store 10 test memories via API:
@@ -209,7 +209,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
 1. **SQLite-vec phase:**
    ```bash
    export MCP_MEMORY_STORAGE_BACKEND=sqlite_vec
-   uv run python scripts/server/run_http_server.py &
+   memory launch &
    SERVER_PID=$!
 
    # Store 20 memories
@@ -227,7 +227,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
    export MCP_MEMORY_STORAGE_BACKEND=hybrid
    export MCP_HYBRID_SYNC_INTERVAL=10
    # Set Cloudflare credentials...
-   uv run python scripts/server/run_http_server.py &
+   memory launch &
    SERVER_PID=$!
 
    # Wait for startup
@@ -263,7 +263,7 @@ python scripts/sync/check_cloudflare_sync.py --tag hybrid-test --verify-hashes
 
 **Setup:**
 1. Database with 1000+ memories
-2. HTTP server running: `uv run python scripts/server/run_http_server.py`
+2. HTTP server running: `memory launch`
 3. Dashboard at `http://127.0.0.1:8000/`
 
 **Execution:**
@@ -468,8 +468,8 @@ time curl -s "http://127.0.0.1:8000/api/search/by-tag" \
 **Context:** Ensure all MCP tools conform to protocol schema
 
 **Setup:**
-1. Start MCP server: `uv run memory server`
-2. Use MCP Inspector: `npx @modelcontextprotocol/inspector uv run memory server`
+1. Start MCP server: `memory server`
+2. Use MCP Inspector: `npx @modelcontextprotocol/inspector memory server`
 
 **Execution:**
 1. Connect with MCP Inspector
@@ -488,7 +488,7 @@ time curl -s "http://127.0.0.1:8000/api/search/by-tag" \
 **Evidence Collection:**
 ```bash
 # Capture tools/list output
-npx @modelcontextprotocol/inspector uv run memory server \
+npx @modelcontextprotocol/inspector memory server \
   --command "tools/list" > tools_schema.json
 
 # Validate schema format

--- a/docs/tutorials/demo-session-walkthrough.md
+++ b/docs/tutorials/demo-session-walkthrough.md
@@ -100,7 +100,7 @@ export MCP_HTTP_ENABLED=true
 export MCP_HTTP_HOST=0.0.0.0
 export MCP_HTTP_PORT=8000
 export MCP_API_KEY="your-secure-key"
-python scripts/server/run_http_server.py
+memory launch
 
 # Access points
 # API: http://server:8000/api/docs

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ cd mcp-memory-service
 python install.py --server-mode --storage-backend sqlite_vec
 export MCP_HTTP_HOST=0.0.0.0
 export MCP_API_KEY="your-secure-key"
-python scripts/run_http_server.py
+memory launch
 ```
 
 ### 2. Client Configuration


### PR DESCRIPTION
## Summary

Modernizes server startup commands across 23 documentation files. Replaces outdated/dead command references with the modern `memory` lifecycle CLI (`memory launch`, `memory server`, `memory restart`).

## Why

Audit (against `CLAUDE.md` guidance) found:
- **Dead references** to scripts/files that no longer exist
- **Legacy commands** that still work but are explicitly labeled non-preferred by the project's own conventions

## Changes

**Fixed broken references:**
| Was | Issue | Fix |
|---|---|---|
| `python scripts/run_http_server.py` | Path moved to `scripts/server/` | `memory launch` |
| `./start_all_servers.sh` | File no longer exists | `memory launch` |
| `./stop_all_servers.sh`, `./status_servers.sh` | Do not exist | `memory stop` / `memory info` |
| `python run_server.py` (in AGENTS.md) | Not the documented entry point | `memory launch` |
| `python -m src.mcp_memory_service.server` | Invalid module path (no `src.` prefix) | `memory launch` + alternatives |

**Modernized legacy patterns:**
| Was | Now |
|---|---|
| `uv run memory server` (HTTP context) | `memory launch` |
| `uv run memory server` (stdio / MCP Inspector) | `memory server` |
| `python scripts/server/run_http_server.py` | `memory launch` |
| `./scripts/update_and_restart.sh` | `memory restart` |

**Intentionally preserved** (still correct):
- `ExecStart=` paths in `docs/deployment/systemd-service.md` — systemd needs absolute Python paths
- Spawn fallback chain in `claude-hooks/PLUGIN.md` — documents reality of the bootstrapper
- `python -m mcp_memory_service.server` — valid MCP stdio entry point
- Legacy callouts in `docs/memory-ontology.md` — already labeled `(legacy)`
- `archive/**/*.md` — historical, out of scope

## Files Changed

23 files, +88/-84 net.

<details>
<summary>File list</summary>

- `.claude/directives/storage-backends.md`
- `CONTRIBUTING.md`
- `docs/assets/images/README.md`
- `docs/cloudflare-setup.md`
- `docs/development/ai-agent-instructions.md`
- `docs/features/knowledge-graph-dashboard.md`
- `docs/first-time-setup.md`
- `docs/guides/AGENTS.md`
- `docs/guides/mdns-service-discovery.md`
- `docs/guides/migration.md`
- `docs/http-server-management.md`
- `docs/integration/homebrew.md`
- `docs/integration/multi-client.md`
- `docs/mastery/local-setup-and-run.md`
- `docs/mastery/testing-guide.md`
- `docs/natural-memory-triggers/cli-reference.md`
- `docs/natural-memory-triggers/installation-guide.md`
- `docs/oauth-setup.md`
- `docs/setup-guide.md`
- `docs/sqlite-vec-backend.md`
- `docs/testing/regression-tests.md`
- `docs/tutorials/demo-session-walkthrough.md`
- `examples/README.md`

</details>

## Test plan

- [x] No source code changes (docs only)
- [x] `grep` sweep verified zero remaining dead refs in active docs
- [x] All replacements cross-checked against `CLAUDE.md` "Essential Commands" section
- [ ] Reviewer spot-check on a few representative file diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)