### PR TITLE
fix(consolidation): map recommendation values onto the API's public contract

### DIFF
--- a/src/mcp_memory_service/web/api/consolidation.py
+++ b/src/mcp_memory_service/web/api/consolidation.py
@@ -228,11 +228,12 @@ async def get_recommendations(time_horizon: str, user: AuthenticationResult = De
         # lowercase/snake_case values ("consolidation_beneficial", "optional",
         # "no_action", "error") that never matched the allowlist this endpoint
         # checked against, so every response fell through to "UNKNOWN"
-        # regardless of actual state (#340).
+        # regardless of actual state (#328).
         _RECOMMENDATION_MAP = {
             "consolidation_beneficial": "CONSOLIDATION_BENEFICIAL",
             "optional": "NO_CONSOLIDATION_NEEDED",
             "no_action": "NO_CONSOLIDATION_NEEDED",
+            "error": "UNKNOWN",
         }
         raw_rec = recommendations.get("recommendation", "unknown")
         safe_rec = _RECOMMENDATION_MAP.get(raw_rec, "UNKNOWN")

--- a/src/mcp_memory_service/web/api/consolidation.py
+++ b/src/mcp_memory_service/web/api/consolidation.py
@@ -222,10 +222,20 @@ async def get_recommendations(time_horizon: str, user: AuthenticationResult = De
         # Get recommendations
         recommendations = await consolidator.get_consolidation_recommendations(time_horizon)
 
-        # Sanitize all values before returning to prevent stack-trace exposure (CWE-209)
-        _SAFE_RECOMMENDATIONS = {"CONSOLIDATION_BENEFICIAL", "NO_CONSOLIDATION_NEEDED", "UNKNOWN"}
-        raw_rec = recommendations.get("recommendation", "UNKNOWN")
-        safe_rec = raw_rec if raw_rec in _SAFE_RECOMMENDATIONS else "UNKNOWN"
+        # Map the consolidator's internal recommendation values onto this
+        # endpoint's public contract, and sanitize before returning to
+        # prevent stack-trace exposure (CWE-209). The consolidator returns
+        # lowercase/snake_case values ("consolidation_beneficial", "optional",
+        # "no_action", "error") that never matched the allowlist this endpoint
+        # checked against, so every response fell through to "UNKNOWN"
+        # regardless of actual state (#340).
+        _RECOMMENDATION_MAP = {
+            "consolidation_beneficial": "CONSOLIDATION_BENEFICIAL",
+            "optional": "NO_CONSOLIDATION_NEEDED",
+            "no_action": "NO_CONSOLIDATION_NEEDED",
+        }
+        raw_rec = recommendations.get("recommendation", "unknown")
+        safe_rec = _RECOMMENDATION_MAP.get(raw_rec, "UNKNOWN")
 
         try:
             safe_count = int(recommendations.get("memory_count", 0))

--- a/tests/web/api/test_consolidation_recommendations.py
+++ b/tests/web/api/test_consolidation_recommendations.py
@@ -1,0 +1,86 @@
+"""
+Regression tests for the /api/consolidation/recommendations/{time_horizon}
+sanitization mismatch (#340).
+
+The endpoint's CWE-209 sanitization allowlisted only uppercase values
+("CONSOLIDATION_BENEFICIAL", "NO_CONSOLIDATION_NEEDED", "UNKNOWN"), but
+DreamInspiredConsolidator.get_consolidation_recommendations() has always
+returned lowercase/snake_case values ("consolidation_beneficial", "optional",
+"no_action", "error"). None of those ever matched the allowlist, so every
+call to this endpoint returned "recommendation": "UNKNOWN" regardless of the
+consolidator's actual assessment.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from mcp_memory_service.web.api import consolidation as consolidation_api
+from mcp_memory_service.web.oauth.middleware import AuthenticationResult
+
+
+def _make_user() -> AuthenticationResult:
+    return AuthenticationResult(
+        authenticated=True, client_id="test-client", scope="read", auth_method="test"
+    )
+
+
+async def _call_get_recommendations(monkeypatch, raw_recommendations: dict) -> dict:
+    consolidator = SimpleNamespace(
+        get_consolidation_recommendations=AsyncMock(return_value=raw_recommendations)
+    )
+    monkeypatch.setattr(
+        "mcp_memory_service.api.client.get_consolidator", lambda: consolidator
+    )
+    return await consolidation_api.get_recommendations(
+        time_horizon="weekly", user=_make_user()
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ("consolidation_beneficial", "CONSOLIDATION_BENEFICIAL"),
+        ("optional", "NO_CONSOLIDATION_NEEDED"),
+        ("no_action", "NO_CONSOLIDATION_NEEDED"),
+    ],
+)
+async def test_known_recommendation_values_map_correctly(
+    monkeypatch, raw_value, expected
+):
+    result = await _call_get_recommendations(
+        monkeypatch,
+        {
+            "recommendation": raw_value,
+            "memory_count": 5,
+            "reasons": ["Memory state looks healthy"],
+            "estimated_duration_seconds": 0.05,
+        },
+    )
+    assert result["recommendation"] == expected
+    assert result["memory_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_error_recommendation_is_sanitized_not_leaked(monkeypatch):
+    """The 'error' path must never expose exception text (CWE-209)."""
+    result = await _call_get_recommendations(
+        monkeypatch,
+        {
+            "recommendation": "error",
+            "error": "Traceback (most recent call last): secret/path/leak",
+            "memory_count": 0,
+        },
+    )
+    assert result["recommendation"] == "UNKNOWN"
+    assert "Traceback" not in str(result)
+    assert "secret/path/leak" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_value_falls_back_to_unknown(monkeypatch):
+    result = await _call_get_recommendations(
+        monkeypatch, {"recommendation": "some_future_value", "memory_count": 1}
+    )
+    assert result["recommendation"] == "UNKNOWN"


### PR DESCRIPTION
Carried over from Codeberg PR #339, authored by **timkjr**. The commits keep their original authorship; I moved the branch because the project migrated to GitHub today and it would have been rude to ask for the work twice.

Original discussion: https://codeberg.org/doobidoo/mcp-memory-service/pulls/339

Two commits, two files, +101/-4. The second one maps the error recommendation explicitly and fixes a stray issue reference.

I have not rebased it onto current `main`, so the diff is against the merge base. CI on this PR will say whether it still applies cleanly.

@timkjr if you would rather own this PR yourself, say so and I will close it in favour of one you open.