### PR TITLE
fix(consolidation): tighten temporal_proximity to 7-day window

### DIFF
--- a/src/mcp_memory_service/consolidation/associations.py
+++ b/src/mcp_memory_service/consolidation/associations.py
@@ -237,7 +237,12 @@ class CreativeAssociationEngine(ConsolidationBase):
         return concepts
     
     def _analyze_temporal_relationship(self, mem1: Memory, mem2: Memory) -> Optional[str]:
-        """Analyze temporal relationship between memories."""
+        """Analyze temporal relationship between memories.
+
+        Returns a label only when two memories are genuinely close in time
+        (within 7 days).  Wider gaps do not constitute meaningful temporal
+        proximity for association discovery.
+        """
         if not (mem1.created_at and mem2.created_at):
             return None
         
@@ -248,12 +253,8 @@ class CreativeAssociationEngine(ConsolidationBase):
             return "same_day"
         elif days_diff < 7:
             return "same_week"
-        elif days_diff < 30:
-            return "same_month"
-        elif days_diff < 365:
-            return "same_year"
         else:
-            return "different_years"
+            return None
     
     def _has_similar_structure(self, text1: str, text2: str) -> bool:
         """Check if texts have similar structural patterns."""


### PR DESCRIPTION
## Description

`_analyze_temporal_relationship` previously **never returned `None`** — even memories created years apart received a `temporal_proximity` connection reason, unconditionally inflating confidence scores by +0.1 for every pair analyzed.

## Problem

The function returned a label for *any* time gap:
- `same_day`, `same_week`, `same_month`, `same_year`, `different_years`

Since the caller only checks `if temporal_relationship:` (truthy), **all memory pairs** got the `temporal_proximity` boost — making the signal meaningless and producing noise associations.

## Fix

Return `None` for gaps > 7 days. Only `same_day` and `same_week` qualify as genuine temporal proximity.

## Impact

- Reduces noise associations in the graph
- Gives the forgetting engine better signal via `connection_boost` (fewer spurious edges =枢纽 memories stand out more clearly)
- No breaking changes — downstream code already handles `None` correctly

## Testing

- All 15 tests in `test_associations.py` pass ✅
- All 44 tests in `test_relationship_inference.py` pass ✅

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes have been tested locally
- [x] All existing tests pass
- [x] Documentation updated where needed