### PR TITLE
fix(security): wrap log f-strings with _sanitize_log_value in graph.py (CodeQL #483-#486)

### DIFF
--- a/src/mcp_memory_service/storage/graph.py
+++ b/src/mcp_memory_service/storage/graph.py
@@ -32,6 +32,7 @@ from typing import List, Dict, Any, Tuple, Optional
 from datetime import datetime, timezone
 
 from mcp_memory_service.models.ontology import is_symmetric_relationship, validate_relationship
+from mcp_memory_service.compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +186,7 @@ class GraphStorage:
             return False
 
         if source_hash == target_hash:
-            logger.warning(f"Cannot create self-loop: {source_hash}")
+            logger.warning(f"Cannot create self-loop: {_sanitize_log_value(source_hash)}")
             return False
 
         # Validate similarity score bounds
@@ -225,9 +226,9 @@ class GraphStorage:
                             VALUES (?, ?, ?, ?, ?, ?, ?)
                         """, (target_hash, source_hash, similarity, connection_types_json,
                               metadata_json, created_at, relationship_type))
-                        logger.debug(f"Stored bidirectional association: {source_hash} ↔ {target_hash} (type: {relationship_type})")
+                        logger.debug(f"Stored bidirectional association: {_sanitize_log_value(source_hash)} ↔ {_sanitize_log_value(target_hash)} (type: {_sanitize_log_value(relationship_type)})")
                     else:
-                        logger.debug(f"Stored directed association: {source_hash} → {target_hash} (type: {relationship_type})")
+                        logger.debug(f"Stored directed association: {_sanitize_log_value(source_hash)} → {_sanitize_log_value(target_hash)} (type: {_sanitize_log_value(relationship_type)})")
 
                     conn.commit()
                 finally:
@@ -637,7 +638,7 @@ class GraphStorage:
                     "created_at": result['created_at']
                 }
             else:
-                logger.debug(f"No association found: {source_hash} ↔ {target_hash}")
+                logger.debug(f"No association found: {_sanitize_log_value(source_hash)} ↔ {_sanitize_log_value(target_hash)}")
                 return None
 
         except sqlite3.Error as e:


### PR DESCRIPTION
## Summary

- Wraps 4 raw f-string logger calls in `storage/graph.py` with `_sanitize_log_value()` from `compat.py`
- Dismisses CodeQL alert #467 (`py/unused-global-variable` for `MCP_AUTO_EXTRACT_DEFAULT`) as false positive — the variable is imported via lazy import in `server/handlers/memory.py:259`, which CodeQL does not track across module boundaries

## Alerts resolved

| Alert | Location | Rule |
|-------|----------|------|
| #483 | `graph.py:188` | `py/log-injection` — `source_hash` in warning |
| #484 | `graph.py:228` | `py/log-injection` — `source_hash`, `target_hash`, `relationship_type` in debug |
| #485 | `graph.py:230` | `py/log-injection` — same variables in directed association debug |
| #486 | `graph.py:640` | `py/log-injection` — `source_hash`, `target_hash` in not-found debug |
| #467 | `config.py:1325` | `py/unused-global-variable` — dismissed as FP |

## Notes

SHA-256 hashes cannot contain `\n`, `\r`, or `\x1b` in practice, so these are technically false positives. `_sanitize_log_value()` strips exactly those characters — no behaviour change, CodeQL satisfied.

Pattern follows the same approach applied in `sqlite_vec.py` and established in PR #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)