### PR TITLE
fix(harvest): multi-CLI session directory resolution

### DIFF
--- a/claude-hooks/README-SESSION-HARVEST.md
+++ b/claude-hooks/README-SESSION-HARVEST.md
@@ -136,6 +136,35 @@ separators with `-`, mirroring the Python side
 directory under `~/.claude/projects/`. The endpoint rejects absolute paths
 and `..` components (CodeQL #383/#384).
 
+### Multi-CLI support (Kiro CLI, etc.)
+
+When `project_path` is not provided to the `memory_harvest` MCP tool, the
+server resolves the session directory in this order:
+
+1. **`MCP_HARVEST_SESSION_DIR`** environment variable — explicit override,
+   works with any CLI. Set it in your systemd service or shell profile.
+2. **`~/.claude/projects/{cwd}`** — default for Claude Code users.
+3. **`~/.kiro/sessions/cli/`** — fallback if the Claude path doesn't exist.
+   Kiro CLI stores sessions as JSONL files in this directory; the parser
+   auto-detects the format from the `"kind"` field in each line.
+
+For Kiro CLI users running the memory service as a systemd unit:
+
+```ini
+# ~/.config/systemd/user/mcp-memory-service.service
+[Service]
+Environment=MCP_HARVEST_SESSION_DIR=/home/youruser/.kiro/sessions/cli
+```
+
+Or pass it explicitly in each call:
+
+```json
+{"project_path": "/home/youruser/.kiro/sessions/cli", "sessions": 1}
+```
+
+The JSONL parser supports both formats transparently — no configuration
+needed beyond pointing to the correct directory.
+
 ## Tests
 
 ```bash

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2667,12 +2667,21 @@ Examples:
         # Resolve project directory
         project_path = arguments.get("project_path")
         if not project_path:
-            # Default: ~/.claude/projects/ — auto-detect from cwd
-            cwd = _Path.cwd()
-            claude_projects = _Path.home() / ".claude" / "projects"
-            # Convert cwd to Claude's project dir naming: replace path sep with -
-            project_dir_name = str(cwd).replace(os.sep, "-")
-            project_path = claude_projects / project_dir_name
+            # Check env var override first (supports any CLI)
+            env_override = os.environ.get("MCP_HARVEST_SESSION_DIR")
+            if env_override:
+                project_path = _Path(env_override)
+            else:
+                # Default: Claude Code project dir from cwd
+                cwd = _Path.cwd()
+                claude_projects = _Path.home() / ".claude" / "projects"
+                project_dir_name = str(cwd).replace(os.sep, "-")
+                project_path = claude_projects / project_dir_name
+                # Fallback: Kiro CLI sessions if Claude path doesn't exist
+                if not project_path.exists():
+                    kiro_sessions = _Path.home() / ".kiro" / "sessions" / "cli"
+                    if kiro_sessions.exists():
+                        project_path = kiro_sessions
         else:
             project_path = _Path(project_path)
 


### PR DESCRIPTION
## Summary

When `project_path` is not provided to `memory_harvest`, the server now resolves the session directory with a 3-level fallback:

1. `MCP_HARVEST_SESSION_DIR` env var — explicit override for any CLI
2. `~/.claude/projects/{cwd}` — default for Claude Code users
3. `~/.kiro/sessions/cli/` — fallback if Claude path doesn't exist

The JSONL parser already supports both formats transparently (detects Kiro format from the `kind` field).

## Motivation

Kiro CLI (AWS) stores sessions in `~/.kiro/sessions/cli/*.jsonl` with a different JSONL schema. The parser was already multi-format capable (PR #979), but the path resolution in `handle_memory_harvest` was hardcoded to Claude's directory structure.

## Changes

- `server_impl.py`: 3-level path resolution (env → Claude → Kiro fallback)
- `claude-hooks/README-SESSION-HARVEST.md`: documented multi-CLI support section

## Testing

- 81 harvest tests passing
- Manually tested with real Kiro CLI sessions (3 candidates extracted)
- No changes to existing Claude Code behavior (remains default)

Closes #1024
Refs: discussion #927