### PR TITLE
fix(security): close three transport and OAuth advisories

### DIFF
--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -261,6 +261,14 @@ class MemoryServer:
         self.server = Server(SERVER_NAME)
         self.system_info = get_system_info()
 
+        # Whether this instance is reachable by a caller who does not already
+        # have filesystem access on the host. Defaults to False, which is the
+        # stdio case: the caller is a local process that could read those files
+        # anyway. Every remote transport must set this to True before serving,
+        # which is what makes `local_only_tools()` take effect. See
+        # `_reject_local_only()`.
+        self.remote_transport = False
+
         # Initialize query time tracking
         self.query_times = deque(maxlen=50)  # Keep last 50 query times for averaging
 
@@ -1521,12 +1529,22 @@ class MemoryServer:
         into a confused-deputy primitive that can read any file the
         server process can read.
 
-        The HTTP MCP shim filters these out of `tools/list` and rejects
-        `tools/call` for them (including their deprecated aliases). Stdio
-        keeps them since the caller already has the filesystem access the
-        handler would otherwise grant.
+        Enforced here, in `list_tools()` and `call_tool()`, so that every
+        transport inherits the filter rather than each one having to
+        remember it. Until 2026-09-05 only the HTTP MCP shim in
+        `web/api/mcp.py` applied it, which left the Streamable HTTP and SSE
+        transports serving these tools to remote callers
+        (GHSA-7crr-2r7w-cpfm). The shim keeps its own checks: it answers
+        JSON-RPC directly and also has to cover the deprecated aliases.
+
+        Stdio keeps these tools, since the caller already has the
+        filesystem access the handler would otherwise grant.
         """
         return frozenset({"memory_harvest", "memory_ingest"})
+
+    def _reject_local_only(self, name: str) -> bool:
+        """True when `name` must not be served to the current caller."""
+        return self.remote_transport and name in self.local_only_tools()
 
     async def list_tools(self) -> List[types.Tool]:
         """Return the canonical MCP tool list from declarative registry."""
@@ -1536,6 +1554,8 @@ class MemoryServer:
 
             tools = []
             for tool_def in TOOL_REGISTRY:
+                if self._reject_local_only(tool_def.name):
+                    continue
                 annotations = None
                 if tool_def.annotations:
                     annotations = types.ToolAnnotations(**tool_def.annotations)
@@ -1559,6 +1579,17 @@ class MemoryServer:
         logger.info("=== HANDLING TOOL CALL: %s ===", _sanitize_log_value(name))
         if arguments is None:
             arguments = {}
+
+        # Refuse before the handler resolves, so a remote caller cannot reach a
+        # filesystem tool by naming it directly even though tools/list hid it.
+        if self._reject_local_only(name):
+            logger.warning(
+                "Refused local-only tool over a remote transport: %s",
+                _sanitize_log_value(name),
+            )
+            return [types.TextContent(type="text", text=json.dumps(
+                {"error": f"Tool not available over this transport: {name}"}
+            ))]
 
         # Resolve handler from routing table
         from mcp_memory_service.tools.routing import resolve_handler

--- a/src/mcp_memory_service/utils/startup_orchestrator.py
+++ b/src/mcp_memory_service/utils/startup_orchestrator.py
@@ -40,7 +40,125 @@ from ..server.environment import check_uv_environment, check_version_consistency
 import mcp.server.stdio
 from mcp.server import InitializationOptions, NotificationOptions
 
+from ..compat import _sanitize_log_value
+
 logger = logging.getLogger(__name__)
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True when `host` can only be reached from the machine itself."""
+    import ipaddress  # inline import: only needed by this one helper, keeps module import cheap
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # Not an IP literal. That covers a hostname we cannot resolve here, and
+        # also the empty string, which binds every interface rather than
+        # loopback. The safe answer to "is this only reachable locally" is no.
+        return False
+
+
+def _assert_bind_is_authenticated(host: str, port: int) -> None:
+    """Refuse to serve MCP to the network with no authentication configured.
+
+    The default bind is loopback, so this only fires when someone
+    deliberately widened it without setting up auth, which is exactly the
+    deployment GHSA-2hh8-qjxc-43x3 describes. Documenting "do not expose SSE"
+    is not a control. Refusing to start is.
+    """
+    from ..config import OAUTH_ENABLED, API_KEY
+    if _is_loopback_host(host) or OAUTH_ENABLED or API_KEY:
+        return
+    raise RuntimeError(
+        f"Refusing to start an MCP transport on {host}:{port} with no authentication "
+        "configured. Its endpoints expose the full MCP tool surface. Set MCP_API_KEY, "
+        "or enable OAuth with MCP_OAUTH_ENABLED=true, or bind to 127.0.0.1."
+    )
+
+
+async def _credentials_authenticate(scope) -> bool:
+    """True when the request carries a credential this server accepts.
+
+    Three ways in, tried in order: an OAuth bearer token, an X-API-Key
+    header, and a bearer token that is really the API key (which some MCP
+    clients send that way).
+    """
+    from ..config import OAUTH_ENABLED, API_KEY
+    from ..web.oauth.middleware import (
+        authenticate_bearer_token,
+        authenticate_api_key,
+    )
+
+    headers = dict(scope.get("headers", []))
+    auth_header = headers.get(b"authorization", b"").decode("latin-1")
+    api_key_header = headers.get(b"x-api-key", b"").decode("latin-1")
+
+    is_bearer = auth_header.lower().startswith("bearer ")
+    token = auth_header[7:] if is_bearer else ""
+
+    if is_bearer and OAUTH_ENABLED and (await authenticate_bearer_token(token)).authenticated:
+        return True
+    if api_key_header and API_KEY and authenticate_api_key(api_key_header).authenticated:
+        return True
+    if is_bearer and API_KEY and authenticate_api_key(token).authenticated:
+        return True
+    return False
+
+
+async def _send_unauthorized(scope, receive, send) -> None:
+    """Answer 401 with the WWW-Authenticate header OAuth clients expect."""
+    from starlette.responses import Response as StarletteResponse
+    from ..config import OAUTH_ENABLED, OAUTH_ISSUER
+
+    resource_metadata_url = f"{OAUTH_ISSUER.rstrip('/')}/.well-known/oauth-protected-resource"
+    www_auth = (
+        f'Bearer resource_metadata="{resource_metadata_url}"'
+        if OAUTH_ENABLED and OAUTH_ISSUER else "Bearer"
+    )
+    response = StarletteResponse(
+        '{"error":"unauthorized","error_description":"Valid Bearer token or API key required"}',
+        status_code=401,
+        headers={"WWW-Authenticate": www_auth, "Content-Type": "application/json"},
+    )
+    await response(scope, receive, send)
+
+
+async def _sse_request_is_allowed(path: str, scope, receive, send) -> bool:
+    """Gate the two SSE endpoints that carry the MCP surface.
+
+    `/sse` and `/messages/` both reach the full tool list, so both are
+    gated; `/health` and unknown paths are not, and are answered by the
+    caller. Until 2026-09-05 none of them was gated at all
+    (GHSA-2hh8-qjxc-43x3).
+
+    Returns False only when it has already answered the request with 401.
+    """
+    if path != "/sse" and not path.startswith("/messages/"):
+        return True
+    from ..config import OAUTH_ENABLED, API_KEY
+    if not (OAUTH_ENABLED or API_KEY):
+        # Nothing configured to check against. _assert_bind_is_authenticated()
+        # has already refused a non-loopback bind in this case, so what is left
+        # is a deliberate local-only server.
+        return True
+    return await check_transport_auth(scope, receive, send)
+
+
+async def check_transport_auth(scope, receive, send) -> bool:
+    """Validate auth on an ASGI request. Returns True if authorized, else
+    answers 401 itself and returns False.
+
+    Shared by the Streamable HTTP and SSE transports. It lived inside
+    run_streamable_http() until 2026-09-05, which is part of why SSE served
+    /sse and /messages/ with no auth at all (GHSA-2hh8-qjxc-43x3): the check
+    was not reachable from there. A second copy would have drifted, so it is
+    one function now.
+    """
+    if await _credentials_authenticate(scope):
+        return True
+    await _send_unauthorized(scope, receive, send)
+    return False
 
 
 class StartupCheckOrchestrator:
@@ -97,7 +215,7 @@ class InitializationRetryManager:
 
         while retry_count <= self.max_retries and not init_success:
             if retry_count > 0:
-                self.logger.warning(f"Retrying initialization (attempt {retry_count}/{self.max_retries})...")
+                self.logger.warning("Retrying initialization (attempt %s/%s)...", retry_count, self.max_retries)
 
             init_task = asyncio.create_task(server.initialize())
             try:
@@ -113,12 +231,12 @@ class InitializationRetryManager:
                 # Don't cancel the task, let it complete in the background
                 break
             except Exception as init_error:
-                self.logger.error(f"Initialization error: {str(init_error)}")
+                self.logger.error("Initialization error: %s", _sanitize_log_value(init_error))
                 self.logger.error(traceback.format_exc())
                 retry_count += 1
 
                 if retry_count <= self.max_retries:
-                    self.logger.info(f"Waiting {self.retry_delay} seconds before retry...")
+                    self.logger.info("Waiting %s seconds before retry...", self.retry_delay)
                     await asyncio.sleep(self.retry_delay)
 
         return init_success
@@ -218,7 +336,7 @@ class ServerRunManager:
         """Run server with SSE (Server-Sent Events) transport over HTTP."""
         from mcp.server.sse import SseServerTransport
         from starlette.responses import Response
-        import uvicorn
+        import uvicorn  # inline import: heavy, and only the HTTP transports need it
 
         init_options = InitializationOptions(
             server_name=SERVER_NAME,
@@ -237,6 +355,10 @@ class ServerRunManager:
             ),
         )
 
+        # Remote transport: filesystem tools are filtered out of tools/list and
+        # refused on tools/call. See MemoryServer.local_only_tools().
+        self.server.remote_transport = True
+
         sse = SseServerTransport("/messages/")
         server_instance = self.server.server
 
@@ -251,6 +373,9 @@ class ServerRunManager:
                         return
 
             path = scope.get("path", "")
+            if not await _sse_request_is_allowed(path, scope, receive, send):
+                return
+
             if path == "/sse":
                 async with sse.connect_sse(scope, receive, send) as streams:
                     await server_instance.run(
@@ -273,7 +398,10 @@ class ServerRunManager:
         from ..config import safe_get_int_env
         sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
         sse_port = safe_get_int_env('MCP_SSE_PORT', MCP_SSE_PORT, min_value=1024, max_value=65535)
-        self.logger.info(f"Starting SSE transport on {sse_host}:{sse_port}")
+
+        _assert_bind_is_authenticated(sse_host, sse_port)
+
+        self.logger.info("Starting SSE transport on %s:%s", _sanitize_log_value(sse_host), sse_port)
         config = uvicorn.Config(
             app,
             host=sse_host,
@@ -295,10 +423,14 @@ class ServerRunManager:
         OAuth 2.1 endpoints (discovery, DCR, authorization, token) alongside
         the MCP transport endpoint, and requires Bearer token auth on /mcp.
         """
-        import uvicorn
+        import uvicorn  # inline import: heavy, and only the HTTP transports need it
         from starlette.responses import Response as StarletteResponse
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
         from ..config import OAUTH_ENABLED, API_KEY
+
+        # Remote transport: filesystem tools are filtered out of tools/list and
+        # refused on tools/call. See MemoryServer.local_only_tools().
+        self.server.remote_transport = True
 
         server_instance = self.server.server
         session_manager = StreamableHTTPSessionManager(
@@ -407,58 +539,19 @@ class ServerRunManager:
 
         async def _check_auth_from_scope(scope, receive, send) -> bool:
             """Validate auth on /mcp requests. Returns True if authorized."""
-            from ..web.oauth.middleware import (
-                authenticate_bearer_token,
-                authenticate_api_key,
-            )
-
-            # Extract headers from ASGI scope
-            headers = dict(scope.get("headers", []))
-            auth_header = headers.get(b"authorization", b"").decode("latin-1")
-            api_key_header = headers.get(b"x-api-key", b"").decode("latin-1")
-
-            # Try Bearer token (OAuth)
-            is_bearer = auth_header.lower().startswith("bearer ")
-            token = auth_header[7:] if is_bearer else ""
-
-            # Try Bearer token (OAuth)
-            if is_bearer and OAUTH_ENABLED:
-                result = await authenticate_bearer_token(token)
-                if result.authenticated:
-                    return True
-
-            # Try API key via header
-            if api_key_header and API_KEY:
-                result = authenticate_api_key(api_key_header)
-                if result.authenticated:
-                    return True
-
-            # Try Bearer token as API key fallback
-            if is_bearer and API_KEY:
-                result = authenticate_api_key(token)
-                if result.authenticated:
-                    return True
-
-            # Auth failed - send 401
-            from ..config import OAUTH_ISSUER as _issuer
-            _resource_metadata_url = f"{_issuer.rstrip('/')}/.well-known/oauth-protected-resource"
-            _www_auth = f'Bearer resource_metadata="{_resource_metadata_url}"' if OAUTH_ENABLED and _issuer else "Bearer"
-            response = StarletteResponse(
-                '{"error":"unauthorized","error_description":"Valid Bearer token or API key required"}',
-                status_code=401,
-                headers={
-                    "WWW-Authenticate": _www_auth,
-                    "Content-Type": "application/json",
-                },
-            )
-            await response(scope, receive, send)
-            return False
+            return await check_transport_auth(scope, receive, send)
 
         # Re-read env at runtime; see run_sse() for rationale.
         from ..config import safe_get_int_env
         sse_host = os.environ.get('MCP_SSE_HOST', MCP_SSE_HOST)
         sse_port = safe_get_int_env('MCP_SSE_PORT', MCP_SSE_PORT, min_value=1024, max_value=65535)
-        self.logger.info(f"Starting Streamable HTTP transport on {sse_host}:{sse_port}")
+        # Same guard as SSE. /mcp gates on `OAUTH_ENABLED or API_KEY`, so with
+        # neither set it serves the full tool surface unauthenticated, exactly
+        # like SSE did. The advisory named SSE because that transport had no
+        # gate at all; the unauthenticated-bind case is common to both.
+        _assert_bind_is_authenticated(sse_host, sse_port)
+
+        self.logger.info("Starting Streamable HTTP transport on %s:%s", _sanitize_log_value(sse_host), sse_port)
         config = uvicorn.Config(
             app,
             host=sse_host,
@@ -478,13 +571,13 @@ class ServerRunManager:
             # Check if this contains the LM Studio cancelled notification error
             if 'notifications/cancelled' in error_str or 'ValidationError' in error_str:
                 self.logger.info("LM Studio sent a cancelled notification - this is expected behavior")
-                self.logger.debug(f"Full error for debugging: {error_str}")
+                self.logger.debug("Full error for debugging: %s", _sanitize_log_value(error_str))
                 # Don't re-raise - just continue gracefully
             else:
-                self.logger.error(f"ExceptionGroup in server.run: {str(e)}")
+                self.logger.error("ExceptionGroup in server.run: %s", _sanitize_log_value(e))
                 self.logger.error(traceback.format_exc())
                 raise
         else:
-            self.logger.error(f"Error in server.run: {str(e)}")
+            self.logger.error("Error in server.run: %s", _sanitize_log_value(e))
             self.logger.error(traceback.format_exc())
             raise

--- a/src/mcp_memory_service/web/oauth/authorization.py
+++ b/src/mcp_memory_service/web/oauth/authorization.py
@@ -817,6 +817,30 @@ async def _handle_client_credentials_grant(
     final_client_id: str, final_client_secret: str
 ) -> TokenResponse:
     """Handle OAuth client_credentials grant type."""
+    # Registration gates the grant, not just at registration time. Refusing
+    # only in /oauth/register would leave every client that registered while
+    # DCR was open still holding the grant, and those are exactly the
+    # self-service registrations GHSA-6mvm-q4j3-27qg describes. If this
+    # deployment cannot say who registered a client, it cannot honour a
+    # machine-to-machine grant from one.
+    from ...config import DCR_REGISTRATION_KEY
+    if not DCR_REGISTRATION_KEY:
+        logger.warning(
+            "Refused client_credentials: registration is open, so a registered "
+            "client is not evidence of owner consent"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": "unauthorized_client",
+                "error_description": (
+                    "The client_credentials grant is disabled while Dynamic Client "
+                    "Registration is open. Set MCP_DCR_REGISTRATION_KEY, or use "
+                    "authorization_code with PKCE."
+                ),
+            },
+        )
+
     if not final_client_id or not final_client_secret:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/src/mcp_memory_service/web/oauth/registration.py
+++ b/src/mcp_memory_service/web/oauth/registration.py
@@ -118,6 +118,39 @@ def _validate_registration_key(raw_request: Request) -> None:
         )
 
 
+def _refuse_client_credentials_while_open(grant_types) -> None:
+    """Reject a self-service registration that asks for client_credentials.
+
+    With MCP_DCR_REGISTRATION_KEY unset this endpoint is open by design, for
+    RFC 7591 and Claude.ai Remote MCP. That is defensible for
+    authorization_code, which puts a human in the loop before any token
+    exists. client_credentials has no such step: a caller could register
+    itself as confidential, exchange its own client_id and client_secret, and
+    hold a read-write token without the owner ever being consulted
+    (GHSA-6mvm-q4j3-27qg). The grant is machine-to-machine, so the
+    registration behind it has to be gated too.
+
+    The token endpoint refuses the same combination independently. That is
+    not redundant: this check only covers registrations made from now on,
+    while the advisory is about clients that already registered.
+    """
+    if not grant_types or "client_credentials" not in grant_types:
+        return
+    if DCR_REGISTRATION_KEY:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "error": "invalid_client_metadata",
+            "error_description": (
+                "The client_credentials grant requires gated registration. "
+                "Set MCP_DCR_REGISTRATION_KEY and register with it, or use "
+                "authorization_code with PKCE."
+            ),
+        },
+    )
+
+
 @router.post(
     "/register",
     response_model=ClientRegistrationResponse,
@@ -149,6 +182,8 @@ async def register_client(
 
         if request.response_types:
             validate_response_types(request.response_types)
+
+        _refuse_client_credentials_while_open(request.grant_types)
 
         # Prepare default values
         grant_types = request.grant_types or ["authorization_code"]

--- a/tests/unit/test_oauth_open_dcr_client_credentials.py
+++ b/tests/unit/test_oauth_open_dcr_client_credentials.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GHSA-6mvm-q4j3-27qg: open DCR must not hand out client_credentials.
+
+GHSA-5p27-64mv-pr73 stopped a *public* client from authenticating as a
+confidential one. It did not stop a caller from registering itself as
+confidential in the first place. With MCP_DCR_REGISTRATION_KEY unset,
+/oauth/register is open by design (RFC 7591, Claude.ai Remote MCP), so a
+caller could register with grant_types ["client_credentials"], exchange its
+own credentials, and hold a read-write token that the owner never granted.
+
+The policy these tests pin down: a machine-to-machine grant requires that
+registration itself be gated. authorization_code with PKCE stays open,
+because a human authorises before any token exists.
+
+Both halves are asserted on purpose. Refusing only at registration would
+leave every client that registered while DCR was open still holding the
+grant, which is the population the advisory is actually about.
+"""
+
+import pytest
+
+
+class TestRegistrationRefusesClientCredentialsWhenOpen:
+
+    @pytest.mark.asyncio
+    async def test_open_dcr_refuses_client_credentials(self, monkeypatch):
+        from fastapi import HTTPException
+        from mcp_memory_service.web.oauth import registration
+
+        monkeypatch.setattr(registration, "DCR_REGISTRATION_KEY", None)
+        req = registration.ClientRegistrationRequest(
+            client_name="self-service",
+            grant_types=["client_credentials"],
+            token_endpoint_auth_method="client_secret_basic",
+        )
+        with pytest.raises(HTTPException) as exc:
+            await registration.register_client(req)
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"] == "invalid_client_metadata"
+
+    @pytest.mark.asyncio
+    async def test_open_dcr_still_allows_authorization_code(self, monkeypatch):
+        """The flow Claude.ai Remote MCP needs must keep working.
+
+        A fix that closed open DCR entirely would be no fix, it would be a
+        different outage.
+        """
+        from mcp_memory_service.web.oauth import registration
+
+        monkeypatch.setattr(registration, "DCR_REGISTRATION_KEY", None)
+        req = registration.ClientRegistrationRequest(
+            client_name="claude-ai-style",
+            redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+            grant_types=["authorization_code"],
+            token_endpoint_auth_method="none",
+        )
+        resp = await registration.register_client(req)
+        assert resp.client_id
+        assert "authorization_code" in resp.grant_types
+
+
+class TestTokenEndpointRefusesGrantWhenRegistrationIsOpen:
+
+    @pytest.mark.asyncio
+    async def test_grant_refused_while_dcr_open(self, monkeypatch):
+        """Closes the clients that registered before the registration-time fix."""
+        from fastapi import HTTPException
+        from mcp_memory_service.web.oauth import authorization
+        import mcp_memory_service.config as config  # inline import: patched per test
+
+        monkeypatch.setattr(config, "DCR_REGISTRATION_KEY", None)
+        with pytest.raises(HTTPException) as exc:
+            await authorization._handle_client_credentials_grant("cid", "secret")
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"] == "unauthorized_client"
+
+    @pytest.mark.asyncio
+    async def test_gated_dcr_reaches_client_authentication(self, monkeypatch):
+        """With registration gated, the grant is allowed to proceed far enough
+        to authenticate the client, and then fails on the credentials rather
+        than on policy. Asserting the error CHANGES is what shows the policy
+        gate was passed rather than silently still blocking."""
+        from fastapi import HTTPException
+        from mcp_memory_service.web.oauth import authorization
+        import mcp_memory_service.config as config  # inline import: patched per test
+
+        monkeypatch.setattr(config, "DCR_REGISTRATION_KEY", "a-registration-key")
+        with pytest.raises(HTTPException) as exc:
+            await authorization._handle_client_credentials_grant("unknown", "wrong")
+        assert exc.value.detail["error"] != "unauthorized_client"

--- a/tests/unit/test_remote_transport_guards.py
+++ b/tests/unit/test_remote_transport_guards.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guards for the two transport-level advisories fixed on 2026-09-05.
+
+GHSA-7crr-2r7w-cpfm: `local_only_tools()` was applied only by the FastAPI
+JSON-RPC shim, so the Streamable HTTP and SSE transports served the
+filesystem tools (`memory_harvest`, `memory_ingest`) to remote callers.
+
+GHSA-2hh8-qjxc-43x3: the SSE transport served `/sse` and `/messages/` with
+no authentication at all, and would happily do so on a non-loopback bind.
+
+The point of testing at the MemoryServer level rather than per transport is
+that a future transport inherits the guard instead of having to remember it.
+That is precisely what went wrong the first time.
+"""
+
+import json
+
+import pytest
+
+# Via the package, not mcp_memory_service.server_impl directly: the direct
+# import races the package __init__ and raises a circular ImportError.
+from mcp_memory_service.server import MemoryServer
+from mcp_memory_service.utils.startup_orchestrator import _is_loopback_host
+
+
+LOCAL_ONLY = ("memory_harvest", "memory_ingest")
+
+
+@pytest.fixture
+def server():
+    """A MemoryServer that never touches storage.
+
+    `list_tools()` reads the declarative registry and `call_tool()` refuses
+    local-only names before any handler resolves, so neither path needs a
+    backend for what is asserted here.
+    """
+    return MemoryServer()
+
+
+class TestLocalOnlyToolsOverRemoteTransports:
+
+    def test_defaults_to_local(self, server):
+        """stdio is the default and keeps the filesystem tools."""
+        assert server.remote_transport is False
+
+    @pytest.mark.asyncio
+    async def test_stdio_lists_local_only_tools(self, server):
+        names = {t.name for t in await server.list_tools()}
+        for tool in LOCAL_ONLY:
+            assert tool in names, f"{tool} should be available over stdio"
+
+    @pytest.mark.asyncio
+    async def test_remote_hides_local_only_tools(self, server):
+        server.remote_transport = True
+        names = {t.name for t in await server.list_tools()}
+        for tool in LOCAL_ONLY:
+            assert tool not in names, f"{tool} must not be listed to a remote caller"
+        # The filter must not empty the list; the other tools still ship.
+        assert len(names) > 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool", LOCAL_ONLY)
+    async def test_remote_refuses_direct_call(self, server, tool):
+        """Hiding a tool from tools/list is not enough on its own.
+
+        A caller can name the tool directly, so the refusal has to sit in
+        call_tool() as well, and it has to happen before the handler
+        resolves.
+        """
+        server.remote_transport = True
+        result = await server.call_tool(tool, {"project_path": "/etc"})
+        payload = json.loads(result[0].text)
+        assert "error" in payload
+        assert "not available over this transport" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_remote_still_serves_other_tools(self, server):
+        """The guard is scoped to the local-only set, not a blanket block."""
+        server.remote_transport = True
+        assert server._reject_local_only("memory_search") is False
+        assert server._reject_local_only("memory_harvest") is True
+
+
+class TestLoopbackDetection:
+    """`_is_loopback_host` decides whether SSE may start without auth, so an
+    over-permissive answer here is the whole vulnerability."""
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "127.0.0.53"])
+    def test_loopback(self, host):
+        assert _is_loopback_host(host) is True
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.5", "10.0.0.1", "::", "example.com"])
+    def test_not_loopback(self, host):
+        assert _is_loopback_host(host) is False
+
+    def test_bind_guard_refuses_open_network_bind(self, monkeypatch):
+        """Binding to the network with no auth configured must not start."""
+        import mcp_memory_service.config as config  # inline import: patched per test
+        from mcp_memory_service.utils import startup_orchestrator as so
+
+        monkeypatch.setattr(config, "OAUTH_ENABLED", False)
+        monkeypatch.setattr(config, "API_KEY", None)
+        with pytest.raises(RuntimeError, match="no authentication configured"):
+            so._assert_bind_is_authenticated("0.0.0.0", 8000)
+
+    def test_bind_guard_allows_loopback_without_auth(self, monkeypatch):
+        import mcp_memory_service.config as config  # inline import: patched per test
+        from mcp_memory_service.utils import startup_orchestrator as so
+
+        monkeypatch.setattr(config, "OAUTH_ENABLED", False)
+        monkeypatch.setattr(config, "API_KEY", None)
+        so._assert_bind_is_authenticated("127.0.0.1", 8000)
+
+    def test_bind_guard_allows_network_bind_with_api_key(self, monkeypatch):
+        import mcp_memory_service.config as config  # inline import: patched per test
+        from mcp_memory_service.utils import startup_orchestrator as so
+
+        monkeypatch.setattr(config, "OAUTH_ENABLED", False)
+        monkeypatch.setattr(config, "API_KEY", "a-key")
+        so._assert_bind_is_authenticated("0.0.0.0", 8000)
+
+    def test_empty_host_is_not_loopback(self):
+        """An empty bind address means every interface, not loopback.
+
+        Worth its own test because the obvious implementation groups "" with
+        "localhost" as a falsy-ish default, which fails open.
+        """
+        assert _is_loopback_host("") is False

--- a/tests/web/test_oauth_hardening.py
+++ b/tests/web/test_oauth_hardening.py
@@ -458,6 +458,23 @@ async def test_body_limit_no_double_start_when_response_already_started():
 REG_PATCH = "mcp_memory_service.web.oauth.registration.get_oauth_storage"
 
 
+@pytest.fixture
+def gated_dcr(monkeypatch):
+    """Precondition for the client_credentials grant since GHSA-6mvm-q4j3-27qg.
+
+    The grant is refused outright while Dynamic Client Registration is open,
+    because a self-registered client is not evidence of owner consent. These
+    tests are about what happens *after* that policy gate, so they have to
+    pass it first. Both spellings are patched: registration.py binds the
+    constant at import, authorization.py reads it per call.
+    """
+    import mcp_memory_service.config as config  # inline import: patched per test
+    from mcp_memory_service.web.oauth import registration as registration_mod
+
+    monkeypatch.setattr(config, "DCR_REGISTRATION_KEY", "test-registration-key")
+    monkeypatch.setattr(registration_mod, "DCR_REGISTRATION_KEY", "test-registration-key")
+
+
 async def _register(storage, **kwargs):
     from mcp_memory_service.web.oauth.models import ClientRegistrationRequest
     from mcp_memory_service.web.oauth.registration import register_client
@@ -485,7 +502,7 @@ async def test_registration_issues_no_secret_to_public_client():
 
 
 @pytest.mark.asyncio
-async def test_registration_still_issues_secret_to_confidential_client():
+async def test_registration_still_issues_secret_to_confidential_client(gated_dcr):
     storage = MemoryOAuthStorage()
     resp = await _register(
         storage,
@@ -523,7 +540,7 @@ async def test_client_credentials_rejects_unregistered_grant():
 
 
 @pytest.mark.asyncio
-async def test_client_credentials_rejects_public_client_with_secret():
+async def test_client_credentials_rejects_public_client_with_secret(gated_dcr):
     """Auth method is read off the stored client, not inferred from the request."""
     storage = MemoryOAuthStorage()
     secret = "leaked-from-registration"
@@ -548,7 +565,7 @@ async def test_client_credentials_rejects_public_client_with_secret():
 
 
 @pytest.mark.asyncio
-async def test_client_credentials_allows_properly_registered_client():
+async def test_client_credentials_allows_properly_registered_client(gated_dcr):
     storage = MemoryOAuthStorage()
     secret = "s3cret-value"
     await storage.store_client(
@@ -569,7 +586,7 @@ async def test_client_credentials_allows_properly_registered_client():
 
 
 @pytest.mark.asyncio
-async def test_full_reported_chain_is_broken_end_to_end():
+async def test_full_reported_chain_is_broken_end_to_end(gated_dcr):
     """The reported chain, start to finish, must not yield a token."""
     storage = MemoryOAuthStorage()
     reg = await _register(


### PR DESCRIPTION
Closes the three critical advisories reported by @alivirgo on 27 August. All three were checked against 11.9.0 in the reports and reproduced against current `main` before anything was changed.

## GHSA-7crr-2r7w-cpfm — filesystem tools reachable over remote transports

`local_only_tools()` names `memory_harvest` and `memory_ingest`, both of which take a caller-controlled filesystem path. The filter was applied in exactly one place, `web/api/mcp.py`, so Streamable HTTP and SSE served them to remote callers.

The cause was the location, not a missing call. A guard each transport has to remember is a guard the next transport will not have. It now lives in `MemoryServer.list_tools()` and `call_tool()`, which every transport goes through, and the transports set `remote_transport = True`. `call_tool()` refuses **before** the handler resolves, since hiding a tool from `tools/list` does nothing about a caller that names it directly.

## GHSA-2hh8-qjxc-43x3 — SSE served /sse and /messages/ unauthenticated

The auth check existed, but as a closure inside `run_streamable_http()`, so it was simply not reachable from `run_sse()`. That is the whole explanation. It is now `check_transport_auth()` at module level and both transports call it; a second copy would have drifted apart again.

Added a startup guard as well: a transport refuses to start on a non-loopback bind with neither `MCP_API_KEY` nor OAuth configured. The advisory correctly notes the default bind is loopback, which is why this has not been exploited, but a default is not a control.

**Extended beyond the report:** the same guard now covers Streamable HTTP. Its `/mcp` gate is conditional on `OAUTH_ENABLED or API_KEY`, so with neither set it was equally open. The advisory named SSE because SSE had no gate at all, not because Streamable HTTP was safe in that configuration.

## GHSA-6mvm-q4j3-27qg — open DCR plus client_credentials

GHSA-5p27-64mv-pr73 stopped a public client from acting confidential. It did not stop a caller from registering itself as confidential in the first place.

The policy this settles: **a machine-to-machine grant requires that registration itself be gated.** `authorization_code` with PKCE stays open, because a human authorises before any token exists, and that is the flow Claude.ai Remote MCP needs. A fix that closed open DCR outright would not be a fix, it would be a different outage.

The gate sits at both ends, at `/oauth/register` and at the token endpoint. That is not belt-and-braces: refusing only at registration would leave every client that registered while DCR was open still holding the grant, and those are exactly the population the advisory is about.

## On the four changed hardening tests

`test_oauth_hardening.py` has four tests that call `_handle_client_credentials_grant` directly with no registration key set, so the new policy gate rejects them first. They assert the authentication logic, not the registration policy, so they get a `gated_dcr` fixture to pass the gate and reach what they actually test. Deleting them would have thrown away the GHSA-5p27 regression guard.

## Verification

Every fix has a counter-proof. With the guard disabled, the tests that describe the attack fail:

- transport guards disabled: 4 failed, 12 passed
- both DCR gates disabled: 2 failed, 2 passed
- restored: 56 passed across the three files

Without that step a security test can pass vacuously, which is worse than having none.

`bash scripts/pr/pre_pr_check.sh`: 12/13, the one failure is the complexity check, which reports only pre-existing functions I did not touch (`_initialize_storage_with_timeout`, `authorize_post`, `_handle_authorization_code_grant`). Complexity was measured rather than assumed:

| function | main | branch |
|---|---|---|
| `run_streamable_http` | 37 | 25 |
| `register_client` | 15 | 15 |
| `run_sse` | 9 | 10 |

`run_sse` gains exactly one branch, which is the security gate itself. `run_streamable_http` drops by 12 because the auth closure moved out.

Log-injection findings in `startup_orchestrator.py` were inherited, verified present verbatim on `main`, and fixed anyway: `MCP_SSE_HOST` is environment-derived and therefore caller-controlled.