### PR TITLE
feat(reasoning): Phase 1a — transitive closure + abduction (RFC #732)

### DIFF
--- a/src/mcp_memory_service/reasoning/inference.py
+++ b/src/mcp_memory_service/reasoning/inference.py
@@ -158,7 +158,7 @@ class SemanticReasoner:
         max_hops: int = 2
     ) -> List[Tuple[str, str, int]]:
         """
-        Find transitive relationships (A→B→C implies A→C).
+        Find transitive relationships (A->B->C implies A->C).
 
         Delegates to GraphStorage.transitive_closure which uses a recursive CTE
         for efficient in-database traversal.
@@ -173,7 +173,7 @@ class SemanticReasoner:
 
         Example:
             >>> inferred = await reasoner.infer_transitive("causes", max_hops=2)
-            [("hash1", "hash3", 2), ...]  # hash1→hash2→hash3
+            [("hash1", "hash3", 2), ...]  # hash1->hash2->hash3
         """
         if not hasattr(self.graph, 'transitive_closure'):
             logger.warning("GraphStorage does not support transitive_closure")
@@ -225,4 +225,45 @@ class SemanticReasoner:
 
         except Exception as e:
             logger.error(f"Failed to suggest relationships for {hash}: {e}")
+            return []
+
+    async def abduce(
+        self,
+        observation_hash: str,
+        rel_type: str,
+        max_hops: int = 1,
+    ) -> List[Dict[str, Any]]:
+        """
+        Abductive inference: find candidate explanations for an observation.
+
+        Given observation O and relationship type R, finds all memories A
+        where A -[R]-> O (direct or transitive). Returns candidates sorted
+        by distance ascending -- closest explanation first.
+
+        Args:
+            observation_hash: Hash of the memory to explain
+            rel_type: Relationship type to traverse backwards
+            max_hops: Maximum hops to search (1 = direct only)
+
+        Returns:
+            List of {"antecedent": str, "distance": int} dicts
+
+        Example:
+            >>> # If A causes B causes C, abduce("C", "causes", max_hops=2)
+            >>> # returns [{"antecedent": "B", "distance": 1},
+            >>> #          {"antecedent": "A", "distance": 2}]
+        """
+        max_hops = max(1, min(max_hops, 4))
+        try:
+            connected = await self.graph.find_connected(
+                memory_hash=observation_hash,
+                relationship_type=rel_type,
+                direction="incoming",
+                max_hops=max_hops,
+            )
+            results = [{"antecedent": h, "distance": d} for h, d in connected]
+            results.sort(key=lambda x: x["distance"])
+            return results
+        except Exception as e:
+            logger.error(f"Failed to abduce from {observation_hash}: {e}")
             return []

--- a/src/mcp_memory_service/reasoning/inference.py
+++ b/src/mcp_memory_service/reasoning/inference.py
@@ -253,7 +253,7 @@ class SemanticReasoner:
             >>> # returns [{"antecedent": "B", "distance": 1},
             >>> #          {"antecedent": "A", "distance": 2}]
         """
-        max_hops = max(1, min(max_hops, 4))
+        max_hops = max(1, min(int(max_hops or 1), 4))
         try:
             connected = await self.graph.find_connected(
                 memory_hash=observation_hash,
@@ -261,9 +261,7 @@ class SemanticReasoner:
                 direction="incoming",
                 max_hops=max_hops,
             )
-            results = [{"antecedent": h, "distance": d} for h, d in connected]
-            results.sort(key=lambda x: x["distance"])
-            return results
+            return [{"antecedent": h, "distance": d} for h, d in connected]
         except Exception as e:
             logger.error(f"Failed to abduce from {observation_hash}: {e}")
             return []

--- a/src/mcp_memory_service/server/handlers/consolidation.py
+++ b/src/mcp_memory_service/server/handlers/consolidation.py
@@ -39,13 +39,27 @@ async def handle_consolidate_memories(server, arguments: dict) -> List[types.Tex
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
-            return [types.TextContent(type="text", text="Error: Invalid time_horizon. Must be one of: daily, weekly, monthly, quarterly, yearly")]
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
+            return [types.TextContent(type="text", text="Error: Invalid time_horizon. Must be one of: daily, weekly, monthly, quarterly, yearly, incremental")]
 
         logger.info(f"Starting {time_horizon} consolidation")
 
-        # Run consolidation
-        report = await server.consolidator.consolidate(time_horizon)
+        # Run consolidation (with timeout for incremental)
+        if time_horizon == "incremental":
+            import asyncio
+            INCREMENTAL_TIMEOUT_SECONDS = 10
+            try:
+                report = await asyncio.wait_for(
+                    server.consolidator.consolidate(time_horizon),
+                    timeout=INCREMENTAL_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                # Advance last_run_at on timeout to prevent infinite retry loop (#986)
+                if server.consolidator.run_tracker:
+                    await server.consolidator.run_tracker.record_run("incremental", 0)
+                return [types.TextContent(type="text", text="Incremental consolidation timed out (>10s). Partial progress saved.")]
+        else:
+            report = await server.consolidator.consolidate(time_horizon)
 
         # Format response
         result = f"""Consolidation completed successfully!

--- a/src/mcp_memory_service/server/handlers/consolidation.py
+++ b/src/mcp_memory_service/server/handlers/consolidation.py
@@ -19,6 +19,7 @@ Memory consolidation, scheduler control, status monitoring, and recommendations.
 Extracted from server_impl.py Phase 2.2 refactoring.
 """
 
+import asyncio
 import logging
 import traceback
 from typing import List
@@ -46,7 +47,6 @@ async def handle_consolidate_memories(server, arguments: dict) -> List[types.Tex
 
         # Run consolidation (with timeout for incremental)
         if time_horizon == "incremental":
-            import asyncio
             INCREMENTAL_TIMEOUT_SECONDS = 10
             try:
                 report = await asyncio.wait_for(

--- a/src/mcp_memory_service/server/handlers/consolidation.py
+++ b/src/mcp_memory_service/server/handlers/consolidation.py
@@ -19,7 +19,6 @@ Memory consolidation, scheduler control, status monitoring, and recommendations.
 Extracted from server_impl.py Phase 2.2 refactoring.
 """
 
-import asyncio
 import logging
 import traceback
 from typing import List
@@ -40,26 +39,13 @@ async def handle_consolidate_memories(server, arguments: dict) -> List[types.Tex
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
-            return [types.TextContent(type="text", text="Error: Invalid time_horizon. Must be one of: daily, weekly, monthly, quarterly, yearly, incremental")]
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
+            return [types.TextContent(type="text", text="Error: Invalid time_horizon. Must be one of: daily, weekly, monthly, quarterly, yearly")]
 
         logger.info(f"Starting {time_horizon} consolidation")
 
-        # Run consolidation (with timeout for incremental)
-        if time_horizon == "incremental":
-            INCREMENTAL_TIMEOUT_SECONDS = 10
-            try:
-                report = await asyncio.wait_for(
-                    server.consolidator.consolidate(time_horizon),
-                    timeout=INCREMENTAL_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                # Advance last_run_at even on timeout to prevent infinite retry loop (#986)
-                if server.consolidator.run_tracker:
-                    await server.consolidator.run_tracker.record_run("incremental", 0)
-                return [types.TextContent(type="text", text="Incremental consolidation timed out (>10s). Partial progress saved.")]
-        else:
-            report = await server.consolidator.consolidate(time_horizon)
+        # Run consolidation
+        report = await server.consolidator.consolidate(time_horizon)
 
         # Format response
         result = f"""Consolidation completed successfully!
@@ -145,7 +131,7 @@ async def handle_consolidation_recommendations(server, arguments: dict) -> List[
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
             return [types.TextContent(type="text", text="Error: Invalid time_horizon")]
 
         # Get recommendations
@@ -261,7 +247,7 @@ async def handle_trigger_consolidation(server, arguments: dict) -> List[types.Te
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
             return [types.TextContent(type="text", text="Error: Invalid time_horizon")]
 
         # Trigger consolidation

--- a/src/mcp_memory_service/server/handlers/consolidation.py
+++ b/src/mcp_memory_service/server/handlers/consolidation.py
@@ -54,7 +54,7 @@ async def handle_consolidate_memories(server, arguments: dict) -> List[types.Tex
                     timeout=INCREMENTAL_TIMEOUT_SECONDS,
                 )
             except asyncio.TimeoutError:
-                # Advance last_run_at on timeout to prevent infinite retry loop (#986)
+                # Advance last_run_at even on timeout to prevent infinite retry loop (#986)
                 if server.consolidator.run_tracker:
                     await server.consolidator.run_tracker.record_run("incremental", 0)
                 return [types.TextContent(type="text", text="Incremental consolidation timed out (>10s). Partial progress saved.")]
@@ -145,7 +145,7 @@ async def handle_consolidation_recommendations(server, arguments: dict) -> List[
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
             return [types.TextContent(type="text", text="Error: Invalid time_horizon")]
 
         # Get recommendations
@@ -261,7 +261,7 @@ async def handle_trigger_consolidation(server, arguments: dict) -> List[types.Te
         if not time_horizon:
             return [types.TextContent(type="text", text="Error: time_horizon is required")]
 
-        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly"]:
+        if time_horizon not in ["daily", "weekly", "monthly", "quarterly", "yearly", "incremental"]:
             return [types.TextContent(type="text", text="Error: Invalid time_horizon")]
 
         # Trigger consolidation

--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -75,7 +75,7 @@ async def handle_memory_graph(server, arguments: dict) -> List[types.TextContent
         return [types.TextContent(type="text", text="Error: action parameter is required")]
 
     # Validate action
-    valid_actions = ["connected", "path", "subgraph", "extract_entities", "infer", "suggest"]
+    valid_actions = ["connected", "path", "subgraph", "extract_entities", "infer", "suggest", "abduce"]
     if action not in valid_actions:
         return [types.TextContent(
             type="text",
@@ -159,6 +159,9 @@ async def handle_memory_graph(server, arguments: dict) -> List[types.TextContent
         elif action == "suggest":
             return await handle_suggest(arguments)
 
+        elif action == "abduce":
+            return await handle_abduce(arguments)
+
         else:
             # Should never reach here due to validation above
             return [types.TextContent(type="text", text=f"Error: Unknown action '{action}'")]
@@ -223,6 +226,38 @@ async def handle_suggest(arguments: dict) -> List[types.TextContent]:
         "success": True,
         "suggestions": suggestions,
         "count": len(suggestions)
+    }, indent=2))]
+
+
+async def handle_abduce(arguments: dict) -> List[types.TextContent]:
+    """Handle abduce action: find candidate explanations for an observation."""
+    graph = await get_graph_storage()
+    if graph is None:
+        return [types.TextContent(type="text", text=json.dumps({
+            "success": False,
+            "error": f"Graph operations not available for backend: {STORAGE_BACKEND}",
+            "antecedents": []
+        }, indent=2))]
+
+    observation = arguments.get("hash")
+    if not observation:
+        return [types.TextContent(type="text", text=json.dumps({
+            "success": False,
+            "error": "Missing required parameter: hash",
+            "antecedents": []
+        }, indent=2))]
+
+    from ...reasoning.inference import SemanticReasoner
+    reasoner = SemanticReasoner(graph)
+
+    rel_type = arguments.get("rel_type", "causes")
+    max_hops = arguments.get("max_hops", 1)
+
+    results = await reasoner.abduce(observation, rel_type, max_hops)
+    return [types.TextContent(type="text", text=json.dumps({
+        "success": True,
+        "antecedents": results,
+        "count": len(results)
     }, indent=2))]
 
 

--- a/tests/reasoning/test_phase1a.py
+++ b/tests/reasoning/test_phase1a.py
@@ -1,0 +1,796 @@
+"""
+Phase 1a tests: transitive closure, abduction, and handler integration.
+
+Covers:
+  A. GraphStorage.transitive_closure (15 tests)
+  B. GraphStorage.common_neighbors (10 tests)
+  C. SemanticReasoner.abduce (15 tests)
+  D. Handler integration for abduce / infer / suggest (20 tests)
+
+Total: 60 tests
+"""
+
+import json
+import os
+import sys
+import tempfile
+import time
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loading (matching tests/test_semantic_reasoner.py pattern)
+# ---------------------------------------------------------------------------
+
+_tests_dir = Path(__file__).parent.parent
+_graph_path = _tests_dir / "src" / "mcp_memory_service" / "storage" / "graph.py"
+_reasoning_path = _tests_dir / "src" / "mcp_memory_service" / "reasoning" / "inference.py"
+_handler_path = _tests_dir / "src" / "mcp_memory_service" / "server" / "handlers" / "graph.py"
+
+spec = importlib.util.spec_from_file_location("graph_storage_mod", _graph_path)
+_graph_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_graph_mod)
+GraphStorage = _graph_mod.GraphStorage
+
+spec2 = importlib.util.spec_from_file_location("inference_mod", _reasoning_path)
+_inference_mod = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(_inference_mod)
+SemanticReasoner = _inference_mod.SemanticReasoner
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def storage():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".db") as f:
+        db_path = f.name
+    gs = GraphStorage(db_path)
+    conn = await gs._get_connection()
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS memory_graph (
+            source_hash TEXT NOT NULL,
+            target_hash TEXT NOT NULL,
+            similarity REAL NOT NULL,
+            connection_types TEXT NOT NULL,
+            metadata TEXT,
+            created_at REAL NOT NULL,
+            relationship_type TEXT DEFAULT 'related',
+            PRIMARY KEY (source_hash, target_hash)
+        )
+    """)
+    conn.commit()
+    yield gs
+    if gs._connection:
+        gs._connection.close()
+    os.unlink(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _add_edge(gs: GraphStorage, src: str, tgt: str, rel: str) -> None:
+    conn = await gs._get_connection()
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO memory_graph
+            (source_hash, target_hash, similarity, connection_types, metadata, created_at, relationship_type)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (src, tgt, 0.9, '["semantic"]', None, time.time(), rel),
+    )
+    conn.commit()
+
+
+# ===========================================================================
+# Section A: GraphStorage.transitive_closure (15 tests)
+# ===========================================================================
+
+
+class TestTransitiveClosure:
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_returns_empty(self, storage):
+        """A1: empty graph yields no inferred pairs."""
+        result = await storage.transitive_closure("causes", max_hops=2)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_single_direct_edge_no_chain(self, storage):
+        """A2: single A->B edge produces no transitive pair (nothing to close)."""
+        await _add_edge(storage, "A", "B", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_two_hop_chain(self, storage):
+        """A3: A->B->C yields inferred (A, C, 2)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        pairs = {(s, t): d for s, t, d in result}
+        assert ("A", "C") in pairs
+        assert pairs[("A", "C")] == 2
+
+    @pytest.mark.asyncio
+    async def test_three_hop_chain_all_inferred(self, storage):
+        """A4: A->B->C->D with max_hops=3 finds (A,C,2), (A,D,3), (B,D,2)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "C", "D", "causes")
+        result = await storage.transitive_closure("causes", max_hops=3)
+        pairs = {(s, t): d for s, t, d in result}
+        assert ("A", "C") in pairs and pairs[("A", "C")] == 2
+        assert ("A", "D") in pairs and pairs[("A", "D")] == 3
+        assert ("B", "D") in pairs and pairs[("B", "D")] == 2
+
+    @pytest.mark.asyncio
+    async def test_max_hops_limits_distance(self, storage):
+        """A5: max_hops=2 does NOT return a 3-hop pair."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "C", "D", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        pairs = {(s, t) for s, t, d in result}
+        assert ("A", "D") not in pairs
+
+    @pytest.mark.asyncio
+    async def test_max_hops_minimum_two(self, storage):
+        """A6: passing max_hops=1 still finds 2-hop pairs (minimum is 2)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        # even if clamped to 2, the 2-hop result should appear
+        result = await storage.transitive_closure("causes", max_hops=1)
+        pairs = {(s, t) for s, t, d in result}
+        assert ("A", "C") in pairs
+
+    @pytest.mark.asyncio
+    async def test_wrong_rel_type_empty(self, storage):
+        """A7: querying wrong rel_type returns []."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        result = await storage.transitive_closure("fixes", max_hops=2)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_direct_edges_excluded(self, storage):
+        """A8: direct A->C edge is NOT returned as an inferred pair."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "A", "C", "causes")  # direct — must be excluded
+        result = await storage.transitive_closure("causes", max_hops=2)
+        # (A, C) with distance 2 must NOT appear since edge exists directly
+        pairs = {(s, t) for s, t, d in result}
+        assert ("A", "C") not in pairs
+
+    @pytest.mark.asyncio
+    async def test_two_independent_chains(self, storage):
+        """A9: two separate chains both produce their own inferred pairs."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "X", "Y", "causes")
+        await _add_edge(storage, "Y", "Z", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        pairs = {(s, t) for s, t, d in result}
+        assert ("A", "C") in pairs
+        assert ("X", "Z") in pairs
+
+    @pytest.mark.asyncio
+    async def test_diamond_graph(self, storage):
+        """A10: A->B->D and A->C->D: (A, D, 2) should be inferred."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "A", "C", "causes")
+        await _add_edge(storage, "B", "D", "causes")
+        await _add_edge(storage, "C", "D", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        pairs = {(s, t) for s, t, d in result}
+        assert ("A", "D") in pairs
+
+    @pytest.mark.asyncio
+    async def test_cycle_safe(self, storage):
+        """A11: A->B->A cycle doesn't infinite-loop."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "A", "causes")
+        # Should complete without error
+        result = await storage.transitive_closure("causes", max_hops=2)
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_mixed_rel_types_no_bleed(self, storage):
+        """A12: causes chain doesn't produce inferred pairs for fixes."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "X", "Y", "fixes")
+        await _add_edge(storage, "Y", "Z", "fixes")
+        causes_result = await storage.transitive_closure("causes", max_hops=2)
+        fixes_result = await storage.transitive_closure("fixes", max_hops=2)
+        causes_pairs = {(s, t) for s, t, d in causes_result}
+        fixes_pairs = {(s, t) for s, t, d in fixes_result}
+        assert ("X", "Z") not in causes_pairs
+        assert ("A", "C") not in fixes_pairs
+
+    @pytest.mark.asyncio
+    async def test_result_is_list_of_3tuples(self, storage):
+        """A13: result type is List[Tuple[str, str, int]]."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        assert isinstance(result, list)
+        for item in result:
+            assert len(item) == 3
+            s, t, d = item
+            assert isinstance(s, str)
+            assert isinstance(t, str)
+            assert isinstance(d, int)
+
+    @pytest.mark.asyncio
+    async def test_distance_always_gte_2(self, storage):
+        """A14: all distances in result are >= 2 (direct edges excluded)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "C", "D", "causes")
+        result = await storage.transitive_closure("causes", max_hops=3)
+        for _, _, d in result:
+            assert d >= 2
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_pairs(self, storage):
+        """A15: no duplicate (source, target) pairs in result."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "C", "causes")
+        await _add_edge(storage, "A", "D", "causes")
+        await _add_edge(storage, "D", "C", "causes")
+        result = await storage.transitive_closure("causes", max_hops=2)
+        pairs = [(s, t) for s, t, d in result]
+        assert len(pairs) == len(set(pairs))
+
+
+# ===========================================================================
+# Section B: GraphStorage.common_neighbors (10 tests)
+# ===========================================================================
+
+
+class TestCommonNeighbors:
+
+    @pytest.mark.asyncio
+    async def test_isolated_node_returns_empty(self, storage):
+        """B1: node with no edges returns []."""
+        result = await storage.common_neighbors("isolated", min_shared=1)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_triangle_suggests_each_other(self, storage):
+        """B2: A and B both connected to hub -> each suggested to the other."""
+        await _add_edge(storage, "A", "hub", "related")
+        await _add_edge(storage, "B", "hub", "related")
+        result_a = await storage.common_neighbors("A", min_shared=1)
+        candidates = [c for c, _, _ in result_a]
+        assert "B" in candidates
+
+    @pytest.mark.asyncio
+    async def test_min_shared_filters_low_overlap(self, storage):
+        """B3: min_shared=2 filters out candidates sharing only 1 neighbor."""
+        await _add_edge(storage, "A", "hub1", "related")
+        await _add_edge(storage, "B", "hub1", "related")
+        # B shares only 1 neighbor with A — should be excluded at min_shared=2
+        result = await storage.common_neighbors("A", min_shared=2)
+        candidates = [c for c, _, _ in result]
+        assert "B" not in candidates
+
+    @pytest.mark.asyncio
+    async def test_already_connected_excluded(self, storage):
+        """B4: direct neighbors of source are excluded from suggestions."""
+        await _add_edge(storage, "A", "B", "related")
+        await _add_edge(storage, "A", "hub", "related")
+        await _add_edge(storage, "B", "hub", "related")
+        # B is a direct neighbor of A — should not be suggested
+        result = await storage.common_neighbors("A", min_shared=1)
+        candidates = [c for c, _, _ in result]
+        assert "B" not in candidates
+
+    @pytest.mark.asyncio
+    async def test_source_degree_non_negative(self, storage):
+        """B5: source_degree field is a non-negative integer."""
+        await _add_edge(storage, "A", "hub", "related")
+        await _add_edge(storage, "B", "hub", "related")
+        result = await storage.common_neighbors("A", min_shared=1)
+        for _, _, source_degree in result:
+            assert isinstance(source_degree, int)
+            assert source_degree >= 0
+
+    @pytest.mark.asyncio
+    async def test_shared_count_positive(self, storage):
+        """B6: shared_count is a positive integer."""
+        await _add_edge(storage, "A", "hub", "related")
+        await _add_edge(storage, "B", "hub", "related")
+        result = await storage.common_neighbors("A", min_shared=1)
+        for _, shared_count, _ in result:
+            assert isinstance(shared_count, int)
+            assert shared_count > 0
+
+    @pytest.mark.asyncio
+    async def test_bidirectional_counts_as_neighbor(self, storage):
+        """B7: both A->hub and hub->A count for neighborhood."""
+        await _add_edge(storage, "hub", "A", "related")
+        await _add_edge(storage, "hub", "B", "related")
+        result = await storage.common_neighbors("A", min_shared=1)
+        # A and B share hub as a common neighbor via outgoing edges from hub
+        candidates = [c for c, _, _ in result]
+        assert "B" in candidates
+
+    @pytest.mark.asyncio
+    async def test_limit_ten_results(self, storage):
+        """B8: at most 10 candidates returned even if more exist."""
+        hub = "hub"
+        source = "source"
+        await _add_edge(storage, source, hub, "related")
+        for i in range(15):
+            await _add_edge(storage, f"cand{i}", hub, "related")
+        result = await storage.common_neighbors(source, min_shared=1)
+        assert len(result) <= 10
+
+    @pytest.mark.asyncio
+    async def test_result_is_list_of_3tuples(self, storage):
+        """B9: result is List[Tuple[str, int, int]]."""
+        await _add_edge(storage, "A", "hub", "related")
+        await _add_edge(storage, "B", "hub", "related")
+        result = await storage.common_neighbors("A", min_shared=1)
+        assert isinstance(result, list)
+        for item in result:
+            assert len(item) == 3
+            cand, shared, degree = item
+            assert isinstance(cand, str)
+            assert isinstance(shared, int)
+            assert isinstance(degree, int)
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_returns_empty(self, storage):
+        """B10: empty graph returns []."""
+        result = await storage.common_neighbors("anything", min_shared=1)
+        assert result == []
+
+
+# ===========================================================================
+# Section C: SemanticReasoner.abduce (15 tests)
+# ===========================================================================
+
+
+class TestAbduce:
+
+    @pytest.mark.asyncio
+    async def test_empty_graph_returns_empty(self, storage):
+        """C1: empty graph -> []."""
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_direct_incoming_causes_edge(self, storage):
+        """C2: A->obs via causes -> [{antecedent: A, distance: 1}]."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        assert len(result) == 1
+        assert result[0]["antecedent"] == "A"
+        assert result[0]["distance"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_incoming_edges_empty(self, storage):
+        """C3: obs has only outgoing edges -> []."""
+        await _add_edge(storage, "obs", "downstream", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_wrong_rel_type_empty(self, storage):
+        """C4: A->obs via causes, querying fixes -> []."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "fixes", max_hops=1)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_max_hops_1_only_direct(self, storage):
+        """C5: max_hops=1 doesn't return 2-hop antecedent."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        antecedents = [r["antecedent"] for r in result]
+        assert "A" not in antecedents
+        assert "B" in antecedents
+
+    @pytest.mark.asyncio
+    async def test_max_hops_2_returns_two_levels(self, storage):
+        """C6: A->B->obs with max_hops=2 returns B(dist 1) and A(dist 2)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=2)
+        antecedents = {r["antecedent"]: r["distance"] for r in result}
+        assert antecedents.get("B") == 1
+        assert antecedents.get("A") == 2
+
+    @pytest.mark.asyncio
+    async def test_results_sorted_by_distance_ascending(self, storage):
+        """C7: results sorted distance ascending (closest first)."""
+        await _add_edge(storage, "A", "B", "causes")
+        await _add_edge(storage, "B", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=2)
+        distances = [r["distance"] for r in result]
+        assert distances == sorted(distances)
+
+    @pytest.mark.asyncio
+    async def test_multiple_antecedents_at_distance_1(self, storage):
+        """C8: multiple direct antecedents all returned."""
+        await _add_edge(storage, "A", "obs", "causes")
+        await _add_edge(storage, "B", "obs", "causes")
+        await _add_edge(storage, "C", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        antecedents = {r["antecedent"] for r in result}
+        assert antecedents == {"A", "B", "C"}
+
+    @pytest.mark.asyncio
+    async def test_distance_key_present(self, storage):
+        """C9: every result dict has 'distance' key."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        for r in result:
+            assert "distance" in r
+
+    @pytest.mark.asyncio
+    async def test_antecedent_key_present(self, storage):
+        """C10: every result dict has 'antecedent' key."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        for r in result:
+            assert "antecedent" in r
+
+    @pytest.mark.asyncio
+    async def test_max_hops_clamped_to_4(self, storage):
+        """C11: max_hops > 4 clamped to 4 (no error raised)."""
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=10)
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_max_hops_clamped_to_min_1(self, storage):
+        """C12: max_hops=0 clamped to 1 (no error raised)."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=0)
+        assert isinstance(result, list)
+        # clamped to 1, direct antecedent still found
+        antecedents = [r["antecedent"] for r in result]
+        assert "A" in antecedents
+
+    @pytest.mark.asyncio
+    async def test_works_for_supports_rel_type(self, storage):
+        """C13: works with rel_type='supports'."""
+        await _add_edge(storage, "A", "obs", "supports")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "supports", max_hops=1)
+        assert any(r["antecedent"] == "A" for r in result)
+
+    @pytest.mark.asyncio
+    async def test_works_for_related_rel_type(self, storage):
+        """C14: works with rel_type='related'."""
+        await _add_edge(storage, "A", "obs", "related")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "related", max_hops=1)
+        assert any(r["antecedent"] == "A" for r in result)
+
+    @pytest.mark.asyncio
+    async def test_returns_list_of_dicts_not_tuples(self, storage):
+        """C15: return type is List[Dict], not List[Tuple]."""
+        await _add_edge(storage, "A", "obs", "causes")
+        reasoner = SemanticReasoner(storage)
+        result = await reasoner.abduce("obs", "causes", max_hops=1)
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, dict), f"Expected dict, got {type(item)}"
+
+
+# ===========================================================================
+# Section D: Handler integration (20 tests)
+# ===========================================================================
+# We test handlers by building mock graph / reasoner objects so we don't need
+# the full MCP server stack.  Handlers are loaded via importlib the same way.
+
+def _make_graph_mock(find_connected_return=None, transitive_return=None, common_neighbors_return=None):
+    """Build an async-capable mock GraphStorage."""
+    mock = MagicMock()
+    mock.find_connected = AsyncMock(return_value=find_connected_return or [])
+    mock.transitive_closure = AsyncMock(return_value=transitive_return or [])
+    mock.common_neighbors = AsyncMock(return_value=common_neighbors_return or [])
+    mock.shortest_path = AsyncMock(return_value=None)
+    return mock
+
+
+def _parse_text(content_list) -> dict:
+    """Parse the text from a handler return value."""
+    assert len(content_list) == 1
+    return json.loads(content_list[0].text)
+
+
+# We import the handler functions we need to test.
+# Because the handler imports from relative paths (mcp, config, etc.) we need
+# to test them via direct mock-patching at the module level.
+
+import importlib.util as _ilu
+import types as _types_mod
+
+def _load_handler_module():
+    """
+    Load graph handler via importlib, stub out unavailable imports.
+    """
+    # Stub 'mcp' with a minimal types shim
+    mcp_stub = _types_mod.ModuleType("mcp")
+    mcp_types_stub = _types_mod.ModuleType("mcp.types")
+
+    class _TextContent:
+        def __init__(self, type: str, text: str):
+            self.type = type
+            self.text = text
+
+    mcp_types_stub.TextContent = _TextContent
+    mcp_stub.types = mcp_types_stub
+    sys.modules.setdefault("mcp", mcp_stub)
+    sys.modules.setdefault("mcp.types", mcp_types_stub)
+
+    # Stub the storage + config imports used inside the handler
+    config_stub = _types_mod.ModuleType("mcp_memory_service.config")
+    config_stub.SQLITE_VEC_PATH = "/tmp/test.db"
+    config_stub.STORAGE_BACKEND = "sqlite_vec"
+    sys.modules["mcp_memory_service.config"] = config_stub
+
+    graph_storage_stub = _types_mod.ModuleType("mcp_memory_service.storage.graph")
+    graph_storage_stub.GraphStorage = GraphStorage
+    sys.modules["mcp_memory_service.storage.graph"] = graph_storage_stub
+
+    inference_stub = _types_mod.ModuleType("mcp_memory_service.reasoning.inference")
+    inference_stub.SemanticReasoner = SemanticReasoner
+    sys.modules["mcp_memory_service.reasoning.inference"] = inference_stub
+
+    # Load actual handler file by executing it in a fresh module namespace
+    handler_mod = _types_mod.ModuleType("_handler_under_test")
+    handler_mod.__package__ = "mcp_memory_service.server.handlers"
+    handler_src = _handler_path.read_text()
+
+    # Replace relative imports with already-stubbed absolute ones
+    handler_src = handler_src.replace(
+        "from mcp import types",
+        "from mcp import types",
+    )
+    handler_src = handler_src.replace(
+        "from ...storage.graph import GraphStorage",
+        "from mcp_memory_service.storage.graph import GraphStorage",
+    )
+    handler_src = handler_src.replace(
+        "from ...config import SQLITE_VEC_PATH, STORAGE_BACKEND",
+        "from mcp_memory_service.config import SQLITE_VEC_PATH, STORAGE_BACKEND",
+    )
+    handler_src = handler_src.replace(
+        "from ...reasoning.inference import SemanticReasoner",
+        "from mcp_memory_service.reasoning.inference import SemanticReasoner",
+    )
+    exec(compile(handler_src, str(_handler_path), "exec"), handler_mod.__dict__)
+    return handler_mod
+
+
+_handler = _load_handler_module()
+handle_abduce = _handler.handle_abduce
+handle_infer = _handler.handle_infer
+handle_suggest = _handler.handle_suggest
+handle_memory_graph = _handler.handle_memory_graph
+
+
+class TestHandlerIntegration:
+
+    # --- handle_abduce ---
+
+    @pytest.mark.asyncio
+    async def test_abduce_missing_hash_returns_error(self):
+        """D1: missing hash -> error JSON with antecedents=[]."""
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=_make_graph_mock())):
+            result = await handle_abduce({})
+        data = _parse_text(result)
+        assert data["success"] is False
+        assert data["antecedents"] == []
+        assert "hash" in data["error"].lower() or "missing" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_abduce_graph_none_returns_failure(self):
+        """D2: graph=None -> success=False."""
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=None)):
+            result = await handle_abduce({"hash": "obs"})
+        data = _parse_text(result)
+        assert data["success"] is False
+        assert data["antecedents"] == []
+
+    @pytest.mark.asyncio
+    async def test_abduce_success_true(self):
+        """D3: valid call returns success=True."""
+        mock_gs = _make_graph_mock(find_connected_return=[("A", 1)])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_abduce({"hash": "obs", "rel_type": "causes"})
+        data = _parse_text(result)
+        assert data["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_abduce_count_equals_len_antecedents(self):
+        """D4: count == len(antecedents)."""
+        mock_gs = _make_graph_mock(find_connected_return=[("A", 1), ("B", 2)])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_abduce({"hash": "obs", "rel_type": "causes", "max_hops": 2})
+        data = _parse_text(result)
+        assert data["count"] == len(data["antecedents"])
+
+    @pytest.mark.asyncio
+    async def test_abduce_empty_result_count_zero(self):
+        """D5: empty antecedents -> count=0."""
+        mock_gs = _make_graph_mock(find_connected_return=[])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_abduce({"hash": "obs"})
+        data = _parse_text(result)
+        assert data["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_abduce_default_rel_type_is_causes(self):
+        """D6: default rel_type is 'causes'."""
+        mock_gs = _make_graph_mock()
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            await handle_abduce({"hash": "obs"})
+        # find_connected called with relationship_type="causes"
+        call_kwargs = mock_gs.find_connected.call_args
+        assert call_kwargs.kwargs.get("relationship_type") == "causes"
+
+    @pytest.mark.asyncio
+    async def test_abduce_max_hops_passed_through(self):
+        """D7: max_hops parameter passed to reasoner."""
+        mock_gs = _make_graph_mock()
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            await handle_abduce({"hash": "obs", "rel_type": "causes", "max_hops": 3})
+        call_kwargs = mock_gs.find_connected.call_args
+        # max_hops clamped to 3
+        assert call_kwargs.kwargs.get("max_hops") == 3
+
+    @pytest.mark.asyncio
+    async def test_abduce_rel_type_passed_through(self):
+        """D8: rel_type parameter passed through to graph call."""
+        mock_gs = _make_graph_mock()
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            await handle_abduce({"hash": "obs", "rel_type": "supports"})
+        call_kwargs = mock_gs.find_connected.call_args
+        assert call_kwargs.kwargs.get("relationship_type") == "supports"
+
+    @pytest.mark.asyncio
+    async def test_handle_memory_graph_routes_abduce(self):
+        """D9: handle_memory_graph with action='abduce' routes correctly."""
+        mock_gs = _make_graph_mock(find_connected_return=[("A", 1)])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_memory_graph(None, {"action": "abduce", "hash": "obs"})
+        data = _parse_text(result)
+        assert data["success"] is True
+        assert "antecedents" in data
+
+    @pytest.mark.asyncio
+    async def test_handle_memory_graph_abduce_missing_hash(self):
+        """D10: action='abduce' without hash returns error."""
+        mock_gs = _make_graph_mock()
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_memory_graph(None, {"action": "abduce"})
+        data = _parse_text(result)
+        assert data["success"] is False
+
+    # --- handle_infer ---
+
+    @pytest.mark.asyncio
+    async def test_infer_count_equals_len_inferred(self):
+        """D11: count == len(inferred)."""
+        tc_return = [("A", "C", 2), ("B", "D", 2)]
+        mock_gs = _make_graph_mock(transitive_return=tc_return)
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_infer({"rel_type": "causes", "max_hops": 2})
+        data = _parse_text(result)
+        assert data["count"] == len(data["inferred"])
+
+    @pytest.mark.asyncio
+    async def test_infer_items_have_required_keys(self):
+        """D12: inferred items have source, target, distance keys."""
+        mock_gs = _make_graph_mock(transitive_return=[("A", "C", 2)])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_infer({"rel_type": "causes"})
+        data = _parse_text(result)
+        for item in data["inferred"]:
+            assert "source" in item
+            assert "target" in item
+            assert "distance" in item
+
+    @pytest.mark.asyncio
+    async def test_infer_max_hops_passed(self):
+        """D13: max_hops=3 is passed to transitive_closure."""
+        mock_gs = _make_graph_mock(transitive_return=[])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            await handle_infer({"rel_type": "causes", "max_hops": 3})
+        mock_gs.transitive_closure.assert_called_once_with("causes", 3)
+
+    @pytest.mark.asyncio
+    async def test_infer_default_rel_type_related(self):
+        """D14: default rel_type for infer is 'related'."""
+        mock_gs = _make_graph_mock(transitive_return=[])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            await handle_infer({})
+        call_args = mock_gs.transitive_closure.call_args
+        assert call_args[0][0] == "related"
+
+    # --- handle_suggest ---
+
+    @pytest.mark.asyncio
+    async def test_suggest_count_equals_len_suggestions(self):
+        """D15: count == len(suggestions)."""
+        cn_return = [("B", 2, 3)]
+        mock_gs = _make_graph_mock(common_neighbors_return=cn_return)
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_suggest({"hash": "A"})
+        data = _parse_text(result)
+        assert data["count"] == len(data["suggestions"])
+
+    @pytest.mark.asyncio
+    async def test_suggest_items_have_required_keys(self):
+        """D16: suggestion items have target, type, confidence keys."""
+        cn_return = [("B", 2, 3)]
+        mock_gs = _make_graph_mock(common_neighbors_return=cn_return)
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_suggest({"hash": "A"})
+        data = _parse_text(result)
+        for item in data["suggestions"]:
+            assert "target" in item
+            assert "type" in item
+            assert "confidence" in item
+
+    @pytest.mark.asyncio
+    async def test_suggest_missing_hash_returns_error(self):
+        """D17: missing hash -> error JSON."""
+        mock_gs = _make_graph_mock()
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_suggest({})
+        data = _parse_text(result)
+        assert data["success"] is False
+        assert "suggestions" in data
+
+    @pytest.mark.asyncio
+    async def test_abduce_in_valid_actions(self):
+        """D18: 'abduce' is in the valid_actions list."""
+        import inspect
+        src = inspect.getsource(handle_memory_graph)
+        assert '"abduce"' in src or "'abduce'" in src
+
+    @pytest.mark.asyncio
+    async def test_invalid_action_error_mentions_abduce(self):
+        """D19: invalid action error message lists abduce among valid options."""
+        result = await handle_memory_graph(None, {"action": "nonexistent_action"})
+        text = result[0].text
+        assert "abduce" in text
+
+    @pytest.mark.asyncio
+    async def test_abduce_two_hop_mock_both_distances(self):
+        """D20: 2-hop mock returns antecedents at distance 1 and 2."""
+        mock_gs = _make_graph_mock(find_connected_return=[("B", 1), ("A", 2)])
+        with patch.object(_handler, "get_graph_storage", new=AsyncMock(return_value=mock_gs)):
+            result = await handle_abduce({"hash": "obs", "rel_type": "causes", "max_hops": 2})
+        data = _parse_text(result)
+        distances = {item["distance"] for item in data["antecedents"]}
+        assert 1 in distances
+        assert 2 in distances

--- a/tests/reasoning/test_phase1a.py
+++ b/tests/reasoning/test_phase1a.py
@@ -26,7 +26,7 @@ import pytest
 # Module loading (matching tests/test_semantic_reasoner.py pattern)
 # ---------------------------------------------------------------------------
 
-_tests_dir = Path(__file__).parent.parent
+_tests_dir = Path(__file__).parent.parent.parent  # tests/reasoning -> tests -> repo root
 _graph_path = _tests_dir / "src" / "mcp_memory_service" / "storage" / "graph.py"
 _reasoning_path = _tests_dir / "src" / "mcp_memory_service" / "reasoning" / "inference.py"
 _handler_path = _tests_dir / "src" / "mcp_memory_service" / "server" / "handlers" / "graph.py"


### PR DESCRIPTION
## Summary

Phase 1a of RFC #732 — reasoning layer without contradiction code, per the PR sequence approved in #732.

### What's in this PR

- **`SemanticReasoner.abduce()`** — abductive backward inference: given an observation hash and relationship type, find all memories that could explain it (direct + transitive, sorted by distance ascending)
- **`memory_graph(action="abduce")`** — MCP handler wiring for abduction; `hash`, `rel_type` (default `"causes"`), `max_hops` (default `1`)  
- **Re-applies #985 + #989** to the handler — the fork's tool-consolidation refactor had overwritten `consolidation.py`, losing incremental `time_horizon` support and the `last_run_at`-on-timeout fix from #986; re-applied cleanly as the first commit on this branch
- **60 tests** in `tests/reasoning/test_phase1a.py` across 4 sections:

| Section | What | Count |
|---|---|---|
| A | `GraphStorage.transitive_closure` — empty, 2-hop, 3-hop, max_hops limits, cycle safety, diamond, mixed rel types | 15 |
| B | `GraphStorage.common_neighbors` — isolation, triangle suggestions, min_shared filtering, bidirectional edges, limit-10 cap | 10 |
| C | `SemanticReasoner.abduce` — empty graph, direct/2-hop/multi antecedents, rel_type filtering, sort order, hop clamping | 15 |
| D | Handler integration — error paths, parameter pass-through, routing, valid_actions check, 2-hop mock | 20 |

### What's NOT in this PR (per sequence)

No NLI, no contradiction detection, no entity profiles, no auto-supersession — those come in Phase 1b / 2 / 3.

## Test plan

```bash
pytest tests/reasoning/test_phase1a.py -v
pytest tests/test_semantic_reasoner.py -v      # existing tests still pass
pytest tests/test_graph_infer_suggest.py -v   # existing handler tests still pass
```

## Related

- Closes discussion in #732 (Phase 1a)
- Re-applies #985 (incremental consolidation) + #989 (#986 timeout fix) — see first commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)