### PR TITLE
feat(mistake_notes): add mistake_note_update and mistake_note_delete tools (#1035)

### DIFF
--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2393,6 +2393,33 @@ Examples:
                         readOnlyHint=True,
                     ),
                 ),
+                types.Tool(
+                    name="mistake_note_update",
+                    description="Update fields of an existing mistake note. Can update failure_count, error_pattern, context_signature, incorrect_action, or correct_action. Content changes create a new hash (delete + re-store).",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "content_hash": {"type": "string", "description": "Content hash of the mistake note to update"},
+                            "failure_count": {"type": "integer", "description": "New failure count"},
+                            "error_pattern": {"type": "string", "description": "Updated error pattern"},
+                            "context_signature": {"type": "string", "description": "Updated context"},
+                            "incorrect_action": {"type": "string", "description": "Updated incorrect action"},
+                            "correct_action": {"type": "string", "description": "Updated correct action"},
+                        },
+                        "required": ["content_hash"],
+                    },
+                ),
+                types.Tool(
+                    name="mistake_note_delete",
+                    description="Delete a mistake note by content hash. Only deletes memories with memory_type='mistake'.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "content_hash": {"type": "string", "description": "Content hash of the mistake note to delete"},
+                        },
+                        "required": ["content_hash"],
+                    },
+                ),
             ]
             tools.extend(mistake_tools)
             logger.info(f"Added {len(mistake_tools)} mistake note tools")
@@ -2481,6 +2508,12 @@ Examples:
             elif name == "mistake_note_search":
                 logger.info("Calling handle_mistake_note_search")
                 return await self.handle_mistake_note_search(arguments)
+            elif name == "mistake_note_update":
+                logger.info("Calling handle_mistake_note_update")
+                return await self.handle_mistake_note_update(arguments)
+            elif name == "mistake_note_delete":
+                logger.info("Calling handle_mistake_note_delete")
+                return await self.handle_mistake_note_delete(arguments)
 
             # Legacy handlers (for tools that haven't been fully migrated yet)
             # These will be removed once all old tool definitions are removed
@@ -2923,6 +2956,27 @@ Examples:
         result = await self.memory_service.mistake_note_search(
             query=arguments.get("query", ""),
             limit=arguments.get("limit", 5),
+        )
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+    async def handle_mistake_note_update(self, arguments: dict) -> List[types.TextContent]:
+        """Update fields of an existing mistake note."""
+        await self._ensure_storage_initialized()
+        result = await self.memory_service.mistake_note_update(
+            content_hash=arguments.get("content_hash", ""),
+            failure_count=arguments.get("failure_count"),
+            error_pattern=arguments.get("error_pattern"),
+            context_signature=arguments.get("context_signature"),
+            incorrect_action=arguments.get("incorrect_action"),
+            correct_action=arguments.get("correct_action"),
+        )
+        return [types.TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+    async def handle_mistake_note_delete(self, arguments: dict) -> List[types.TextContent]:
+        """Delete a mistake note by content hash."""
+        await self._ensure_storage_initialized()
+        result = await self.memory_service.mistake_note_delete(
+            content_hash=arguments.get("content_hash", ""),
         )
         return [types.TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
 

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -957,3 +957,124 @@ class MemoryService:
 
         except Exception as e:
             return {"notes": [], "count": 0, "error": str(e)}
+
+    async def mistake_note_update(
+        self,
+        content_hash: str,
+        failure_count: Optional[int] = None,
+        error_pattern: Optional[str] = None,
+        context_signature: Optional[str] = None,
+        incorrect_action: Optional[str] = None,
+        correct_action: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Update fields of an existing mistake note.
+
+        Args:
+            content_hash: Hash of the mistake note to update
+            failure_count: New failure count (optional)
+            error_pattern: Updated error pattern (optional)
+            context_signature: Updated context (optional)
+            incorrect_action: Updated incorrect action (optional)
+            correct_action: Updated correct action (optional)
+
+        Returns:
+            Dictionary with operation result
+        """
+        try:
+            mem = await self.storage.get_by_hash(content_hash)
+            if not mem:
+                return {"status": "error", "message": f"No memory found with hash {content_hash}"}
+
+            mem_type = getattr(mem, 'memory_type', None) or (mem.metadata or {}).get("type")
+            if mem_type != "mistake":
+                return {"status": "error", "message": f"Memory {content_hash} is not a mistake note (type={mem_type})"}
+
+            content_changed = any(f is not None for f in [error_pattern, context_signature, incorrect_action, correct_action])
+
+            if content_changed:
+                # Content update requires delete + re-store (hash changes with content)
+                current = _parse_mistake_content(mem.content)
+                new_content = (
+                    f"Pattern: {error_pattern or current['error_pattern']}\n"
+                    f"Context: {context_signature or current['context_signature']}\n"
+                    f"Wrong: {incorrect_action or current['incorrect_action']}\n"
+                    f"Right: {correct_action or current['correct_action']}"
+                )
+                meta = mem.metadata if isinstance(mem.metadata, dict) else {}
+                if failure_count is not None:
+                    meta["failure_count"] = failure_count
+
+                await self.delete_memory(content_hash)
+                result = await self.store_memory(
+                    content=new_content,
+                    tags="mistake-note,error-replay",
+                    memory_type="mistake",
+                    metadata=meta,
+                )
+                new_hash = ""
+                if isinstance(result, dict) and result.get("success"):
+                    m = result.get("memory", {})
+                    new_hash = m.get("content_hash", "") if isinstance(m, dict) else ""
+                return {"status": "updated", "content_hash": new_hash or content_hash}
+
+            # Metadata-only update (failure_count)
+            if failure_count is not None:
+                meta = mem.metadata if isinstance(mem.metadata, dict) else {}
+                meta["failure_count"] = failure_count
+                await self.storage.update_memory_metadata(
+                    content_hash=content_hash,
+                    updates={"metadata": meta},
+                    preserve_timestamps=False,
+                )
+                return {"status": "updated", "content_hash": content_hash}
+
+            return {"status": "error", "message": "No fields to update"}
+
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    async def mistake_note_delete(self, content_hash: str) -> Dict[str, Any]:
+        """
+        Delete a mistake note by content hash.
+
+        Args:
+            content_hash: Hash of the mistake note to delete
+
+        Returns:
+            Dictionary with operation result
+        """
+        try:
+            mem = await self.storage.get_by_hash(content_hash)
+            if not mem:
+                return {"status": "error", "message": f"No memory found with hash {content_hash}"}
+
+            mem_type = getattr(mem, 'memory_type', None) or (mem.metadata or {}).get("type")
+            if mem_type != "mistake":
+                return {"status": "error", "message": f"Memory {content_hash} is not a mistake note (type={mem_type})"}
+
+            await self.delete_memory(content_hash)
+            return {"status": "deleted", "content_hash": content_hash}
+
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+
+def _parse_mistake_content(content: str) -> Dict[str, str]:
+    """Parse structured mistake note content into fields."""
+    fields = {
+        "error_pattern": "",
+        "context_signature": "",
+        "incorrect_action": "",
+        "correct_action": "",
+    }
+    for line in content.split("\n"):
+        if line.startswith("Pattern: "):
+            fields["error_pattern"] = line[9:]
+        elif line.startswith("Context: "):
+            fields["context_signature"] = line[9:]
+        elif line.startswith("Wrong: "):
+            fields["incorrect_action"] = line[7:]
+        elif line.startswith("Right: "):
+            fields["correct_action"] = line[7:]
+    return fields

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -1005,28 +1005,35 @@ class MemoryService:
                 if failure_count is not None:
                     meta["failure_count"] = failure_count
 
-                await self.delete_memory(content_hash)
+                # Store new version FIRST to prevent data loss if store fails
                 result = await self.store_memory(
                     content=new_content,
                     tags="mistake-note,error-replay",
                     memory_type="mistake",
                     metadata=meta,
                 )
+                if not (isinstance(result, dict) and result.get("success")):
+                    return {"status": "error", "message": f"Failed to store updated note: {result}"}
+
                 new_hash = ""
-                if isinstance(result, dict) and result.get("success"):
-                    m = result.get("memory", {})
-                    new_hash = m.get("content_hash", "") if isinstance(m, dict) else ""
+                m = result.get("memory", {})
+                new_hash = m.get("content_hash", "") if isinstance(m, dict) else ""
+
+                # Only delete old after new is safely stored
+                await self.delete_memory(content_hash)
                 return {"status": "updated", "content_hash": new_hash or content_hash}
 
             # Metadata-only update (failure_count)
             if failure_count is not None:
                 meta = mem.metadata if isinstance(mem.metadata, dict) else {}
                 meta["failure_count"] = failure_count
-                await self.storage.update_memory_metadata(
+                success, msg = await self.storage.update_memory_metadata(
                     content_hash=content_hash,
                     updates={"metadata": meta},
                     preserve_timestamps=False,
                 )
+                if not success:
+                    return {"status": "error", "message": f"Metadata update failed: {msg}"}
                 return {"status": "updated", "content_hash": content_hash}
 
             return {"status": "error", "message": "No fields to update"}
@@ -1053,7 +1060,9 @@ class MemoryService:
             if mem_type != "mistake":
                 return {"status": "error", "message": f"Memory {content_hash} is not a mistake note (type={mem_type})"}
 
-            await self.delete_memory(content_hash)
+            result = await self.delete_memory(content_hash)
+            if not (isinstance(result, dict) and result.get("success")):
+                return {"status": "error", "message": f"Delete failed: {result.get('error', 'unknown')}"}
             return {"status": "deleted", "content_hash": content_hash}
 
         except Exception as e:

--- a/tests/services/test_mistake_notes.py
+++ b/tests/services/test_mistake_notes.py
@@ -200,3 +200,133 @@ async def test_mistake_note_add_handles_store_dedup_rejection(memory_service):
     assert r2["status"] == "updated", f"Expected 'updated' but got '{r2['status']}': {r2.get('message','')}"
     assert r2["failure_count"] == 2
     assert r2["content_hash"] == first_hash
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_update_failure_count(memory_service):
+    """Update failure_count on an existing mistake note."""
+    r1 = await memory_service.mistake_note_add(
+        error_pattern="Forgot to run tests before push",
+        context_signature="CI/CD workflow",
+        incorrect_action="Pushed without testing",
+        correct_action="Always run pytest before git push",
+    )
+    assert r1["status"] == "created"
+    content_hash = r1["content_hash"]
+
+    result = await memory_service.mistake_note_update(
+        content_hash=content_hash,
+        failure_count=5,
+    )
+    assert result["status"] == "updated"
+    assert result["content_hash"] == content_hash
+
+    # Verify the update persisted
+    mem = await memory_service.storage.get_by_hash(content_hash)
+    meta = mem.metadata if isinstance(mem.metadata, dict) else {}
+    assert meta.get("failure_count") == 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_update_content_fields(memory_service):
+    """Update content fields (correct_action) on an existing mistake note."""
+    r1 = await memory_service.mistake_note_add(
+        error_pattern="Used wrong branch",
+        context_signature="Git workflow",
+        incorrect_action="Committed to main",
+        correct_action="Create feature branch first",
+    )
+    content_hash = r1["content_hash"]
+
+    result = await memory_service.mistake_note_update(
+        content_hash=content_hash,
+        correct_action="Create feature branch and open PR",
+    )
+    assert result["status"] == "updated"
+    # Content change = new hash (delete + re-store)
+    new_hash = result["content_hash"]
+
+    # Old hash should be gone
+    old_mem = await memory_service.storage.get_by_hash(content_hash)
+    assert old_mem is None
+
+    # New hash should have updated content
+    new_mem = await memory_service.storage.get_by_hash(new_hash)
+    assert new_mem is not None
+    assert "Create feature branch and open PR" in new_mem.content
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_update_nonexistent(memory_service):
+    """Updating a nonexistent hash should return error."""
+    result = await memory_service.mistake_note_update(
+        content_hash="nonexistent_hash_abc123",
+        failure_count=10,
+    )
+    assert result["status"] == "error"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_update_wrong_type(memory_service):
+    """Updating a non-mistake memory should return error."""
+    store_result = await memory_service.store_memory(
+        content="Regular observation",
+        memory_type="observation",
+        tags="test",
+    )
+    content_hash = store_result.get("memory", {}).get("content_hash", "")
+
+    result = await memory_service.mistake_note_update(
+        content_hash=content_hash,
+        failure_count=5,
+    )
+    assert result["status"] == "error"
+    assert "not a mistake note" in result["message"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_delete(memory_service):
+    """Delete an existing mistake note."""
+    r1 = await memory_service.mistake_note_add(
+        error_pattern="Obsolete pattern",
+        context_signature="Old context",
+        incorrect_action="Old wrong",
+        correct_action="Old right",
+    )
+    content_hash = r1["content_hash"]
+
+    result = await memory_service.mistake_note_delete(content_hash=content_hash)
+    assert result["status"] == "deleted"
+
+    # Verify it's gone
+    mem = await memory_service.storage.get_by_hash(content_hash)
+    assert mem is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_delete_nonexistent(memory_service):
+    """Deleting a nonexistent hash should return error."""
+    result = await memory_service.mistake_note_delete(content_hash="nonexistent_hash_xyz")
+    assert result["status"] == "error"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mistake_note_delete_wrong_type(memory_service):
+    """Deleting a non-mistake memory should return error."""
+    store_result = await memory_service.store_memory(
+        content="Regular memory not a mistake",
+        memory_type="observation",
+        tags="test",
+    )
+    content_hash = store_result.get("memory", {}).get("content_hash", "")
+
+    result = await memory_service.mistake_note_delete(content_hash=content_hash)
+    assert result["status"] == "error"
+    assert "not a mistake note" in result["message"].lower()


### PR DESCRIPTION
## Summary

Adds update and delete operations for mistake notes, completing the CRUD surface.

## Changes

- **`mistake_note_update`**: update `failure_count` or content fields (`error_pattern`, `context_signature`, `incorrect_action`, `correct_action`). Metadata-only updates preserve the content hash; content changes use delete + re-store (hash changes accordingly).
- **`mistake_note_delete`**: delete a mistake note by `content_hash`. Returns error if target doesn't exist or isn't `memory_type='mistake'`.
- Both tools validate that the target memory has `memory_type='mistake'` before operating — prevents accidental modification of regular memories.
- Tool schemas registered in `list_tools()` without `readOnlyHint` (write operations).
- 7 new tests: update failure_count, update content fields, update nonexistent, update wrong type, delete, delete nonexistent, delete wrong type.

## Design Decisions

- Content updates require delete + re-store because `content_hash` is derived from content — changing content without changing hash would break integrity.
- Type guard (`memory_type='mistake'`) on both operations prevents using these tools as generic delete/update (use `memory_delete`/`memory_update` for that).

Closes #1035