### PR TITLE
Potential fix for code scanning alert no. 440: Log Injection

### DIFF
--- a/src/mcp_memory_service/storage/sqlite_vec.py
+++ b/src/mcp_memory_service/storage/sqlite_vec.py
@@ -1871,7 +1871,9 @@ SOLUTIONS:
 
             results = await self._execute_with_retry(search_fts)
 
-            logger.debug(f"BM25 search found {len(results)} results for query: {query_clean}")
+            # Sanitize for logging to prevent log injection/forgery via control chars
+            query_for_log = re.sub(r'[\r\n\t\x00-\x1f\x7f]+', ' ', query_clean).strip()
+            logger.debug(f"BM25 search found {len(results)} results for query: {query_for_log}")
             return results
 
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/doobidoo/mcp-memory-service/security/code-scanning/440](https://github.com/doobidoo/mcp-memory-service/security/code-scanning/440)

To fix log injection safely without changing functionality, sanitize untrusted text specifically for logging before including it in log messages. In this case, replace CR/LF (and ideally other control characters) with safe visible/space characters and log the sanitized variant.

Best targeted fix in `src/mcp_memory_service/storage/sqlite_vec.py`:
- In `_search_bm25`, right before the debug log, create `query_for_log` from `query_clean` by removing/replacing `\r` and `\n` (and optionally other ASCII control chars).
- Use `query_for_log` in the debug statement instead of `query_clean`.

No behavioral change to search logic or DB query is needed; only log output is hardened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
