### PR TITLE
chore: release v10.63.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,13 @@
 {
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true
+  "permissions": {
+    "allow": [
+      "Read(//Users/hkr/GitHub/MCP-Context-Provider/instincts/**)",
+      "Skill(superpowers:using-superpowers)",
+      "Skill(superpowers:using-superpowers:*)"
+    ],
+    "additionalDirectories": [
+      "/Users/hkr/GitHub/MCP-Context-Provider/instincts"
+    ]
   },
   "hooks": {
     "PostToolUse": [
@@ -16,5 +23,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,6 @@
 {
-  "permissions": {
-    "allow": [
-      "Read(//Users/hkr/GitHub/MCP-Context-Provider/instincts/**)",
-      "Skill(superpowers:using-superpowers)",
-      "Skill(superpowers:using-superpowers:*)"
-    ],
-    "additionalDirectories": [
-      "/Users/hkr/GitHub/MCP-Context-Provider/instincts"
-    ]
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
   },
   "hooks": {
     "PostToolUse": [
@@ -23,8 +16,5 @@
         ]
       }
     ]
-  },
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.63.0] - 2026-05-20
+
+### Added
+
+- **feat(milvus): low-priority optional overrides — completes Issue #888** ([#978](https://github.com/doobidoo/mcp-memory-service/pull/978), closes [#888](https://github.com/doobidoo/mcp-memory-service/issues/888), @henry201605): Implements the final 4 native Milvus overrides to fully complete Issue #888. `search_by_tag_chronological` pushes tag filter + `sort_desc_key=created_at` to Milvus via `_query_memories` (replaces base-class fetch-all-then-sort fallback, supports pagination). `count_memories_by_tag` uses Milvus `count(*)` query with tag filter (replaces fetch-all-then-len fallback). `is_deleted` checks `metadata.deleted_at` field (returns False if memory not found). `purge_deleted` queries memories with `created_at <= cutoff`, filters those with `deleted_at` in metadata, and hard-deletes tombstones. 17 new mock-based unit tests across 4 test classes.
+
+### Fixed
+
+- **fix(harvest): support Kiro CLI `AssistantMessage` kind + raise system-content threshold to 10k** ([#979](https://github.com/doobidoo/mcp-memory-service/pull/979), closes [#972](https://github.com/doobidoo/mcp-memory-service/issues/972), @filhocf): Adds `"AssistantMessage": "assistant"` to `KIRO_KIND_MAP` so Kiro CLI assistant messages (which use this kind, not `Response`) are correctly parsed. Removes the redundant `len(text) > 2000` filter in `_is_system_content` (already capped at `MAX_CANDIDATE_CONTENT_LENGTH = 500` in extractor). Result: parse yield increases from 1 candidate per 71 messages to 36 candidates per 373 messages.
+
 ## [10.62.0] - 2026-05-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.62.0 - feat(milvus): native search_memories + retrieve_with_quality_boost + recall_memory (server-side filter pushdown, completes #888) + fix(hooks): JSONL transcript parsing — ~1,968 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.63.0 - feat(milvus): low-priority overrides completing #888 (search_by_tag_chronological, count_memories_by_tag, is_deleted, purge_deleted) + fix(harvest): Kiro CLI AssistantMessage + 36x parse yield improvement — ~1,985 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.62.0** (May 20, 2026)
+## Latest Release: **v10.63.0** (May 20, 2026)
 
-**Minor: Native Milvus search_memories, retrieve_with_quality_boost, recall_memory**
+**Minor: Milvus low-priority overrides (completes #888) + Kiro CLI harvest fix**
 
 **What's New:**
-- `feat(milvus)`: Native `search_memories`, `retrieve_with_quality_boost`, and `recall_memory` with server-side filter pushdown — completes medium-priority methods from #888 (@henry201605, PR #970)
-- `fix(hooks)`: Parse Claude Code transcripts as JSONL with nested `message` — restores transcript-based memory capture (PR #971)
+- `feat(milvus)`: Completes Issue #888 — `search_by_tag_chronological`, `count_memories_by_tag`, `is_deleted`, `purge_deleted` natively implemented with server-side filter pushdown (@henry201605, PR #978)
+- `fix(harvest)`: Kiro CLI `AssistantMessage` kind support + remove redundant 2000-char filter — parse yield 36x improvement (@filhocf, PR #979)
 
 ---
 
 **Previous Releases**:
+- **v10.62.0** - feat(milvus): native search_memories + retrieve_with_quality_boost + recall_memory (server-side filter pushdown, completes medium-priority #888) + fix(hooks): JSONL transcript parsing (PRs #970, #971)
 - **v10.61.0** - feat(milvus): native update_memory + update_memories_batch (1 round-trip batch upsert) + feat(sse): Last-Event-ID replay on /api/events reconnect (PRs #966, #953)
 - **v10.60.2** - fix(milvus): replace ANN search() with brute-force query() in semantic dedup — fixes Milvus Lite growing-segment visibility bug (#964, closes #938, @henry201605)
 - **v10.60.1** - fix(milvus): tag_match param in get_all_memories/count_all_memories + fix(hooks): session-end port fallback + fix(consolidation): repair contradiction detection (PRs #958, #960, #961)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.62.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.63.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.62.0">
-<meta property="og:description" content="Native Milvus search_memories, retrieve_with_quality_boost, recall_memory with server-side filter pushdown. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.63.0">
+<meta property="og:description" content="Milvus low-priority overrides completing Issue #888 + Kiro CLI harvest fix with 36x parse yield improvement. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.62 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.63 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.62</h2>
-    <p class="section-subtitle">Native Milvus search_memories with server-side filter pushdown, hooks JSONL transcript fix, and dep updates. ~1,968 tests.</p>
+    <h2 class="section-title">What's New in v10.63</h2>
+    <p class="section-subtitle">Milvus Issue #888 fully complete + Kiro CLI harvest fix with 36x parse yield improvement. ~1,985 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon consolidation">&#128269;</div>
-        <h3>Native Milvus Search with Filter Pushdown</h3>
-        <p>Milvus backend now overrides <code>search_memories</code>, <code>retrieve_with_quality_boost</code>, and <code>recall_memory</code>. Filters (tag, type, date) are pushed to the Milvus server inside the ANN call &mdash; no more N round-trip fallbacks to the base class. Completes the medium-priority method set from issue #888.</p>
+        <h3>Milvus Issue #888 Complete</h3>
+        <p>The final 4 low-priority Milvus overrides are now native: <code>search_by_tag_chronological</code> (tag filter + server-side sort + pagination), <code>count_memories_by_tag</code> (Milvus <code>count(*)</code>), <code>is_deleted</code> (metadata check), and <code>purge_deleted</code> (hard-delete tombstones). All 9 optional BaseStorage methods now have native implementations, eliminating all base-class fallbacks.</p>
       </div>
       <div class="feature-card" data-delay="150">
         <div class="feature-icon http">&#128736;</div>
-        <h3>Hooks JSONL Transcript Parsing</h3>
-        <p>Claude Code transcript format changed to JSONL with a <code>message</code> wrapper. The auto-capture hook now correctly unwraps each line before extracting tool calls, restoring transcript-based memory capture for current Claude Code versions.</p>
+        <h3>Kiro CLI Harvest Fix</h3>
+        <p>Kiro CLI uses <code>AssistantMessage</code> as the message kind (not <code>Response</code>). The harvest parser now maps this correctly and removes a redundant 2000-char filter. Parse yield for Kiro sessions improves 36x: 1 candidate per 71 messages to 36 candidates per 373 messages.</p>
       </div>
       <div class="feature-card" data-delay="300">
         <div class="feature-icon privacy">&#128260;</div>
-        <h3>Quality-Boosted Retrieval</h3>
-        <p><code>retrieve_with_quality_boost</code> re-ranks results by blending embedding similarity with stored quality scores server-side. <code>recall_memory</code> adds temporal recency weighting. Both use Milvus native ANN search for full performance.</p>
+        <h3>Community Contributions</h3>
+        <p>Both improvements in this release come from community contributors: @henry201605 (Milvus overrides, PR #978) and @filhocf (Kiro CLI harvest fix, PR #979). Together they complete a major milestone for Milvus users and significantly improve Kiro IDE integration.</p>
       </div>
     </div>
   </div>
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.62.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.63.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.62.0"
+version = "10.63.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.62.0"
+__version__ = "10.63.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.62.0"
+version = "10.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.63.0

### Changes

**feat(milvus): low-priority optional overrides — completes Issue #888** (PR #978, @henry201605)

Implements the final 4 native Milvus overrides, fully completing Issue #888. All 9 optional BaseStorage methods now have native Milvus implementations:
- `search_by_tag_chronological`: tag filter + `sort_desc_key=created_at` server-side + pagination
- `count_memories_by_tag`: Milvus `count(*)` query with tag filter
- `is_deleted`: checks `metadata.deleted_at` field
- `purge_deleted`: queries + hard-deletes tombstones older than N days
17 new mock-based unit tests added.

**fix(harvest): Kiro CLI AssistantMessage kind + raise system-content threshold to 10k** (PR #979, @filhocf)

Fixes Kiro CLI harvest parsing (issue #972):
- Adds `"AssistantMessage": "assistant"` to `KIRO_KIND_MAP` — Kiro CLI uses this kind for assistant messages, not `Response`
- Removes redundant `len(text) > 2000` filter in `_is_system_content` (extractor.py already caps at `MAX_CANDIDATE_CONTENT_LENGTH = 500`)
- Parse yield improvement: 1 candidate/71 messages → 36 candidates/373 messages (36x)

### Files Updated
- `src/mcp_memory_service/_version.py`: `10.62.0` → `10.63.0`
- `pyproject.toml`: `10.62.0` → `10.63.0`
- `uv.lock`: updated
- `CHANGELOG.md`: v10.63.0 entry added
- `README.md`: Latest Release updated
- `CLAUDE.md`: version callout updated
- `docs/index.html`: badge, What's New section, release notes link updated (MINOR release)

### Special Thanks
- @henry201605 — completing the full Milvus native override set (Issue #888)
- @filhocf — Kiro CLI harvest fix improving parse yield 36x