### PR TITLE
fix(mistake_notes): handle store dedup rejection by incrementing existing note

### DIFF
--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -878,7 +878,7 @@ class MemoryService:
                 # Handle race condition: store's semantic dedup rejected, but we can
                 # still increment the existing note it found (#1034)
                 error_msg = str(result.get("error", ""))
-                match = re.search(r"semantically similar to ([a-f0-9]+)", error_msg)
+                match = re.search(r"semantically similar to ([a-f0-9]+)", error_msg, re.IGNORECASE)
                 if match:
                     existing_hash = match.group(1)
                     existing = await self.storage.get_by_hash(existing_hash)

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -9,6 +9,7 @@ all memory operations, eliminating the DRY violation and ensuring consistent beh
 import json
 import logging
 import math
+import re
 import sys
 from typing import Dict, List, Optional, Any, Union
 
@@ -874,6 +875,30 @@ class MemoryService:
             )
 
             if not result.get("success"):
+                # Handle race condition: store's semantic dedup rejected, but we can
+                # still increment the existing note it found (#1034)
+                error_msg = str(result.get("error", ""))
+                match = re.search(r"semantically similar to ([a-f0-9]+)", error_msg)
+                if match:
+                    existing_hash = match.group(1)
+                    existing = await self.storage.get_by_hash(existing_hash)
+                    if existing:
+                        old_meta = existing.metadata or {}
+                        if isinstance(old_meta, str):
+                            old_meta = json.loads(old_meta) if old_meta else {}
+                        count = old_meta.get("failure_count", 1) + 1
+                        old_meta["failure_count"] = count
+                        await self.storage.update_memory_metadata(
+                            content_hash=existing_hash,
+                            updates={"metadata": old_meta},
+                            preserve_timestamps=False,
+                        )
+                        return {
+                            "status": "updated",
+                            "content_hash": existing_hash,
+                            "failure_count": count,
+                            "message": f"Existing mistake note updated (seen {count} times)",
+                        }
                 return {"status": "error", "message": f"Failed to store: {result}"}
 
             content_hash = ""

--- a/tests/services/test_mistake_notes.py
+++ b/tests/services/test_mistake_notes.py
@@ -155,3 +155,48 @@ async def test_mistake_note_high_threshold_no_dedup(memory_service):
 
     assert r2["status"] == "created"
     assert r2["failure_count"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_add_handles_store_dedup_rejection(memory_service):
+    """When store_memory rejects with semantic duplicate, should increment existing note.
+
+    Regression test for #1034: retrieve_memories misses (score < threshold),
+    but store_memory's own dedup catches it and rejects. Without the fix,
+    this returns status='error'. With the fix, it increments failure_count.
+    """
+    # Create first note normally
+    r1 = await memory_service.mistake_note_add(
+        error_pattern="Post to GitHub without approval",
+        context_signature="GitHub communication",
+        incorrect_action="Posted without showing draft",
+        correct_action="Always show draft and wait for OK",
+    )
+    assert r1["status"] == "created"
+    first_hash = r1["content_hash"]
+
+    # Mock store_memory to simulate dedup rejection pointing to first note
+    original_store = memory_service.store_memory
+
+    async def mock_store(*args, **kwargs):
+        return {"success": False, "error": f"Duplicate content detected (semantically similar to {first_hash})"}
+
+    # High threshold so retrieve_memories won't match
+    with patch("mcp_memory_service.config.MCP_MISTAKE_NOTE_DEDUP_THRESHOLD", 0.99):
+        memory_service.store_memory = mock_store
+        try:
+            r2 = await memory_service.mistake_note_add(
+                error_pattern="Posted on GitHub without user approval",
+                context_signature="GitHub external communication",
+                incorrect_action="Created issue without draft review",
+                correct_action="Show draft EN+PT-BR, wait for explicit OK",
+            )
+        finally:
+            memory_service.store_memory = original_store
+
+    # Without fix: status="error", message="Failed to store: ..."
+    # With fix: status="updated", failure_count=2
+    assert r2["status"] == "updated", f"Expected 'updated' but got '{r2['status']}': {r2.get('message','')}"
+    assert r2["failure_count"] == 2
+    assert r2["content_hash"] == first_hash


### PR DESCRIPTION
## Summary

Fixes #1034. When `mistake_note_add`'s initial similarity check misses (score < threshold) but `store_memory`'s own semantic dedup catches the duplicate within its 24h window, the function now extracts the existing hash from the rejection message and increments its `failure_count`.

## Changes

- `memory_service.py`: catch "semantically similar to {hash}" error, retrieve existing note via `get_by_hash`, increment `failure_count`
- Added `import re` for hash extraction
- New test: `test_mistake_note_add_handles_store_dedup_rejection` with mocked `store_memory` to reliably simulate the race condition

## Testing

6/6 tests passing in `tests/services/test_mistake_notes.py`. New test verifies the exact scenario: RED without fix, GREEN with fix.