### PR TITLE
fix: resolve #1055 — fix(mistake-notes): reject empty correct_action (required != non-empty)

### DIFF
--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -827,6 +827,14 @@ class MemoryService:
         """
         from ..config import MCP_MISTAKE_NOTE_DEDUP_THRESHOLD
 
+        # A mistake note's value is its remediation. Reject empty correct_action —
+        # JSON-schema `required` enforces presence, not non-emptiness (issue #1055).
+        if not (correct_action or "").strip():
+            return {
+                "status": "error",
+                "message": "correct_action must not be empty — a mistake note requires a remediation, not just an error pattern",
+            }
+
         content = (
             f"Pattern: {error_pattern}\n"
             f"Context: {context_signature}\n"
@@ -981,6 +989,13 @@ class MemoryService:
         Returns:
             Dictionary with operation result
         """
+        # Don't allow an existing note's remediation to be blanked (issue #1055).
+        if correct_action is not None and not correct_action.strip():
+            return {
+                "status": "error",
+                "message": "correct_action must not be empty — a mistake note requires a remediation, not just an error pattern",
+            }
+
         try:
             mem = await self.storage.get_by_hash(content_hash)
             if not mem:

--- a/tests/services/test_mistake_notes.py
+++ b/tests/services/test_mistake_notes.py
@@ -60,6 +60,25 @@ async def test_mistake_note_add_creates_new(memory_service):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize("correct_action", ["", "   ", "\n\t "])
+async def test_mistake_note_add_rejects_empty_correct_action(memory_service, correct_action):
+    """Empty/whitespace-only correct_action should be rejected, not stored (#1055)."""
+    result = await memory_service.mistake_note_add(
+        error_pattern="Error with no remediation",
+        context_signature="some context",
+        incorrect_action="Did the wrong thing",
+        correct_action=correct_action,
+    )
+    assert result["status"] == "error"
+    assert "correct_action" in result["message"]
+
+    # Nothing should have been stored
+    search = await memory_service.mistake_note_search(query="Error with no remediation", limit=10)
+    assert search["count"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_mistake_note_add_dedup_increments_count(memory_service):
     """Adding a similar mistake should increment failure_count.
 
@@ -256,6 +275,32 @@ async def test_mistake_note_update_content_fields(memory_service):
     new_mem = await memory_service.storage.get_by_hash(new_hash)
     assert new_mem is not None
     assert "Create feature branch and open PR" in new_mem.content
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("correct_action", ["", "   ", "\n\t "])
+async def test_mistake_note_update_rejects_blanking_correct_action(memory_service, correct_action):
+    """Updating correct_action to empty/whitespace should be rejected (#1055)."""
+    r1 = await memory_service.mistake_note_add(
+        error_pattern="Pattern to keep",
+        context_signature="Git workflow",
+        incorrect_action="Committed to main",
+        correct_action="Create feature branch first",
+    )
+    content_hash = r1["content_hash"]
+
+    result = await memory_service.mistake_note_update(
+        content_hash=content_hash,
+        correct_action=correct_action,
+    )
+    assert result["status"] == "error"
+    assert "correct_action" in result["message"]
+
+    # Original note must be untouched
+    mem = await memory_service.storage.get_by_hash(content_hash)
+    assert mem is not None
+    assert "Create feature branch first" in mem.content
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Implements a fix for #1055.

Closes #1055.

> Contributed by Aigen-Protocol. Tests run locally; relying on CI for the full gate.