### PR TITLE
ci: port the four Forgejo workflows to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,177 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['docs/**', '*.md', 'LICENSE', '.gitignore']
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**', '*.md', 'LICENSE', '.gitignore']
+
+jobs:
+  version-drift-check:
+    runs-on: ubuntu-latest
+    name: Version Drift (site/index.html)
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    # Fails when site/index.html references a MAJOR.MINOR older than
+    # src/mcp_memory_service/_version.py — i.e. a release PR that forgot to
+    # bump the mcpmemory.services landing page. PATCH-only drift is ignored.
+    - name: Check landing page version strings
+      run: bash scripts/ci/check_versions.sh
+
+  plugin-version-check:
+    runs-on: ubuntu-latest
+    name: Plugin Manifest Bump (claude-hooks/)
+    timeout-minutes: 5
+    steps:
+    # fetch-depth: 0 is required — the check asks "did claude-hooks/ change since
+    # the last commit that moved the manifest version", which a shallow clone
+    # cannot answer (the script fails loudly rather than passing on a guess).
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+    # Only enforced on release changes (_version.py moved). Fails when hook code
+    # shipped since the last plugin bump without bumping plugin.json — the
+    # Marketplace cache is version-keyed, so those fixes never reach installed
+    # users. Missed manually in v11.6.0 (issue #170).
+    - name: Check Claude Code plugin manifest version
+      run: bash scripts/ci/check_plugin_version.sh
+
+  hooks-config-secrets:
+    runs-on: ubuntu-latest
+    name: Bundled Hooks Config (no secrets)
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    # claude-hooks/config.json ships with the plugin and is copied into every
+    # user's ~/.claude/hooks/config.json by the installer, so a personal value
+    # committed there is both published and distributed. A real apiKey and a
+    # maintainer-local serverWorkingDir sat in it for months (issue #197).
+    - name: Check bundled hooks config for credentials
+      run: bash scripts/ci/check_hooks_config_secrets.sh
+    # config.json and config.template.json have no shared source, so nothing
+    # keeps their key structure in sync automatically — that's how the
+    # template ended up 8 sections behind (issue #197 follow-up).
+    - name: Check bundled hooks config matches template structure
+      run: bash scripts/ci/check_hooks_config_drift.sh
+
+  hooks-tests:
+    runs-on: ubuntu-latest
+    name: JS Tests (claude-hooks/, opencode/)
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    # No setup-node step: the docker runner image already ships node, which
+    # deploy-site.yml relies on the same way. Before this job existed CI had no
+    # node steps at all, so the claude-hooks/tests files never ran and a JS-only
+    # PR got a green board that meant nothing (issue #202). It covered
+    # claude-hooks/ only until #210 landed an untested TLS gate under opencode/.
+    - name: Run the JS test suites
+      run: bash scripts/ci/run_hooks_tests.sh
+
+  test:
+    runs-on: ubuntu-latest
+    name: Tests + Coverage
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -e ".[dev,sqlite]"
+
+    - name: Verify install
+      run: |
+        python3 -c "import mcp_memory_service; print(mcp_memory_service.__file__)"
+        python3 -m pytest --version
+
+    - name: Run tests with coverage
+      env:
+        MCP_API_KEY: ""
+        MCP_OAUTH_ENABLED: "false"
+        MCP_ALLOW_ANONYMOUS_ACCESS: "true"
+      # Scope: deterministic suite on this minimal self-hosted runner.
+      # - tests/integration excluded: those shell out to `uv`, hit the network, or
+      #   need services not present in the runner image.
+      # - tests/consolidation, tests/benchmarks and `-m "not benchmark"` excluded
+      #   (benchmark fixture / heavy).
+      # - coverage is report-only for now (no --cov-fail-under): re-introduce a gate
+      #   once the deterministic-subset baseline is known and stable.
+      # - no -x: report all failures, not just the first.
+      run: |
+        python3 -m pytest tests/ \
+          --ignore=tests/consolidation \
+          --ignore=tests/benchmarks \
+          --ignore=tests/integration \
+          -m "not benchmark" \
+          --cov=mcp_memory_service \
+          --cov-report=term-missing:skip-covered \
+          --timeout=120 \
+          -q
+
+  ml-extras-tests:
+    runs-on: ubuntu-latest
+    name: Tests with ML Extras (transformers paths)
+    timeout-minutes: 40
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    # The `test` job installs `.[dev,sqlite]` only, so transformers and
+    # sentence-transformers are never imported there. Everything reached through
+    # them — the quality ranker, the SentenceTransformer embedding path, and any
+    # code that branches on a fixed-dimension model being present — has had no CI
+    # coverage at all. That gap was hiding three real failures in
+    # tests/unit/test_multi_store_migration_dimension.py: they pass in a bare
+    # environment only because the hash fallback adapts its dimension to the
+    # database, so the #143 guard never fires. See issue #301.
+    - name: Install dependencies (with ml + nli extras)
+      run: |
+        python3 -m pip install --upgrade pip
+        # CPU wheels only. The default index serves the CUDA build on Linux,
+        # which is an order of magnitude larger and useless on this runner —
+        # tools/docker/Dockerfile pins the same index for the same reason.
+        python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+        python3 -m pip install -e ".[dev,sqlite,ml,nli]"
+
+    # A silent degradation here would be worse than having no job: if the extras
+    # ever stop resolving, the suite would still go green while covering exactly
+    # what `test` already covers. Fail loudly instead.
+    - name: Verify the extras are importable
+      run: |
+        python3 -c "import transformers, sentence_transformers, torch; \
+          import importlib.metadata as m; \
+          print('transformers', m.version('transformers')); \
+          print('sentence-transformers', m.version('sentence-transformers')); \
+          print('torch', m.version('torch')); \
+          print('huggingface-hub', m.version('huggingface-hub'))"
+
+    # Not hermetic on purpose: with a real embedding model installed the storage
+    # layer loads all-MiniLM-L6-v2, so the model has to be on disk. Pulling it in
+    # its own step means a Hub outage fails here with an obvious message instead
+    # of somewhere in the middle of the suite.
+    - name: Warm the embedding model cache
+      run: |
+        python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
+    - name: Run tests with the ml extras present
+      env:
+        MCP_API_KEY: ""
+        MCP_OAUTH_ENABLED: "false"
+        MCP_ALLOW_ANONYMOUS_ACCESS: "true"
+      # Same selection as `test`, deliberately: the three failures this job was
+      # built for live in tests/unit/, not in tests/quality/, so narrowing this to
+      # the quality suite would have missed every one of them. No coverage flags —
+      # `test` already reports coverage and a second report would just be noise.
+      run: |
+        python3 -m pytest tests/ \
+          --ignore=tests/consolidation \
+          --ignore=tests/benchmarks \
+          --ignore=tests/integration \
+          -m "not benchmark" \
+          --timeout=120 \
+          -q

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,238 @@
+# Docker Hub image cleanup.
+#
+# The GHCR job that the pre-Codeberg version of this workflow carried stays dropped.
+# GHCR has not been published to since the lockout, and reviving it would mean a second
+# registry to keep in sync for no benefit. Docker Hub is the only registry this project
+# publishes to; if GHCR is ever wanted back it should be a deliberate decision, not a
+# side effect of the forge move.
+#
+# Multi-arch safe: deletes by TAG NAME via the Docker Hub API, never by manifest digest,
+# so it cannot strip per-platform children of a multi-arch index (the issue #1044 class of
+# bug that hit GHCR does not apply here).
+#
+# Retention: keeps `latest/slim/main/stable` always, the last N patch versions and their
+# variants (-slim, -quality-cpu, …), the last M minor floaters, and ALL "other" tags
+# (major floaters, sha, buildcache, etc). Use `force_delete_tags` to nuke specific tags.
+#
+# Secrets: DOCKER_USERNAME, DOCKER_PASSWORD (Docker Hub access token).
+
+name: Cleanup Docker Images
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'   # weekly, Sunday 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no deletions)'
+        required: false
+        type: boolean
+        default: true
+      keep_versions:
+        description: 'Number of patch versions to keep (e.g. 10.70.3)'
+        required: false
+        type: string
+        default: '5'
+      keep_minor_floaters:
+        description: 'Number of major.minor floating tags to keep (e.g. 10.70, 10.70-slim)'
+        required: false
+        type: string
+        default: '3'
+      force_delete_tags:
+        description: 'Comma-separated exact tag names to force-delete regardless of policy (e.g. citest,citest-slim)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  cleanup-dockerhub:
+    name: Cleanup Docker Hub Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate Docker Hub credentials
+        run: |
+          if [ -z "${{ secrets.DOCKER_USERNAME }}" ] || [ -z "${{ secrets.DOCKER_PASSWORD }}" ]; then
+            echo "Docker Hub credentials not available, skipping"
+            echo "SKIP_DOCKER_CLEANUP=true" >> "$GITHUB_ENV"
+          else
+            echo "Docker Hub credentials available"
+            echo "SKIP_DOCKER_CLEANUP=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install deps
+        if: env.SKIP_DOCKER_CLEANUP != 'true'
+        run: python3 -m pip install --upgrade pip requests python-dateutil
+
+      - name: Create cleanup script
+        if: env.SKIP_DOCKER_CLEANUP != 'true'
+        run: |
+          cat > cleanup_docker_hub.py << 'EOF'
+          #!/usr/bin/env python3
+          """Docker Hub image cleanup — version-aware retention policy."""
+          import os
+          import sys
+          import re
+          import requests
+
+          PROTECTED = {"latest", "slim", "main", "stable"}
+
+          RE_PATCH     = re.compile(r'^(v?\d+\.\d+\.\d+)$')
+          RE_PATCH_VAR = re.compile(r'^(v?\d+\.\d+\.\d+)(-.+)$')
+          RE_MINOR     = re.compile(r'^(v?\d+\.\d+)$')
+          RE_MINOR_VAR = re.compile(r'^(v?\d+\.\d+)(-.+)$')
+
+          def semver_key(s):
+              m = RE_PATCH.match(s) or RE_PATCH_VAR.match(s)
+              if m:
+                  parts = re.findall(r'\d+', m.group(1))
+                  if len(parts) >= 3:
+                      return tuple(int(p) for p in parts[:3])
+              return None
+
+          def minor_key(s):
+              m = RE_MINOR.match(s) or RE_MINOR_VAR.match(s)
+              if m:
+                  parts = re.findall(r'\d+', m.group(1))
+                  if len(parts) >= 2:
+                      return tuple(int(p) for p in parts[:2])
+              return None
+
+          class DockerHubCleaner:
+              def __init__(self, username, password, repository):
+                  self.username = username
+                  self.password = password
+                  self.repository = repository
+                  self.token = None
+                  self.api_base = "https://hub.docker.com/v2"
+
+              def authenticate(self):
+                  r = requests.post(f"{self.api_base}/users/login/",
+                                    json={"username": self.username, "password": self.password})
+                  r.raise_for_status()
+                  self.token = r.json()["token"]
+                  print("Authenticated with Docker Hub")
+                  return True
+
+              def get_tags(self):
+                  url = f"{self.api_base}/repositories/{self.repository}/tags"
+                  headers = {"Authorization": f"Bearer {self.token}"}
+                  tags = []
+                  while url:
+                      r = requests.get(url, headers=headers, params={"page_size": 100})
+                      r.raise_for_status()
+                      data = r.json()
+                      tags.extend(data["results"])
+                      url = data.get("next")
+                  print(f"Found {len(tags)} tags")
+                  return tags
+
+              def delete_tag(self, name, dry_run=False):
+                  if dry_run:
+                      print(f"  [DRY RUN] would delete: {name}")
+                      return True
+                  url = f"{self.api_base}/repositories/{self.repository}/tags/{name}/"
+                  r = requests.delete(url, headers={"Authorization": f"Bearer {self.token}"})
+                  if r.status_code in (200, 202, 204):
+                      print(f"  deleted: {name}")
+                      return True
+                  print(f"  failed to delete {name}: HTTP {r.status_code}")
+                  return False
+
+              def cleanup(self, keep_versions, keep_minor_floaters, dry_run, force_delete):
+                  self.authenticate()
+                  tags = self.get_tags()
+                  names = {t["name"] for t in tags}
+                  failed = 0
+
+                  # Force-delete explicit tags first (escape hatch / test cleanup).
+                  for name in force_delete:
+                      if name and name in names:
+                          print(f"  force-delete requested: {name}")
+                          if not self.delete_tag(name, dry_run):
+                              failed += 1
+                      elif name:
+                          print(f"  force-delete: {name} not present, skipping")
+
+                  patch_tags, patch_var_tags = {}, {}
+                  minor_tags, minor_var_tags = {}, {}
+                  rest = []
+                  for t in tags:
+                      n = t["name"]
+                      if n in PROTECTED or n in force_delete:
+                          continue
+                      if RE_PATCH.match(n):
+                          patch_tags[RE_PATCH.match(n).group(1)] = t; continue
+                      if RE_PATCH_VAR.match(n):
+                          patch_var_tags.setdefault(RE_PATCH_VAR.match(n).group(1), []).append(t); continue
+                      if RE_MINOR.match(n):
+                          minor_tags[RE_MINOR.match(n).group(1)] = t; continue
+                      if RE_MINOR_VAR.match(n):
+                          minor_var_tags.setdefault(RE_MINOR_VAR.match(n).group(1), []).append(t); continue
+                      rest.append(t)
+
+                  keep_patch = set(sorted(patch_tags, key=lambda s: semver_key(s) or (0,0,0), reverse=True)[:keep_versions])
+                  keep_minor = set(sorted(set(minor_tags) | set(minor_var_tags),
+                                          key=lambda s: minor_key(s) or (0,0), reverse=True)[:keep_minor_floaters])
+
+                  print(f"\nKeep patch bases: {sorted(keep_patch, reverse=True)}")
+                  print(f"Keep minor bases: {sorted(keep_minor, reverse=True)}")
+                  deleted = kept = 0
+
+                  def _del(name):
+                      nonlocal deleted, failed
+                      if self.delete_tag(name, dry_run): deleted += 1
+                      else: failed += 1
+
+                  for base, t in patch_tags.items():
+                      if base in keep_patch: kept += 1
+                      else: _del(t["name"])
+                  for base, tl in patch_var_tags.items():
+                      for t in tl:
+                          if base in keep_patch: kept += 1
+                          else: _del(t["name"])
+                  for base, t in minor_tags.items():
+                      if base in keep_minor: kept += 1
+                      else: _del(t["name"])
+                  for base, tl in minor_var_tags.items():
+                      for t in tl:
+                          if base in keep_minor: kept += 1
+                          else: _del(t["name"])
+                  for t in rest:
+                      print(f"  keep {t['name']} (major/other)")
+                      kept += 1
+
+                  print(f"\nSummary: kept {kept}, deleted {deleted}, failed {failed} (dry_run={dry_run})")
+                  return failed
+
+          def main():
+              username = os.environ.get("DOCKER_USERNAME")
+              password = os.environ.get("DOCKER_PASSWORD")
+              repo = os.environ.get("DOCKER_REPOSITORY", "doobidoo/mcp-memory-service")
+              dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
+              keep_versions = int(os.environ.get("KEEP_VERSIONS", "5"))
+              keep_minor = int(os.environ.get("KEEP_MINOR_FLOATERS", "3"))
+              force_delete = [s.strip() for s in os.environ.get("FORCE_DELETE_TAGS", "").split(",") if s.strip()]
+              if not username or not password:
+                  print("Missing DOCKER_USERNAME or DOCKER_PASSWORD"); sys.exit(1)
+              print(f"Docker Hub cleanup for {repo}\n" + "=" * 50)
+              failed = DockerHubCleaner(username, password, repo).cleanup(keep_versions, keep_minor, dry_run, force_delete)
+              if failed:
+                  print(f"\nERROR: {failed} tag deletion(s) failed (e.g. token lacks Delete scope?)")
+                  sys.exit(1)
+          if __name__ == "__main__":
+              main()
+          EOF
+
+      - name: Run Docker Hub cleanup
+        if: env.SKIP_DOCKER_CLEANUP != 'true'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REPOSITORY: doobidoo/mcp-memory-service
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          KEEP_VERSIONS: ${{ github.event.inputs.keep_versions || '5' }}
+          KEEP_MINOR_FLOATERS: ${{ github.event.inputs.keep_minor_floaters || '3' }}
+          FORCE_DELETE_TAGS: ${{ github.event.inputs.force_delete_tags || '' }}
+        run: python3 cleanup_docker_hub.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,28 +1,20 @@
 name: "CodeQL Security Analysis"
 
-# The only workflow on the GitHub side, and it is here on purpose.
+# CodeQL is the security-analysis lane. The rest of CI lives in ci.yml; this stays
+# separate because it reports into the Security tab rather than into check runs, and
+# it is the one analysis the Forgejo CI never had an equivalent for.
 #
-# Development, CI, and releases live on Codeberg (.forgejo/workflows/). Forgejo
-# ignores this directory, so nothing here runs there. CodeQL is the one capability
-# GitHub has that Codeberg has no equivalent for, and the Forgejo CI has no
-# security-analysis job at all — so the mirror carries it and reports into the
-# GitHub Security tab.
-#
-# Deliberate omissions: no release, site-deploy, or image-cleanup workflow may be
-# added here. Publishing belongs to exactly one forge, and that forge is Codeberg.
-# This job needs no repository secrets, and the mirror holds none.
+# This job needs no repository secrets.
 
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
-    # Weekly, Mondays 00:00 UTC. The mirror only receives fast-forwards of main,
-    # so pushes are infrequent and the schedule is what gives regular coverage.
+    # Weekly, Mondays 00:00 UTC, so coverage does not depend on push frequency.
     - cron: '0 0 * * 1'
   workflow_dispatch:
-
-# Pull requests are not triggered on purpose: they are opened on Codeberg, and a
-# PR against the mirror gets redirected rather than reviewed.
 
 permissions:
   contents: read

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,51 @@
+# Deploy pipeline for the mcpmemory.services landing page.
+#
+# Why wrangler and not the Cloudflare git integration: the integration was never
+# wired up for this repo, and direct upload works the same from any forge. Keeping
+# wrangler means the deploy path does not change when the forge does.
+#
+# Trigger: any push to main that touches site/** (e.g. the release PR bumping
+# version strings in site/index.html), or manual workflow_dispatch.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   CLOUDFLARE_API_TOKEN   API token with "Cloudflare Pages: Edit" permission
+#                          (Account-level; NOT the D1/Vectorize token from .env)
+#   CLOUDFLARE_ACCOUNT_ID  Cloudflare account id
+#
+# Both must be recreated on GitHub; secret values cannot be exported from Codeberg.
+
+name: Deploy Site (Cloudflare Pages)
+
+on:
+  push:
+    branches: [main]
+    paths: ['site/**']
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: wrangler pages deploy
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Deploy site/ to Cloudflare Pages
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      run: |
+        node --version
+        npx --yes wrangler@4 pages deploy site \
+          --project-name mcpmemory-services \
+          --branch main \
+          --commit-dirty=true
+
+    - name: Verify deployed version
+      run: |
+        sleep 10
+        expected=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' site/index.html | head -1)
+        live=$(node -e "fetch('https://mcpmemory-services.pages.dev').then(r=>r.text()).then(t=>console.log((t.match(/<title>[^<]*(v[0-9]+\.[0-9]+\.[0-9]+)/)||[,'unknown'])[1]))")
+        echo "expected=$expected live=$live"
+        [ "$expected" = "$live" ] || { echo "::warning::live version ($live) != expected ($expected) — CDN cache may lag"; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+# Release pipeline: PyPI (main + lite) and Docker Hub.
+#
+# Ported back from .forgejo/workflows/release.yml, which was itself adapted from the
+# pre-Codeberg publish-dual.yml + docker-publish.yml. Two things carried over from the
+# Forgejo version on purpose:
+#   - The Docker job uses RAW `docker buildx` instead of the docker/* actions. Fewer
+#     third-party actions means a smaller allowlist and less SHA-pin maintenance, and
+#     buildx is preinstalled on ubuntu-latest.
+#   - The lite package's version is forced from _version.py rather than trusting the
+#     static version in pyproject-lite.toml. That drift once left the lite package stuck
+#     at 10.39.1 for several releases, silently, because `--skip-existing` skips instead
+#     of failing.
+#
+# PyPI auth is still a classic API token. The old GitHub workflows declared
+# `id-token: write` but never actually used OIDC, so Trusted Publishing is new work, not
+# a restore: configure a Trusted Publisher on PyPI for this repo and workflow, then drop
+# PYPI_TOKEN. Until that is done, one publisher at a time is enforced by only one forge
+# holding secrets at all.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   PYPI_TOKEN        classic PyPI API token (project-scoped, value starts with "pypi-")
+#   DOCKER_USERNAME   Docker Hub username (doobidoo)
+#   DOCKER_PASSWORD   Docker Hub access token (NOT account password)
+#
+# Secret values cannot be exported from Codeberg; all three must be recreated here.
+# Trigger: push a tag v*.*.* (or run manually via workflow_dispatch).
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install package + test deps
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e ".[sqlite]" pytest pytest-asyncio
+      - name: Run unit tests
+        run: python3 -m pytest -m unit -q
+
+  publish-pypi:
+    name: Publish to PyPI (main + lite)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install build tooling
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install build hatchling twine
+
+      # --- Main package (with PyTorch) ---
+      - name: Build main package
+        run: python3 -m build
+      - name: Publish main to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python3 -m twine upload dist/* --skip-existing
+
+      # --- Lite package (ONNX only) ---
+      - name: Prepare lite package
+        run: |
+          cp pyproject.toml pyproject-main.toml
+          cp pyproject-lite.toml pyproject.toml
+          # Single source of truth: force the lite version to match the main package
+          # (_version.py). Without this, pyproject-lite.toml's static version drifts and
+          # `twine upload --skip-existing` silently skips an already-published version —
+          # the lite package was stuck at 10.39.1 for many releases this way.
+          VERSION=$(grep -E '^__version__' src/mcp_memory_service/_version.py | sed -E 's/.*"([^"]+)".*/\1/')
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          echo "Lite version synced to $VERSION"
+          rm -rf dist/ build/ ./*.egg-info
+      - name: Build lite package
+        run: python3 -m build
+      - name: Publish lite to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python3 -m twine upload dist/* --skip-existing
+      - name: Restore pyproject.toml
+        if: always()
+        run: mv pyproject-main.toml pyproject.toml
+
+  publish-docker:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+    needs: test
+    # Only on a real version tag. The image tags are derived from github.ref_name, so a
+    # manual workflow_dispatch (ref_name = "main") would push junk "main" tags and clobber
+    # "latest". Manual dispatch is for PyPI catch-up only.
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      IMAGE: docker.io/doobidoo/mcp-memory-service
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Derive version tags from the git tag
+        id: ver
+        # REF comes in through env, not string interpolation: a ref name reaching the
+        # shell via ${{ }} is the standard Actions injection sink. Only the maintainer
+        # can push tags here, so this is defence in depth rather than an open hole.
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          case "$REF" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "Refusing to build image tags from unexpected ref: $REF" >&2; exit 1 ;;
+          esac
+          V="${REF#v}"
+          echo "v=$V"          >> "$GITHUB_OUTPUT"
+          echo "minor=${V%.*}" >> "$GITHUB_OUTPUT"
+          echo "major=${V%%.*}" >> "$GITHUB_OUTPUT"
+          echo "Building tags for version: $V"
+
+      - name: Docker Hub login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login docker.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Create buildx builder
+        run: docker buildx create --use --name cb-builder 2>/dev/null || docker buildx use cb-builder
+
+      # Standard (full, torch) image: amd64-only by design. ARM users who need the full
+      # image build it locally on native ARM hardware (no emulation). See runbook.
+      - name: Build + push Standard (amd64)
+        run: |
+          docker buildx build --platform linux/amd64 --push \
+            -f tools/docker/Dockerfile --build-arg SKIP_MODEL_DOWNLOAD=true \
+            -t "$IMAGE:${{ steps.ver.outputs.v }}" \
+            -t "$IMAGE:${{ steps.ver.outputs.minor }}" \
+            -t "$IMAGE:${{ steps.ver.outputs.major }}" \
+            -t "$IMAGE:latest" .
+
+      # Slim (ONNX) image — light enough for multi-arch under emulation.
+      - name: Build + push Slim (amd64 + arm64)
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 --push \
+            -f tools/docker/Dockerfile.slim --build-arg SKIP_MODEL_DOWNLOAD=true \
+            -t "$IMAGE:${{ steps.ver.outputs.v }}-slim" \
+            -t "$IMAGE:${{ steps.ver.outputs.minor }}-slim" \
+            -t "$IMAGE:${{ steps.ver.outputs.major }}-slim" \
+            -t "$IMAGE:slim" .


### PR DESCRIPTION
First half of the forge move. Codeberg lost its Actions secrets earlier today, so nothing can publish from there any more; this brings CI, release, site deploy and image cleanup back to GitHub Actions.

The mechanical part: `runs-on: docker` becomes `ubuntu-latest`, and the `data.forgejo.org` action refs become `actions/checkout` pinned at v6.0.2. That indirection only ever existed because github.com was unreachable from the self-hosted runner.

Three things that were not mechanical:

**An injection sink.** `release.yml` interpolated `${{ github.ref_name }}` straight into a shell command to derive image tags. The ref now arrives through `env` and is checked against `v0.0.0` shape before use. Only the maintainer can push tags here, so this is defence in depth rather than an open hole.

**codeql.yml's header** described the mirror topology, which this move inverts. It now also runs on pull requests, which was pointless while PRs lived on another forge.

**The GHCR job stays dropped** from `cleanup-images.yml`. Nothing has been published to GHCR since the lockout, and reviving it should be a decision rather than a side effect of changing forge.

### Why no third-party actions

This repository is set to `allowed_actions: selected` with `github_owned_allowed: true`, an empty `patterns_allowed` list, and `sha_pinning_required: true`. A third-party action would not fail review, it would fail at run time. The ported workflows use only `actions/checkout` and raw `docker buildx`, so they run against the existing allowlist unchanged.

### PyPI auth

Still a classic token. The pre-Codeberg workflows declared `id-token: write` but authenticated with `secrets.PYPI_TOKEN` via twine, so Trusted Publishing is new work, not a restore. It needs a publisher configured on the PyPI side and is tracked separately.

### Verification

This PR is where GitHub Actions runs for the first time since the lockout, so the CI result on this PR is itself the test.