### PR TITLE
ci: add non-blocking changelog-reminder soft gate

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,108 @@
+name: Changelog Reminder
+
+# Soft gate (non-blocking): when a PR changes shipping code under src/ but does
+# not touch CHANGELOG.md, post a sticky reminder to add an entry under
+# [Unreleased]. This never fails the check — it only nudges. Escape hatches:
+#   - add the `skip-changelog` label to suppress (CI-only/refactor/no-op cases)
+#   - touch CHANGELOG.md and the reminder auto-resolves
+# The release agent (github-release-manager) remains the backstop that compiles
+# the final CHANGELOG at release time.
+#
+# Security: all PR-controlled data (labels, file paths) is read via the GitHub
+# REST API into JS variables inside actions/github-script — never interpolated
+# into a shell `run:` step — so there is no workflow command-injection surface.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changelog-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const MARKER = "<!-- changelog-reminder -->";
+            const pr = context.payload.pull_request;
+            if (!pr) { return; }
+
+            const prNumber = pr.number;
+            const labels = (pr.labels || []).map(l => l.name);
+            const skip = labels.includes("skip-changelog");
+
+            // Collect changed files (paginated).
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const paths = files.map(f => f.filename);
+            const touchedSrc = paths.some(p => p.startsWith("src/"));
+            const touchedChangelog = paths.includes("CHANGELOG.md");
+
+            // Find any existing reminder comment by this workflow.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(c => (c.body || "").includes(MARKER));
+
+            // Reminder needed only when shipping code changed, CHANGELOG was not
+            // touched, and the author did not opt out via label.
+            const needsReminder = touchedSrc && !touchedChangelog && !skip;
+
+            if (!needsReminder) {
+              // Auto-resolve: drop a stale reminder if the condition cleared.
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const body = [
+              MARKER,
+              "### Changelog reminder",
+              "",
+              "This PR changes code under `src/` but does not touch `CHANGELOG.md`.",
+              "Please add a one-line entry under the `## [Unreleased]` heading, following",
+              "[Keep a Changelog](https://keepachangelog.com/) (`### Added` / `### Fixed` / `### Changed`):",
+              "",
+              "```markdown",
+              "## [Unreleased]",
+              "",
+              "### Fixed",
+              "",
+              "- short description of the change (issue #NNN, PR #MMM, @your-handle)",
+              "```",
+              "",
+              "**This is a non-blocking reminder** — it will not fail CI.",
+              "If no entry is warranted (CI-only, internal refactor, no user-visible change),",
+              "add the `skip-changelog` label and this comment disappears.",
+            ].join("\n");
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## What

Adds a **non-blocking** `Changelog Reminder` workflow. When a PR changes shipping code under `src/` but does not touch `CHANGELOG.md`, it posts a single sticky comment asking for an entry under `## [Unreleased]`.

Motivation: the PR template already has a `CHANGELOG.md` checkbox, but it's silently ignorable — e.g. #1057 shipped a `src/` fix with no changelog entry, which had to be backfilled by hand after merge.

## How

- Trigger: `pull_request_target` on `[opened, synchronize, reopened, labeled, unlabeled]` so it re-evaluates on new pushes and label changes.
- Logic (via `actions/github-script`, SHA-pinned to match repo convention):
  - Lists changed files. Reminder fires only when `src/` changed **and** `CHANGELOG.md` did not.
  - **Sticky**: finds its own prior comment via a `<!-- changelog-reminder -->` marker and updates it instead of spamming on every push.
  - **Auto-resolves**: once `CHANGELOG.md` is touched (or `src/` is no longer in the diff), the stale reminder is deleted.
- **Escape hatch**: the `skip-changelog` label suppresses it (CI-only, internal refactor, no user-visible change). Label created in this change.

## Non-blocking by design

The job only comments — it never fails the check, and it is **not** added to required status checks. `github-release-manager` remains the backstop that compiles the final CHANGELOG at release time. This nudges contributors without adding merge friction.

## Security

All PR-controlled data (labels, file paths) is read via the REST API into JS variables inside `github-script` — never interpolated into a shell `run:` step — so there is no workflow command-injection surface.

## Testing notes

This PR touches only `.github/`, so the reminder correctly does **not** fire on itself (a CI-only change warrants no changelog entry). The first real exercise will be on the next `src/`-touching PR (e.g. #1056).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
