### PR TITLE
feat(harvest): support OpenAI-compatible LLM endpoints in classifier

### DIFF
--- a/src/mcp_memory_service/harvest/classifier.py
+++ b/src/mcp_memory_service/harvest/classifier.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass
 from typing import List, Optional
 
+import httpx
+
 from .models import HarvestCandidate
 
 logger = logging.getLogger(__name__)
@@ -78,17 +80,47 @@ class ClassificationResult:
 class HarvestClassifier:
     """LLM-based classifier for harvest candidates.
 
-    Uses Groq API (fast, cheap) with fallback to skip classification
-    if no LLM is available. Integrates with existing GroqAgentBridge.
+    Uses an OpenAI-compatible endpoint when ``HARVEST_LLM_BASE_URL`` is set
+    (Ollama, vLLM, DeepSeek, LiteLLM, OpenAI, …) and otherwise falls back to
+    Groq. If neither is available, classification is skipped and regex
+    candidates are returned unfiltered.
     """
 
     def __init__(self, groq_api_key: Optional[str] = None):
-        self._groq_bridge = None
+        self._bridge = None
+        self._compat = False
         self._api_key = groq_api_key or os.environ.get("GROQ_API_KEY")
+        # Optional OpenAI-compatible endpoint. When HARVEST_LLM_BASE_URL is set it
+        # takes precedence over Groq, so harvest classification works against a
+        # local/offline model (e.g. Ollama) with no Groq key required.
+        self._llm_base_url = os.environ.get("HARVEST_LLM_BASE_URL")
+        self._llm_model = os.environ.get("HARVEST_LLM_MODEL")
+        self._llm_api_key = os.environ.get("HARVEST_LLM_API_KEY")
 
     def _ensure_initialized(self):
-        """Lazy-init Groq bridge."""
-        if self._groq_bridge is not None:
+        """Lazy-init the LLM bridge: OpenAI-compatible endpoint if configured, else Groq."""
+        if self._bridge is not None:
+            return True
+
+        # Prefer an OpenAI-compatible endpoint when configured — enables local/offline
+        # classification (Ollama, vLLM, …) with no Groq dependency or API key.
+        if self._llm_base_url:
+            if not self._llm_model:
+                logger.warning(
+                    "HARVEST_LLM_BASE_URL set but HARVEST_LLM_MODEL is missing — "
+                    "OpenAI-compatible classification unavailable"
+                )
+                return False
+            self._bridge = _OpenAICompatClassifierBridge(
+                base_url=self._llm_base_url,
+                model=self._llm_model,
+                api_key=self._llm_api_key,
+            )
+            self._compat = True
+            logger.info(
+                "Harvest classifier: OpenAI-compatible bridge initialized (%s)",
+                self._llm_base_url,
+            )
             return True
 
         if not self._api_key:
@@ -97,7 +129,7 @@ class HarvestClassifier:
 
         try:
             from groq import Groq
-            self._groq_bridge = _GroqClassifierBridge(api_key=self._api_key)
+            self._bridge = _GroqClassifierBridge(api_key=self._api_key)
             logger.info("Harvest classifier: Groq bridge initialized")
             return True
         except ImportError:
@@ -154,10 +186,14 @@ class HarvestClassifier:
             context=context[:2000],
         )
 
-        models = ["llama-3.1-8b-instant", "llama-3.3-70b-versatile"]
+        models = (
+            [self._llm_model]
+            if self._compat
+            else ["llama-3.1-8b-instant", "llama-3.3-70b-versatile"]
+        )
         for model in models:
             try:
-                result = self._groq_bridge.call_model(
+                result = self._bridge.call_model(
                     prompt=prompt,
                     model=model,
                     max_tokens=300,
@@ -238,9 +274,9 @@ class HarvestClassifier:
         prompt = DEDUP_PROMPT_TEMPLATE.format(candidates_text=candidates_text)
 
         try:
-            result = self._groq_bridge.call_model(
+            result = self._bridge.call_model(
                 prompt=prompt,
-                model="llama-3.1-8b-instant",
+                model=(self._llm_model if self._compat else "llama-3.1-8b-instant"),
                 max_tokens=100,
                 temperature=0.0,
                 system_message="You deduplicate memories. Respond only with a JSON array of indices.",
@@ -291,4 +327,71 @@ class _GroqClassifierBridge:
                 "tokens_used": response.usage.total_tokens,
             }
         except Exception as e:
+            return {"status": "error", "error": str(e)}
+
+
+class _OpenAICompatClassifierBridge:
+    """Thin sync wrapper around any OpenAI-compatible /v1/chat/completions endpoint.
+
+    Exposes the same ``call_model`` interface as :class:`_GroqClassifierBridge`, so the
+    classifier works unchanged against Ollama, vLLM, DeepSeek, LiteLLM, or OpenAI itself.
+    Mirrors the request shape used by the quality system's
+    ``AIQualityEvaluator._score_with_openai_compatible``.
+    """
+
+    def __init__(self, base_url: str, model: str, api_key: Optional[str] = None):
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._api_key = api_key or "none"
+        self._client = httpx.Client(timeout=30.0)
+
+    def call_model(self, prompt: str, model: str = "",
+                   max_tokens: int = 300, temperature: float = 0.1,
+                   system_message: Optional[str] = None) -> dict:
+        """Call the endpoint and return a result dict matching _GroqClassifierBridge."""
+        model = model or self._model
+
+        messages = []
+        if system_message:
+            messages.append({"role": "system", "content": system_message})
+        messages.append({"role": "user", "content": prompt})
+
+        payload = {"model": model, "messages": messages}
+        # OpenAI's gpt-5.x family rejects max_tokens/temperature (HTTP 400) and needs
+        # headroom for reasoning tokens before emitting output — mirror the quality
+        # system (see ai_evaluator._score_with_openai_compatible, issue #797).
+        if model.startswith("gpt-5"):
+            payload["max_completion_tokens"] = max(max_tokens, 800)
+        else:
+            payload["max_tokens"] = max_tokens
+            payload["temperature"] = temperature
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._api_key}",
+        }
+
+        try:
+            response = self._client.post(
+                f"{self._base_url}/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
+            content = data["choices"][0]["message"]["content"]
+            usage = data.get("usage") or {}
+            return {
+                "status": "success",
+                "response": content,
+                "model": model,
+                "tokens_used": usage.get("total_tokens", 0),
+            }
+        except httpx.HTTPStatusError as e:
+            # Keep "429" in the message so the classifier's rate-limit fallback triggers.
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text[:200]}",
+            }
+        except (httpx.RequestError, KeyError, IndexError, TypeError, ValueError) as e:
             return {"status": "error", "error": str(e)}

--- a/src/mcp_memory_service/harvest/classifier.py
+++ b/src/mcp_memory_service/harvest/classifier.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 
 import httpx
 
+from ..compat import _sanitize_log_value
 from .models import HarvestCandidate
 
 logger = logging.getLogger(__name__)
@@ -113,15 +114,12 @@ class HarvestClassifier:
         if self._bridge is not None:
             return True
 
-        # Prefer an OpenAI-compatible endpoint when configured — enables local/offline
-        # classification (Ollama, vLLM, …) with no Groq dependency or API key.
-        if self._llm_base_url:
-            if not self._llm_model:
-                logger.warning(
-                    "HARVEST_LLM_BASE_URL set but HARVEST_LLM_MODEL is missing — "
-                    "OpenAI-compatible classification unavailable"
-                )
-                return False
+        # Prefer an OpenAI-compatible endpoint when fully configured — enables
+        # local/offline classification (Ollama, vLLM, …) with no Groq dependency.
+        # If the base URL is set but the model is missing, fall through to the Groq
+        # path so a present GROQ_API_KEY still works (issue #1053: "keep Groq as the
+        # default backward-compatible path").
+        if self._llm_base_url and self._llm_model:
             self._bridge = _OpenAICompatClassifierBridge(
                 base_url=self._llm_base_url,
                 model=self._llm_model,
@@ -130,9 +128,14 @@ class HarvestClassifier:
             self._compat = True
             logger.info(
                 "Harvest classifier: OpenAI-compatible bridge initialized (%s)",
-                self._llm_base_url,
+                _sanitize_log_value(self._llm_base_url),
             )
             return True
+        if self._llm_base_url and not self._llm_model:
+            logger.warning(
+                "HARVEST_LLM_BASE_URL set but HARVEST_LLM_MODEL is missing — "
+                "falling back to Groq if available"
+            )
 
         if not self._api_key:
             logger.warning("No GROQ_API_KEY — LLM classification unavailable")
@@ -354,7 +357,6 @@ class _OpenAICompatClassifierBridge:
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._api_key = api_key or "none"
-        self._client = httpx.Client(timeout=30.0)
 
     def call_model(self, prompt: str, model: str = "",
                    max_tokens: int = 300, temperature: float = 0.1,
@@ -383,13 +385,18 @@ class _OpenAICompatClassifierBridge:
         }
 
         try:
-            response = self._client.post(
-                f"{self._base_url}/chat/completions",
-                headers=headers,
-                json=payload,
-            )
-            response.raise_for_status()
-            data = response.json()
+            # Per-request client so the connection pool / file descriptors are always
+            # released — the bridge is held on HarvestClassifier for its lifetime with
+            # no cleanup hook, and harvest classification is sequential (not a hot
+            # batch path), so pooling buys little here. (Review note on #1053.)
+            with httpx.Client(timeout=30.0) as client:
+                response = client.post(
+                    f"{self._base_url}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
             content = data["choices"][0]["message"]["content"]
             usage = data.get("usage") or {}
             return {

--- a/src/mcp_memory_service/harvest/classifier.py
+++ b/src/mcp_memory_service/harvest/classifier.py
@@ -97,6 +97,17 @@ class HarvestClassifier:
         self._llm_model = os.environ.get("HARVEST_LLM_MODEL")
         self._llm_api_key = os.environ.get("HARVEST_LLM_API_KEY")
 
+    # Backward-compat alias: the bridge attribute used to be ``_groq_bridge``.
+    # Existing tests (and any external code) inject a bridge via that name, so keep
+    # it working — it maps to the now-provider-agnostic ``_bridge``.
+    @property
+    def _groq_bridge(self):
+        return self._bridge
+
+    @_groq_bridge.setter
+    def _groq_bridge(self, value):
+        self._bridge = value
+
     def _ensure_initialized(self):
         """Lazy-init the LLM bridge: OpenAI-compatible endpoint if configured, else Groq."""
         if self._bridge is not None:

--- a/tests/harvest/test_classifier_openai_compat.py
+++ b/tests/harvest/test_classifier_openai_compat.py
@@ -4,8 +4,9 @@ The harvest classifier was hardcoded to Groq. These tests cover the new
 ``HARVEST_LLM_BASE_URL`` / ``HARVEST_LLM_MODEL`` / ``HARVEST_LLM_API_KEY`` path
 that routes classification through any OpenAI-compatible ``/v1/chat/completions``
 endpoint (Ollama, vLLM, DeepSeek, LiteLLM, OpenAI), and that the Groq behavior is
-unchanged when those vars are absent.
+unchanged / falls back correctly when those vars are absent or incomplete.
 """
+import sys
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -28,19 +29,39 @@ def _ok_response(content):
     return resp
 
 
+def _patch_httpx(*, returns=None, side_effect=None):
+    """Patch the per-request ``httpx.Client`` used by the bridge.
+
+    The bridge opens ``with httpx.Client() as client:`` per call, so we patch the
+    class to yield a mock client. Returns (patcher, mock_client) — use the mock_client
+    to assert on ``.post`` calls.
+    """
+    client = MagicMock()
+    if side_effect is not None:
+        client.post.side_effect = side_effect
+    else:
+        client.post.return_value = returns
+    ctx = MagicMock()
+    ctx.__enter__.return_value = client
+    ctx.__exit__.return_value = False
+    patcher = patch("mcp_memory_service.harvest.classifier.httpx.Client", return_value=ctx)
+    return patcher, client
+
+
 @pytest.mark.unit
 def test_compat_bridge_call_model_success():
     bridge = _OpenAICompatClassifierBridge(
         base_url="http://localhost:11434/v1/", model="qwen2.5:7b", api_key=None
     )
-    with patch.object(bridge._client, "post", return_value=_ok_response("hello")) as post:
+    patcher, client = _patch_httpx(returns=_ok_response("hello"))
+    with patcher:
         result = bridge.call_model(prompt="hi", system_message="sys")
 
     assert result["status"] == "success"
     assert result["response"] == "hello"
     assert result["tokens_used"] == 42
 
-    args, kwargs = post.call_args
+    args, kwargs = client.post.call_args
     # trailing slash on base_url is stripped → exactly one /chat/completions
     assert args[0] == "http://localhost:11434/v1/chat/completions"
     assert kwargs["headers"]["Authorization"] == "Bearer none"  # default when no key
@@ -54,10 +75,11 @@ def test_compat_bridge_gpt5_uses_max_completion_tokens():
     bridge = _OpenAICompatClassifierBridge(
         base_url="https://api.openai.com/v1", model="gpt-5-mini", api_key="sk-x"
     )
-    with patch.object(bridge._client, "post", return_value=_ok_response("ok")) as post:
+    patcher, client = _patch_httpx(returns=_ok_response("ok"))
+    with patcher:
         bridge.call_model(prompt="hi")
 
-    payload = post.call_args.kwargs["json"]
+    payload = client.post.call_args.kwargs["json"]
     assert "max_completion_tokens" in payload
     assert "max_tokens" not in payload
     assert "temperature" not in payload
@@ -69,12 +91,12 @@ def test_compat_bridge_http_error_preserves_429_for_fallback():
     err = httpx.HTTPStatusError(
         "boom", request=MagicMock(), response=MagicMock(status_code=429, text="rate limited")
     )
-    with patch.object(bridge._client, "post", side_effect=err):
+    patcher, _ = _patch_httpx(side_effect=err)
+    with patcher:
         result = bridge.call_model(prompt="hi")
 
     assert result["status"] == "error"
-    # "429" must survive so _classify_single's rate-limit fallback path triggers
-    assert "429" in result["error"]
+    assert "429" in result["error"]  # so _classify_single's rate-limit fallback fires
 
 
 @pytest.mark.unit
@@ -90,13 +112,30 @@ def test_ensure_initialized_prefers_openai_compatible(monkeypatch):
 
 
 @pytest.mark.unit
-def test_base_url_without_model_is_unavailable(monkeypatch):
+def test_base_url_without_model_and_no_groq_key_is_unavailable(monkeypatch):
     monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
     monkeypatch.delenv("HARVEST_LLM_MODEL", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
 
     clf = HarvestClassifier()
+    # base_url set but no model AND no Groq key → nothing usable
     assert clf._ensure_initialized() is False
+
+
+@pytest.mark.unit
+def test_base_url_without_model_falls_back_to_groq(monkeypatch):
+    """Issue #1053: a present GROQ_API_KEY must still work if HARVEST_LLM_MODEL is missing."""
+    monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("HARVEST_LLM_MODEL", raising=False)
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+
+    clf = HarvestClassifier()
+    # groq may not be installed in CI → stub the module + the bridge so the fall-through path runs
+    with patch.dict(sys.modules, {"groq": MagicMock()}), \
+         patch("mcp_memory_service.harvest.classifier._GroqClassifierBridge") as MockGroq:
+        assert clf._ensure_initialized() is True
+        assert clf._compat is False          # used Groq, not the compat bridge
+        MockGroq.assert_called_once()
 
 
 @pytest.mark.unit
@@ -124,10 +163,42 @@ def test_classify_routes_through_compat_endpoint(monkeypatch):
         '"memory_type": "bug", "confidence": 0.9}'
     )
     cands = [HarvestCandidate(content="orig", memory_type="bug", confidence=0.5)]
-    with patch.object(clf._bridge._client, "post", return_value=_ok_response(classify_json)):
+    patcher, _ = _patch_httpx(returns=_ok_response(classify_json))
+    with patcher:
         out = clf.classify(cands)
 
     assert len(out) == 1
     assert out[0].content == "refined"
     assert out[0].confidence == 0.9
     assert "llm-verified" in out[0].tags
+
+
+@pytest.mark.unit
+def test_classify_dedup_routes_through_compat_endpoint(monkeypatch):
+    """Two kept candidates trigger _deduplicate — exercises the compat dedup branch (review note)."""
+    monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("HARVEST_LLM_MODEL", "qwen2.5:7b")
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    clf = HarvestClassifier()
+    assert clf._ensure_initialized() is True
+
+    def _keep(refined):
+        return _ok_response(
+            '{"keep": true, "reason": "r", "refined_content": "%s", '
+            '"memory_type": "convention", "confidence": 0.8}' % refined
+        )
+
+    # 2 classify calls (both kept) then 1 dedup call returning indices-to-keep [0]
+    responses = [_keep("A refined"), _keep("B refined"), _ok_response("[0]")]
+    cands = [
+        HarvestCandidate(content="A", memory_type="convention", confidence=0.7),
+        HarvestCandidate(content="B", memory_type="convention", confidence=0.7),
+    ]
+    patcher, client = _patch_httpx(side_effect=responses)
+    with patcher:
+        out = clf.classify(cands)
+
+    assert client.post.call_count == 3          # 2 classify + 1 dedup, all via compat endpoint
+    assert len(out) == 1                         # dedup kept only index 0
+    assert out[0].content == "A refined"

--- a/tests/harvest/test_classifier_openai_compat.py
+++ b/tests/harvest/test_classifier_openai_compat.py
@@ -1,0 +1,133 @@
+"""Tests for OpenAI-compatible LLM provider support in the harvest classifier (issue #1053).
+
+The harvest classifier was hardcoded to Groq. These tests cover the new
+``HARVEST_LLM_BASE_URL`` / ``HARVEST_LLM_MODEL`` / ``HARVEST_LLM_API_KEY`` path
+that routes classification through any OpenAI-compatible ``/v1/chat/completions``
+endpoint (Ollama, vLLM, DeepSeek, LiteLLM, OpenAI), and that the Groq behavior is
+unchanged when those vars are absent.
+"""
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from mcp_memory_service.harvest.classifier import (
+    HarvestClassifier,
+    _OpenAICompatClassifierBridge,
+)
+from mcp_memory_service.harvest.models import HarvestCandidate
+
+
+def _ok_response(content):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"total_tokens": 42},
+    }
+    return resp
+
+
+@pytest.mark.unit
+def test_compat_bridge_call_model_success():
+    bridge = _OpenAICompatClassifierBridge(
+        base_url="http://localhost:11434/v1/", model="qwen2.5:7b", api_key=None
+    )
+    with patch.object(bridge._client, "post", return_value=_ok_response("hello")) as post:
+        result = bridge.call_model(prompt="hi", system_message="sys")
+
+    assert result["status"] == "success"
+    assert result["response"] == "hello"
+    assert result["tokens_used"] == 42
+
+    args, kwargs = post.call_args
+    # trailing slash on base_url is stripped → exactly one /chat/completions
+    assert args[0] == "http://localhost:11434/v1/chat/completions"
+    assert kwargs["headers"]["Authorization"] == "Bearer none"  # default when no key
+    assert kwargs["json"]["model"] == "qwen2.5:7b"
+    assert kwargs["json"]["max_tokens"] == 300
+    assert kwargs["json"]["messages"][0]["role"] == "system"
+
+
+@pytest.mark.unit
+def test_compat_bridge_gpt5_uses_max_completion_tokens():
+    bridge = _OpenAICompatClassifierBridge(
+        base_url="https://api.openai.com/v1", model="gpt-5-mini", api_key="sk-x"
+    )
+    with patch.object(bridge._client, "post", return_value=_ok_response("ok")) as post:
+        bridge.call_model(prompt="hi")
+
+    payload = post.call_args.kwargs["json"]
+    assert "max_completion_tokens" in payload
+    assert "max_tokens" not in payload
+    assert "temperature" not in payload
+
+
+@pytest.mark.unit
+def test_compat_bridge_http_error_preserves_429_for_fallback():
+    bridge = _OpenAICompatClassifierBridge(base_url="http://x/v1", model="m")
+    err = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock(status_code=429, text="rate limited")
+    )
+    with patch.object(bridge._client, "post", side_effect=err):
+        result = bridge.call_model(prompt="hi")
+
+    assert result["status"] == "error"
+    # "429" must survive so _classify_single's rate-limit fallback path triggers
+    assert "429" in result["error"]
+
+
+@pytest.mark.unit
+def test_ensure_initialized_prefers_openai_compatible(monkeypatch):
+    monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("HARVEST_LLM_MODEL", "qwen2.5:7b")
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    clf = HarvestClassifier()
+    assert clf._ensure_initialized() is True
+    assert clf._compat is True
+    assert isinstance(clf._bridge, _OpenAICompatClassifierBridge)
+
+
+@pytest.mark.unit
+def test_base_url_without_model_is_unavailable(monkeypatch):
+    monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.delenv("HARVEST_LLM_MODEL", raising=False)
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    clf = HarvestClassifier()
+    assert clf._ensure_initialized() is False
+
+
+@pytest.mark.unit
+def test_backward_compatible_no_provider_returns_candidates_unfiltered(monkeypatch):
+    monkeypatch.delenv("HARVEST_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    clf = HarvestClassifier()
+    cands = [HarvestCandidate(content="x", memory_type="bug", confidence=0.7)]
+    # No provider configured → input returned unchanged, no crash (existing behavior)
+    assert clf.classify(cands) == cands
+
+
+@pytest.mark.unit
+def test_classify_routes_through_compat_endpoint(monkeypatch):
+    monkeypatch.setenv("HARVEST_LLM_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("HARVEST_LLM_MODEL", "qwen2.5:7b")
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    clf = HarvestClassifier()
+    assert clf._ensure_initialized() is True
+
+    classify_json = (
+        '{"keep": true, "reason": "useful", "refined_content": "refined", '
+        '"memory_type": "bug", "confidence": 0.9}'
+    )
+    cands = [HarvestCandidate(content="orig", memory_type="bug", confidence=0.5)]
+    with patch.object(clf._bridge._client, "post", return_value=_ok_response(classify_json)):
+        out = clf.classify(cands)
+
+    assert len(out) == 1
+    assert out[0].content == "refined"
+    assert out[0].confidence == 0.9
+    assert "llm-verified" in out[0].tags


### PR DESCRIPTION
## What

The harvest LLM classifier was hardcoded to Groq (`HarvestClassifier` → `_GroqClassifierBridge`), so:

- with no `GROQ_API_KEY`, LLM classification was unavailable entirely, and
- it couldn't run against local/self-hosted models (Ollama, vLLM, …).

This adds OpenAI-compatible endpoint support so any `/v1/chat/completions` server can drive harvest classification, with **no behavior change** when the new vars are unset.

Closes #1053.

## How

- New `_OpenAICompatClassifierBridge` (sync `httpx.Client`) exposing the **same `call_model` interface** as `_GroqClassifierBridge`, so `classify()` / `_deduplicate()` are otherwise untouched.
- New env vars, mirroring the `MCP_QUALITY_AI_*` convention already used by the quality system:
  - `HARVEST_LLM_BASE_URL` — e.g. `http://localhost:11434/v1`
  - `HARVEST_LLM_MODEL` — e.g. `qwen2.5:7b-instruct`
  - `HARVEST_LLM_API_KEY` — optional (defaults to `none`, fine for Ollama)
- `_ensure_initialized()` prefers the OpenAI-compatible bridge when `HARVEST_LLM_BASE_URL` is set; otherwise the Groq path is unchanged.
- Request shape mirrors `quality/ai_evaluator._score_with_openai_compatible`:
  - `gpt-5*` uses `max_completion_tokens` (no `temperature` / `max_tokens`) — #797 parity
  - HTTP errors keep `429` in the message so the classifier's existing rate-limit fallback still fires

One judgment call: I used a **standalone sync bridge** rather than reusing the quality helper, since that path is `async` and sharing it would couple `harvest → quality`. Happy to refactor into a shared util if you'd prefer (raised in #1053).

## Backward compatibility

Absent the new env vars, the Groq path runs exactly as before. No changes to the classification prompt or dedup logic.

## Testing

Added `tests/harvest/test_classifier_openai_compat.py` (7 cases): bridge success path, `gpt-5` token-param handling, HTTP-error → `429` preserved, provider selection, missing-model guard, backward-compat no-op, and an end-to-end `classify()` routed through a mocked compat endpoint.

```bash
pytest tests/harvest/test_classifier_openai_compat.py
# 7 passed
```

> Transparency: I verified syntax + these 7 tests locally in an isolated venv. I did **not** run the full suite or `scripts/pr/pre_pr_check.sh` in my environment — relying on CI for the full gate. Glad to address anything it flags.
