### PR TITLE
fix(scripts): handle corrupted UTF-8 in regenerate_embeddings.py

### DIFF
--- a/scripts/maintenance/regenerate_embeddings.py
+++ b/scripts/maintenance/regenerate_embeddings.py
@@ -49,6 +49,9 @@ async def regenerate_embeddings():
 
         # Get count first
         if hasattr(actual_storage, 'conn'):
+            # Tolerate corrupted UTF-8 from file sync corruption (Insync/OneDrive + WAL)
+            actual_storage.conn.text_factory = lambda b: b.decode('utf-8', errors='replace')
+
             cursor = actual_storage.conn.execute('SELECT COUNT(*) FROM memories')
             total_count = cursor.fetchone()[0]
             logger.info(f"Found {total_count} memories to process")


### PR DESCRIPTION
## Summary

Fixes #1038. The `regenerate_embeddings.py` script crashes with `sqlite3.OperationalError: Could not decode to UTF-8` when any memory has corrupted encoding bytes.

## Changes

One-line fix: set `text_factory` with `errors="replace"` on the connection before reading memories. This allows the script to process all valid memories and replace invalid bytes with the Unicode replacement character instead of crashing on the first bad row.

## Root Cause

File sync tools (Insync, OneDrive) can corrupt SQLite WAL files during sync, introducing invalid UTF-8 bytes into memory content. The script should be resilient to this.

## Testing

Verified locally with a database containing corrupted entries — script now completes successfully and regenerates embeddings for all readable memories.