### PR TITLE
feat(entities): Phase 1b — configurable terms + frequency-based extraction (RFC #732)

### DIFF
--- a/src/mcp_memory_service/reasoning/entities.py
+++ b/src/mcp_memory_service/reasoning/entities.py
@@ -1,19 +1,20 @@
 """Lightweight entity extraction using heuristics (no ML dependencies).
 
-Extracts high-precision entities: @mentions, #tags, URLs, and file paths.
+Extracts high-precision entities: @mentions, #tags, URLs, file paths,
+configured terms, and frequency-promoted tokens from memory batches.
 CamelCase/ALLCAPS patterns removed (too noisy for free-form text).
-Integrated into maintain cycle as batch extraction step.
 """
 
 import re
+from collections import Counter
 from dataclasses import dataclass
-from typing import List, Dict, Any
+from typing import Dict, List, Any, Optional
 
 @dataclass
 class Entity:
     name: str
-    entity_type: str  # person, project, service, file, url, tag
-    source: str  # content, metadata
+    entity_type: str  # person, project, service, file, url, tag, configured, frequent
+    source: str  # content, metadata, configured, frequency
 
 # Patterns — high precision only
 _MENTION_RE = re.compile(r'@([\w.-]+)')
@@ -21,26 +22,61 @@ _HASHTAG_RE = re.compile(r'#([\w-]+)')
 _URL_RE = re.compile(r'https?://[^\s<>\"\']+')
 _PATH_RE = re.compile(r'(?:^|[\s(])(/[\w./-]+|[\w./]*[a-zA-Z][\w./]*\.\w{1,5})(?=[\s),:;]|$)', re.MULTILINE)
 
+# Token splitter for frequency analysis
+_TOKEN_RE = re.compile(r'[\w][\w\'-]*[\w]')
+
 
 class EntityExtractor:
     """Extract entities from memory content and metadata.
 
-    Uses high-precision patterns only (@mentions, #tags, URLs, paths).
-    CamelCase/ALLCAPS removed per review feedback (too many false positives).
+    Uses high-precision patterns (@mentions, #tags, URLs, paths) plus
+    optional configurable terms and frequency-based batch extraction.
+
+    Args:
+        configured_terms: Dict mapping term (str) to entity_type (str).
+            Case-insensitive substring match. Entities extracted with
+            source='configured'.
+        frequency_threshold: Minimum occurrences across a batch for a token
+            to be promoted to a 'frequent' entity. 0 disables frequency
+            extraction (default). Applied in extract_entities_batch() only.
+        min_token_length: Minimum character length for frequency tokens (default 4).
     """
 
-    def extract_entities(self, content: str, metadata: Dict[str, Any] | None = None) -> List[Entity]:
+    def __init__(
+        self,
+        configured_terms: Optional[Dict[str, str]] = None,
+        frequency_threshold: int = 0,
+        min_token_length: int = 4,
+    ):
+        self._configured_terms: Dict[str, str] = configured_terms or {}
+        # Build case-insensitive lookup: lower(term) -> (original_term, entity_type)
+        self._configured_lower: Dict[str, tuple] = {
+            k.lower(): (k, v) for k, v in self._configured_terms.items()
+        }
+        self._frequency_threshold = frequency_threshold
+        self._min_token_length = min_token_length
+
+    def extract_entities(self, content: str, metadata: Optional[Dict[str, Any]] = None) -> List[Entity]:
+        """Extract entities from a single memory.
+
+        Args:
+            content: Memory text content.
+            metadata: Optional metadata dict (supports 'tags' key).
+
+        Returns:
+            Deduplicated list of Entity objects.
+        """
         metadata = metadata or {}
         entities: List[Entity] = []
         seen: set = set()
 
-        def _add(name: str, etype: str, source: str):
+        def _add(name: str, etype: str, source: str) -> None:
             key = (name.lower(), etype)
             if key not in seen:
                 seen.add(key)
                 entities.append(Entity(name=name, entity_type=etype, source=source))
 
-        # Content-based extraction (high precision only)
+        # Content-based regex extraction (high precision)
         for m in _MENTION_RE.finditer(content):
             _add(m.group(1), 'person', 'content')
 
@@ -55,7 +91,13 @@ class EntityExtractor:
             if '/' in path or '.' in path:
                 _add(path, 'file', 'content')
 
-        # Metadata-based extraction
+        # Configurable term matching (case-insensitive substring)
+        content_lower = content.lower()
+        for term_lower, (term_original, etype) in self._configured_lower.items():
+            if term_lower in content_lower:
+                _add(term_original, etype, 'configured')
+
+        # Metadata tag extraction
         tags = metadata.get('tags', [])
         if isinstance(tags, str):
             tags = [t.strip() for t in tags.split(',') if t.strip()]
@@ -63,3 +105,75 @@ class EntityExtractor:
             _add(tag, 'tag', 'metadata')
 
         return entities
+
+    def extract_entities_batch(
+        self,
+        contents: List[str],
+        metadata_list: Optional[List[Optional[Dict[str, Any]]]] = None,
+    ) -> Dict[str, List[Entity]]:
+        """Extract entities from a batch of memories.
+
+        Runs per-memory extraction and, when frequency_threshold > 0,
+        promotes tokens appearing across >= frequency_threshold memories
+        to 'frequent' entities.
+
+        Args:
+            contents: List of memory text strings.
+            metadata_list: Optional per-memory metadata (same length as contents).
+
+        Returns:
+            Dict mapping content index (str) to List[Entity].
+            Frequency-promoted entities are appended to each memory that
+            contains the frequent token.
+        """
+        if metadata_list is None:
+            metadata_list = [None] * len(contents)
+
+        # Per-memory extraction
+        results: Dict[str, List[Entity]] = {}
+        for i, (content, meta) in enumerate(zip(contents, metadata_list)):
+            results[str(i)] = self.extract_entities(content, meta)
+
+        # Frequency promotion across the batch
+        if self._frequency_threshold > 0 and contents:
+            freq_entities = self._find_frequent_entities(contents)
+            for i, content in enumerate(contents):
+                content_lower = content.lower()
+                seen_names = {e.name.lower() for e in results[str(i)]}
+                for entity in freq_entities:
+                    if entity.name.lower() in content_lower and entity.name.lower() not in seen_names:
+                        results[str(i)].append(entity)
+                        seen_names.add(entity.name.lower())
+
+        return results
+
+    def _find_frequent_entities(self, contents: List[str]) -> List[Entity]:
+        """Find tokens that appear in >= frequency_threshold distinct memories.
+
+        Counts per-memory occurrences (not raw token count) so a token
+        appearing 100x in one memory doesn't dominate.
+
+        Args:
+            contents: List of memory text strings.
+
+        Returns:
+            List of Entity objects with source='frequency'.
+        """
+        # Count in how many memories each token appears
+        memory_presence: Counter = Counter()
+        for content in contents:
+            tokens = {
+                t.lower() for t in _TOKEN_RE.findall(content)
+                if len(t) >= self._min_token_length
+            }
+            memory_presence.update(tokens)
+
+        frequent: List[Entity] = []
+        for token, count in memory_presence.items():
+            if count >= self._frequency_threshold:
+                frequent.append(Entity(
+                    name=token,
+                    entity_type='frequent',
+                    source='frequency',
+                ))
+        return frequent

--- a/tests/test_entity_extraction.py
+++ b/tests/test_entity_extraction.py
@@ -127,3 +127,206 @@ class TestGraphEntityStorage:
     async def test_get_entity_profile_empty(self, graph):
         profile = await graph.get_entity_profile("nonexistent")
         assert profile == {}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1b tests — configurable terms + frequency-based batch extraction
+# ---------------------------------------------------------------------------
+
+class TestConfiguredTerms:
+    """EntityExtractor with user-defined term list."""
+
+    def test_configured_term_found(self):
+        extractor = EntityExtractor(configured_terms={"redis": "service"})
+        entities = extractor.extract_entities("We use Redis for caching")
+        names = [e.name for e in entities if e.entity_type == "service"]
+        assert "redis" in names
+
+    def test_configured_term_case_insensitive(self):
+        extractor = EntityExtractor(configured_terms={"PostgreSQL": "service"})
+        entities = extractor.extract_entities("migrated to postgresql last week")
+        names = [e.name.lower() for e in entities if e.entity_type == "service"]
+        assert "postgresql" in names
+
+    def test_configured_term_source_is_configured(self):
+        extractor = EntityExtractor(configured_terms={"kafka": "service"})
+        entities = extractor.extract_entities("Kafka consumer group reset")
+        matches = [e for e in entities if e.name.lower() == "kafka"]
+        assert len(matches) == 1
+        assert matches[0].source == "configured"
+
+    def test_configured_term_not_in_content(self):
+        extractor = EntityExtractor(configured_terms={"redis": "service"})
+        entities = extractor.extract_entities("No database mentions here")
+        types = [e.entity_type for e in entities]
+        assert "service" not in types
+
+    def test_multiple_configured_terms(self):
+        extractor = EntityExtractor(configured_terms={
+            "redis": "service",
+            "postgres": "service",
+            "hanuman": "agent",
+        })
+        entities = extractor.extract_entities("Redis query failed; postgres fallback; agent hanuman notified")
+        names = {e.name.lower() for e in entities}
+        assert "redis" in names
+        assert "postgres" in names
+        assert "hanuman" in names
+
+    def test_configured_term_deduplication(self):
+        """Term appearing multiple times should produce one entity."""
+        extractor = EntityExtractor(configured_terms={"redis": "service"})
+        entities = extractor.extract_entities("redis redis redis")
+        service_entities = [e for e in entities if e.entity_type == "service"]
+        assert len(service_entities) == 1
+
+    def test_configured_term_does_not_suppress_regex(self):
+        """Regex extraction still runs alongside configured terms."""
+        extractor = EntityExtractor(configured_terms={"redis": "service"})
+        entities = extractor.extract_entities("@alice uses redis and #caching")
+        types = {e.entity_type for e in entities}
+        assert "person" in types
+        assert "service" in types
+        assert "tag" in types
+
+    def test_empty_configured_terms(self):
+        extractor = EntityExtractor(configured_terms={})
+        entities = extractor.extract_entities("some content without special terms")
+        # Should still work — just no configured entities
+        configured = [e for e in entities if e.source == "configured"]
+        assert configured == []
+
+
+class TestFrequencyExtraction:
+    """EntityExtractor.extract_entities_batch with frequency_threshold."""
+
+    def test_batch_returns_per_index_results(self):
+        extractor = EntityExtractor()
+        results = extractor.extract_entities_batch(["@alice here", "@bob there"])
+        assert "0" in results and "1" in results
+
+    def test_batch_empty_input(self):
+        extractor = EntityExtractor(frequency_threshold=2)
+        results = extractor.extract_entities_batch([])
+        assert results == {}
+
+    def test_frequency_threshold_zero_disables_promotion(self):
+        """With threshold=0, no frequency entities should appear."""
+        contents = ["word1 word2 word3"] * 5
+        extractor = EntityExtractor(frequency_threshold=0)
+        results = extractor.extract_entities_batch(contents)
+        for entities in results.values():
+            assert all(e.source != "frequency" for e in entities)
+
+    def test_frequent_token_promoted(self):
+        """Token in >= threshold memories is promoted."""
+        contents = [
+            "postgres is the primary database",
+            "postgres connection pool exhausted",
+            "migrated postgres to version 15",
+        ]
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        freq_names = {
+            e.name for entities in results.values()
+            for e in entities if e.source == "frequency"
+        }
+        assert "postgres" in freq_names
+
+    def test_infrequent_token_not_promoted(self):
+        """Token below threshold is not promoted."""
+        contents = [
+            "postgres is great",
+            "postgres rocks",
+            "mysql is also here",  # only once
+        ]
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        freq_names = {
+            e.name for entities in results.values()
+            for e in entities if e.source == "frequency"
+        }
+        assert "mysql" not in freq_names
+
+    def test_frequent_entity_source_is_frequency(self):
+        contents = ["redis cache hit"] * 4
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        redis_entities = [
+            e for entities in results.values()
+            for e in entities if e.name == "redis"
+        ]
+        assert all(e.source == "frequency" for e in redis_entities)
+
+    def test_frequent_entity_type_is_frequent(self):
+        contents = ["kafka consumer lag"] * 4
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        kafka_entities = [
+            e for entities in results.values()
+            for e in entities if e.name == "kafka"
+        ]
+        assert all(e.entity_type == "frequent" for e in kafka_entities)
+
+    def test_min_token_length_filters_short_tokens(self):
+        """Tokens shorter than min_token_length are not promoted."""
+        contents = ["or is and to be"] * 5
+        extractor = EntityExtractor(frequency_threshold=3, min_token_length=4)
+        results = extractor.extract_entities_batch(contents)
+        freq_names = {
+            e.name for entities in results.values()
+            for e in entities if e.source == "frequency"
+        }
+        # All tokens above are 2-3 chars — none should be promoted
+        assert len(freq_names) == 0
+
+    def test_frequency_counted_per_memory_not_raw_count(self):
+        """A token appearing 100x in one memory counts as 1, not 100."""
+        contents = [
+            "redis " * 100,  # 100 occurrences in one memory
+            "postgres is here",  # redis absent
+            "other content here",  # redis absent
+        ]
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        freq_names = {
+            e.name for entities in results.values()
+            for e in entities if e.source == "frequency"
+        }
+        # redis only appears in 1 distinct memory → below threshold of 3
+        assert "redis" not in freq_names
+
+    def test_frequency_does_not_duplicate_regex_entities(self):
+        """Frequent token already extracted by regex should not be duplicated."""
+        contents = ["#redis cache config"] * 4
+        extractor = EntityExtractor(frequency_threshold=3)
+        results = extractor.extract_entities_batch(contents)
+        for entities in results.values():
+            redis_entities = [e for e in entities if e.name.lower() == "redis"]
+            assert len(redis_entities) <= 1
+
+    def test_batch_with_metadata(self):
+        meta_list = [{"tags": ["python"]}, {"tags": ["go"]}]
+        extractor = EntityExtractor()
+        results = extractor.extract_entities_batch(["content a", "content b"], meta_list)
+        py_tags = [e for e in results["0"] if e.name == "python" and e.source == "metadata"]
+        assert len(py_tags) == 1
+
+    def test_configured_plus_frequency_combined(self):
+        """Configured terms and frequency extraction work together."""
+        contents = [
+            "postgres upgrade scheduled",
+            "postgres replica lag",
+            "postgres autovacuum tuning",
+        ]
+        extractor = EntityExtractor(
+            configured_terms={"postgres": "service"},
+            frequency_threshold=3,
+        )
+        results = extractor.extract_entities_batch(contents)
+        for entities in results.values():
+            sources = {e.source for e in entities if e.name.lower() == "postgres"}
+            # Should appear as 'configured' (from term list), not duplicated as 'frequency'
+            assert "configured" in sources
+            configured_count = sum(1 for e in entities if e.name.lower() == "postgres")
+            assert configured_count == 1


### PR DESCRIPTION
## Summary

Phase 1b of RFC #732: extends `EntityExtractor` with two new capabilities discussed in the issue thread.

### Changes

**`src/mcp_memory_service/reasoning/entities.py`**

- `configured_terms: Dict[str, str]` constructor arg — user-supplied term→type mapping, case-insensitive substring match, `source='configured'`
- `frequency_threshold: int` constructor arg — tokens appearing in ≥ N distinct memories in a batch are promoted to `entity_type='frequent'`, `source='frequency'`
- `min_token_length: int` constructor arg — minimum token length for frequency promotion (default 4, filters out stop words)
- `extract_entities_batch(contents, metadata_list)` — batch extraction that runs per-memory regex + configured-term extraction, then applies frequency promotion across the batch
- Frequency counted per-memory (not raw token count), so a token appearing 100× in one memory counts as 1, not 100
- Deduplication: frequency promotion skips tokens already extracted by regex or configured-terms in the same memory

**`tests/test_entity_extraction.py`**

- 20 new tests in two classes: `TestConfiguredTerms` (8 tests) and `TestFrequencyExtraction` (12 tests)
- Covers: case-insensitive matching, source attribution, deduplication, per-memory frequency counting, min_token_length filtering, combined configured+frequency mode, metadata passthrough in batch

### Design decisions

- No ML/ONNX dependency — stays heuristic, consistent with existing approach
- Configurable terms are substring-matched (not token-boundary) to handle compound terms like `postgresql` matching a configured term `postgres`
- Frequency threshold counts distinct memories, not raw occurrences — prevents a single verbose memory from inflating counts
- `extract_entities_batch` returns `Dict[str, List[Entity]]` keyed by string index for forward compatibility with hash-keyed APIs

Depends on: none (standalone; Phase 1a #1006 is independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)