### PR TITLE
fix(consolidation): derive DBSCAN eps from the data's own k-distance curve

### DIFF
--- a/src/mcp_memory_service/consolidation/clustering.py
+++ b/src/mcp_memory_service/consolidation/clustering.py
@@ -24,6 +24,7 @@ import re
 try:
     from sklearn.cluster import DBSCAN
     from sklearn.cluster import AgglomerativeClustering
+    from sklearn.neighbors import NearestNeighbors
     SKLEARN_AVAILABLE = True
 except ImportError:
     SKLEARN_AVAILABLE = False
@@ -177,17 +178,18 @@ class SemanticClusteringEngine(ConsolidationBase):
         if n_samples <= min_samples:
             return 0.3  # Too few points to estimate a k-distance curve.
 
-        normalized = embeddings / np.clip(
-            np.linalg.norm(embeddings, axis=1, keepdims=True), 1e-12, None
-        )
-        cosine_distance = 1.0 - (normalized @ normalized.T)
+        # Use NearestNeighbors rather than a full n x n distance matrix: the
+        # matrix approach is O(n^2) in both memory and time, which is fine at
+        # a few thousand memories but becomes expensive as a store grows.
+        # NearestNeighbors handles the metric's normalization itself, so no
+        # separate L2-normalization step is needed here either.
+        neighbors = NearestNeighbors(n_neighbors=min_samples + 1, metric='cosine')
+        neighbors.fit(embeddings)
+        distances, _ = neighbors.kneighbors(embeddings)
 
-        # k-th nearest neighbor distance for every point (excludes itself,
-        # since distance-to-self is 0 and always the closest).
-        k_distances = np.sort(
-            np.partition(cosine_distance, min_samples, axis=1)[:, :min_samples + 1],
-            axis=1,
-        )[:, -1]
+        # Column 0 is always distance-to-self (0.0); the k-th neighbor
+        # distance for each point is the last column.
+        k_distances = np.sort(distances[:, -1])
         sorted_k_distances = np.sort(k_distances)
 
         # Knee = point of maximum distance from the line connecting the

--- a/src/mcp_memory_service/consolidation/clustering.py
+++ b/src/mcp_memory_service/consolidation/clustering.py
@@ -112,7 +112,7 @@ class SemanticClusteringEngine(ConsolidationBase):
         memories_with_embeddings = [m for m in memories if m.embedding]
         
         if len(memories_with_embeddings) < self.min_cluster_size:
-            self.logger.warning(f"Only {len(memories_with_embeddings)} memories have embeddings, need at least {self.min_cluster_size}")
+            self.logger.warning("Only %s memories have embeddings, need at least %s", len(memories_with_embeddings), self.min_cluster_size)
             return []
         
         # Extract embeddings matrix
@@ -132,25 +132,72 @@ class SemanticClusteringEngine(ConsolidationBase):
         # Filter by minimum cluster size
         valid_clusters = [c for c in clusters if len(c.memory_hashes) >= self.min_cluster_size]
         
-        self.logger.info(f"Created {len(valid_clusters)} valid clusters from {len(memories_with_embeddings)} memories")
+        self.logger.info("Created %s valid clusters from %s memories", len(valid_clusters), len(memories_with_embeddings))
         return valid_clusters
     
     async def _dbscan_clustering(self, embeddings: np.ndarray) -> np.ndarray:
         """Perform DBSCAN clustering on embeddings."""
         _require_sklearn('dbscan')
 
-        # Adaptive epsilon based on data size and dimensionality
-        n_samples, n_features = embeddings.shape
-        eps = 0.5 - (n_samples / 10000) * 0.1  # Decrease eps for larger datasets
-        eps = max(0.2, min(0.7, eps))  # Clamp between 0.2 and 0.7
-        
         min_samples = max(2, self.min_cluster_size // 2)
-        
+        eps = self._estimate_eps(embeddings, min_samples)
+
         clustering = DBSCAN(eps=eps, min_samples=min_samples, metric='cosine')
         labels = clustering.fit_predict(embeddings)
-        
-        self.logger.debug(f"DBSCAN: eps={eps}, min_samples={min_samples}, found {len(set(labels))} clusters")
+
+        self.logger.debug("DBSCAN: eps=%.4f, min_samples=%s, found %s clusters", eps, min_samples, len(set(labels)))
         return labels
+
+    @staticmethod
+    def _estimate_eps(embeddings: np.ndarray, min_samples: int) -> float:
+        """Pick DBSCAN's eps from the data's own k-distance curve.
+
+        The previous formula derived eps purely from dataset size
+        (`0.5 - n/10000, clamped to [0.2, 0.7]`), which bakes in an assumption
+        about how similar this embedding model's vectors are to unrelated
+        content. Some sentence-embedding models (e.g. the all-MiniLM-L6-v2
+        default) produce a narrow, elevated baseline cosine similarity across
+        semantically unrelated text, so a size-only eps that looked
+        reasonable chained memories into one giant cluster via
+        density-reachability rather than finding several coherent ones
+        (observed: 989/1104 memories collapsed into a single cluster with
+        coherence 0.461).
+
+        This is the standard k-distance heuristic for choosing DBSCAN's eps
+        (Ester et al., 1996): compute each point's distance to its
+        `min_samples`-th nearest neighbor, sort ascending, and pick eps at
+        the "knee" -- the point of maximum deviation from a straight line
+        between the curve's endpoints. Below the knee, points sit in dense
+        neighborhoods (candidate clusters); above it, distances jump sharply
+        (noise/outliers). This adapts to whatever embedding model produced
+        the vectors instead of assuming a fixed similarity scale, since the
+        knee reflects this dataset's actual density, not a guess.
+        """
+        n_samples = embeddings.shape[0]
+        if n_samples <= min_samples:
+            return 0.3  # Too few points to estimate a k-distance curve.
+
+        normalized = embeddings / np.clip(
+            np.linalg.norm(embeddings, axis=1, keepdims=True), 1e-12, None
+        )
+        cosine_distance = 1.0 - (normalized @ normalized.T)
+
+        # k-th nearest neighbor distance for every point (excludes itself,
+        # since distance-to-self is 0 and always the closest).
+        k_distances = np.sort(
+            np.partition(cosine_distance, min_samples, axis=1)[:, :min_samples + 1],
+            axis=1,
+        )[:, -1]
+        sorted_k_distances = np.sort(k_distances)
+
+        # Knee = point of maximum distance from the line connecting the
+        # curve's first and last (normalized) points.
+        x = np.linspace(0.0, 1.0, num=len(sorted_k_distances))
+        y_range = sorted_k_distances[-1] - sorted_k_distances[0]
+        y = (sorted_k_distances - sorted_k_distances[0]) / y_range if y_range > 1e-12 else x
+        knee_index = int(np.argmax(y - x))
+
+        return max(float(sorted_k_distances[knee_index]), 0.05)
     
     async def _hierarchical_clustering(self, embeddings: np.ndarray) -> np.ndarray:
         """Perform hierarchical clustering on embeddings."""
@@ -167,7 +214,7 @@ class SemanticClusteringEngine(ConsolidationBase):
         )
         labels = clustering.fit_predict(embeddings)
         
-        self.logger.debug(f"Hierarchical: n_clusters={n_clusters}, found {len(set(labels))} clusters")
+        self.logger.debug("Hierarchical: n_clusters=%s, found %s clusters", n_clusters, len(set(labels)))
         return labels
     
     async def _simple_clustering(self, embeddings: np.ndarray) -> np.ndarray:
@@ -208,7 +255,7 @@ class SemanticClusteringEngine(ConsolidationBase):
                 for member in cluster_members:
                     labels[member] = -1
         
-        self.logger.debug(f"Simple clustering: threshold={similarity_threshold}, found {current_cluster} clusters")
+        self.logger.debug("Simple clustering: threshold=%s, found %s clusters", similarity_threshold, current_cluster)
         return labels
     
     async def _create_clusters(
@@ -391,7 +438,7 @@ class SemanticClusteringEngine(ConsolidationBase):
                 )
                 result_clusters.append(merged_cluster)
         
-        self.logger.info(f"Merged {len(clusters)} clusters into {len(result_clusters)}")
+        self.logger.info("Merged %s clusters into %s", len(clusters), len(result_clusters))
         return result_clusters
     
     async def _merge_cluster_group(self, clusters: List[MemoryCluster]) -> MemoryCluster:

--- a/tests/consolidation/test_dbscan_eps_estimation.py
+++ b/tests/consolidation/test_dbscan_eps_estimation.py
@@ -1,0 +1,130 @@
+"""
+Regression tests for DBSCAN eps estimation (chaining fix, upstream issue
+observed in production: 989/1104 memories collapsed into a single cluster
+with coherence 0.461).
+
+The old `_dbscan_clustering` derived eps purely from dataset size
+(`0.5 - n/10000`, clamped to [0.2, 0.7]) with no reference to the actual
+similarity distribution of the embeddings being clustered. Some
+sentence-embedding models (e.g. the all-MiniLM-L6-v2 default) produce a
+narrow, elevated baseline cosine similarity across unrelated content, so that
+size-only eps let DBSCAN's density-reachability chain unrelated memories
+into one giant cluster.
+
+These tests exercise `_estimate_eps` directly (pure numpy, no scikit-learn
+required) and verify -- via a from-scratch connected-components check at a
+given eps, so no DBSCAN/sklearn dependency is needed here either -- that the
+new knee-based eps avoids the chaining failure mode on synthetic data shaped
+like the production symptom.
+"""
+
+import numpy as np
+import pytest
+
+from mcp_memory_service.consolidation.clustering import SemanticClusteringEngine
+
+
+def _old_formula_eps(n_samples: int) -> float:
+    """Reproduce the pre-fix size-only eps formula for comparison."""
+    return max(0.2, min(0.7, 0.5 - (n_samples / 10000) * 0.1))
+
+
+def _cosine_distance_matrix(embeddings: np.ndarray) -> np.ndarray:
+    normalized = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+    return 1.0 - (normalized @ normalized.T)
+
+
+def _largest_connected_component(distance: np.ndarray, eps: float) -> int:
+    """BFS connected-components size at a given eps -- what DBSCAN's
+    density-reachability effectively produces for a fully-dense neighborhood
+    graph (a superset of true DBSCAN clusters, but sufficient to prove
+    whether an eps value structurally permits one component to swallow
+    (almost) everything)."""
+    n = distance.shape[0]
+    adjacency = distance <= eps
+    np.fill_diagonal(adjacency, False)
+    visited = np.zeros(n, dtype=bool)
+    largest = 0
+    for start in range(n):
+        if visited[start]:
+            continue
+        stack = [start]
+        visited[start] = True
+        size = 0
+        while stack:
+            node = stack.pop()
+            size += 1
+            neighbors = np.where(adjacency[node] & ~visited)[0]
+            visited[neighbors] = True
+            stack.extend(neighbors.tolist())
+        largest = max(largest, size)
+    return largest
+
+
+@pytest.mark.unit
+class TestEstimateEps:
+    def test_falls_back_to_default_for_tiny_datasets(self):
+        embeddings = np.random.default_rng(0).normal(size=(3, 8))
+        eps = SemanticClusteringEngine._estimate_eps(embeddings, min_samples=5)
+        assert eps == 0.3
+
+    def test_returns_a_sane_positive_value(self):
+        rng = np.random.default_rng(1)
+        embeddings = rng.normal(size=(50, 16))
+        eps = SemanticClusteringEngine._estimate_eps(embeddings, min_samples=3)
+        assert 0.05 <= eps <= 2.0
+
+    def test_separates_two_tight_clusters_from_each_other(self):
+        """Two well-separated dense blobs: the knee-based eps must sit below
+        the inter-cluster gap, so each blob stays its own component rather
+        than merging into one."""
+        rng = np.random.default_rng(2)
+        dim = 16
+        base_a = rng.normal(size=dim)
+        base_b = -base_a  # maximally dissimilar direction under cosine
+        cluster_a = base_a + rng.normal(scale=0.02, size=(25, dim))
+        cluster_b = base_b + rng.normal(scale=0.02, size=(25, dim))
+        embeddings = np.vstack([cluster_a, cluster_b])
+
+        eps = SemanticClusteringEngine._estimate_eps(embeddings, min_samples=3)
+        distance = _cosine_distance_matrix(embeddings)
+        largest = _largest_connected_component(distance, eps)
+
+        # Each blob has 25 points; a correct eps keeps them apart.
+        assert largest <= 26, (
+            f"eps={eps} merged the two separated clusters into one "
+            f"component of size {largest}"
+        )
+
+    def test_reproduces_less_chaining_than_the_old_size_only_formula(self):
+        """Reproduce the production chaining symptom: a slow random-walk
+        manifold in embedding space, which mimics an embedding model with a
+        narrow/elevated baseline similarity (adjacent points are close, but
+        the old size-only eps was loose enough to chain distant, unrelated
+        points together transitively). The new eps must produce a
+        meaningfully smaller largest component than the old formula on the
+        same data.
+        """
+        rng = np.random.default_rng(3)
+        n, dim = 200, 16
+        steps = rng.normal(scale=0.05, size=(n, dim))
+        walk = np.cumsum(steps, axis=0)
+        embeddings = walk + rng.normal(scale=0.01, size=(n, dim))
+
+        distance = _cosine_distance_matrix(embeddings)
+        min_samples = 3
+
+        new_eps = SemanticClusteringEngine._estimate_eps(embeddings, min_samples)
+        old_eps = _old_formula_eps(n)
+
+        new_largest = _largest_connected_component(distance, new_eps)
+        old_largest = _largest_connected_component(distance, old_eps)
+
+        assert new_largest < old_largest, (
+            f"new eps={new_eps:.4f} (largest component {new_largest}) did not "
+            f"reduce chaining vs. old eps={old_eps:.4f} "
+            f"(largest component {old_largest})"
+        )
+        # The old formula is expected to reproduce the production symptom:
+        # most of the dataset ends up in one chained component.
+        assert old_largest > n * 0.5

--- a/tests/consolidation/test_dbscan_eps_estimation.py
+++ b/tests/consolidation/test_dbscan_eps_estimation.py
@@ -11,11 +11,13 @@ narrow, elevated baseline cosine similarity across unrelated content, so that
 size-only eps let DBSCAN's density-reachability chain unrelated memories
 into one giant cluster.
 
-These tests exercise `_estimate_eps` directly (pure numpy, no scikit-learn
-required) and verify -- via a from-scratch connected-components check at a
-given eps, so no DBSCAN/sklearn dependency is needed here either -- that the
-new knee-based eps avoids the chaining failure mode on synthetic data shaped
-like the production symptom.
+These tests exercise `_estimate_eps` directly. It uses
+`sklearn.neighbors.NearestNeighbors` internally for the k-distance lookup
+(replacing an earlier full n x n distance matrix, which was O(n^2) memory
+and time -- flagged in review), so scikit-learn is required to run these
+tests. Chaining verification itself uses a from-scratch connected-components
+check rather than DBSCAN, so no additional dependency is needed for that
+part.
 """
 
 import numpy as np


### PR DESCRIPTION
Carried over from Codeberg PR #340, authored by **timkjr**, commits unchanged.

Original discussion: https://codeberg.org/doobidoo/mcp-memory-service/pulls/340

Two commits, two files, +194/-13. Deriving eps from the data's own k-distance curve instead of a constant is the right instinct, and the follow-up commit avoids building an O(n^2) distance matrix while doing it.

Not rebased onto current `main`; the diff is against the merge base.

@timkjr same offer as on the other one: if you would rather open this yourself, I will close this in favour of yours.