### PR TITLE
docs: migrate stale GitHub refs to Codeberg

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Report an issue (Codeberg)
-    url: https://codeberg.org/doobidoo/mcp-memory-service/issues
-    about: This repository is a mirror. Bug reports, feature requests, and pull requests are handled on Codeberg.
-  - name: Documentation and Wiki
+  - name: 📚 Documentation & Wiki
     url: https://codeberg.org/doobidoo/mcp-memory-service/wiki
-    about: Setup guides, troubleshooting, and advanced usage
-  - name: Search existing issues
-    url: https://codeberg.org/doobidoo/mcp-memory-service/issues?state=all
-    about: Check whether your issue has already been reported or solved
+    about: Check the Wiki for setup guides, troubleshooting, and advanced usage
+  - name: 💬 Codeberg Issues
+    url: https://codeberg.org/doobidoo/mcp-memory-service/issues
+    about: Ask questions, share ideas, or discuss general topics with the community
+  - name: 🔍 Search Existing Issues
+    url: https://codeberg.org/doobidoo/mcp-memory-service/issues
+    about: Check if your issue has already been reported or solved

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Fix bugs, implement features, or improve performance.
 Help make the project accessible to more users (future goal).
 
 ### 💬 Community Support
-Answer questions in Issues, Discussions, or help other users.
+Answer questions in Issues or help other users.
 
 ## Getting Started
 
@@ -280,7 +280,7 @@ When adding features or making significant changes:
 4. Update AGENTS.md or CLAUDE.md if development workflow changes
 
 **Advanced Workflow Automation**:
-- See [Context Provider Workflow Automation](https://github.com/doobidoo/mcp-memory-service/wiki/Context-Provider-Workflow-Automation) for automating development workflows with intelligent patterns
+- See [Context Provider Workflow Automation](https://codeberg.org/doobidoo/mcp-memory-service/wiki/Context-Provider-Workflow-Automation) for automating development workflows with intelligent patterns
 
 ### API Documentation
 
@@ -355,7 +355,7 @@ The following areas require extra care. PRs touching them receive additional scr
 
 ### Handling a security vulnerability
 
-Do **not** open a public issue. Use GitHub's private [Security Advisories](https://github.com/doobidoo/mcp-memory-service/security/advisories/new) to report vulnerabilities confidentially.
+Do **not** open a public issue. Report vulnerabilities confidentially by opening a private [issue on Codeberg](https://codeberg.org/doobidoo/mcp-memory-service/issues) (mark it as confidential).
 
 ## Autonomous Agents & AI-Generated PRs
 
@@ -433,15 +433,15 @@ For feature requests, describe:
 
 ### Getting Help
 
-- **Documentation**: Check the [Wiki](https://github.com/doobidoo/mcp-memory-service/wiki) first
-- **Issues**: Search existing [issues](https://github.com/doobidoo/mcp-memory-service/issues) before creating new ones
-- **Discussions**: Use [GitHub Discussions](https://github.com/doobidoo/mcp-memory-service/discussions) for questions
+- **Documentation**: Check the [Wiki](https://codeberg.org/doobidoo/mcp-memory-service/wiki) first
+- **Issues**: Search existing [issues](https://codeberg.org/doobidoo/mcp-memory-service/issues) before creating new ones
+- **Discussions**: Open an [issue on Codeberg](https://codeberg.org/doobidoo/mcp-memory-service/issues) for questions
 - **Response Time**: Maintainers typically respond within 2-3 days
 
 ### Communication Channels
 
-- **GitHub Issues**: Bug reports and feature requests
-- **GitHub Discussions**: General questions and community discussion
+- **Codeberg Issues**: Bug reports and feature requests
+- **Codeberg Issues**: General questions and community discussion via issues
 - **Pull Requests**: Code contributions and reviews
 
 ### For AI Agents
@@ -449,7 +449,7 @@ For feature requests, describe:
 If you're an AI coding assistant, also check:
 - [AGENTS.md](AGENTS.md) - Generic AI agent instructions
 - [CLAUDE.md](CLAUDE.md) - Claude-specific guidelines
-- [Context Provider Workflow Automation](https://github.com/doobidoo/mcp-memory-service/wiki/Context-Provider-Workflow-Automation) - Automate development workflows with intelligent patterns
+- [Context Provider Workflow Automation](https://codeberg.org/doobidoo/mcp-memory-service/wiki/Context-Provider-Workflow-Automation) - Automate development workflows with intelligent patterns
 
 ## Recognition
 
@@ -473,4 +473,4 @@ We value all contributions! Contributors are:
 
 Thank you for contributing to MCP Memory Service! Your efforts help make AI assistants more capable and useful for everyone. 🚀
 
-If you have questions not covered here, please open a [Discussion](https://github.com/doobidoo/mcp-memory-service/discussions) or check our [Wiki](https://github.com/doobidoo/mcp-memory-service/wiki).
+If you have questions not covered here, please open an [issue on Codeberg](https://codeberg.org/doobidoo/mcp-memory-service/issues) or check our [Wiki](https://codeberg.org/doobidoo/mcp-memory-service/wiki).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We actively maintain and provide security updates for the following versions of 
 
 | Version | Supported          | Notes |
 | ------- | ------------------ | ----- |
-| 8.x.x   | :white_check_mark: | Current stable release - full support |
-| 7.x.x   | :white_check_mark: | Previous stable - security fixes only |
-| < 7.0   | :x:                | No longer supported |
+| 11.x.x  | :white_check_mark: | Current stable release - full support |
+| 10.x.x  | :white_check_mark: | Previous stable - security fixes only |
+| < 10.0  | :x:                | No longer supported |
 
 ## Reporting a Vulnerability
 
@@ -18,16 +18,16 @@ We take the security of MCP Memory Service seriously. If you discover a security
 
 **For sensitive security issues**, please use one of these private reporting methods:
 
-1. **GitHub Security Advisory** (Preferred):
-   - Navigate to the [Security Advisories](https://github.com/doobidoo/mcp-memory-service/security/advisories) page
-   - Click "Report a vulnerability"
+1. **Codeberg Issue** (Preferred):
+   - Open a confidential [issue on Codeberg](https://codeberg.org/doobidoo/mcp-memory-service/issues) (Codeberg/Forgejo has no Security Advisories feature)
+   - Mark it as confidential and note it is a security report
    - Provide detailed information about the vulnerability
 
 2. **Direct Contact**:
-   - Open a GitHub Discussion with `[SECURITY]` prefix for initial contact
+   - Open a Codeberg issue with `[SECURITY]` prefix for initial contact
    - We'll provide a secure communication channel for details
 
-**For non-sensitive security concerns**, you may open a regular GitHub issue.
+**For non-sensitive security concerns**, you may open a regular Codeberg issue.
 
 ### What to Include
 
@@ -154,7 +154,7 @@ Security patches are released as:
 - **Out-of-band releases** for critical vulnerabilities
 
 Security advisories are published at:
-- [GitHub Security Advisories](https://github.com/doobidoo/mcp-memory-service/security/advisories)
+- [Codeberg Issues](https://codeberg.org/doobidoo/mcp-memory-service/issues)
 - [CHANGELOG.md](CHANGELOG.md) with `[SECURITY]` tag
 - Release notes for affected versions
 
@@ -181,7 +181,7 @@ We recognize security researchers who help make MCP Memory Service more secure:
 ## Contact
 
 For security concerns that don't fit the above categories:
-- **General Security Questions**: [GitHub Discussions](https://github.com/doobidoo/mcp-memory-service/discussions)
+- **General Security Questions**: [Codeberg issue](https://codeberg.org/doobidoo/mcp-memory-service/issues)
 - **Project Security**: See reporting instructions above
 
 ---


### PR DESCRIPTION
## Summary

Migrate 13 stale `github.com/doobidoo` links to their `codeberg.org/doobidoo` equivalents across community-facing documentation.

## Changes

### CONTRIBUTING.md
- Update 8 URLs: wiki, issues, discussions (→ Codeberg issues), security advisories (→ confidential Codeberg issue)
- Relabel "GitHub Discussions" / "GitHub Issues" → "Codeberg Issues" in Community Support and Communication Channels sections

### SECURITY.md
- Update supported-version table: 8.x/7.x/<7.0 → 11.x/10.x/<10.0 to reflect current releases
- Migrate 5 URLs/references: Security Advisories → confidential Codeberg issues; GitHub Discussions → Codeberg issues

### .github/ISSUE_TEMPLATE/config.yml
- Update 3 contact-link URLs and descriptions to point to Codeberg wiki/issues
- Improve emoji labels for readability

## Verification
- `grep -r 'github.com/doobidoo'` across the 3 files returns 0 hits
- No functional or code changes; docs-only
- YAML structure validated