### PR TITLE
feat(search): multi-signal ranked search mode (RFC #1008 §2)

### DIFF
--- a/src/mcp_memory_service/reasoning/__init__.py
+++ b/src/mcp_memory_service/reasoning/__init__.py
@@ -1,4 +1,4 @@
-"""Reasoning module — entity extraction, linking, inference, NLI, temporal edges, mutability, and multi-strategy search."""
+"""Reasoning module — entity extraction, linking, inference, NLI, temporal edges, mutability, multi-strategy search, and ranked search."""
 
 from .entities import Entity, EntityExtractor
 from .entity_linker import EntityLinker
@@ -6,6 +6,7 @@ from .nli import NLIClassifier, NLIResult, detect_contradictions_nli
 from .temporal import TemporalEdge, store_temporal_association, filter_temporal_edges, classify_temporal_relationship
 from .mutability import classify_mutability, contradiction_action
 from .multi_strategy import rrf_fuse, multi_strategy_search
+from .ranked_search import RankedSearchWeights, compute_ranked_score, apply_ranked_rerank
 
 __all__ = [
     "Entity",
@@ -22,4 +23,7 @@ __all__ = [
     "contradiction_action",
     "rrf_fuse",
     "multi_strategy_search",
+    "RankedSearchWeights",
+    "compute_ranked_score",
+    "apply_ranked_rerank",
 ]

--- a/src/mcp_memory_service/reasoning/ranked_search.py
+++ b/src/mcp_memory_service/reasoning/ranked_search.py
@@ -1,0 +1,113 @@
+"""Multi-signal search ranking (RFC #1008 §2).
+
+Combines semantic similarity with time decay, access frequency, and quality score.
+"""
+
+import math
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class RankedSearchWeights:
+    """Weights for multi-signal ranking."""
+    semantic: float = 0.6
+    time_decay: float = 0.2
+    access_frequency: float = 0.1
+    quality: float = 0.1
+
+    def normalized(self) -> "RankedSearchWeights":
+        total = self.semantic + self.time_decay + self.access_frequency + self.quality
+        if total <= 0:
+            return RankedSearchWeights()
+        return RankedSearchWeights(
+            semantic=self.semantic / total,
+            time_decay=self.time_decay / total,
+            access_frequency=self.access_frequency / total,
+            quality=self.quality / total,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "RankedSearchWeights":
+        if not data:
+            return cls()
+
+        def _safe_float(val, default: float) -> float:
+            if val is None:
+                return default
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            semantic=_safe_float(data.get("semantic"), 0.6),
+            time_decay=_safe_float(data.get("time_decay"), 0.2),
+            access_frequency=_safe_float(data.get("access_frequency"), 0.1),
+            quality=_safe_float(data.get("quality"), 0.1),
+        ).normalized()
+
+
+def compute_ranked_score(
+    semantic_score: float,
+    memory,
+    weights: Optional[RankedSearchWeights] = None,
+    now: Optional[float] = None,
+) -> Tuple[float, Dict[str, Any]]:
+    """Compute final ranked score and signal breakdown."""
+    w = (weights or RankedSearchWeights()).normalized()
+    ts_now = now or time.time()
+
+    semantic = max(0.0, min(1.0, float(semantic_score)))
+
+    try:
+        decay_window = float(os.environ.get("MEMORY_DECAY_WINDOW_DAYS", "30"))
+    except (TypeError, ValueError):
+        decay_window = 30.0
+    reference = memory.last_accessed_at or memory.created_at or ts_now
+    days_since = max(0.0, (ts_now - reference) / 86400.0)
+    time_decay_score = math.exp(-days_since / max(decay_window, 1.0))
+
+    access_count = max(0, int(memory.access_count or 0))
+    access_score = min(1.0, math.log(access_count + 1) / math.log(100))
+
+    quality_score = max(0.0, min(1.0, float(memory.quality_score or 0.0)))
+
+    final = (
+        w.semantic * semantic
+        + w.time_decay * time_decay_score
+        + w.access_frequency * access_score
+        + w.quality * quality_score
+    )
+
+    breakdown = {
+        "semantic_score": round(semantic, 4),
+        "time_decay_score": round(time_decay_score, 4),
+        "access_score": round(access_score, 4),
+        "quality_score": round(quality_score, 4),
+        "ranked_score": round(final, 4),
+        "weights": {"semantic": w.semantic, "time_decay": w.time_decay, "access_frequency": w.access_frequency, "quality": w.quality},
+    }
+    return final, breakdown
+
+
+def apply_ranked_rerank(
+    candidates: List[Any],
+    weights: Optional[RankedSearchWeights] = None,
+    now: Optional[float] = None,
+) -> List[Any]:
+    """Rerank MemoryQueryResult candidates by multi-signal score."""
+    for result in candidates:
+        semantic = result.relevance_score
+        final, breakdown = compute_ranked_score(semantic, result.memory, weights=weights, now=now)
+        if result.debug_info is None:
+            result.debug_info = {}
+        result.debug_info.update(breakdown)
+        result.debug_info["original_semantic_score"] = semantic
+        result.debug_info["ranked"] = True
+        result.relevance_score = final
+
+    candidates.sort(key=lambda r: r.relevance_score, reverse=True)
+    return candidates

--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -865,7 +865,8 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             quality_boost=arguments.get("quality_boost", 0.0),
             limit=limit,
             include_debug=arguments.get("include_debug", False),
-            include_superseded=arguments.get("include_superseded", False)
+            include_superseded=arguments.get("include_superseded", False),
+            ranking_weights=arguments.get("ranking_weights"),
         )
 
         # Check for errors

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -1568,7 +1568,7 @@ Examples:
                             },
                             "mode": {
                                 "type": "string",
-                                "enum": ["semantic", "exact", "hybrid"],
+                                "enum": ["semantic", "exact", "hybrid", "ranked"],
                                 "default": "semantic",
                                 "description": "Search mode"
                             },
@@ -1610,6 +1610,16 @@ Examples:
                                 "maximum": 1,
                                 "default": 0,
                                 "description": "Quality weight for reranking (0.0-1.0)"
+                            },
+                            "ranking_weights": {
+                                "type": "object",
+                                "description": "Custom weights for ranked mode (keys: semantic, time_decay, access_frequency, quality). Values are normalized to sum=1.0.",
+                                "properties": {
+                                    "semantic": {"type": "number"},
+                                    "time_decay": {"type": "number"},
+                                    "access_frequency": {"type": "number"},
+                                    "quality": {"type": "number"}
+                                }
                             },
                             "limit": {
                                 "type": "integer",

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -1000,7 +1000,8 @@ class MemoryStorage(ABC):
         quality_boost: float = 0.0,
         limit: int = 10,
         include_debug: bool = False,
-        include_superseded: bool = False
+        include_superseded: bool = False,
+        ranking_weights: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
         """
         Unified memory search with flexible modes and filters.
@@ -1032,6 +1033,7 @@ class MemoryStorage(ABC):
             - semantic: Vector similarity search (default) - finds conceptually similar content
             - exact: Case-insensitive substring match - finds memories where content contains the query string
             - hybrid: Semantic search with quality-based reranking
+            - ranked: Semantic search with multi-signal reranking (time decay + access frequency + quality)
 
         Time Filters:
             - time_expr: Natural language like "yesterday", "last week", "2 days ago", "last month"
@@ -1083,13 +1085,13 @@ class MemoryStorage(ABC):
         """
         try:
             # Validate mode
-            if mode not in ("semantic", "exact", "hybrid"):
+            if mode not in ("semantic", "exact", "hybrid", "ranked"):
                 return {
                     "memories": [],
                     "total": 0,
                     "query": query,
                     "mode": mode,
-                    "error": f"Invalid mode: {mode}. Must be 'semantic', 'exact', or 'hybrid'"
+                    "error": f"Invalid mode: {mode}. Must be 'semantic', 'exact', 'hybrid', or 'ranked'"
                 }
 
             # Validate quality_boost
@@ -1157,7 +1159,30 @@ class MemoryStorage(ABC):
             # Perform search based on mode
             results = []
 
-            if mode == "exact":
+            if mode == "ranked":
+                # Multi-signal ranked search — feeds into shared post-filter tail
+                if not query:
+                    return {
+                        "memories": [],
+                        "total": 0,
+                        "query": query,
+                        "mode": mode,
+                        "error": "query required for ranked mode"
+                    }
+                from ..reasoning.ranked_search import apply_ranked_rerank, RankedSearchWeights
+                oversample = limit * 3
+                candidates = await self.retrieve(
+                    query, n_results=oversample, tags=tags,
+                    include_superseded=include_superseded,
+                    start_time=start_time, end_time=end_time,
+                )
+                if candidates:
+                    weights = RankedSearchWeights.from_dict(ranking_weights)
+                    candidates = apply_ranked_rerank(candidates, weights=weights)
+                results = candidates
+                pre_filter_count = len(results)
+
+            elif mode == "exact":
                 # Exact string match
                 if not query:
                     return {

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -1170,11 +1170,12 @@ class MemoryStorage(ABC):
                         "error": "query required for ranked mode"
                     }
                 from ..reasoning.ranked_search import apply_ranked_rerank, RankedSearchWeights
-                oversample = limit * 3
+                # Over-fetch without pre-filtering: the shared tail applies
+                # tag_match and time filters uniformly (fixes #1028 review).
+                oversample = limit * 5 if (tags or start_time or end_time) else limit * 3
                 candidates = await self.retrieve(
-                    query, n_results=oversample, tags=tags,
+                    query, n_results=oversample,
                     include_superseded=include_superseded,
-                    start_time=start_time, end_time=end_time,
                 )
                 if candidates:
                     weights = RankedSearchWeights.from_dict(ranking_weights)

--- a/tests/reasoning/test_ranked_search.py
+++ b/tests/reasoning/test_ranked_search.py
@@ -131,3 +131,118 @@ class TestApplyRankedRerank:
         results = apply_ranked_rerank([r], now=now)
         assert results[0].debug_info is not None
         assert results[0].debug_info.get("ranked") is True
+
+
+class TestRankedModeIntegration:
+    """Integration tests for ranked mode in search_memories (bug fixes PR #1028)."""
+
+    @pytest.fixture
+    def mock_storage(self):
+        """Create mock memories for testing ranked mode post-filter."""
+        import time
+
+        now = time.time()
+
+        # Use MagicMock to avoid Memory __post_init__ validation
+        mem_both_tags = MagicMock()
+        mem_both_tags.content = "Python async patterns for web development"
+        mem_both_tags.content_hash = "hash1"
+        mem_both_tags.tags = ["python", "async"]
+        mem_both_tags.memory_type = "note"
+        mem_both_tags.created_at = now - 3600
+        mem_both_tags.quality_score = 0.8
+        mem_both_tags.access_count = 5
+        mem_both_tags.last_accessed_at = now - 60
+        mem_both_tags.to_dict.return_value = {
+            "content": mem_both_tags.content,
+            "content_hash": "hash1",
+            "tags": ["python", "async"],
+        }
+
+        mem_one_tag = MagicMock()
+        mem_one_tag.content = "Python basics tutorial"
+        mem_one_tag.content_hash = "hash2"
+        mem_one_tag.tags = ["python"]
+        mem_one_tag.memory_type = "note"
+        mem_one_tag.created_at = now - 7200
+        mem_one_tag.quality_score = 0.6
+        mem_one_tag.access_count = 2
+        mem_one_tag.last_accessed_at = now - 600
+        mem_one_tag.to_dict.return_value = {
+            "content": mem_one_tag.content,
+            "content_hash": "hash2",
+            "tags": ["python"],
+        }
+
+        return mem_both_tags, mem_one_tag, now
+
+    @pytest.mark.asyncio
+    async def test_ranked_mode_respects_tag_match_all(self, mock_storage):
+        """Bug: tag_match='all' was ignored in ranked mode because retrieve()
+        pre-filters with OR semantics. The shared tail must apply the AND filter."""
+        from mcp_memory_service.models.memory import MemoryQueryResult
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+        import time
+
+        mem_both_tags, mem_one_tag, now = mock_storage
+
+        storage = SqliteVecMemoryStorage.__new__(SqliteVecMemoryStorage)
+
+        # Patch retrieve to return both memories (no pre-filtering by tags)
+        async def fake_retrieve(query, n_results=10, **kwargs):
+            return [
+                MemoryQueryResult(memory=mem_both_tags, relevance_score=0.85, debug_info=None),
+                MemoryQueryResult(memory=mem_one_tag, relevance_score=0.80, debug_info=None),
+            ]
+
+        storage.retrieve = fake_retrieve
+
+        result = await storage.search_memories(
+            query="python",
+            mode="ranked",
+            tags=["python", "async"],
+            tag_match="all",
+            limit=10,
+        )
+
+        # Only mem_both_tags has BOTH tags — mem_one_tag should be filtered out
+        assert result["total"] == 1, f"Expected 1 result with tag_match=all, got {result['total']}"
+        assert result["memories"][0]["content_hash"] == "hash1"
+
+    @pytest.mark.asyncio
+    async def test_ranked_mode_no_double_time_filter(self, mock_storage):
+        """Bug: ranked mode passed start_time/end_time to retrieve() AND the
+        shared tail re-applied the same filter. Ranked should NOT pass time
+        params to retrieve() — let the tail handle it uniformly."""
+        from mcp_memory_service.models.memory import MemoryQueryResult
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+        import time
+
+        mem_both_tags, mem_one_tag, now = mock_storage
+
+        storage = SqliteVecMemoryStorage.__new__(SqliteVecMemoryStorage)
+
+        retrieve_kwargs_captured = []
+
+        async def fake_retrieve(query, n_results=10, **kwargs):
+            retrieve_kwargs_captured.append(kwargs)
+            return [
+                MemoryQueryResult(memory=mem_both_tags, relevance_score=0.85, debug_info=None),
+                MemoryQueryResult(memory=mem_one_tag, relevance_score=0.80, debug_info=None),
+            ]
+
+        storage.retrieve = fake_retrieve
+
+        result = await storage.search_memories(
+            query="python",
+            mode="ranked",
+            after="2026-01-01",
+            limit=10,
+        )
+
+        # Verify retrieve was NOT called with start_time/end_time
+        call_kwargs = retrieve_kwargs_captured[0]
+        assert call_kwargs.get("start_time") is None, \
+            "ranked mode should NOT pass start_time to retrieve() — tail handles time filter"
+        assert call_kwargs.get("end_time") is None, \
+            "ranked mode should NOT pass end_time to retrieve() — tail handles time filter"

--- a/tests/reasoning/test_ranked_search.py
+++ b/tests/reasoning/test_ranked_search.py
@@ -1,0 +1,133 @@
+"""Tests for multi-signal ranked search (RFC #1008 §2).
+
+Defines expected behavior for mode="ranked" in search_memories.
+"""
+
+import math
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+class TestRankedSearchWeights:
+    """Test weight normalization and defaults."""
+
+    def test_import(self):
+        from mcp_memory_service.reasoning.ranked_search import RankedSearchWeights
+        assert RankedSearchWeights is not None
+
+    def test_defaults_sum_to_one(self):
+        from mcp_memory_service.reasoning.ranked_search import RankedSearchWeights
+        w = RankedSearchWeights()
+        assert abs((w.semantic + w.time_decay + w.access_frequency + w.quality) - 1.0) < 0.001
+
+    def test_custom_weights_normalized(self):
+        from mcp_memory_service.reasoning.ranked_search import RankedSearchWeights
+        w = RankedSearchWeights(semantic=6, time_decay=2, access_frequency=1, quality=1)
+        n = w.normalized()
+        assert abs((n.semantic + n.time_decay + n.access_frequency + n.quality) - 1.0) < 0.001
+        assert abs(n.semantic - 0.6) < 0.001
+
+    def test_from_dict(self):
+        from mcp_memory_service.reasoning.ranked_search import RankedSearchWeights
+        w = RankedSearchWeights.from_dict({"semantic": 0.5, "time_decay": 0.3, "access_frequency": 0.1, "quality": 0.1})
+        assert abs(w.semantic - 0.5) < 0.001
+
+
+class TestComputeRankedScore:
+    """Test the scoring function."""
+
+    def test_pure_semantic(self):
+        """With w1=1.0 and others=0, score should equal semantic."""
+        from mcp_memory_service.reasoning.ranked_search import compute_ranked_score, RankedSearchWeights
+        w = RankedSearchWeights(semantic=1.0, time_decay=0.0, access_frequency=0.0, quality=0.0)
+        mem = MagicMock(
+            metadata={"access_count": 5, "last_accessed_at": None, "quality_score": 0.8},
+            created_at=1000.0,
+        )
+        mem.quality_score = 0.8
+        mem.access_count = 5
+        mem.last_accessed_at = None
+        score, breakdown = compute_ranked_score(0.85, mem, weights=w)
+        assert abs(score - 0.85) < 0.01
+
+    def test_access_count_boosts(self):
+        """Higher access_count should produce higher score (all else equal)."""
+        from mcp_memory_service.reasoning.ranked_search import compute_ranked_score, RankedSearchWeights
+        import time
+        w = RankedSearchWeights(semantic=0.0, time_decay=0.0, access_frequency=1.0, quality=0.0)
+        now = time.time()
+
+        mem_low = MagicMock(quality_score=0.5, access_count=1, last_accessed_at=now, created_at=now)
+        mem_high = MagicMock(quality_score=0.5, access_count=50, last_accessed_at=now, created_at=now)
+
+        score_low, _ = compute_ranked_score(0.5, mem_low, weights=w, now=now)
+        score_high, _ = compute_ranked_score(0.5, mem_high, weights=w, now=now)
+        assert score_high > score_low
+
+    def test_recent_memory_scores_higher(self):
+        """Recently accessed memory should score higher on time_decay."""
+        from mcp_memory_service.reasoning.ranked_search import compute_ranked_score, RankedSearchWeights
+        import time
+        w = RankedSearchWeights(semantic=0.0, time_decay=1.0, access_frequency=0.0, quality=0.0)
+        now = time.time()
+
+        mem_old = MagicMock(quality_score=0.5, access_count=1, last_accessed_at=now - 86400*60, created_at=now - 86400*60)
+        mem_new = MagicMock(quality_score=0.5, access_count=1, last_accessed_at=now - 3600, created_at=now - 3600)
+
+        score_old, _ = compute_ranked_score(0.5, mem_old, weights=w, now=now)
+        score_new, _ = compute_ranked_score(0.5, mem_new, weights=w, now=now)
+        assert score_new > score_old
+
+    def test_breakdown_contains_all_signals(self):
+        """Breakdown dict should contain all 4 signal scores."""
+        from mcp_memory_service.reasoning.ranked_search import compute_ranked_score
+        import time
+        now = time.time()
+        mem = MagicMock(quality_score=0.7, access_count=3, last_accessed_at=now, created_at=now)
+        _, breakdown = compute_ranked_score(0.8, mem, now=now)
+        assert "semantic_score" in breakdown
+        assert "time_decay_score" in breakdown
+        assert "access_score" in breakdown
+        assert "quality_score" in breakdown
+        assert "ranked_score" in breakdown
+
+
+class TestApplyRankedRerank:
+    """Test the reranking function on a list of candidates."""
+
+    def test_reranks_by_composite_score(self):
+        """Candidates should be reordered by ranked score."""
+        from mcp_memory_service.reasoning.ranked_search import apply_ranked_rerank
+        import time
+        now = time.time()
+
+        # Candidate A: high semantic but old
+        a = MagicMock()
+        a.relevance_score = 0.9
+        a.memory = MagicMock(quality_score=0.3, access_count=0, last_accessed_at=now - 86400*90, created_at=now - 86400*90)
+        a.debug_info = None
+
+        # Candidate B: lower semantic but recent + high quality
+        b = MagicMock()
+        b.relevance_score = 0.7
+        b.memory = MagicMock(quality_score=0.9, access_count=20, last_accessed_at=now - 60, created_at=now - 3600)
+        b.debug_info = None
+
+        results = apply_ranked_rerank([a, b], now=now)
+        # B should rank higher due to recency + quality + access
+        assert results[0] is b
+
+    def test_preserves_debug_info(self):
+        """Reranking should add debug info to each result."""
+        from mcp_memory_service.reasoning.ranked_search import apply_ranked_rerank
+        import time
+        now = time.time()
+
+        r = MagicMock()
+        r.relevance_score = 0.8
+        r.memory = MagicMock(quality_score=0.5, access_count=2, last_accessed_at=now, created_at=now)
+        r.debug_info = None
+
+        results = apply_ranked_rerank([r], now=now)
+        assert results[0].debug_info is not None
+        assert results[0].debug_info.get("ranked") is True


### PR DESCRIPTION
Substitute PR for #1028 — rebased onto current main after conflict in `reasoning/__init__.py` (temporal/mutability/multi_strategy exports added since the original PR was opened).

All code changes are identical to #1028 final state (@filhocf). Conflict was only in `__init__.py` exports — merged both sets.

Closes #1028