### PR TITLE
chore: release v10.65.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [10.65.1] - 2026-05-24
+
+### Fixed
+
+- **fix(prompts): guard `learning_session` against unresolved CLI `$N` placeholders** ([#1000](https://github.com/doobidoo/mcp-memory-service/pull/1000)): Adds regex-based detection of unresolved CLI positional placeholders (`$1`, `$2`, etc.) in `_prompt_learning_session` to prevent storing them as real memories when the prompt template is invoked without required arguments. Closes [#998](https://github.com/doobidoo/mcp-memory-service/issues/998).
+
+### Changed
+
+- **docs: make audit log plugin privacy-safe by default** ([#999](https://github.com/doobidoo/mcp-memory-service/pull/999)): Example audit-log plugin now defaults to `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=safe`, which strips or hashes sensitive fields. Raw mode (`MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=raw`) is available for debugging. Optional HMAC key (`MCP_PLUGIN_AUDIT_LOG_HMAC_KEY`) enables deterministic pseudonymisation of user identifiers.
+
 ## [10.65.0] - 2026-05-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Before merging or releasing:
 
 MCP Memory Service is a semantic memory layer for AI applications, accessible via REST API and MCP transport. It provides persistent storage for 14+ AI clients including Claude Desktop, OpenCode, LangGraph, CrewAI, and any HTTP client. It uses vector embeddings for semantic search, supports multiple storage backends (SQLite-vec, Cloudflare, Hybrid), and includes advanced features like memory consolidation, quality scoring, and OAuth 2.1 team collaboration.
 
-**Current Version:** v10.65.0 - feat(opencode): /memory slash command, TUI toasts, status bridge — /memory search <query>, /memory health, working Solid TUI sidebar widget, per-instance status snapshot, session-summary upsert dedup fix — ~1,828 tests — see [CHANGELOG.md](CHANGELOG.md) for details
+**Current Version:** v10.65.1 - fix(prompts): guard learning_session against unresolved CLI $N placeholders + docs: privacy-safe audit log default — ~1,828 tests — see [CHANGELOG.md](CHANGELOG.md) for details
 
 > **🎯 v10.0.0 Milestone**: This major release represents a complete API consolidation - 34 tools unified into 12 with enhanced capabilities. All deprecated tools continue working with warnings until v11.0. See `docs/MIGRATION.md` for migration guide.
 

--- a/README.md
+++ b/README.md
@@ -509,22 +509,18 @@ The `:quality-cpu` image pre-exports both models at build time and ships only `o
 ---
 
 
-## Latest Release: **v10.65.0** (May 24, 2026)
+## Latest Release: **v10.65.1** (May 24, 2026)
 
-**Minor: OpenCode `/memory` slash commands, TUI sidebar widget, status bridge**
+**Patch: Guard learning_session against unresolved CLI placeholders, privacy-safe audit log default**
 
 **What's New:**
-- `feat(opencode)`: `/memory`, `/memory search <query>`, `/memory health` slash commands in OpenCode (PR #997)
-- `feat(opencode)`: Working Solid TUI sidebar widget (`memory-status-tui.tsx`) compiled via `babel-preset-solid`
-- `feat(opencode)`: Per-instance status snapshot at `~/.config/opencode/.memory-status.json`
-- `fix(opencode)`: TUI toasts now fire correctly — `variant` field was missing, causing silent 400s
-- `fix(opencode)`: Session-summary upsert on `session.idle` eliminates duplicate summaries in vector DB
-- `fix(opencode)`: `/memory health` now hits `/api/health/detailed` (hardened endpoint post-GHSA-73hc-m4hx-79pj)
-- `fix(opencode)`: Multi-project status corruption fix (per Gemini code review)
+- `fix(prompts)`: Detect unresolved CLI `$N` placeholders in `_prompt_learning_session` — prevents storing template artifacts as memories (PR #1000, closes #998)
+- `docs`: Audit-log example plugin defaults to `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=safe`; raw mode and optional HMAC pseudonymisation available (PR #999)
 
 ---
 
 **Previous Releases**:
+- **v10.65.0** - feat(opencode): `/memory` slash commands, TUI toasts, status bridge, working Solid TUI sidebar widget, session-summary dedup fix (PR #997)
 - **v10.64.2** - fix(opencode): replace dead chat.message hook with event-based message.part.updated + add export default {id,server} for V1 plugin compat + use node:https Agent with rejectUnauthorized=false for self-signed cert support (PR #995)
 - **v10.64.1** - fix(consolidation): association confidence threshold raised to 0.5 (PR #991) + fix(consolidation): `last_run_at` advance on timeout (#989, closes #986) + fix(oauth): remove `offline_access` per SEP-2207 (#990) + fix(consolidation): temporal proximity 7-day window (#988)
 - **v10.64.0** - feat(consolidation): incremental time_horizon for memory_consolidate (#985, @filhocf) + fix(web): repair /api/quality/trends AttributeError (#982) + docs(research): contradiction resolution approaches (#984)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "10.65.0"
+version = "10.65.1"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "10.65.0"
+__version__ = "10.65.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "10.65.0"
+version = "10.65.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Release v10.65.1

PATCH release bundling two merged PRs.

## Changes

### Fixed
- **fix(prompts): guard `learning_session` against unresolved CLI `$N` placeholders** (PR #1000, closes #998): Regex-based detection prevents storing `$1`/`$2` template artifacts as real memories when `_prompt_learning_session` is invoked without required arguments.

### Changed
- **docs: make audit log plugin privacy-safe by default** (PR #999): Example audit-log plugin now defaults to `MCP_PLUGIN_AUDIT_LOG_PRIVACY_MODE=safe`. Raw mode and optional HMAC pseudonymisation (`MCP_PLUGIN_AUDIT_LOG_HMAC_KEY`) available for debugging.

## Files Updated
- `pyproject.toml` — 10.65.0 → 10.65.1
- `src/mcp_memory_service/_version.py` — 10.65.0 → 10.65.1
- `uv.lock` — regenerated
- `CHANGELOG.md` — new [10.65.1] section
- `README.md` — Latest Release updated, v10.65.0 moved to Previous Releases
- `CLAUDE.md` — version callout updated

## Test plan
- [ ] CI passes on this PR
- [ ] `pyproject.toml` version = `10.65.1`
- [ ] `_version.py` version = `10.65.1`
- [ ] CHANGELOG has `[10.65.1]` section with Fixed + Changed entries
- [ ] No landing page changes (PATCH release — skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)