### PR TITLE
chore: release v10.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.64.0] - 2026-05-22
+
+### Added
+
+- **feat(consolidation): incremental time horizon for `memory_consolidate`** ([#985](https://github.com/doobidoo/mcp-memory-service/pull/985), closes [#983](https://github.com/doobidoo/mcp-memory-service/issues/983), @filhocf): New `time_horizon="incremental"` mode processes only memories created since the last consolidation run, enabling safe invocation from session Stop hooks with bounded latency. Uses a DB-based atomic lock (`BEGIN IMMEDIATE` + `locked` column) to prevent concurrent runs across multiple processes. Enforces a 10-second timeout via `asyncio.wait_for` at the handler level. Skips decay and forgetting phases (those remain on monthly/yearly horizons); runs clustering, compression, and association discovery on the incremental window. Bootstraps with a 24-hour window on first run, then advances a `created_at > last_run_at` cursor. New `consolidation/run_tracker.py` module tracks run state. 15 new unit tests added. Relates to RFC [#732](https://github.com/doobidoo/mcp-memory-service/issues/732).
+- **docs(research): contradiction resolution approaches reference** ([#984](https://github.com/doobidoo/mcp-memory-service/pull/984), @rudi193-cmd / Sean Campbell): New `docs/research/contradiction-resolution-approaches.md` — a system-neutral survey of invalidation models, detection mechanisms, and a decision guide for implementors, written in support of RFC #732.
+
+### Fixed
+
+- **fix(web): repair `GET /api/quality/trends` AttributeError** ([#982](https://github.com/doobidoo/mcp-memory-service/pull/982), closes [#981](https://github.com/doobidoo/mcp-memory-service/issues/981), reported by @TonbiLX): The endpoint raised a 500 on every storage backend due to two stacked bugs: `recall_by_timeframe` is a server-tool handler, not a storage method, and `search_all_memories` has never existed on the storage interface. Fixed by replacing both with `get_memories_by_time_range` using a DB-side BETWEEN filter. Quality trends endpoint now returns correct data.
+
+### Maintenance
+
+- **chore: migrate binaries to Git LFS + remove generated statistics** ([e08e606c](https://github.com/doobidoo/mcp-memory-service/commit/e08e606c)): Binary assets moved to Git LFS; generated statistics files removed from version control.
+- **chore: remove stale archive directories** ([14c742ff](https://github.com/doobidoo/mcp-memory-service/commit/14c742ff)): Deleted obsolete archive directories that accumulated in the repository.
+- **fix(docs): remove dead links to deleted archive files** ([bde77499](https://github.com/doobidoo/mcp-memory-service/commit/bde77499)): Documentation links pointing to the removed archive files cleaned up.
+
 ## [10.63.0] - 2026-05-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.63.0 - feat(milvus): low-priority overrides completing #888 (search_by_tag_chronological, count_memories_by_tag, is_deleted, purge_deleted) + fix(harvest): Kiro CLI AssistantMessage + 36x parse yield improvement — ~1,985 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.64.0 - feat(consolidation): incremental time_horizon for memory_consolidate (#985, @filhocf) + fix(web): repair /api/quality/trends AttributeError (#982) + docs(research): contradiction resolution approaches (#984) — ~1,828 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -496,17 +496,19 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.63.0** (May 20, 2026)
+## Latest Release: **v10.64.0** (May 22, 2026)
 
-**Minor: Milvus low-priority overrides (completes #888) + Kiro CLI harvest fix**
+**Minor: Incremental memory consolidation + quality trends fix**
 
 **What's New:**
-- `feat(milvus)`: Completes Issue #888 — `search_by_tag_chronological`, `count_memories_by_tag`, `is_deleted`, `purge_deleted` natively implemented with server-side filter pushdown (@henry201605, PR #978)
-- `fix(harvest)`: Kiro CLI `AssistantMessage` kind support + remove redundant 2000-char filter — parse yield 36x improvement (@filhocf, PR #979)
+- `feat(consolidation)`: `memory_consolidate(action="run", time_horizon="incremental")` — processes only memories since the last run, DB-atomic lock, 10s timeout, safe to call from session Stop hooks (@filhocf, PR #985, closes #983)
+- `fix(web)`: `GET /api/quality/trends` no longer returns 500 on every backend — two stacked AttributeErrors fixed, now uses correct storage interface (PR #982, reported by @TonbiLX)
+- `docs(research)`: contradiction resolution approaches reference doc added for RFC #732 (@rudi193-cmd / Sean Campbell, PR #984)
 
 ---
 
 **Previous Releases**:
+- **v10.63.0** - feat(milvus): low-priority overrides completing #888 (search_by_tag_chronological, count_memories_by_tag, is_deleted, purge_deleted) + fix(harvest): Kiro CLI AssistantMessage + 36x parse yield improvement (PRs #978, #979)
 - **v10.62.0** - feat(milvus): native search_memories + retrieve_with_quality_boost + recall_memory (server-side filter pushdown, completes medium-priority #888) + fix(hooks): JSONL transcript parsing (PRs #970, #971)
 - **v10.61.0** - feat(milvus): native update_memory + update_memories_batch (1 round-trip batch upsert) + feat(sse): Last-Event-ID replay on /api/events reconnect (PRs #966, #953)
 - **v10.60.2** - fix(milvus): replace ANN search() with brute-force query() in semantic dedup — fixes Milvus Lite growing-segment visibility bug (#964, closes #938, @henry201605)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.63.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v10.64.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v10.63.0">
-<meta property="og:description" content="Milvus low-priority overrides completing Issue #888 + Kiro CLI harvest fix with 36x parse yield improvement. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
+<meta property="og:title" content="MCP Memory Service v10.64.0">
+<meta property="og:description" content="Incremental memory consolidation for session Stop hooks + quality trends endpoint fix. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
@@ -116,7 +116,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v10.63 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v10.64 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -136,23 +136,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v10.63</h2>
-    <p class="section-subtitle">Milvus Issue #888 fully complete + Kiro CLI harvest fix with 36x parse yield improvement. ~1,985 tests.</p>
+    <h2 class="section-title">What's New in v10.64</h2>
+    <p class="section-subtitle">Incremental memory consolidation for session Stop hooks + quality trends endpoint fix. ~1,828 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
-        <div class="feature-icon consolidation">&#128269;</div>
-        <h3>Milvus Issue #888 Complete</h3>
-        <p>The final 4 low-priority Milvus overrides are now native: <code>search_by_tag_chronological</code> (tag filter + server-side sort + pagination), <code>count_memories_by_tag</code> (Milvus <code>count(*)</code>), <code>is_deleted</code> (metadata check), and <code>purge_deleted</code> (hard-delete tombstones). All 9 optional BaseStorage methods now have native implementations, eliminating all base-class fallbacks.</p>
+        <div class="feature-icon consolidation">&#9889;</div>
+        <h3>Incremental Consolidation</h3>
+        <p>New <code>time_horizon="incremental"</code> for <code>memory_consolidate</code> processes only memories created since the last run. DB-based atomic lock prevents concurrent runs across processes; 10-second timeout makes it safe to invoke from session Stop hooks. Bootstraps with a 24-hour window on first run, then advances a cursor. (@filhocf, PR #985)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon http">&#128736;</div>
-        <h3>Kiro CLI Harvest Fix</h3>
-        <p>Kiro CLI uses <code>AssistantMessage</code> as the message kind (not <code>Response</code>). The harvest parser now maps this correctly and removes a redundant 2000-char filter. Parse yield for Kiro sessions improves 36x: 1 candidate per 71 messages to 36 candidates per 373 messages.</p>
+        <div class="feature-icon http">&#128200;</div>
+        <h3>Quality Trends Endpoint Fixed</h3>
+        <p>The <code>GET /api/quality/trends</code> endpoint returned a 500 error on every storage backend due to two stacked <code>AttributeError</code> bugs. Both are resolved — the endpoint now uses the correct storage interface and returns accurate trend data. (PR #982, reported by @TonbiLX)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon privacy">&#128260;</div>
-        <h3>Community Contributions</h3>
-        <p>Both improvements in this release come from community contributors: @henry201605 (Milvus overrides, PR #978) and @filhocf (Kiro CLI harvest fix, PR #979). Together they complete a major milestone for Milvus users and significantly improve Kiro IDE integration.</p>
+        <div class="feature-icon privacy">&#128196;</div>
+        <h3>Contradiction Resolution Docs</h3>
+        <p>New research document <code>docs/research/contradiction-resolution-approaches.md</code> — a system-neutral comparison of invalidation models, detection mechanisms, and a decision guide for RFC #732. Contributed by @rudi193-cmd / Sean Campbell (PR #984).</p>
       </div>
     </div>
   </div>
@@ -203,7 +203,7 @@ footer a{color:var(--cyan)}
     <p class="section-subtitle">Battle-tested with comprehensive testing and optimized for performance.</p>
     <div class="stats-grid">
       <div class="stat-card" data-delay="0">
-        <div class="stat-number" data-target="1968">0</div>
+        <div class="stat-number" data-target="1828">0</div>
         <div class="stat-label">Tests</div>
       </div>
       <div class="stat-card" data-delay="100">
@@ -242,7 +242,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.63.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v10.64.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.63.0"
+version = "10.64.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.63.0"
+__version__ = "10.64.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.63.0"
+version = "10.64.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **MINOR release**: v10.63.0 → v10.64.0
- Version bumped in `pyproject.toml`, `src/mcp_memory_service/_version.py`, `uv.lock`
- CHANGELOG, README, CLAUDE.md, and landing page (`docs/index.html`) updated

## What's in this release

### Headline: Incremental Memory Consolidation (#985, @filhocf)

New `time_horizon="incremental"` for `memory_consolidate`:
- Processes only memories created since the last consolidation run (cursor-based)
- DB-based atomic lock (`BEGIN IMMEDIATE` + `locked` column) — multi-process safe
- 10-second `asyncio.wait_for` timeout — safe to invoke from session Stop hooks
- Skips decay/forgetting phases; runs clustering + compression + association discovery
- Bootstraps with 24h window on first run, then uses `created_at > last_run_at` cursor
- New `consolidation/run_tracker.py` module + 15 unit tests
- Closes #983; relates to RFC #732

### Quality Trends Fix (#982, reported by @TonbiLX)

`GET /api/quality/trends` returned 500 on every backend due to two stacked `AttributeError` bugs (`recall_by_timeframe` is a server handler, not a storage method; `search_all_memories` never existed). Fixed to use `get_memories_by_time_range` with DB-side BETWEEN filter.

### Contradiction Resolution Reference Doc (#984, @rudi193-cmd / Sean Campbell)

New `docs/research/contradiction-resolution-approaches.md` — system-neutral survey of invalidation models, detection mechanisms, and decision guide for RFC #732 implementors.

### Maintenance

- Git LFS migration for binary assets + generated statistics cleanup (e08e606c)
- Stale archive directory removal (14c742ff)
- Dead-link cleanup in docs (bde77499)

## Pending (do not block)

Issue #986 — `last_run_at` not advanced on timeout (hot-loop risk). Two fix shapes already outlined in the issue; deferred to a follow-up patch.

## Merge instructions

Branch protection requires `--admin` flag:
```bash
gh pr merge --admin --squash <PR_NUMBER>
```

After merge, create the annotated tag on main:
```bash
git checkout main && git pull origin main
git tag -a v10.64.0 -m "Release v10.64.0"
git push origin v10.64.0
```

Then publish the landing page:
```bash
mkdir -p /tmp/herenow-publish && \
cp docs/index.html docs/brain-icon.png /tmp/herenow-publish/ && \
~/.agents/skills/here-now/scripts/publish.sh /tmp/herenow-publish --slug merry-realm-j835 && \
rm -rf /tmp/herenow-publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)