### PR TITLE
fix(oauth): remove offline_access from PRM scopes_supported per SEP-2207

### DIFF
--- a/src/mcp_memory_service/web/oauth/discovery.py
+++ b/src/mcp_memory_service/web/oauth/discovery.py
@@ -42,7 +42,7 @@ async def oauth_protected_resource_metadata() -> OAuthProtectedResourceMetadata:
     return OAuthProtectedResourceMetadata(
         resource=OAUTH_ISSUER,
         authorization_servers=[OAUTH_ISSUER],
-        scopes_supported=["read", "write", "admin", "offline_access"],
+        scopes_supported=["read", "write", "admin"],
         bearer_methods_supported=["header"],
         resource_documentation=f"{OAUTH_ISSUER}/docs",
     )

--- a/tests/unit/test_oauth_refresh.py
+++ b/tests/unit/test_oauth_refresh.py
@@ -441,12 +441,13 @@ def test_discovery_advertises_offline_access_scope():
     assert "offline_access" in body["scopes_supported"]
 
 
-def test_protected_resource_metadata_advertises_offline_access():
+def test_protected_resource_metadata_excludes_offline_access():
+    """PRM scopes_supported MUST NOT advertise grant-behavior scopes per SEP-2207."""
     client = _discovery_client()
     response = client.get("/.well-known/oauth-protected-resource")
     assert response.status_code == 200
     body = response.json()
-    assert "offline_access" in body["scopes_supported"]
+    assert "offline_access" not in body["scopes_supported"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Description

Removes `offline_access` from the `scopes_supported` field of the Protected Resource Metadata (PRM) endpoint while keeping it in the Authorization Server metadata, and reverses the corresponding test assertion. Aligns the implementation with MCP SEP-2207 (OIDC Refresh Token).

## Motivation

PR #766 introduced the `refresh_token` grant and the `offline_access` scope. At merge time, `offline_access` was added to both metadata endpoints:

- `/.well-known/oauth-protected-resource` (PRM) — list of resource scopes
- `/.well-known/oauth-authorization-server` (AS metadata) — list of grant scopes

Per SEP-2207, PRM `scopes_supported` MUST advertise only **resource-access scopes** (the permissions a token grants against the resource). `offline_access` is a **grant-behavior scope** — it requests that the AS issue a refresh token alongside the access token — and therefore belongs in the AS metadata, not the PRM.

Spec-compliant OAuth clients reading the PRM would otherwise interpret `offline_access` as a resource scope and construct token requests incorrectly. After this fix, clients see `offline_access` only via AS metadata, where it correctly signals that the AS supports refresh-token issuance.

This was a regression introduced by PR #766 (author: @netizen1119, also the author of this PR).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test improvement

## Changes

**`src/mcp_memory_service/web/oauth/discovery.py`** (PRM endpoint, ~line 45):

Before: `scopes_supported=["read", "write", "admin", "offline_access"]`
After:  `scopes_supported=["read", "write", "admin"]`

AS metadata (same file, ~line 72) is unchanged and continues to advertise `offline_access` — the correct location.

**`tests/unit/test_oauth_refresh.py`** (PRM test, ~line 442):

The existing test `test_protected_resource_metadata_advertises_offline_access` was pinning the spec-violating behavior. It is:

- Renamed → `test_protected_resource_metadata_excludes_offline_access`
- Assertion inverted: `in` → `not in`
- Docstring added referencing SEP-2207

The companion test `test_discovery_advertises_offline_access_scope` (AS metadata endpoint) is unchanged — `offline_access` correctly remains advertised there.

## Verification

​```
$ pytest tests/unit/test_oauth_refresh.py::test_protected_resource_metadata_excludes_offline_access \
         tests/unit/test_oauth_refresh.py::test_discovery_advertises_offline_access_scope -v
...
========================= 2 passed in 2.26s =========================
​```

## Related

- Original feature PR: #766 (`f27dd15b`)
- Spec: SEP-2207 (OIDC Refresh Token)