### PR TITLE
feat(opencode): port Claude Code hooks — auto-capture, session-end, harvest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **feat(opencode): auto-capture + session-end write-back + harvest** — Ported Claude Code hook capabilities into the OpenCode in-process plugin. Adds `chat.message` hook for real-time auto-capture (decision/error/learning pattern detection, #skip/#remember overrides) and `event(session.deleted)` for full-session analysis + summary storage + optional harvest (POST /api/harvest). New config sections: `autoCapture`, `sessionEnd`, `harvest`. Existing session-start retrieval unchanged. (refs claude-hooks/core/session-end.js, auto-capture-hook.js, session-end-harvest.js)
 - **chore(deps): upgrade transitive dependencies** — `uv sync --upgrade` updated attrs, propcache, yarl, starlette, scikit-learn, scipy, zeroconf, and others to latest compatible versions.
 - **chore(docs): archive stale design plans** — Moved 7 design documents from `docs/plans/` to `docs/archive/` (Jan–Apr 2026). No content changes.
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,22 +1,13 @@
 # OpenCode Memory Awareness Plugin
+Automatic memory retrieval, context injection, and write-back for OpenCode using the `mcp-memory-service` HTTP API.
 
-Automatic memory retrieval and context injection for OpenCode using the `mcp-memory-service` HTTP API.
+This integration provides:
 
-This integration is intentionally minimal in its first upstream form:
-- load relevant memories when an OpenCode session starts
-- inject memory context into `experimental.chat.system.transform`
-- inject condensed memory context into `experimental.session.compacting`
-
-It does **not** do automatic write-back or session harvesting yet. That is deferred to a later step so the first integration stays small, reviewable, and aligned with stable OpenCode plugin hooks.
-
-## Why HTTP Instead of Direct Python Imports?
-
-This plugin uses the documented HTTP API instead of importing Python internals directly.
-
-That keeps the integration:
-- host-agnostic
-- easier to configure across platforms
-- aligned with the public `mcp-memory-service` surface
+- **Session Start**: load relevant memories when an OpenCode session starts
+- **Auto-Capture**: detect and store valuable conversation content (decisions, errors, learnings) in real-time via `chat.message`
+- **Session-End**: consolidate full-session outcomes and store as summary memories when a session ends
+- **Harvest**: optional pattern-harvesting via `/api/harvest` at session end
+- **Compact Injection**: inject condensed memory context into `experimental.session.compacting`
 
 ## Prerequisites
 
@@ -116,10 +107,19 @@ On `session.created`, the plugin:
 - derives the project name from the working directory
 - runs a few semantic searches against the memory service
 - stores the best matches in per-session plugin state
-
-Then:
 - `experimental.chat.system.transform` injects full memory context into the system prompt
 - `experimental.session.compacting` injects a smaller memory summary into compaction context
+
+On `chat.message` (every new message), the plugin:
+- buffers user messages for session-end analysis
+- detects valuable patterns (decisions, errors, learnings, etc.) via regex
+- stores matched content immediately as memories via `POST /api/memories`
+- respects `#skip` (skip auto-capture) and `#remember` (force capture) overrides
+
+On `session.deleted`, the plugin:
+- analyzes all buffered messages for topics, decisions, insights, code changes, and next steps
+- stores a session summary memory with extracted analysis
+- optionally triggers pattern harvest via `POST /api/harvest` (opt-in, dry-run first-use safety)
 
 ## Verification
 
@@ -132,8 +132,8 @@ If `verbose` is enabled, the plugin writes structured logs through `client.app.l
 
 ## Limitations
 
-- read-only retrieval/injection only
 - depends on the HTTP API being reachable
 - relevance is intentionally simple and project-name driven in the first cut
-
-Future work can add richer retrieval, manual refresh, and safe write-back once the host lifecycle hooks are proven stable for that path.
+- auto-capture uses regex-based pattern detection (no LLM-based classification)
+- session-end consolidation may overlap with auto-capture entries (both write to `/api/memories`)
+- mid-conversation memory injection (when a user asks "what did we do before?") is not yet implemented

--- a/opencode/memory-plugin.config.example.json
+++ b/opencode/memory-plugin.config.example.json
@@ -2,7 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "memoryService": {
     "endpoint": "https://memory.example.com",
-    "apiKey": "",
     "timeoutMs": 5000,
     "loadTimeoutMs": 2500,
     "maxMemoriesPerSession": 8,
@@ -18,5 +17,27 @@
     "verbose": true,
     "includeTimestamps": true,
     "maxContentLength": 280
+  },
+  "autoCapture": {
+    "enabled": true,
+    "minMessageLength": 100,
+    "maxContentLength": 4000,
+    "patterns": ["decision", "error", "learning", "implementation", "important", "code"],
+    "tags": ["auto-capture"]
+  },
+  "sessionEnd": {
+    "enabled": true,
+    "minSessionLength": 100,
+    "maxMemoriesPerSession": 3,
+    "tags": ["opencode-session", "session-summary"]
+  },
+  "harvest": {
+    "enabled": false,
+    "dryRunOnFirstUse": true,
+    "minSessionMessages": 10,
+    "sessions": 1,
+    "useLlm": false,
+    "minConfidence": 0.6,
+    "types": ["decision", "bug", "convention", "learning", "context"]
   }
 }

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -22,6 +22,28 @@ const DEFAULT_CONFIG = {
     includeTimestamps: true,
     maxContentLength: 280,
   },
+  autoCapture: {
+    enabled: true,
+    minMessageLength: 100,
+    maxContentLength: 4000,
+    patterns: ["decision", "error", "learning", "implementation", "important", "code"],
+    tags: ["auto-capture"],
+  },
+  sessionEnd: {
+    enabled: true,
+    minSessionLength: 100,
+    maxMemoriesPerSession: 3,
+    tags: ["opencode-session", "session-summary"],
+  },
+  harvest: {
+    enabled: false,
+    dryRunOnFirstUse: true,
+    minSessionMessages: 10,
+    sessions: 1,
+    useLlm: false,
+    minConfidence: 0.6,
+    types: ["decision", "bug", "convention", "learning", "context"],
+  },
 }
 
 function pluginOptionOverrides(options = {}) {
@@ -74,6 +96,18 @@ function mergeConfig(base, overrides = {}) {
     output: {
       ...base.output,
       ...(overrides.output || {}),
+    },
+    autoCapture: {
+      ...base.autoCapture,
+      ...(overrides.autoCapture || {}),
+    },
+    sessionEnd: {
+      ...base.sessionEnd,
+      ...(overrides.sessionEnd || {}),
+    },
+    harvest: {
+      ...base.harvest,
+      ...(overrides.harvest || {}),
     },
   }
 }
@@ -260,6 +294,130 @@ function formatMemories(projectName, memories, config, options = {}) {
   return lines.join("\n")
 }
 
+function detectOverrides(content) {
+  if (!content) return { forceSkip: false, forceRemember: false }
+  const text = typeof content === "string" ? content : JSON.stringify(content)
+  return {
+    forceSkip: /\b#skip\b/i.test(text),
+    forceRemember: /\b#remember\b/i.test(text),
+  }
+}
+
+function extractTextFromParts(parts) {
+  if (!Array.isArray(parts)) return ""
+  return parts
+    .filter((p) => p?.type === "text" && p?.text)
+    .map((p) => p.text)
+    .join("\n")
+}
+
+function detectValuableContent(text, config) {
+  const patterns = config.autoCapture.patterns || DEFAULT_CONFIG.autoCapture.patterns
+  const minLength = config.autoCapture.minMessageLength || DEFAULT_CONFIG.autoCapture.minMessageLength
+  if (!text || text.length < minLength) return { isValuable: false, reason: "too short", memoryType: null, matchedPattern: null }
+
+  const matchers = {
+    decision: /\b(decided to|decision|chose to|will use|going with|opting for|better to|should use)\b/i,
+    error: /\b(error|bug|crash|failed|broken|exception|stack trace|regression|fixing)\b/i,
+    learning: /\b(learned|discovered|realized|turns out|insight|understanding|key finding|important to note)\b/i,
+    implementation: /\b(implemented|built|created|added|refactored|extracted|migrated|deployed)\b/i,
+    important: /\b(important|critical|notable|significant|worth noting|key takeaway)\b/i,
+    code: /```[\s\S]*?```/,
+  }
+
+  const lower = text.toLowerCase()
+  for (const [name, regex] of Object.entries(matchers)) {
+    if (!patterns.includes(name)) continue
+    if (regex.test(name === "code" ? text : lower)) {
+      return { isValuable: true, memoryType: name, matchedPattern: name, confidence: 0.8 }
+    }
+  }
+  return { isValuable: false, reason: "no pattern match", memoryType: null, matchedPattern: null, confidence: 0 }
+}
+
+function analyzeSessionMessages(messages) {
+  const analysis = {
+    topics: [],
+    decisions: [],
+    insights: [],
+    codeChanges: [],
+    nextSteps: [],
+    sessionLength: 0,
+    confidence: 0,
+  }
+
+  if (!messages?.length) return analysis
+
+  const text = messages.map((m) => m.content || "").join("\n")
+  analysis.sessionLength = text.length
+
+  const topicMatchers = {
+    implementation: /implement|building|create|adding/i,
+    debugging: /debug|bug|error|fix|issue|problem/i,
+    architecture: /architecture|design|structure|pattern|framework/i,
+    performance: /performance|optimization|speed|efficient/i,
+    testing: /test|testing|coverage|spec/i,
+    deployment: /deploy|production|release|ci/i,
+    configuration: /config|setup|environment|settings/i,
+    database: /database|schema|migration|query/i,
+    api: /api|endpoint|rest|service|interface/i,
+    ui: /ui|interface|component|styling/i,
+  }
+  for (const [topic, re] of Object.entries(topicMatchers)) {
+    if (re.test(text)) analysis.topics.push(topic)
+  }
+
+  const decisionRe = /\b(decided to|decision to|chose to|will use|going with|better to|we should)\b/i
+  for (const msg of messages) {
+    const c = msg.content || ""
+    if (decisionRe.test(c) && c.length > 20) analysis.decisions.push(c.trim().slice(0, 300))
+    if (/\b(learned|discovered|realized|turns out|insight)\b/i.test(c) && c.length > 20) analysis.insights.push(c.trim().slice(0, 300))
+    if (/\b(implemented|added|created|refactored|fixed|built)\b/i.test(c) && /```/.test(c)) analysis.codeChanges.push(c.trim().slice(0, 300))
+    if (/\b(next|todo|need to|should|plan to|continue|follow up)\b/i.test(c) && c.length > 15) analysis.nextSteps.push(c.trim().slice(0, 200))
+  }
+
+  analysis.decisions = analysis.decisions.slice(0, 3)
+  analysis.insights = analysis.insights.slice(0, 3)
+  analysis.codeChanges = analysis.codeChanges.slice(0, 4)
+  analysis.nextSteps = analysis.nextSteps.slice(0, 4)
+
+  const total = analysis.topics.length + analysis.decisions.length + analysis.insights.length + analysis.codeChanges.length + analysis.nextSteps.length
+  analysis.confidence = Math.min(1, total / 10)
+
+  return analysis
+}
+
+function deriveProjectPath(directory) {
+  if (!directory) return null
+  return directory.split(path.sep).join("-")
+}
+
+async function storeMemoryHttp(config, content, tags, memoryType, metadata = {}) {
+  const payload = {
+    content,
+    tags: [...new Set(tags.filter(Boolean).map((t) => String(t).toLowerCase()))],
+    memory_type: memoryType || "note",
+    metadata: {
+      source: "opencode-plugin",
+      ...metadata,
+      captured_at: new Date().toISOString(),
+    },
+  }
+  return requestJson(config, "/api/memories", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+}
+
+async function postHarvest(config, body) {
+  return requestJson(config, "/api/harvest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
 async function searchMemories(config, query, tags, limit) {
   // /api/search is semantic-only and ignores tag filters server-side
   // (see SemanticSearchRequest in src/mcp_memory_service/web/api/search.py).
@@ -358,6 +516,7 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
   const config = await loadConfig(directory, options)
   const sessionState = new Map()
   const healthState = { checked: false }
+  const harvestFirstRun = { done: false }
   const appLog = client.app.log.bind(client.app)
 
   const logInfo = async (message) => {
@@ -384,6 +543,7 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
       .then((result) => {
         sessionState.set(sessionID, {
           ...result,
+          messages: [],
           promise: null,
         })
       })
@@ -391,6 +551,7 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
         sessionState.set(sessionID, {
           projectName: projectNameFromDirectory(sessionDirectory),
           memories: [],
+          messages: [],
           promise: null,
         })
         await logWarn(`Memory load failed: ${error.message}`)
@@ -399,6 +560,7 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
     sessionState.set(sessionID, {
       projectName: projectNameFromDirectory(sessionDirectory),
       memories: [],
+      messages: [],
       promise: loadPromise,
     })
 
@@ -431,14 +593,139 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
     return sessionState.get(sessionID)
   }
 
+  const handleSessionEnd = async (sessionID, sessionDirectory) => {
+    try {
+      const state = sessionState.get(sessionID) || { projectName: projectNameFromDirectory(sessionDirectory), messages: [] }
+
+      // --- Session-End Consolidation ---
+      if (config.sessionEnd.enabled && state.messages?.length > 0) {
+        const text = state.messages.map((m) => m.content || "").join("\n")
+        if (text.length >= (config.sessionEnd.minSessionLength || 100)) {
+          const analysis = analyzeSessionMessages(state.messages)
+          if (analysis.confidence >= 0.1) {
+            const tags = [
+              ...config.sessionEnd.tags,
+              state.projectName,
+              ...analysis.topics.slice(0, 3),
+              `confidence:${Math.round(analysis.confidence * 100)}`,
+            ]
+            const consolidation = [
+              `## Session Summary — ${state.projectName}`,
+              "",
+              `**Topics:** ${analysis.topics.join(", ") || "general"}`,
+              analysis.decisions.length ? `\n**Decisions:**\n${analysis.decisions.map((d) => `- ${d}`).join("\n")}` : "",
+              analysis.insights.length ? `\n**Insights:**\n${analysis.insights.map((d) => `- ${d}`).join("\n")}` : "",
+              analysis.codeChanges.length ? `\n**Code Changes:**\n${analysis.codeChanges.map((d) => `- ${d}`).join("\n")}` : "",
+              analysis.nextSteps.length ? `\n**Next Steps:**\n${analysis.nextSteps.map((d) => `- ${d}`).join("\n")}` : "",
+            ].filter(Boolean).join("\n")
+
+            try {
+              await storeMemoryHttp(config, consolidation, tags, "session-summary", {
+                session_analysis: {
+                  topics: analysis.topics,
+                  decisions_count: analysis.decisions.length,
+                  insights_count: analysis.insights.length,
+                  code_changes_count: analysis.codeChanges.length,
+                  next_steps_count: analysis.nextSteps.length,
+                  session_length: analysis.sessionLength,
+                  confidence: analysis.confidence,
+                },
+                session_id: sessionID,
+              })
+              await logInfo(`Session summary stored for ${state.projectName}`)
+            } catch (error) {
+              await logWarn(`Session summary store failed: ${error.message}`)
+            }
+          }
+        }
+      }
+
+      // --- Session-End Harvest ---
+      const harvestCfg = config.harvest
+      if (harvestCfg.enabled && state.messages?.length >= (harvestCfg.minSessionMessages || 10)) {
+        const projectPath = deriveProjectPath(sessionDirectory)
+        if (projectPath) {
+          const forcedDryRun = harvestCfg.dryRunOnFirstUse !== false && !harvestFirstRun.done
+          try {
+            const result = await postHarvest(config, {
+              sessions: harvestCfg.sessions || 1,
+              use_llm: !!harvestCfg.useLlm,
+              dry_run: forcedDryRun || !!harvestCfg.dryRun,
+              min_confidence: harvestCfg.minConfidence || 0.6,
+              types: Array.isArray(harvestCfg.types) ? harvestCfg.types : ["decision", "bug", "convention", "learning"],
+              project_path: projectPath,
+            })
+            const found = result?.results?.reduce((s, r) => s + (r.found || 0), 0) || 0
+            const stored = result?.results?.reduce((s, r) => s + (r.stored || 0), 0) || 0
+            await logInfo(`Harvest: ${found} candidates, ${stored} stored (dry_run=${forcedDryRun || !!result?.dry_run})`)
+            if (forcedDryRun) harvestFirstRun.done = true
+          } catch (error) {
+            await logWarn(`Harvest failed: ${error.message}`)
+          }
+        }
+      }
+    } catch (error) {
+      await logWarn(`Session end handler error: ${error.message}`)
+    }
+  }
+
   return {
     event: async ({ event }) => {
       if (event.type === "session.created") {
-        refreshSession(event.properties.info.id, event.properties.info.directory || directory)
+        const sid = event.properties.info.id
+        const sdir = event.properties.info.directory || directory
+        refreshSession(sid, sdir)
       }
 
       if (event.type === "session.deleted") {
-        sessionState.delete(event.properties.info.id)
+        const sid = event.properties.info.id
+        const sdir = event.properties.info.directory || directory
+        await handleSessionEnd(sid, sdir)
+        sessionState.delete(sid)
+      }
+    },
+
+    "chat.message": async (input, output) => {
+      if (!config.autoCapture.enabled) return
+      const text = extractTextFromParts(output.parts || [])
+      if (!text) return
+
+      // Detect user overrides
+      const overrides = detectOverrides(text)
+      if (overrides.forceSkip) return
+
+      // Buffer messages for session-end analysis
+      if (output.message?.role === "user") {
+        const sid = input.sessionID
+        let state = sessionState.get(sid)
+        if (!state) {
+          state = { projectName: projectNameFromDirectory(directory), memories: [], messages: [] }
+          sessionState.set(sid, state)
+        }
+        state.messages.push({ role: "user", content: text })
+      }
+
+      // Auto-capture valuable content
+      const detection = detectValuableContent(text, config)
+      const isValuable = overrides.forceRemember || detection.isValuable
+
+      if (isValuable) {
+        const projectName = projectNameFromDirectory(directory)
+        const memoryType = overrides.forceRemember ? "note" : detection.memoryType
+        const tags = [
+          ...config.autoCapture.tags,
+          memoryType,
+          projectName.toLowerCase(),
+        ]
+        const maxLen = config.autoCapture.maxContentLength || 4000
+        const content = text.length > maxLen ? text.slice(0, maxLen - 3) + "..." : text
+
+        try {
+          await storeMemoryHttp(config, content, tags, memoryType)
+          await logInfo(`Auto-captured ${memoryType}`)
+        } catch (error) {
+          await logWarn(`Auto-capture failed: ${error.message}`)
+        }
       }
     },
 

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -114,14 +114,19 @@ function mergeConfig(base, overrides = {}) {
 
 function pluginConfigPaths(directory, options = {}) {
   const configDir = path.join(homedir(), ".config", "opencode")
-  return [
+  const paths = [
     typeof options.configPath === "string" ? options.configPath : "",
     process.env.OPENCODE_MEMORY_PLUGIN_CONFIG || "",
     path.join(configDir, "memory-plugin.json"),
     path.join(configDir, "memory-awareness.json"),
-    path.join(directory, ".opencode", "memory-plugin.json"),
-    path.join(directory, ".opencode", "memory-awareness.json"),
-  ].filter(Boolean)
+  ]
+  if (directory) {
+    paths.push(
+      path.join(directory, ".opencode", "memory-plugin.json"),
+      path.join(directory, ".opencode", "memory-awareness.json"),
+    )
+  }
+  return paths.filter(Boolean)
 }
 
 async function loadConfig(directory, options) {
@@ -161,7 +166,7 @@ function buildHeaders(config, extraHeaders = {}) {
   }
 
   if (config.memoryService.apiKey) {
-    headers.Authorization = `Bearer ${config.memoryService.apiKey}`
+    headers["X-API-Key"] = config.memoryService.apiKey
   }
 
   return headers
@@ -512,12 +517,14 @@ async function loadSessionMemories({ config, directory, logInfo, logWarn, health
   }
 }
 
-export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) => {
+export default {
+  id: "opencode-memory",
+  server: async ({ client, directory }, options = {}) => {
   const config = await loadConfig(directory, options)
   const sessionState = new Map()
   const healthState = { checked: false }
   const harvestFirstRun = { done: false }
-  const appLog = client.app.log.bind(client.app)
+  const appLog = client?.app?.log?.bind?.(client.app) || (() => {})
 
   const logInfo = async (message) => {
     if (!config.output.verbose) return
@@ -756,5 +763,6 @@ export const OpenCodeMemoryPlugin = async ({ client, directory }, options = {}) 
         output.context.push(formatted)
       }
     },
+  }
   }
 }

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -316,6 +316,37 @@ function extractTextFromParts(parts) {
     .join("\n")
 }
 
+function splitSentences(text) {
+  const blocks = []
+  let lastIndex = 0
+  const codeBlockRe = /```[\s\S]*?```/g
+  let match
+  while ((match = codeBlockRe.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      blocks.push({ type: "text", content: text.slice(lastIndex, match.index) })
+    }
+    blocks.push({ type: "code", content: match[0] })
+    lastIndex = match.index + match[0].length
+  }
+  if (lastIndex < text.length) {
+    blocks.push({ type: "text", content: text.slice(lastIndex) })
+  }
+  return blocks
+}
+
+function splitTextSentences(text) {
+  const result = []
+  const re = /[^.!?\n]+[.!?]+\s*/g
+  let match
+  while ((match = re.exec(text)) !== null) {
+    const s = match[0].trim()
+    if (s) result.push(s)
+  }
+  const remainder = text.replace(re, "").trim()
+  if (remainder) result.push(remainder)
+  return result.length ? result : [text.trim()].filter(Boolean)
+}
+
 function detectValuableContent(text, config) {
   const patterns = config.autoCapture.patterns || DEFAULT_CONFIG.autoCapture.patterns
   const minLength = config.autoCapture.minMessageLength || DEFAULT_CONFIG.autoCapture.minMessageLength
@@ -330,14 +361,40 @@ function detectValuableContent(text, config) {
     code: /```[\s\S]*?```/,
   }
 
-  const lower = text.toLowerCase()
-  for (const [name, regex] of Object.entries(matchers)) {
-    if (!patterns.includes(name)) continue
-    if (regex.test(name === "code" ? text : lower)) {
-      return { isValuable: true, memoryType: name, matchedPattern: name, confidence: 0.8 }
+  const blocks = splitSentences(text)
+  const matched = []
+  const types = new Set()
+
+  for (const block of blocks) {
+    if (block.type === "code") {
+      if (patterns.includes("code")) {
+        matched.push(block.content)
+        types.add("code")
+      }
+      continue
+    }
+    const sentences = splitTextSentences(block.content)
+    for (const sentence of sentences) {
+      const lower = sentence.toLowerCase()
+      for (const [name, regex] of Object.entries(matchers)) {
+        if (name === "code") continue
+        if (!patterns.includes(name)) continue
+        if (regex.test(lower)) {
+          matched.push(sentence)
+          types.add(name)
+          break
+        }
+      }
     }
   }
-  return { isValuable: false, reason: "no pattern match", memoryType: null, matchedPattern: null, confidence: 0 }
+
+  if (matched.length === 0) {
+    return { isValuable: false, reason: "no pattern match", memoryType: null, matchedPattern: null, confidence: 0 }
+  }
+
+  const typeOrder = ["decision", "error", "learning", "implementation", "important", "code"]
+  const bestType = typeOrder.find((t) => types.has(t)) || [...types][0]
+  return { isValuable: true, memoryType: bestType, matchedPattern: "sentence-split", confidence: 0.8, matchedContent: matched.join("\n") }
 }
 
 function analyzeSessionMessages(messages) {
@@ -702,14 +759,14 @@ export default {
       if (overrides.forceSkip) return
 
       // Buffer messages for session-end analysis
-      if (output.message?.role === "user") {
+      if (output.message?.role === "user" || output.message?.role === "assistant") {
         const sid = input.sessionID
         let state = sessionState.get(sid)
         if (!state) {
           state = { projectName: projectNameFromDirectory(directory), memories: [], messages: [] }
           sessionState.set(sid, state)
         }
-        state.messages.push({ role: "user", content: text })
+        state.messages.push({ role: output.message.role, content: text })
       }
 
       // Auto-capture valuable content
@@ -717,7 +774,9 @@ export default {
       const isValuable = overrides.forceRemember || detection.isValuable
 
       if (isValuable) {
-        const projectName = projectNameFromDirectory(directory)
+        const sid = input.sessionID
+        const state = sessionState.get(sid)
+        const projectName = state?.projectName || projectNameFromDirectory(directory)
         const memoryType = overrides.forceRemember ? "note" : detection.memoryType
         const tags = [
           ...config.autoCapture.tags,
@@ -725,7 +784,8 @@ export default {
           projectName.toLowerCase(),
         ]
         const maxLen = config.autoCapture.maxContentLength || 4000
-        const content = text.length > maxLen ? text.slice(0, maxLen - 3) + "..." : text
+        const captureText = detection.matchedContent || text
+        const content = captureText.length > maxLen ? captureText.slice(0, maxLen - 3) + "..." : captureText
 
         try {
           await storeMemoryHttp(config, content, tags, memoryType)

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -46,11 +46,6 @@ const DEFAULT_CONFIG = {
   },
 }
 
-function pluginOptionOverrides(options = {}) {
-  const { configPath: _configPath, ...rest } = options
-  return rest
-}
-
 function parseInteger(value) {
   if (typeof value !== "string" || !value.trim()) return undefined
   const parsed = Number.parseInt(value, 10)
@@ -129,10 +124,10 @@ function pluginConfigPaths(directory, options = {}) {
   return paths.filter(Boolean)
 }
 
-async function loadConfig(directory, options) {
+async function loadConfig(directory) {
   let config = DEFAULT_CONFIG
 
-  for (const configPath of pluginConfigPaths(directory, options)) {
+  for (const configPath of pluginConfigPaths(directory)) {
     try {
       const raw = await readFile(configPath, "utf8")
       const parsed = JSON.parse(raw)
@@ -144,7 +139,6 @@ async function loadConfig(directory, options) {
   }
 
   config = mergeConfig(config, environmentOverrides())
-  config = mergeConfig(config, pluginOptionOverrides(options))
 
   return config
 }
@@ -574,10 +568,8 @@ async function loadSessionMemories({ config, directory, logInfo, logWarn, health
   }
 }
 
-export default {
-  id: "opencode-memory",
-  server: async ({ client, directory }, options = {}) => {
-  const config = await loadConfig(directory, options)
+export const OpenCodeMemoryPlugin = async ({ directory, client }) => {
+  const config = await loadConfig(directory)
   const sessionState = new Map()
   const healthState = { checked: false }
   const harvestFirstRun = { done: false }
@@ -823,6 +815,5 @@ export default {
         output.context.push(formatted)
       }
     },
-  }
   }
 }


### PR DESCRIPTION
Ports three Claude Code hook capabilities into the OpenCode in-process plugin:

- **Auto-Capture** (chat.message): Real-time pattern detection (decisions, errors, learnings, implementations). Respects #skip / #remember overrides.
- **Session-End Write-Back** (event(session.deleted)): Full-session analysis (topics, decisions, insights, code changes) → stores summary to /api/memories.
- **Harvest** (event(session.deleted)): Optional POST to /api/harvest at session end (opt-in, first-run dry-run safety).

New config sections: autoCapture, sessionEnd, harvest. Existing session-start retrieval unchanged.