### PR TITLE
feat(reasoning): multi-strategy retrieval with RRF fusion (RFC #1008 §6)

### DIFF
--- a/src/mcp_memory_service/reasoning/__init__.py
+++ b/src/mcp_memory_service/reasoning/__init__.py
@@ -1,8 +1,9 @@
-"""Reasoning module — entity extraction, linking, inference, and NLI."""
+"""Reasoning module — entity extraction, linking, inference, NLI, and multi-strategy search."""
 
 from .entities import Entity, EntityExtractor
 from .entity_linker import EntityLinker
 from .nli import NLIClassifier, NLIResult, detect_contradictions_nli
+from .multi_strategy import rrf_fuse, multi_strategy_search
 
 __all__ = [
     "Entity",
@@ -11,4 +12,6 @@ __all__ = [
     "NLIClassifier",
     "NLIResult",
     "detect_contradictions_nli",
+    "rrf_fuse",
+    "multi_strategy_search",
 ]

--- a/src/mcp_memory_service/reasoning/multi_strategy.py
+++ b/src/mcp_memory_service/reasoning/multi_strategy.py
@@ -1,0 +1,66 @@
+"""Multi-strategy retrieval with RRF fusion (RFC #1008 §6)."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def rrf_fuse(ranked_lists: List[List[str]], k: int = 60, limit: Optional[int] = None) -> List[str]:
+    """Reciprocal Rank Fusion — merge multiple ranked lists into one."""
+    scores: Dict[str, float] = {}
+    for ranked in ranked_lists:
+        for rank, item in enumerate(ranked):
+            scores[item] = scores.get(item, 0.0) + 1.0 / (k + rank + 1)
+    sorted_items = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)
+    if limit:
+        sorted_items = sorted_items[:limit]
+    return sorted_items
+
+
+async def multi_strategy_search(
+    storage,
+    query: str,
+    limit: int = 10,
+    strategies: Optional[List[str]] = None,
+    tags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Run multiple search strategies and fuse results via RRF."""
+    strategies = strategies or ["semantic"]
+    ranked_lists: List[List[str]] = []
+    all_memories: Dict[str, Dict] = {}
+
+    for strategy in strategies:
+        try:
+            if strategy == "semantic":
+                result = await storage.search_memories(query=query, mode="semantic", limit=limit * 2)
+                memories = result.get("memories", []) if isinstance(result, dict) else []
+                hashes = []
+                for m in memories:
+                    h = m.get("content_hash", "")
+                    if h:
+                        hashes.append(h)
+                        if h not in all_memories:
+                            all_memories[h] = m
+                ranked_lists.append(hashes)
+
+            elif strategy == "tag" and tags:
+                results = await storage.search_by_tag(tags)
+                hashes = []
+                for m in results:
+                    h = m.content_hash if hasattr(m, 'content_hash') else m.get("content_hash", "")
+                    if h:
+                        hashes.append(h)
+                        if h not in all_memories:
+                            all_memories[h] = {"content_hash": h, "content": getattr(m, 'content', ''), "tags": getattr(m, 'tags', [])}
+                ranked_lists.append(hashes)
+        except Exception as e:
+            logger.warning(f"Strategy '{strategy}' failed: {e}")
+            continue
+
+    if not ranked_lists:
+        return {"memories": [], "total": 0, "query": query, "mode": "multi_strategy"}
+
+    fused_hashes = rrf_fuse(ranked_lists, k=60, limit=limit)
+    memories = [all_memories[h] for h in fused_hashes if h in all_memories]
+    return {"memories": memories, "total": len(memories), "query": query, "mode": "multi_strategy"}

--- a/src/mcp_memory_service/reasoning/multi_strategy.py
+++ b/src/mcp_memory_service/reasoning/multi_strategy.py
@@ -1,7 +1,8 @@
 """Multi-strategy retrieval with RRF fusion (RFC #1008 §6)."""
 
+import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,35 @@ def rrf_fuse(ranked_lists: List[List[str]], k: int = 60, limit: Optional[int] = 
     return sorted_items
 
 
+async def _run_semantic(storage, query: str, limit: int) -> Tuple[List[str], Dict[str, Dict]]:
+    """Run semantic strategy, return (hashes, memory_map)."""
+    result = await storage.search_memories(query=query, mode="semantic", limit=limit * 2)
+    memories = result.get("memories", []) if isinstance(result, dict) else []
+    hashes = []
+    mem_map: Dict[str, Dict] = {}
+    for m in memories:
+        h = m.get("content_hash", "")
+        if h:
+            hashes.append(h)
+            if h not in mem_map:
+                mem_map[h] = m
+    return hashes, mem_map
+
+
+async def _run_tag(storage, tags: List[str], limit: int) -> Tuple[List[str], Dict[str, Dict]]:
+    """Run tag strategy, return (hashes, memory_map)."""
+    results = await storage.search_by_tag_chronological(tags, limit=limit * 2)
+    hashes = []
+    mem_map: Dict[str, Dict] = {}
+    for m in results:
+        h = m.content_hash if hasattr(m, 'content_hash') else m.get("content_hash", "")
+        if h:
+            hashes.append(h)
+            if h not in mem_map:
+                mem_map[h] = {"content_hash": h, "content": getattr(m, 'content', ''), "tags": getattr(m, 'tags', [])}
+    return hashes, mem_map
+
+
 async def multi_strategy_search(
     storage,
     query: str,
@@ -25,38 +55,33 @@ async def multi_strategy_search(
     strategies: Optional[List[str]] = None,
     tags: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
-    """Run multiple search strategies and fuse results via RRF."""
+    """Run multiple search strategies concurrently and fuse results via RRF."""
     strategies = strategies or ["semantic"]
+    tasks = []
+
+    for strategy in strategies:
+        if strategy == "semantic":
+            tasks.append(_run_semantic(storage, query, limit))
+        elif strategy == "tag" and tags:
+            tasks.append(_run_tag(storage, tags, limit))
+
+    if not tasks:
+        return {"memories": [], "total": 0, "query": query, "mode": "multi_strategy"}
+
+    # Run all strategies concurrently
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
     ranked_lists: List[List[str]] = []
     all_memories: Dict[str, Dict] = {}
 
-    for strategy in strategies:
-        try:
-            if strategy == "semantic":
-                result = await storage.search_memories(query=query, mode="semantic", limit=limit * 2)
-                memories = result.get("memories", []) if isinstance(result, dict) else []
-                hashes = []
-                for m in memories:
-                    h = m.get("content_hash", "")
-                    if h:
-                        hashes.append(h)
-                        if h not in all_memories:
-                            all_memories[h] = m
-                ranked_lists.append(hashes)
-
-            elif strategy == "tag" and tags:
-                results = await storage.search_by_tag(tags)
-                hashes = []
-                for m in results:
-                    h = m.content_hash if hasattr(m, 'content_hash') else m.get("content_hash", "")
-                    if h:
-                        hashes.append(h)
-                        if h not in all_memories:
-                            all_memories[h] = {"content_hash": h, "content": getattr(m, 'content', ''), "tags": getattr(m, 'tags', [])}
-                ranked_lists.append(hashes)
-        except Exception as e:
-            logger.warning(f"Strategy '{strategy}' failed: {e}")
+    for result in results:
+        if isinstance(result, Exception):
+            logger.warning(f"Strategy failed: {result}")
             continue
+        hashes, mem_map = result
+        if hashes:
+            ranked_lists.append(hashes)
+            all_memories.update(mem_map)
 
     if not ranked_lists:
         return {"memories": [], "total": 0, "query": query, "mode": "multi_strategy"}

--- a/tests/reasoning/test_multi_strategy.py
+++ b/tests/reasoning/test_multi_strategy.py
@@ -47,9 +47,9 @@ class TestMultiStrategySearch:
                 {"content_hash": "c", "content": "memory c", "similarity_score": 0.7},
             ]
         })
-        storage.search_by_tag = AsyncMock(return_value=[
-            MagicMock(content_hash="b", content="memory b"),
-            MagicMock(content_hash="d", content="memory d"),
+        storage.search_by_tag_chronological = AsyncMock(return_value=[
+            MagicMock(content_hash="b", content="memory b", tags=["important"]),
+            MagicMock(content_hash="d", content="memory d", tags=["important"]),
         ])
         result = await multi_strategy_search(
             storage, query="test query", limit=5,
@@ -67,7 +67,7 @@ class TestMultiStrategySearch:
         storage.search_memories = AsyncMock(return_value={
             "memories": [{"content_hash": "a", "content": "ok", "similarity_score": 0.9}]
         })
-        storage.search_by_tag = AsyncMock(side_effect=Exception("broken"))
+        storage.search_by_tag_chronological = AsyncMock(side_effect=Exception("broken"))
         result = await multi_strategy_search(
             storage, query="test", limit=5, strategies=["semantic", "tag"],
         )

--- a/tests/reasoning/test_multi_strategy.py
+++ b/tests/reasoning/test_multi_strategy.py
@@ -1,0 +1,74 @@
+"""Tests for multi-strategy retrieval with RRF fusion (RFC #1008 §6)."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestRRFFusion:
+    def test_import(self):
+        from mcp_memory_service.reasoning.multi_strategy import rrf_fuse
+        assert rrf_fuse is not None
+
+    def test_single_strategy(self):
+        from mcp_memory_service.reasoning.multi_strategy import rrf_fuse
+        result = rrf_fuse([["a", "b", "c"]], k=60)
+        assert result[0] == "a"
+
+    def test_two_strategies_consensus(self):
+        from mcp_memory_service.reasoning.multi_strategy import rrf_fuse
+        result = rrf_fuse([["a", "b", "c", "d"], ["b", "a", "d", "c"]], k=60)
+        assert result[0] in ("a", "b")
+        assert result[-1] in ("c", "d")
+
+    def test_unique_items_from_different_strategies(self):
+        from mcp_memory_service.reasoning.multi_strategy import rrf_fuse
+        result = rrf_fuse([["a", "b"], ["c", "d"]], k=60)
+        assert set(result) == {"a", "b", "c", "d"}
+
+    def test_limit_results(self):
+        from mcp_memory_service.reasoning.multi_strategy import rrf_fuse
+        result = rrf_fuse([["a", "b", "c", "d", "e"]], k=60, limit=3)
+        assert len(result) == 3
+
+
+class TestMultiStrategySearch:
+    def test_import_search(self):
+        from mcp_memory_service.reasoning.multi_strategy import multi_strategy_search
+        assert multi_strategy_search is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_fused_results(self):
+        from mcp_memory_service.reasoning.multi_strategy import multi_strategy_search
+        storage = AsyncMock()
+        storage.search_memories = AsyncMock(return_value={
+            "memories": [
+                {"content_hash": "a", "content": "memory a", "similarity_score": 0.9},
+                {"content_hash": "b", "content": "memory b", "similarity_score": 0.8},
+                {"content_hash": "c", "content": "memory c", "similarity_score": 0.7},
+            ]
+        })
+        storage.search_by_tag = AsyncMock(return_value=[
+            MagicMock(content_hash="b", content="memory b"),
+            MagicMock(content_hash="d", content="memory d"),
+        ])
+        result = await multi_strategy_search(
+            storage, query="test query", limit=5,
+            strategies=["semantic", "tag"], tags=["important"],
+        )
+        assert "memories" in result
+        assert result["mode"] == "multi_strategy"
+        hashes = [m["content_hash"] for m in result["memories"]]
+        assert "b" in hashes
+
+    @pytest.mark.asyncio
+    async def test_graceful_strategy_failure(self):
+        from mcp_memory_service.reasoning.multi_strategy import multi_strategy_search
+        storage = AsyncMock()
+        storage.search_memories = AsyncMock(return_value={
+            "memories": [{"content_hash": "a", "content": "ok", "similarity_score": 0.9}]
+        })
+        storage.search_by_tag = AsyncMock(side_effect=Exception("broken"))
+        result = await multi_strategy_search(
+            storage, query="test", limit=5, strategies=["semantic", "tag"],
+        )
+        assert len(result["memories"]) >= 1


### PR DESCRIPTION
## Summary

Adds multi-strategy retrieval that runs multiple search strategies in parallel and fuses results using Reciprocal Rank Fusion (RRF).

## Changes

- **`rrf_fuse`**: RRF algorithm for merging ranked lists from different strategies
- **`multi_strategy_search`**: orchestrates semantic + tag strategies in parallel
- **Graceful degradation**: if one strategy fails, others still return results
- **Configurable**: k parameter and limit
- **Tests**: fusion correctness, single-strategy fallback, empty results

## Motivation

Single-strategy search misses results that would be found by alternative approaches. RRF fusion combines multiple weak signals into a stronger ranking without requiring score calibration across strategies.

Part of RFC #1008 (Multi-Signal Retrieval, Temporal Awareness & Multi-Engine Memory Sharing) §6.