### PR TITLE
fix(reasoning): log warning when NLI backend is unimplemented (#1033)

### DIFF
--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -50,6 +50,11 @@ class NLIClassifier:
         """Classify relationship between two texts."""
         if self.backend == "heuristic":
             return self._heuristic_classify(premise, hypothesis)
+        logger.warning(
+            "NLI backend '%s' is not implemented; returning neutral. "
+            "Only 'heuristic' is currently supported.",
+            self.backend,
+        )
         return NLIResult(label="neutral", confidence=0.0)
 
     async def classify_batch(self, pairs: List[Tuple[str, str]]) -> List[NLIResult]:

--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -45,16 +45,19 @@ class NLIClassifier:
         if backend == "auto":
             backend = os.environ.get("MCP_NLI_BACKEND", "heuristic")
         self.backend = backend
+        self._warned_unimplemented = False
 
     async def classify(self, premise: str, hypothesis: str) -> NLIResult:
         """Classify relationship between two texts."""
         if self.backend == "heuristic":
             return self._heuristic_classify(premise, hypothesis)
-        logger.warning(
-            "NLI backend '%s' is not implemented; returning neutral. "
-            "Only 'heuristic' is currently supported.",
-            self.backend,
-        )
+        if not self._warned_unimplemented:
+            logger.warning(
+                "NLI backend '%s' is not implemented; returning neutral. "
+                "Only 'heuristic' is currently supported.",
+                self.backend,
+            )
+            self._warned_unimplemented = True
         return NLIResult(label="neutral", confidence=0.0)
 
     async def classify_batch(self, pairs: List[Tuple[str, str]]) -> List[NLIResult]:

--- a/tests/reasoning/test_nli.py
+++ b/tests/reasoning/test_nli.py
@@ -226,3 +226,16 @@ class TestUnimplementedBackendWarning:
         assert result.label == "neutral"
         assert result.confidence == 0.0
         assert "some_unknown_backend" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_only_once_in_batch(self, caplog):
+        """Warning should only be emitted once per classifier instance, not per call."""
+        import logging
+        from mcp_memory_service.reasoning.nli import NLIClassifier
+        classifier = NLIClassifier(backend="transformers")
+        pairs = [("A", "B"), ("C", "D"), ("E", "F")]
+        with caplog.at_level(logging.WARNING):
+            results = await classifier.classify_batch(pairs)
+        assert len(results) == 3
+        assert all(r.label == "neutral" for r in results)
+        assert caplog.text.count("not implemented") == 1

--- a/tests/reasoning/test_nli.py
+++ b/tests/reasoning/test_nli.py
@@ -196,3 +196,33 @@ class TestMemoryResolveBatch:
         from mcp_memory_service.reasoning.nli import NLIResult
         # If we get here without import error, the module structure is correct
         assert True
+
+
+# ─── Unimplemented backend warning Tests ──────────────────────────────────────
+
+class TestUnimplementedBackendWarning:
+    """Test that unimplemented backends emit a warning."""
+
+    @pytest.mark.asyncio
+    async def test_transformers_backend_logs_warning(self, caplog):
+        """Backend 'transformers' should log warning and return neutral."""
+        import logging
+        from mcp_memory_service.reasoning.nli import NLIClassifier
+        classifier = NLIClassifier(backend="transformers")
+        with caplog.at_level(logging.WARNING):
+            result = await classifier.classify("A is true", "A is false")
+        assert result.label == "neutral"
+        assert result.confidence == 0.0
+        assert "not implemented" in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_backend_logs_warning(self, caplog):
+        """Any unknown backend should log warning and return neutral."""
+        import logging
+        from mcp_memory_service.reasoning.nli import NLIClassifier
+        classifier = NLIClassifier(backend="some_unknown_backend")
+        with caplog.at_level(logging.WARNING):
+            result = await classifier.classify("premise", "hypothesis")
+        assert result.label == "neutral"
+        assert result.confidence == 0.0
+        assert "some_unknown_backend" in caplog.text


### PR DESCRIPTION
When `MCP_NLI_BACKEND` is set to a value other than `"heuristic"` (e.g. `"transformers"`), the classifier now emits a warning instead of silently returning `neutral/0.0`. This makes misconfiguration visible in logs.

- Added `logger.warning()` in the fallthrough branch of `NLIClassifier.classify()`
- Added 2 tests covering transformers and unknown backends

Closes #1033