### PR TITLE
fix(hooks): parse Claude Code transcripts as JSONL with nested message

### DIFF
--- a/claude-hooks/core/auto-capture-hook.js
+++ b/claude-hooks/core/auto-capture-hook.js
@@ -102,9 +102,22 @@ async function readStdin() {
 async function parseTranscript(transcriptPath) {
     try {
         const content = await fs.readFile(transcriptPath, 'utf8');
-        const transcript = JSON.parse(content);
 
-        if (!Array.isArray(transcript) || transcript.length === 0) {
+        // Claude Code writes transcripts as JSONL (newline-delimited JSON),
+        // one message envelope per line. Tolerate trailing whitespace and skip
+        // malformed lines instead of failing the whole hook.
+        const transcript = [];
+        for (const line of content.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+                transcript.push(JSON.parse(trimmed));
+            } catch {
+                // skip malformed line
+            }
+        }
+
+        if (transcript.length === 0) {
             return null;
         }
 
@@ -114,13 +127,16 @@ async function parseTranscript(transcriptPath) {
 
         for (let i = transcript.length - 1; i >= 0; i--) {
             const msg = transcript[i];
-            const role = msg.role || msg.type;
+            // Claude Code envelope nests the actual message under `message`;
+            // fall back to flat shape for compatibility with older formats.
+            const role = msg.message?.role || msg.role || msg.type;
+            const content = msg.message?.content ?? msg.content;
 
             if (!lastAssistant && role === 'assistant') {
-                lastAssistant = extractTextContent(msg.content);
+                lastAssistant = extractTextContent(content);
             }
             if (!lastUser && role === 'user') {
-                lastUser = extractTextContent(msg.content);
+                lastUser = extractTextContent(content);
             }
 
             if (lastUser && lastAssistant) break;

--- a/claude-hooks/core/auto-capture-hook.js
+++ b/claude-hooks/core/auto-capture-hook.js
@@ -111,7 +111,11 @@ async function parseTranscript(transcriptPath) {
             const trimmed = line.trim();
             if (!trimmed) continue;
             try {
-                transcript.push(JSON.parse(trimmed));
+                const parsed = JSON.parse(trimmed);
+                const items = Array.isArray(parsed) ? parsed : [parsed];
+                for (const item of items) {
+                    if (item && typeof item === 'object') transcript.push(item);
+                }
             } catch {
                 // skip malformed line
             }


### PR DESCRIPTION
## Summary

The `auto-capture` PostToolUse hook is silently broken on every tool call because it parses Claude Code session transcripts with the wrong shape:

- Transcripts are **JSONL** (one envelope per line), not a single JSON array, so `JSON.parse(content)` always fails on line 2.
- The actual chat object is nested under `message`, so even with the parse fixed `msg.content` is `undefined` and the captured combined message is `User: [no message]\n\nAssistant: [no response]`.

Net effect: no memories are auto-stored, ever. The hook only logs:

```
[auto-capture] Failed to parse transcript: Unexpected non-whitespace character after JSON at position 124 (line 2 column 1)
```

## Changes

`claude-hooks/core/auto-capture-hook.js`:

- Parse the transcript line-by-line; skip blank and malformed lines instead of failing the whole hook.
- Resolve `role` from `msg.message.role` → `msg.role` → `msg.type` (fall back chain keeps older flat formats working).
- Resolve content from `msg.message.content` ?? `msg.content`.

21 insertions, 5 deletions. No behavior change for valid transcripts in the old (flat) format, and the previously-empty case now returns real content.

## Repro

1. Install `claude-hooks` and enable auto-capture.
2. Run any Bash/Edit/Write tool in Claude Code.
3. `stderr` of the hook contains the parse error above; no `POST /api/memories` ever fires.

## Test plan

- [x] Verified on a real `~/.claude/projects/**/<session>.jsonl`: `userMessage` and `assistantMessage` are non-empty after the fix (previously both empty).
- [x] Old single-array transcript shape still parses (line split yields one element, fallback chain handles flat `role`/`content`).
- [ ] Reviewer to confirm `detectPatterns()` now sees real content and stores at least one memory in a normal session.