### PR TITLE
fix(consolidation): raise association confidence threshold to 0.5

### DIFF
--- a/src/mcp_memory_service/consolidation/associations.py
+++ b/src/mcp_memory_service/consolidation/associations.py
@@ -88,7 +88,7 @@ class CreativeAssociationEngine(ConsolidationBase):
             if self.min_similarity <= similarity <= self.max_similarity:
                 analysis = await self._analyze_association(mem1, mem2, similarity)
                 
-                if analysis.confidence_score > 0.5:  # Minimum confidence threshold
+                if analysis.confidence_score >= 0.5:  # Minimum confidence threshold
                     association = await self._create_association_memory(analysis)
                     associations.append(association)
         

--- a/src/mcp_memory_service/consolidation/associations.py
+++ b/src/mcp_memory_service/consolidation/associations.py
@@ -88,7 +88,7 @@ class CreativeAssociationEngine(ConsolidationBase):
             if self.min_similarity <= similarity <= self.max_similarity:
                 analysis = await self._analyze_association(mem1, mem2, similarity)
                 
-                if analysis.confidence_score > 0.3:  # Minimum confidence threshold
+                if analysis.confidence_score > 0.5:  # Minimum confidence threshold
                     association = await self._create_association_memory(analysis)
                     associations.append(association)
         


### PR DESCRIPTION
## Description

Raises the minimum confidence threshold for persisting creative associations from 0.3 to 0.5.

## Problem

The previous threshold of 0.3 was too permissive. The confidence score is calculated as:

```
total = similarity (0.3–0.7) + reason_boost (0.1/reason) + concept_boost + tag_boost
```

With `min_similarity=0.3` and just one connection reason, `total = 0.3 + 0.1 = 0.4 > 0.3` — nearly every pair that entered the sweet spot passed the gate. The threshold provided almost no filtering.

## Fix

Raise threshold to 0.5. Now associations need either:
- Higher base similarity (≥ 0.5), OR
- Multiple connection reasons / shared concepts / shared tags

This ensures only meaningful associations are stored.

## Impact

- Fewer noise edges in the graph → better `memory_graph` query results
- Forgetting engine's `connection_boost` becomes more discriminating (hub memories stand out)
- No breaking changes

## Testing

- All 59 consolidation tests pass ✅ (test_associations + test_relationship_inference)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes have been tested locally
- [x] All existing tests pass
- [x] Documentation updated where needed