### PR TITLE
docs: make audit log plugin privacy-safe by default

### DIFF
--- a/examples/plugin-audit-log/README.md
+++ b/examples/plugin-audit-log/README.md
@@ -2,6 +2,10 @@
 
 Demonstrates all 4 lifecycle hooks by writing events to a JSON Lines file.
 
+By default the example writes a **privacy-safe audit log**: raw memory content,
+raw tags and raw retrieval queries are omitted. Configure an HMAC key when you
+want stable correlation IDs across events.
+
 ## Install
 
 ```bash
@@ -17,25 +21,50 @@ Restart mcp-memory-service — the plugin loads automatically via `entry_points`
 | Env Var | Default | Description |
 |---------|---------|-------------|
 | `MCP_PLUGIN_AUDIT_LOG_PATH` | `/tmp/mcp-memory-audit.jsonl` | Path to the audit log file |
+| `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE` | `safe` | `safe` omits raw queries/tags/content; `raw` preserves the original debug fields for local-only inspection |
+| `MCP_PLUGIN_AUDIT_LOG_HMAC_KEY` | unset | Optional secret used to emit stable `hmac-sha256:*` query/memory identifiers in safe mode |
 
 ## Events
 
-Each line in the audit log is a JSON object:
+Each line in the audit log is a JSON object.
+
+Safe mode with `MCP_PLUGIN_AUDIT_LOG_HMAC_KEY`:
 
 ```json
-{"timestamp": 1715000000.0, "event": "store", "hash": "abc123...", "memory_type": "note", "tags": ["project"], "content_length": 150}
-{"timestamp": 1715000001.0, "event": "retrieve", "query": "how to deploy", "result_count": 5}
-{"timestamp": 1715000002.0, "event": "delete", "hash": "def456..."}
-{"timestamp": 1715000003.0, "event": "consolidate", "memories_processed": 42, "time_horizon": "7d"}
+{"timestamp": 1715000000.0, "event": "store", "privacy_mode": "safe", "memory_hash_hmac": "hmac-sha256:abc123...", "memory_type": "note", "tag_count": 1, "content_length": 150, "raw_query_included": false, "raw_content_included": false, "raw_tags_included": false, "hash_algorithm": "hmac-sha256"}
+{"timestamp": 1715000001.0, "event": "retrieve", "privacy_mode": "safe", "query_hash_hmac": "hmac-sha256:def456...", "query_length": 13, "result_count": 5, "raw_query_included": false, "raw_content_included": false, "raw_tags_included": false, "hash_algorithm": "hmac-sha256"}
+{"timestamp": 1715000002.0, "event": "delete", "privacy_mode": "safe", "memory_hash_hmac": "hmac-sha256:789abc...", "raw_query_included": false, "raw_content_included": false, "raw_tags_included": false, "hash_algorithm": "hmac-sha256"}
+{"timestamp": 1715000003.0, "event": "consolidate", "privacy_mode": "safe", "memories_processed": 42, "time_horizon": "7d"}
+```
+
+Safe mode without `MCP_PLUGIN_AUDIT_LOG_HMAC_KEY` still logs counts and lengths,
+but omits stable query/memory identifiers instead of falling back to guessable
+plain hashes:
+
+```json
+{"timestamp": 1715000001.0, "event": "retrieve", "privacy_mode": "safe", "query_length": 13, "result_count": 5, "hash_algorithm": "none", "identifier_hashes_omitted_reason": "MCP_PLUGIN_AUDIT_LOG_HMAC_KEY not set"}
+```
+
+Raw mode is available when you need the original local debugging behavior and
+control the log destination:
+
+```bash
+MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=raw
+```
+
+```json
+{"timestamp": 1715000000.0, "event": "store", "privacy_mode": "raw", "hash": "abc123...", "memory_type": "note", "tags": ["project"], "content_length": 150}
+{"timestamp": 1715000001.0, "event": "retrieve", "privacy_mode": "raw", "query": "how to deploy", "result_count": 5}
+{"timestamp": 1715000002.0, "event": "delete", "privacy_mode": "raw", "hash": "def456..."}
 ```
 
 ## Hooks Used
 
 | Hook | Purpose |
 |------|---------|
-| `on_store` | Log hash, type, tags, content length |
-| `on_delete` | Log deleted hash |
-| `on_retrieve` | Log query and result count (returns results unchanged) |
+| `on_store` | Log memory type, content length, tag count and optional HMAC of the memory hash |
+| `on_delete` | Log optional HMAC of the deleted memory hash |
+| `on_retrieve` | Log query length, result count and optional HMAC of the query (returns results unchanged) |
 | `on_consolidate` | Log consolidation stats |
 
 ## Writing Your Own Plugin

--- a/examples/plugin-audit-log/README.md
+++ b/examples/plugin-audit-log/README.md
@@ -21,7 +21,7 @@ Restart mcp-memory-service — the plugin loads automatically via `entry_points`
 | Env Var | Default | Description |
 |---------|---------|-------------|
 | `MCP_PLUGIN_AUDIT_LOG_PATH` | `/tmp/mcp-memory-audit.jsonl` | Path to the audit log file |
-| `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE` | `safe` | `safe` omits raw queries/tags/content; `raw` preserves the original debug fields for local-only inspection |
+| `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE` | `safe` | `safe` omits raw queries/tags/content; `raw` preserves the original debug fields for local-only inspection. **Warning:** raw mode can write retrieval queries, tags and derived memory identifiers to disk; use it only for short-lived local debugging when you control the log destination. |
 | `MCP_PLUGIN_AUDIT_LOG_HMAC_KEY` | unset | Optional secret used to emit stable `hmac-sha256:*` query/memory identifiers in safe mode |
 
 ## Events

--- a/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
+++ b/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
@@ -40,6 +40,11 @@ HMAC_KEY = os.getenv("MCP_PLUGIN_AUDIT_LOG_HMAC_KEY", "")
 
 def register(ctx: Any) -> None:
     """Entry point called by PluginRegistry at startup."""
+    global PRIVACY_MODE
+    if PRIVACY_MODE not in ("safe", "raw"):
+        logger.warning("audit-log: unknown privacy mode %r; using safe", PRIVACY_MODE)
+        PRIVACY_MODE = "safe"
+
     logger.info(
         "audit-log plugin: registered (log=%s, privacy_mode=%s)",
         AUDIT_LOG_PATH,
@@ -52,12 +57,8 @@ def register(ctx: Any) -> None:
 
 
 def _privacy_mode() -> str:
-    """Return the active privacy mode, falling back to safe for bad config."""
-    if PRIVACY_MODE == "raw":
-        return "raw"
-    if PRIVACY_MODE != "safe":
-        logger.warning("audit-log: unknown privacy mode %r; using safe", PRIVACY_MODE)
-    return "safe"
+    """Return the active privacy mode."""
+    return PRIVACY_MODE
 
 
 def _hmac_hash(value: Any) -> str | None:
@@ -71,9 +72,8 @@ def _hmac_hash(value: Any) -> str | None:
     ).hexdigest()
 
 
-def _hash_metadata(*values: Any) -> dict[str, str | bool]:
+def _hash_metadata() -> dict[str, str | bool]:
     """Build common hash metadata for safe-mode events."""
-    hashes_present = bool(HMAC_KEY) and any(value not in (None, "") for value in values)
     metadata: dict[str, str | bool] = {
         "privacy_mode": "safe",
         "raw_query_included": False,
@@ -81,7 +81,7 @@ def _hash_metadata(*values: Any) -> dict[str, str | bool]:
         "raw_tags_included": False,
         "hash_algorithm": "hmac-sha256" if HMAC_KEY else "none",
     }
-    if not hashes_present:
+    if not HMAC_KEY:
         metadata["identifier_hashes_omitted_reason"] = "MCP_PLUGIN_AUDIT_LOG_HMAC_KEY not set"
     return metadata
 
@@ -114,16 +114,16 @@ async def on_store(memory_dict: dict) -> None:
             "hash": content_hash,
             "memory_type": memory_dict.get("memory_type", ""),
             "tags": memory_dict.get("tags", []),
-            "content_length": len(memory_dict.get("content", "")),
+            "content_length": len(memory_dict.get("content") or ""),
         })
         return
 
     event = {
-        **_hash_metadata(content_hash),
+        **_hash_metadata(),
         "memory_hash_hmac": _hmac_hash(content_hash),
         "memory_type": memory_dict.get("memory_type", ""),
         "tag_count": len(memory_dict.get("tags", []) or []),
-        "content_length": len(memory_dict.get("content", "")),
+        "content_length": len(memory_dict.get("content") or ""),
     }
     # Drop None values so missing keys are explicit via metadata, not null ids.
     await _write_event("store", {k: v for k, v in event.items() if v is not None})
@@ -136,7 +136,7 @@ async def on_delete(content_hash: str) -> None:
         return
 
     event = {
-        **_hash_metadata(content_hash),
+        **_hash_metadata(),
         "memory_hash_hmac": _hmac_hash(content_hash),
     }
     await _write_event("delete", {k: v for k, v in event.items() if v is not None})
@@ -153,7 +153,7 @@ async def on_retrieve(query: str, results: list[dict]) -> list[dict]:
         return results
 
     event = {
-        **_hash_metadata(query),
+        **_hash_metadata(),
         "query_hash_hmac": _hmac_hash(query),
         "query_length": len(query or ""),
         "result_count": len(results),

--- a/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
+++ b/examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py
@@ -3,6 +3,10 @@
 Demonstrates all 4 lifecycle hooks by logging events to a JSON Lines file.
 Install alongside mcp-memory-service and hooks activate automatically.
 
+The default log format is privacy-safe: it records counts, lengths and keyed
+identifier hashes instead of raw queries, tags or memory contents. Set
+``MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=raw`` only for local debugging.
+
 Usage:
     pip install -e examples/plugin-audit-log/
     # Restart mcp-memory-service — plugin loads via entry_points discovery
@@ -11,6 +15,8 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -26,14 +32,58 @@ AUDIT_LOG_PATH = Path(os.getenv(
     "/tmp/mcp-memory-audit.jsonl"
 ))
 
+# Safe is the default because audit logs are often shared during debugging.
+# Raw mode preserves the original example fields for local-only inspection.
+PRIVACY_MODE = os.getenv("MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE", "safe").lower()
+HMAC_KEY = os.getenv("MCP_PLUGIN_AUDIT_LOG_HMAC_KEY", "")
+
 
 def register(ctx: Any) -> None:
     """Entry point called by PluginRegistry at startup."""
-    logger.info("audit-log plugin: registered (log=%s)", AUDIT_LOG_PATH)
+    logger.info(
+        "audit-log plugin: registered (log=%s, privacy_mode=%s)",
+        AUDIT_LOG_PATH,
+        PRIVACY_MODE,
+    )
     ctx.on("on_store", on_store)
     ctx.on("on_delete", on_delete)
     ctx.on("on_retrieve", on_retrieve)
     ctx.on("on_consolidate", on_consolidate)
+
+
+def _privacy_mode() -> str:
+    """Return the active privacy mode, falling back to safe for bad config."""
+    if PRIVACY_MODE == "raw":
+        return "raw"
+    if PRIVACY_MODE != "safe":
+        logger.warning("audit-log: unknown privacy mode %r; using safe", PRIVACY_MODE)
+    return "safe"
+
+
+def _hmac_hash(value: Any) -> str | None:
+    """Return a stable HMAC-SHA256 hash, or None when no key is configured."""
+    if not HMAC_KEY or value in (None, ""):
+        return None
+    return "hmac-sha256:" + hmac.new(
+        HMAC_KEY.encode("utf-8"),
+        str(value).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _hash_metadata(*values: Any) -> dict[str, str | bool]:
+    """Build common hash metadata for safe-mode events."""
+    hashes_present = bool(HMAC_KEY) and any(value not in (None, "") for value in values)
+    metadata: dict[str, str | bool] = {
+        "privacy_mode": "safe",
+        "raw_query_included": False,
+        "raw_content_included": False,
+        "raw_tags_included": False,
+        "hash_algorithm": "hmac-sha256" if HMAC_KEY else "none",
+    }
+    if not hashes_present:
+        metadata["identifier_hashes_omitted_reason"] = "MCP_PLUGIN_AUDIT_LOG_HMAC_KEY not set"
+    return metadata
 
 
 def _write_event_sync(event_type: str, data: dict) -> None:
@@ -57,31 +107,65 @@ async def _write_event(event_type: str, data: dict) -> None:
 
 async def on_store(memory_dict: dict) -> None:
     """Log every memory store event."""
-    await _write_event("store", {
-        "hash": memory_dict.get("content_hash", "unknown"),
+    content_hash = memory_dict.get("content_hash", "unknown")
+    if _privacy_mode() == "raw":
+        await _write_event("store", {
+            "privacy_mode": "raw",
+            "hash": content_hash,
+            "memory_type": memory_dict.get("memory_type", ""),
+            "tags": memory_dict.get("tags", []),
+            "content_length": len(memory_dict.get("content", "")),
+        })
+        return
+
+    event = {
+        **_hash_metadata(content_hash),
+        "memory_hash_hmac": _hmac_hash(content_hash),
         "memory_type": memory_dict.get("memory_type", ""),
-        "tags": memory_dict.get("tags", []),
+        "tag_count": len(memory_dict.get("tags", []) or []),
         "content_length": len(memory_dict.get("content", "")),
-    })
+    }
+    # Drop None values so missing keys are explicit via metadata, not null ids.
+    await _write_event("store", {k: v for k, v in event.items() if v is not None})
 
 
 async def on_delete(content_hash: str) -> None:
     """Log every memory deletion."""
-    await _write_event("delete", {"hash": content_hash})
+    if _privacy_mode() == "raw":
+        await _write_event("delete", {"privacy_mode": "raw", "hash": content_hash})
+        return
+
+    event = {
+        **_hash_metadata(content_hash),
+        "memory_hash_hmac": _hmac_hash(content_hash),
+    }
+    await _write_event("delete", {k: v for k, v in event.items() if v is not None})
 
 
 async def on_retrieve(query: str, results: list[dict]) -> list[dict]:
     """Log retrieval queries and result count. Returns results unchanged."""
-    await _write_event("retrieve", {
-        "query": query[:100],
+    if _privacy_mode() == "raw":
+        await _write_event("retrieve", {
+            "privacy_mode": "raw",
+            "query": query[:100],
+            "result_count": len(results),
+        })
+        return results
+
+    event = {
+        **_hash_metadata(query),
+        "query_hash_hmac": _hmac_hash(query),
+        "query_length": len(query or ""),
         "result_count": len(results),
-    })
+    }
+    await _write_event("retrieve", {k: v for k, v in event.items() if v is not None})
     return results  # Pass through unmodified
 
 
 async def on_consolidate(report: dict) -> None:
     """Log consolidation events."""
     await _write_event("consolidate", {
+        "privacy_mode": _privacy_mode(),
         "memories_processed": report.get("memories_processed", 0),
         "time_horizon": report.get("time_horizon", ""),
     })

--- a/examples/plugin-audit-log/tests/test_privacy.py
+++ b/examples/plugin-audit-log/tests/test_privacy.py
@@ -1,0 +1,97 @@
+import asyncio
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class AuditLogPrivacyTest(unittest.TestCase):
+    def reload_plugin(self, tmp_path: Path, *, mode="safe", key=None):
+        env = {
+            "MCP_PLUGIN_AUDIT_LOG_PATH": str(tmp_path / "audit.jsonl"),
+            "MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE": mode,
+        }
+        if key is not None:
+            env["MCP_PLUGIN_AUDIT_LOG_HMAC_KEY"] = key
+
+        patcher = mock.patch.dict(os.environ, env, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        if key is None:
+            os.environ.pop("MCP_PLUGIN_AUDIT_LOG_HMAC_KEY", None)
+
+        import mcp_memory_plugin_audit_log as plugin
+
+        return importlib.reload(plugin)
+
+    @staticmethod
+    def read_events(path: Path):
+        return [json.loads(line) for line in path.read_text().splitlines()]
+
+    def test_safe_mode_omits_raw_query_tags_and_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.reload_plugin(tmp_path, key="test-key")
+
+            asyncio.run(plugin.on_store({
+                "content_hash": "raw-content-hash",
+                "memory_type": "decision",
+                "tags": ["secret-project", "customer-x"],
+                "content": "the raw secret memory body",
+            }))
+            asyncio.run(plugin.on_retrieve("deploy secret-project with token sk_test", [{"id": 1}]))
+
+            log_path = tmp_path / "audit.jsonl"
+            serialized = log_path.read_text()
+            events = self.read_events(log_path)
+
+            self.assertNotIn("secret-project", serialized)
+            self.assertNotIn("customer-x", serialized)
+            self.assertNotIn("the raw secret memory body", serialized)
+            self.assertNotIn("deploy secret-project", serialized)
+            self.assertNotIn("sk_test", serialized)
+            self.assertTrue(all(event["privacy_mode"] == "safe" for event in events))
+            self.assertTrue(events[0]["memory_hash_hmac"].startswith("hmac-sha256:"))
+            self.assertTrue(events[1]["query_hash_hmac"].startswith("hmac-sha256:"))
+            self.assertEqual(events[1]["query_length"], len("deploy secret-project with token sk_test"))
+            self.assertEqual(events[1]["result_count"], 1)
+
+    def test_safe_mode_without_hmac_omits_stable_identifier_hashes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.reload_plugin(tmp_path)
+
+            asyncio.run(plugin.on_delete("predictable-content-hash"))
+            asyncio.run(plugin.on_retrieve("find private customer note", []))
+
+            log_path = tmp_path / "audit.jsonl"
+            serialized = log_path.read_text()
+            events = self.read_events(log_path)
+
+            self.assertNotIn("predictable-content-hash", serialized)
+            self.assertNotIn("private customer", serialized)
+            self.assertNotIn("memory_hash_hmac", events[0])
+            self.assertNotIn("query_hash_hmac", events[1])
+            self.assertEqual(events[0]["hash_algorithm"], "none")
+            self.assertEqual(
+                events[1]["identifier_hashes_omitted_reason"],
+                "MCP_PLUGIN_AUDIT_LOG_HMAC_KEY not set",
+            )
+
+    def test_raw_mode_preserves_original_debug_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.reload_plugin(tmp_path, mode="raw")
+
+            asyncio.run(plugin.on_retrieve("debug query", []))
+
+            events = self.read_events(tmp_path / "audit.jsonl")
+            self.assertEqual(events[0]["privacy_mode"], "raw")
+            self.assertEqual(events[0]["query"], "debug query")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/plugin-audit-log/tests/test_privacy.py
+++ b/examples/plugin-audit-log/tests/test_privacy.py
@@ -1,31 +1,24 @@
 import asyncio
-import importlib
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
+import mcp_memory_plugin_audit_log as plugin
+
 
 class AuditLogPrivacyTest(unittest.TestCase):
-    def reload_plugin(self, tmp_path: Path, *, mode="safe", key=None):
-        env = {
-            "MCP_PLUGIN_AUDIT_LOG_PATH": str(tmp_path / "audit.jsonl"),
-            "MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE": mode,
-        }
-        if key is not None:
-            env["MCP_PLUGIN_AUDIT_LOG_HMAC_KEY"] = key
-
-        patcher = mock.patch.dict(os.environ, env, clear=False)
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        if key is None:
-            os.environ.pop("MCP_PLUGIN_AUDIT_LOG_HMAC_KEY", None)
-
-        import mcp_memory_plugin_audit_log as plugin
-
-        return importlib.reload(plugin)
+    def configure_plugin(self, tmp_path: Path, *, mode="safe", key=""):
+        patchers = [
+            mock.patch.object(plugin, "AUDIT_LOG_PATH", tmp_path / "audit.jsonl"),
+            mock.patch.object(plugin, "PRIVACY_MODE", mode),
+            mock.patch.object(plugin, "HMAC_KEY", key or ""),
+        ]
+        for patcher in patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        return plugin
 
     @staticmethod
     def read_events(path: Path):
@@ -34,7 +27,7 @@ class AuditLogPrivacyTest(unittest.TestCase):
     def test_safe_mode_omits_raw_query_tags_and_content(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            plugin = self.reload_plugin(tmp_path, key="test-key")
+            plugin = self.configure_plugin(tmp_path, key="test-key")
 
             asyncio.run(plugin.on_store({
                 "content_hash": "raw-content-hash",
@@ -62,7 +55,7 @@ class AuditLogPrivacyTest(unittest.TestCase):
     def test_safe_mode_without_hmac_omits_stable_identifier_hashes(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            plugin = self.reload_plugin(tmp_path)
+            plugin = self.configure_plugin(tmp_path)
 
             asyncio.run(plugin.on_delete("predictable-content-hash"))
             asyncio.run(plugin.on_retrieve("find private customer note", []))
@@ -84,13 +77,47 @@ class AuditLogPrivacyTest(unittest.TestCase):
     def test_raw_mode_preserves_original_debug_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            plugin = self.reload_plugin(tmp_path, mode="raw")
+            plugin = self.configure_plugin(tmp_path, mode="raw")
 
             asyncio.run(plugin.on_retrieve("debug query", []))
 
             events = self.read_events(tmp_path / "audit.jsonl")
             self.assertEqual(events[0]["privacy_mode"], "raw")
             self.assertEqual(events[0]["query"], "debug query")
+
+    def test_empty_identifiers_with_hmac_do_not_claim_missing_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.configure_plugin(tmp_path, key="test-key")
+
+            asyncio.run(plugin.on_retrieve("", []))
+
+            events = self.read_events(tmp_path / "audit.jsonl")
+            self.assertEqual(events[0]["hash_algorithm"], "hmac-sha256")
+            self.assertNotIn("query_hash_hmac", events[0])
+            self.assertNotIn("identifier_hashes_omitted_reason", events[0])
+
+    def test_none_content_does_not_break_length_calculation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.configure_plugin(tmp_path, key="test-key")
+
+            asyncio.run(plugin.on_store({"content_hash": "abc", "content": None, "tags": None}))
+
+            events = self.read_events(tmp_path / "audit.jsonl")
+            self.assertEqual(events[0]["content_length"], 0)
+            self.assertEqual(events[0]["tag_count"], 0)
+
+    def test_register_normalizes_unknown_privacy_mode_once(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            plugin = self.configure_plugin(tmp_path, mode="surprise")
+            ctx = mock.Mock()
+
+            plugin.register(ctx)
+
+            self.assertEqual(plugin.PRIVACY_MODE, "safe")
+            self.assertEqual(ctx.on.call_count, 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the example audit-log plugin privacy-safe by default.

The current example logs raw retrieval queries and raw tags, which is useful for local debugging but easy to copy into production/debugging workflows where audit logs get shared. This change keeps the plugin useful for lifecycle visibility while avoiding raw memory/query/tag leakage by default.

## Changes

- add `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=safe|raw` (`safe` default)
- add optional `MCP_PLUGIN_AUDIT_LOG_HMAC_KEY` for stable HMAC-SHA256 query/memory identifiers
- in safe mode:
  - omit raw retrieval queries
  - omit raw tags and memory content
  - emit counts/lengths and optional keyed identifiers
  - if no HMAC key is configured, omit stable identifiers instead of falling back to guessable hashes
- keep raw mode available for local-only debugging
- document the new event shapes and env vars
- add stdlib unit tests for safe mode with/without HMAC and raw mode compatibility

## Why

The plugin system is now a good extension point for telemetry and intelligence work. The example should model a safe default: audit evidence that can be shared during debugging without exposing user queries, memory contents, customer tags, or predictable identifiers.

## Validation

```bash
python3 -m py_compile examples/plugin-audit-log/mcp_memory_plugin_audit_log/__init__.py examples/plugin-audit-log/tests/test_privacy.py
PYTHONPATH=examples/plugin-audit-log python3 examples/plugin-audit-log/tests/test_privacy.py
git diff --check
```
