### PR TITLE
feat(milvus): implement search_memories, retrieve_with_quality_boost, recall_memory

### DIFF
--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -2524,8 +2524,8 @@ class MilvusMemoryStorage(MemoryStorage):
         try:
             from ..utils.time_parser import parse_time_expression
             start_time, end_time = parse_time_expression(query)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to parse time expression from query, falling back to standard retrieve: %s", exc)
 
         if start_time is not None or end_time is not None:
             # Build time filter for Milvus
@@ -2596,8 +2596,8 @@ class MilvusMemoryStorage(MemoryStorage):
             try:
                 from ..utils.time_parser import parse_time_expression
                 start_time, end_time = parse_time_expression(time_expr)
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to parse time_expr '%s', ignoring time filter: %s", time_expr, exc)
 
         if not time_expr:
             if after:
@@ -2638,22 +2638,42 @@ class MilvusMemoryStorage(MemoryStorage):
             if not query:
                 return {"memories": [], "total": 0, "query": query, "mode": mode,
                         "error": "query required for exact mode"}
-            matched_memories = await self.get_by_exact_content(query)
-            results = [
-                MemoryQueryResult(memory=m, relevance_score=1.0, debug_info=None)
-                for m in matched_memories
-            ]
-            pre_filter_count = len(results)
-            # Apply time/tag post-filter for exact mode (can't push to Milvus text search)
-            if start_time is not None:
-                results = [r for r in results if r.memory.created_at and r.memory.created_at >= start_time]
-            if end_time is not None:
-                results = [r for r in results if r.memory.created_at and r.memory.created_at <= end_time]
-            if tags:
-                if tag_match == "all":
-                    results = [r for r in results if all(t in r.memory.tags for t in tags)]
-                else:
-                    results = [r for r in results if any(t in r.memory.tags for t in tags)]
+
+            if self._has_content_lower and combined_filter:
+                # Push all filters (content + time + tags) to Milvus in one query
+                needle = query.lower().replace('"', '\\"')
+                content_filter = f'content_lower like "%{needle}%"'
+                final_filter = (
+                    f"({combined_filter}) and ({content_filter})"
+                    if combined_filter else content_filter
+                )
+                matched_memories = await self._query_memories(
+                    filter_expr=final_filter,
+                    limit=_MILVUS_MAX_LIMIT,
+                    sort_desc_key="created_at",
+                )
+                results = [
+                    MemoryQueryResult(memory=m, relevance_score=1.0, debug_info=None)
+                    for m in matched_memories
+                ]
+                pre_filter_count = len(results)
+            else:
+                # Fallback: fetch by content, then post-filter
+                matched_memories = await self.get_by_exact_content(query)
+                results = [
+                    MemoryQueryResult(memory=m, relevance_score=1.0, debug_info=None)
+                    for m in matched_memories
+                ]
+                pre_filter_count = len(results)
+                if start_time is not None:
+                    results = [r for r in results if r.memory.created_at and r.memory.created_at >= start_time]
+                if end_time is not None:
+                    results = [r for r in results if r.memory.created_at and r.memory.created_at <= end_time]
+                if tags:
+                    if tag_match == "all":
+                        results = [r for r in results if all(t in r.memory.tags for t in tags)]
+                    else:
+                        results = [r for r in results if any(t in r.memory.tags for t in tags)]
 
         elif mode in ("semantic", "hybrid"):
             if not query and not combined_filter:
@@ -2668,11 +2688,7 @@ class MilvusMemoryStorage(MemoryStorage):
                             "error": "Failed to generate query embedding"}
 
                 fetch_n = self._retrieve_fetch_limit(fetch_limit, combined_filter)
-                if self._has_bm25 and mode == "hybrid":
-                    hits = await self._run_hybrid_search(
-                        query, query_embedding, combined_filter, fetch_n
-                    )
-                elif self._has_bm25:
+                if self._has_bm25:
                     hits = await self._run_hybrid_search(
                         query, query_embedding, combined_filter, fetch_n
                     )

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -2445,6 +2445,309 @@ class MilvusMemoryStorage(MemoryStorage):
         logger.info("mark_superseded_batch: marked %d memories as superseded", marked)
         return marked
 
+    # -- search_memories / retrieve_with_quality_boost / recall_memory --------
+
+    async def retrieve_with_quality_boost(
+        self,
+        query: str,
+        n_results: int = 10,
+        tags: Optional[List[str]] = None,
+        quality_boost: Optional[bool] = None,
+        quality_weight: Optional[float] = None,
+        include_superseded: bool = False,
+    ) -> List["MemoryQueryResult"]:
+        """Quality-boosted retrieval using Milvus native hybrid search.
+
+        Over-fetches 3x via the native Milvus retrieve (which already uses
+        hybrid BM25+vector when available), then reranks by a composite
+        score combining semantic similarity and quality_score from metadata.
+        """
+        from ..config import MCP_QUALITY_BOOST_ENABLED, MCP_QUALITY_BOOST_WEIGHT
+
+        if quality_boost is None:
+            quality_boost = MCP_QUALITY_BOOST_ENABLED
+        if quality_weight is None:
+            quality_weight = MCP_QUALITY_BOOST_WEIGHT
+
+        if not 0.0 <= quality_weight <= 1.0:
+            raise ValueError(f"quality_weight must be 0.0-1.0, got {quality_weight}")
+
+        if not quality_boost:
+            return await self.retrieve(
+                query, n_results, tags=tags, include_superseded=include_superseded
+            )
+
+        # Over-fetch for reranking pool
+        oversample = 3
+        candidates = await self.retrieve(
+            query, n_results * oversample, tags=tags, include_superseded=include_superseded
+        )
+        if not candidates:
+            return []
+
+        # Rerank by composite score
+        semantic_weight = 1.0 - quality_weight
+        for result in candidates:
+            semantic_score = result.relevance_score
+            q_score = result.memory.quality_score
+
+            result.relevance_score = (
+                semantic_weight * semantic_score + quality_weight * q_score
+            )
+            if result.debug_info is None:
+                result.debug_info = {}
+            result.debug_info.update({
+                "original_semantic_score": semantic_score,
+                "quality_score": q_score,
+                "quality_weight": quality_weight,
+                "semantic_weight": semantic_weight,
+                "reranked": True,
+            })
+
+        candidates.sort(key=lambda r: r.relevance_score, reverse=True)
+        return candidates[:n_results]
+
+    async def recall_memory(self, query: str, n_results: int = 5) -> List[Memory]:
+        """Recall memories with time-expression awareness.
+
+        Parses natural language time expressions from the query (e.g.,
+        "last week", "yesterday") and applies a Milvus time-range filter
+        on ``created_at``. Falls back to plain semantic retrieve if no
+        time expression is detected.
+        """
+        if not self._ensure_initialized():
+            return []
+
+        # Try to parse time expression from query
+        start_time = None
+        end_time = None
+        try:
+            from ..utils.time_parser import parse_time_expression
+            start_time, end_time = parse_time_expression(query)
+        except Exception:  # noqa: BLE001
+            pass
+
+        if start_time is not None or end_time is not None:
+            # Build time filter for Milvus
+            filters: List[str] = []
+            if start_time is not None:
+                filters.append(f"created_at >= {start_time}")
+            if end_time is not None:
+                filters.append(f"created_at <= {end_time}")
+            time_filter = " and ".join(filters)
+
+            # Use vector search with time filter
+            query_embedding = self._embed_query(query)
+            if query_embedding is None:
+                return []
+
+            fetch_n = self._retrieve_fetch_limit(n_results, time_filter)
+            if self._has_bm25:
+                hits = await self._run_hybrid_search(
+                    query, query_embedding, time_filter, fetch_n
+                )
+            else:
+                hits = await self._run_search(query_embedding, time_filter, fetch_n)
+
+            results = self._rank_and_trim(hits, query, n_results, 0.0)
+            return [r.memory for r in results[:n_results]]
+
+        # No time expression — fall back to standard retrieve
+        results = await self.retrieve(query, n_results)
+        return [r.memory for r in results]
+
+    async def search_memories(
+        self,
+        query: Optional[str] = None,
+        mode: str = "semantic",
+        time_expr: Optional[str] = None,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        tag_match: str = "any",
+        quality_boost: float = 0.0,
+        limit: int = 10,
+        include_debug: bool = False,
+        include_superseded: bool = False,
+    ) -> Dict[str, Any]:
+        """Unified memory search with Milvus-native filtering.
+
+        Pushes time and tag filters into Milvus filter expressions for
+        server-side filtering instead of Python-side post-filtering.
+        Supports all modes: semantic, exact, hybrid.
+        """
+        if not self._ensure_initialized():
+            return {"memories": [], "total": 0, "query": query, "mode": mode,
+                    "error": "Milvus storage not initialized"}
+
+        # Validate inputs
+        if mode not in ("semantic", "exact", "hybrid"):
+            return {"memories": [], "total": 0, "query": query, "mode": mode,
+                    "error": f"Invalid mode: {mode}"}
+        if not 0.0 <= quality_boost <= 1.0:
+            return {"memories": [], "total": 0, "query": query, "mode": mode,
+                    "error": f"Invalid quality_boost: {quality_boost}"}
+
+        # -- Parse time filters --
+        start_time: Optional[float] = None
+        end_time: Optional[float] = None
+
+        if time_expr:
+            try:
+                from ..utils.time_parser import parse_time_expression
+                start_time, end_time = parse_time_expression(time_expr)
+            except Exception:  # noqa: BLE001
+                pass
+
+        if not time_expr:
+            if after:
+                try:
+                    from datetime import datetime as _dt
+                    start_time = _dt.fromisoformat(after).timestamp()
+                except ValueError:
+                    return {"memories": [], "total": 0, "query": query, "mode": mode,
+                            "error": f"Invalid after date: {after}"}
+            if before:
+                try:
+                    from datetime import datetime as _dt
+                    end_time = _dt.fromisoformat(before).timestamp()
+                except ValueError:
+                    return {"memories": [], "total": 0, "query": query, "mode": mode,
+                            "error": f"Invalid before date: {before}"}
+
+        # -- Build Milvus filter expression (push filters server-side) --
+        filter_parts: List[str] = []
+        if start_time is not None:
+            filter_parts.append(f"created_at >= {start_time}")
+        if end_time is not None:
+            filter_parts.append(f"created_at <= {end_time}")
+        if tags:
+            tag_expr, matched = self._tag_like_clauses(
+                tags, joiner="and" if tag_match == "all" else "or"
+            )
+            if matched:
+                filter_parts.append(tag_expr)
+
+        combined_filter = " and ".join(filter_parts) if filter_parts else ""
+
+        # -- Execute search based on mode --
+        results: List[MemoryQueryResult] = []
+        pre_filter_count = 0
+
+        if mode == "exact":
+            if not query:
+                return {"memories": [], "total": 0, "query": query, "mode": mode,
+                        "error": "query required for exact mode"}
+            matched_memories = await self.get_by_exact_content(query)
+            results = [
+                MemoryQueryResult(memory=m, relevance_score=1.0, debug_info=None)
+                for m in matched_memories
+            ]
+            pre_filter_count = len(results)
+            # Apply time/tag post-filter for exact mode (can't push to Milvus text search)
+            if start_time is not None:
+                results = [r for r in results if r.memory.created_at and r.memory.created_at >= start_time]
+            if end_time is not None:
+                results = [r for r in results if r.memory.created_at and r.memory.created_at <= end_time]
+            if tags:
+                if tag_match == "all":
+                    results = [r for r in results if all(t in r.memory.tags for t in tags)]
+                else:
+                    results = [r for r in results if any(t in r.memory.tags for t in tags)]
+
+        elif mode in ("semantic", "hybrid"):
+            if not query and not combined_filter:
+                return {"memories": [], "total": 0, "query": query, "mode": mode,
+                        "error": "At least one filter required (query, time, or tags)"}
+
+            if query:
+                fetch_limit = limit * 3 if quality_boost > 0 else limit
+                query_embedding = self._embed_query(query)
+                if query_embedding is None:
+                    return {"memories": [], "total": 0, "query": query, "mode": mode,
+                            "error": "Failed to generate query embedding"}
+
+                fetch_n = self._retrieve_fetch_limit(fetch_limit, combined_filter)
+                if self._has_bm25 and mode == "hybrid":
+                    hits = await self._run_hybrid_search(
+                        query, query_embedding, combined_filter, fetch_n
+                    )
+                elif self._has_bm25:
+                    hits = await self._run_hybrid_search(
+                        query, query_embedding, combined_filter, fetch_n
+                    )
+                else:
+                    hits = await self._run_search(query_embedding, combined_filter, fetch_n)
+
+                results = self._rank_and_trim(hits, query, len(hits), 0.0)
+                pre_filter_count = len(results)
+
+                # Apply quality boost reranking
+                if quality_boost > 0:
+                    semantic_weight = 1.0 - quality_boost
+                    for r in results:
+                        orig = r.relevance_score
+                        r.relevance_score = (
+                            semantic_weight * orig + quality_boost * r.memory.quality_score
+                        )
+                    results.sort(key=lambda r: r.relevance_score, reverse=True)
+            else:
+                # Time/tag only — use Milvus query with filter
+                try:
+                    rows = await self._call_client(
+                        "query",
+                        collection_name=self.collection_name,
+                        filter=combined_filter,
+                        output_fields=list(self._OUTPUT_FIELDS),
+                        limit=min(limit * 3, _MILVUS_MAX_LIMIT),
+                    )
+                    for row in (rows or []):
+                        mem = self._entity_to_memory(row)
+                        if mem:
+                            results.append(
+                                MemoryQueryResult(memory=mem, relevance_score=0.5, debug_info=None)
+                            )
+                    pre_filter_count = len(results)
+                except Exception as exc:  # noqa: BLE001
+                    logger.error("search_memories: query failed: %s", exc)
+
+        # Filter superseded
+        if not include_superseded:
+            results = [r for r in results if not r.memory.metadata.get("superseded_by")]
+
+        # Limit
+        results = results[:limit]
+
+        # Build response
+        memories = []
+        for r in results:
+            mem_dict = r.memory.to_dict()
+            mem_dict["similarity_score"] = r.relevance_score
+            if r.debug_info:
+                mem_dict["debug_info"] = r.debug_info
+            memories.append(mem_dict)
+
+        response: Dict[str, Any] = {
+            "memories": memories,
+            "total": len(memories),
+            "query": query,
+            "mode": mode,
+        }
+
+        if include_debug:
+            response["debug"] = {
+                "time_filter": {"time_expr": time_expr, "after": after, "before": before,
+                                "start_timestamp": start_time, "end_timestamp": end_time},
+                "tag_filter": tags,
+                "quality_boost": quality_boost,
+                "milvus_filter": combined_filter,
+                "pre_filter_count": pre_filter_count,
+                "post_filter_count": len(memories),
+                "limit": limit,
+            }
+
+        return response
+
     # -- Stats / misc --------------------------------------------------------
 
     async def get_stats(self) -> Dict[str, Any]:

--- a/tests/storage/test_milvus_search_methods.py
+++ b/tests/storage/test_milvus_search_methods.py
@@ -1,0 +1,348 @@
+"""Unit tests for MilvusMemoryStorage search method overrides:
+- retrieve_with_quality_boost
+- recall_memory
+- search_memories
+
+Mock-based — no live Milvus server required.
+
+Reference: https://github.com/doobidoo/mcp-memory-service/issues/888
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pymilvus")
+pytest.importorskip("sentence_transformers")
+
+from src.mcp_memory_service.models.memory import Memory, MemoryQueryResult  # noqa: E402
+from src.mcp_memory_service.storage.milvus import MilvusMemoryStorage  # noqa: E402
+
+
+# -- Fixtures ----------------------------------------------------------------
+
+
+def _make_storage(has_bm25: bool = True) -> MilvusMemoryStorage:
+    """Return a MilvusMemoryStorage skipping __init__."""
+    storage = MilvusMemoryStorage.__new__(MilvusMemoryStorage)
+    storage.collection_name = "unit_test_collection"
+    storage.embedding_dimension = 4
+    storage.embedding_model_name = "test-model"
+    storage.embedding_model = MagicMock()
+    storage.embedding_model.encode = MagicMock(
+        return_value=np.array([[0.1, 0.2, 0.3, 0.4]])
+    )
+    storage._initialized = True
+    storage.client = MagicMock()
+    storage._has_content_lower = True
+    storage._has_bm25 = has_bm25
+    storage._lock = None
+    storage._call_client = AsyncMock()
+    storage._generate_embedding = MagicMock(return_value=[0.1, 0.2, 0.3, 0.4])
+    return storage
+
+
+def _make_hit(
+    content_hash: str = "h1",
+    content: str = "test content",
+    distance: float = 0.9,
+    metadata: Optional[Dict[str, Any]] = None,
+    created_at: Optional[float] = None,
+    tags: str = ",test,",
+) -> Dict[str, Any]:
+    """Build a Milvus search hit."""
+    now = time.time()
+    return {
+        "id": content_hash,
+        "distance": distance,
+        "content": content,
+        "tags": tags,
+        "memory_type": "note",
+        "metadata": json.dumps(metadata or {}),
+        "created_at": created_at or (now - 100),
+        "updated_at": now - 50,
+        "created_at_iso": None,
+        "updated_at_iso": None,
+    }
+
+
+# -- retrieve_with_quality_boost ---------------------------------------------
+
+
+class TestRetrieveWithQualityBoost:
+    """Tests for native retrieve_with_quality_boost."""
+
+    @pytest.mark.asyncio
+    async def test_quality_boost_disabled_uses_plain_retrieve(self):
+        """When quality_boost=False, delegates to retrieve directly."""
+        storage = _make_storage()
+        storage.retrieve = AsyncMock(return_value=[
+            MemoryQueryResult(
+                memory=Memory(content="c1", content_hash="h1", tags=["t"]),
+                relevance_score=0.9,
+                debug_info=None,
+            )
+        ])
+
+        results = await storage.retrieve_with_quality_boost(
+            "test query", n_results=5, quality_boost=False
+        )
+
+        assert len(results) == 1
+        storage.retrieve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_quality_boost_reranks_by_composite_score(self):
+        """Results are reranked by composite (semantic + quality) score."""
+        storage = _make_storage()
+
+        # Item A: high semantic, low quality
+        mem_a = Memory(content="a", content_hash="ha", tags=["t"],
+                       metadata={"quality_score": 0.2})
+        # Item B: low semantic, high quality
+        mem_b = Memory(content="b", content_hash="hb", tags=["t"],
+                       metadata={"quality_score": 0.95})
+
+        storage.retrieve = AsyncMock(return_value=[
+            MemoryQueryResult(memory=mem_a, relevance_score=0.9, debug_info=None),
+            MemoryQueryResult(memory=mem_b, relevance_score=0.5, debug_info=None),
+        ])
+
+        results = await storage.retrieve_with_quality_boost(
+            "test", n_results=2, quality_boost=True, quality_weight=0.7
+        )
+
+        # B should rank higher: 0.3*0.5 + 0.7*0.95 = 0.815
+        # A: 0.3*0.9 + 0.7*0.2 = 0.41
+        assert results[0].memory.content_hash == "hb"
+        assert results[1].memory.content_hash == "ha"
+
+    @pytest.mark.asyncio
+    async def test_quality_boost_over_fetches_3x(self):
+        """Retrieves 3x n_results for reranking pool."""
+        storage = _make_storage()
+        storage.retrieve = AsyncMock(return_value=[])
+
+        await storage.retrieve_with_quality_boost(
+            "test", n_results=5, quality_boost=True
+        )
+
+        call_args = storage.retrieve.call_args
+        assert call_args[0][1] == 15  # 5 * 3
+
+    @pytest.mark.asyncio
+    async def test_invalid_quality_weight_raises(self):
+        """quality_weight outside 0-1 raises ValueError."""
+        storage = _make_storage()
+        with pytest.raises(ValueError):
+            await storage.retrieve_with_quality_boost(
+                "test", quality_weight=1.5
+            )
+
+
+# -- recall_memory -----------------------------------------------------------
+
+
+class TestRecallMemory:
+    """Tests for native recall_memory with time expression parsing."""
+
+    @pytest.mark.asyncio
+    async def test_no_time_expression_uses_retrieve(self):
+        """When no time expression in query, falls back to retrieve."""
+        storage = _make_storage()
+        storage.retrieve = AsyncMock(return_value=[
+            MemoryQueryResult(
+                memory=Memory(content="c1", content_hash="h1", tags=["t"]),
+                relevance_score=0.8,
+                debug_info=None,
+            )
+        ])
+
+        results = await storage.recall_memory("python patterns", n_results=3)
+
+        assert len(results) == 1
+        assert results[0].content == "c1"
+
+    @pytest.mark.asyncio
+    async def test_with_time_expression_applies_filter(self):
+        """Time expressions are parsed and used as Milvus filter."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", content="recent stuff", distance=0.85),
+        ])
+
+        with patch("src.mcp_memory_service.utils.time_parser.parse_time_expression") as mock_parse:
+            mock_parse.return_value = (time.time() - 86400, time.time())
+            results = await storage.recall_memory("what happened yesterday", n_results=5)
+
+        assert len(results) == 1
+        # Verify hybrid search was called with a time filter
+        call_args = storage._run_hybrid_search.call_args
+        filter_expr = call_args[0][2]  # third positional arg is tag_filter
+        assert "created_at >=" in filter_expr
+
+    @pytest.mark.asyncio
+    async def test_not_initialized_returns_empty(self):
+        """Returns empty list when not initialized."""
+        storage = _make_storage()
+        storage._initialized = False
+        results = await storage.recall_memory("test")
+        assert results == []
+
+
+# -- search_memories ---------------------------------------------------------
+
+
+class TestSearchMemories:
+    """Tests for native search_memories with Milvus-pushed filters."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_mode_returns_error(self):
+        """Invalid mode returns error dict."""
+        storage = _make_storage()
+        result = await storage.search_memories(query="test", mode="invalid")
+        assert result["error"] is not None
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_invalid_quality_boost_returns_error(self):
+        """quality_boost outside 0-1 returns error."""
+        storage = _make_storage()
+        result = await storage.search_memories(query="test", quality_boost=2.0)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_semantic_mode_uses_hybrid_search(self):
+        """Semantic mode with BM25 enabled uses hybrid search."""
+        storage = _make_storage(has_bm25=True)
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", distance=0.9),
+        ])
+
+        result = await storage.search_memories(query="test query", mode="semantic")
+
+        assert result["total"] == 1
+        storage._run_hybrid_search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exact_mode_uses_get_by_exact_content(self):
+        """Exact mode uses get_by_exact_content."""
+        storage = _make_storage()
+        storage.get_by_exact_content = AsyncMock(return_value=[
+            Memory(content="exact match", content_hash="h1", tags=["t"]),
+        ])
+
+        result = await storage.search_memories(query="exact match", mode="exact")
+
+        assert result["total"] == 1
+        storage.get_by_exact_content.assert_called_once_with("exact match")
+
+    @pytest.mark.asyncio
+    async def test_time_filter_pushed_to_milvus(self):
+        """Time filters are pushed as Milvus filter expressions."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", distance=0.85),
+        ])
+
+        result = await storage.search_memories(
+            query="test", after="2026-01-01", before="2026-06-01"
+        )
+
+        # Verify filter expression includes created_at constraints
+        call_args = storage._run_hybrid_search.call_args
+        filter_expr = call_args[0][2]
+        assert "created_at >=" in filter_expr
+        assert "created_at <=" in filter_expr
+
+    @pytest.mark.asyncio
+    async def test_tag_filter_pushed_to_milvus(self):
+        """Tag filters are pushed as Milvus like expressions."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", distance=0.85, tags=",python,"),
+        ])
+
+        result = await storage.search_memories(
+            query="test", tags=["python"]
+        )
+
+        call_args = storage._run_hybrid_search.call_args
+        filter_expr = call_args[0][2]
+        assert "like" in filter_expr.lower() or "tags" in filter_expr.lower()
+
+    @pytest.mark.asyncio
+    async def test_time_only_search_uses_query(self):
+        """Time-only search (no query) uses Milvus query with filter."""
+        storage = _make_storage()
+        now = time.time()
+        storage._call_client = AsyncMock(return_value=[
+            {"id": "h1", "content": "c1", "tags": ",test,", "memory_type": "note",
+             "metadata": "{}", "created_at": now - 50, "updated_at": now - 10,
+             "created_at_iso": None, "updated_at_iso": None},
+        ])
+
+        result = await storage.search_memories(
+            query=None, after="2026-01-01"
+        )
+
+        assert result["total"] == 1
+        # Should use "query" method, not "search"
+        call_args = storage._call_client.call_args
+        assert call_args[0][0] == "query"
+
+    @pytest.mark.asyncio
+    async def test_include_debug_adds_debug_info(self):
+        """include_debug=True adds debug section to response."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", distance=0.9),
+        ])
+
+        result = await storage.search_memories(
+            query="test", include_debug=True
+        )
+
+        assert "debug" in result
+        assert "milvus_filter" in result["debug"]
+
+    @pytest.mark.asyncio
+    async def test_superseded_filtered_by_default(self):
+        """Superseded memories are filtered out by default."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", metadata={"superseded_by": "winner"}),
+            _make_hit(content_hash="h2", metadata={}),
+        ])
+
+        result = await storage.search_memories(query="test")
+
+        assert result["total"] == 1
+        assert result["memories"][0]["content_hash"] == "h2"
+
+    @pytest.mark.asyncio
+    async def test_include_superseded_true(self):
+        """include_superseded=True returns superseded memories."""
+        storage = _make_storage()
+        storage._run_hybrid_search = AsyncMock(return_value=[
+            _make_hit(content_hash="h1", metadata={"superseded_by": "winner"}),
+            _make_hit(content_hash="h2", metadata={}),
+        ])
+
+        result = await storage.search_memories(query="test", include_superseded=True)
+
+        assert result["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_not_initialized_returns_error(self):
+        """Returns error when not initialized."""
+        storage = _make_storage()
+        storage._initialized = False
+        result = await storage.search_memories(query="test")
+        assert "error" in result


### PR DESCRIPTION
## Summary

Implements native Milvus overrides for three 🟡 medium-priority search methods from #888.

## Changes

### `search_memories` — Unified search with server-side filtering

Key optimization: **pushes time and tag filters into Milvus filter expressions** instead of fetching all results and filtering in Python.

- Supports all modes: `semantic`, `exact`, `hybrid`
- Time filters (`time_expr`, `after`, `before`) → Milvus `created_at >= X` filter
- Tag filters → Milvus `tags like` expressions
- Quality boost reranking in-place after Milvus search
- Time/tag-only queries (no text) use `client.query(filter=...)` directly
- `include_debug` response includes `milvus_filter` showing what was pushed server-side

### `retrieve_with_quality_boost` — Quality-aware reranking

- Over-fetches 3x via native Milvus hybrid retrieve
- Reranks by composite: `semantic_weight * similarity + quality_weight * quality_score`
- Debug info includes original scores and weights

### `recall_memory` — Time-expression-aware recall

- Parses natural language time expressions ("yesterday", "last week")
- Applies as Milvus `created_at` filter for server-side time filtering
- Falls back to plain `retrieve()` when no time expression detected

## Tests (18 new)

- `TestRetrieveWithQualityBoost`: 4 tests (disabled path, reranking, over-fetch, validation)
- `TestRecallMemory`: 3 tests (no time expr, with time expr, uninitialized)
- `TestSearchMemories`: 11 tests (mode validation, hybrid/exact modes, time/tag filter push, time-only query, debug info, superseded filtering)

## Context

Part of #888. Completes the 🟡 medium-priority methods. After this PR, only the 🟢 low-priority methods remain.

## Labels

`backend:milvus`