### PR TITLE
Fix auto-capture Stop hook pairing next prompt with previous answer

### DIFF
--- a/claude-hooks/core/auto-capture-hook.js
+++ b/claude-hooks/core/auto-capture-hook.js
@@ -126,8 +126,10 @@ async function parseTranscript(transcriptPath) {
             return null;
         }
 
-        // Find last user and assistant messages
-        let lastUser = null;
+        // Pair the last assistant turn with the user message that precedes it.
+        // Two independent backward scans can mis-pair when the user already typed
+        // their next prompt before the Stop hook reads the transcript (Q2 + A1).
+        let assistantIndex = -1;
         let lastAssistant = null;
 
         for (let i = transcript.length - 1; i >= 0; i--) {
@@ -137,14 +139,30 @@ async function parseTranscript(transcriptPath) {
             const role = msg.message?.role || msg.role || msg.type;
             const content = msg.message?.content ?? msg.content;
 
-            if (!lastAssistant && role === 'assistant') {
-                lastAssistant = extractTextContent(content);
+            if (role === 'assistant') {
+                const text = extractTextContent(content);
+                if (text) {
+                    lastAssistant = text;
+                    assistantIndex = i;
+                    break;
+                }
             }
-            if (!lastUser && role === 'user') {
-                lastUser = extractTextContent(content);
-            }
+        }
 
-            if (lastUser && lastAssistant) break;
+        let lastUser = null;
+        if (assistantIndex > 0) {
+            for (let i = assistantIndex - 1; i >= 0; i--) {
+                const msg = transcript[i];
+                const role = msg.message?.role || msg.role || msg.type;
+                const content = msg.message?.content ?? msg.content;
+
+                if (role !== 'user') continue;
+                // Claude Code stores tool results under the user role; skip those.
+                if (isToolResultOnly(content)) continue;
+
+                lastUser = extractTextContent(content);
+                if (lastUser) break;
+            }
         }
 
         return {
@@ -156,6 +174,14 @@ async function parseTranscript(transcriptPath) {
         console.error('[auto-capture] Failed to parse transcript:', error.message);
         return null;
     }
+}
+
+/**
+ * True when a user-role envelope is only tool_result blocks (no real prompt text).
+ */
+function isToolResultOnly(content) {
+    if (!Array.isArray(content) || content.length === 0) return false;
+    return content.every(block => block && block.type === 'tool_result');
 }
 
 /**

--- a/claude-hooks/tests/auto-capture-parse-transcript.test.js
+++ b/claude-hooks/tests/auto-capture-parse-transcript.test.js
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for auto-capture parseTranscript pairing (#1069).
+ * Run: node --test claude-hooks/tests/auto-capture-parse-transcript.test.js
+ */
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const os = require('os');
+const path = require('path');
+
+const { parseTranscript } = require('../core/auto-capture-hook');
+
+async function withTranscript(lines, fn) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ac-parse-'));
+    const file = path.join(dir, 'transcript.jsonl');
+    await fs.writeFile(file, lines.map((o) => JSON.stringify(o)).join('\n') + '\n', 'utf8');
+    try {
+        return await fn(file);
+    } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+    }
+}
+
+test('pairs last assistant with preceding user, not a later follow-up', async () => {
+    const result = await withTranscript(
+        [
+            { message: { role: 'user', content: 'Q1' } },
+            { message: { role: 'assistant', content: 'A1 Decision: ship it' } },
+            { message: { role: 'user', content: 'Q2 follow-up' } },
+        ],
+        (file) => parseTranscript(file),
+    );
+
+    assert.equal(result.userMessage, 'Q1');
+    assert.equal(result.assistantMessage, 'A1 Decision: ship it');
+});
+
+test('skips tool_result-only user envelopes when pairing', async () => {
+    const result = await withTranscript(
+        [
+            { message: { role: 'user', content: 'real question' } },
+            {
+                message: {
+                    role: 'user',
+                    content: [{ type: 'tool_result', content: 'ok' }],
+                },
+            },
+            { message: { role: 'assistant', content: 'the answer' } },
+        ],
+        (file) => parseTranscript(file),
+    );
+
+    assert.equal(result.userMessage, 'real question');
+    assert.equal(result.assistantMessage, 'the answer');
+});


### PR DESCRIPTION
## Summary
- Fixes #1069: `parseTranscript` in `auto-capture-hook.js` no longer uses two independent backward scans
- Finds the last assistant message first, then walks backward for the preceding real user prompt
- Skips user-role envelopes that are only `tool_result` blocks
- Adds a small unit test for the race case and tool_result skip

## Test plan
- [x] `node --test claude-hooks/tests/auto-capture-parse-transcript.test.js`
- [x] Manual: long answer, type follow-up quickly, confirm stored memory pairs Q1 with A1
