### PR TITLE
fix(opencode) don't use https for http access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix(opencode): don't use https for http access**: Fix connection failure while using local `http` endpoint with the opencode plugin.
+
 ### CI
 
 - **chore(ci): pin all GitHub Actions to full SHA hashes** ([#1005](https://github.com/doobidoo/mcp-memory-service/pull/1005)): Supply chain hardening against TeamPCP-style tag-mutation attacks. All 20 workflow files now use full 40-character commit SHA hashes instead of floating version tags (`@v1`, `@v4`, `@v6`, `@v7` etc.) — 109 `uses:` entries across 18 unique action refs. Highest-risk refs: `gaurav-nelson/github-action-markdown-link-check` (community maintainer), `snok/container-retention-policy` (community), and `anthropics/claude-code-action` (runs with `CLAUDE_CODE_OAUTH_TOKEN`). Human-readable `# vtag` comments preserved. `peter-evans/create-pull-request` was already SHA-pinned.

--- a/opencode/memory-plugin.js
+++ b/opencode/memory-plugin.js
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
+import http from "node:http"
 import https from "node:https"
 import path from "node:path"
 
@@ -14,14 +15,15 @@ function httpsFetch(url, options = {}) {
     const { method = "GET", headers = {}, body, signal } = options
     const parsed = new URL(url)
 
-    const req = https.request(
+    const isHttps = parsed.protocol === "https:"
+    const req = (isHttps ? https : http).request(
       {
         hostname: parsed.hostname,
-        port: parsed.port || (parsed.protocol === "https:" ? 443 : 80),
+        port: parsed.port || (isHttps ? 443 : 80),
         path: parsed.pathname + parsed.search,
         method,
         headers,
-        agent: tlsAgent,
+        agent: isHttps ? tlsAgent : undefined,
         signal,
       },
       (res) => {


### PR DESCRIPTION
# Pull Request

## Description

Fix connection failure while using local `http` endpoint with the opencode plugin.

## Motivation

Use of the opencode plugin with a local memory server was failing. `/memory health` would show `ECONNREFUSED` for the endpoint even though it was working fine with `curl`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes

Making requests conditionally go through `http` or `https` depending on the protocol, instead of always `https`.

## Testing

### How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] MCP Inspector validation

### Test Coverage

- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Test coverage maintained/improved

## Regression Prevention (required for Bug fix PRs)

N/A-there are no unit tests for the opencode plugin.

## Captured Learnings (recommended)

N/A

## Related Issues

N/A

## Screenshots
N/A

## Documentation

- [ ] Updated README.md
- [ ] Updated CLAUDE.md
- [ ] Updated AGENTS.md
- [x] Updated CHANGELOG.md
- [ ] Updated Wiki pages
- [ ] Updated code comments/docstrings
- [ ] Added API documentation
- [x] No documentation needed

## Pre-submission Checklist

- [x] ✅ My code follows the project's coding standards (PEP 8, type hints)
- [x] ✅ I have performed a self-review of my code
- [-] ✅ I have commented my code, particularly in hard-to-understand areas: change is obvious, no
- [-] ✅ I have made corresponding changes to the documentation: the documentation already mentions that this is possible
- [x] ✅ My changes generate no new warnings
- [-] ✅ I have added tests that prove my fix is effective or that my feature works: no test framework for opencode plugin
- [-] ✅ New and existing unit tests pass locally with my changes
- [-] ✅ Any dependent changes have been merged and published: no dependent changes
- [x] ✅ I have updated CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [x] ✅ I have checked that no sensitive data is exposed (API keys, tokens, passwords)
- [-] ✅ I have verified this works with all supported storage backends (if applicable): this is completely unrelated to storage backends

## Additional Notes

N/A
