### PR TITLE
ci: restrict quality-cpu Docker build to linux/amd64 (fix #1002)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -178,7 +178,11 @@ jobs:
       with:
         context: .
         file: ./tools/docker/Dockerfile.quality-cpu
-        platforms: linux/amd64,linux/arm64
+        # amd64 only: the builder stage installs CPU PyTorch (~750 MB) and
+        # converts models to ONNX. Running this under QEMU arm64 emulation on
+        # GitHub-hosted runners consistently exceeds the 6-hour job limit
+        # (issue #1002). arm64 users should use :slim or :latest instead.
+        platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta-quality-cpu.outputs.tags }}
         labels: ${{ steps.meta-quality-cpu.outputs.labels }}


### PR DESCRIPTION
## Problem

The `Build Quality CPU image` job has timed out at the 6-hour GitHub Actions limit on every release since v10.64.0, causing the `:quality-cpu` Docker image to never be published to Docker Hub.

**Root cause:** The `Dockerfile.quality-cpu` builder stage installs CPU PyTorch (~750 MB) and converts two quality-ranking models to ONNX. When building for `linux/arm64` under QEMU emulation on `ubuntu-latest` runners, this consistently exceeds the 6-hour job limit.

Slim and Standard builds complete in 2–5 min because they skip model download (`SKIP_MODEL_DOWNLOAD=true`). Quality CPU cannot skip this step — it is the point of the image.

| Release | Run | Outcome |
|---------|-----|---------|
| v10.65.1 | [26370772634](https://github.com/doobidoo/mcp-memory-service/actions/runs/26370772634) | ❌ timeout |
| v10.65.0 | [26354870224](https://github.com/doobidoo/mcp-memory-service/actions/runs/26354870224) | ❌ timeout |
| v10.64.2 | [26340049687](https://github.com/doobidoo/mcp-memory-service/actions/runs/26340049687) | ❌ timeout |
| v10.64.1 | [26325954923](https://github.com/doobidoo/mcp-memory-service/actions/runs/26325954923) | ❌ timeout |
| v10.64.0 | [26272395543](https://github.com/doobidoo/mcp-memory-service/actions/runs/26272395543) | ❌ timeout |

## Fix

Restrict `platforms` for the quality-cpu job to `linux/amd64` only. arm64 users can use `:slim` or `:latest` which build multi-arch successfully.

## Test plan

- [ ] `Build Quality CPU image` job completes in < 30 min on next tag push
- [ ] `:quality-cpu` image appears on Docker Hub after merge + release
- [ ] Slim and Standard images unaffected (still linux/amd64,linux/arm64)

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)