### PR TITLE
chore(release): v11.11.0

### DIFF
--- a/.claude/directives/version-management.md
+++ b/.claude/directives/version-management.md
@@ -21,7 +21,7 @@ feature-branches → main (development)
 1. **Development**: All feature/fix branches merge to `main`
 2. **Release Preparation**: Create `release/vX.Y.Z` branch from `main`
 3. **Version Bump**: Update version files on release branch
-4. **PR & Merge**: Create PR, squash-merge it
+4. **PR & Merge**: Create PR, wait for CI, merge it
 5. **Tag**: Create the annotated tag locally and push it **with git**:
    ```bash
    git tag -a vX.Y.Z -m "<summary>" <merge-sha>
@@ -83,15 +83,15 @@ Always bumped together, in one commit:
 1. `src/mcp_memory_service/_version.py` (`__version__ = "X.Y.Z"`) — this is the canonical source
 2. `pyproject.toml` (line ~7: `version = "X.Y.Z"`)
 3. `README.md` (Latest Release section)
-4. `CLAUDE.md` (Current Version line)
-5. `CHANGELOG.md` (convert [Unreleased] to [X.Y.Z] with date)
-6. `uv lock` to update the dependency lock file
+4. `CHANGELOG.md` (convert [Unreleased] to [X.Y.Z] with date)
+5. `uv lock` to update the dependency lock file
 
-Of those six, **only `_version.py` and `pyproject.toml` are covered by a CI gate.**
-`CLAUDE.md` is the one that actually gets forgotten — v11.8.2 shipped without it, and
-nothing failed, so main announced the previous version until someone noticed by eye.
-Check it explicitly (`grep -n '^\*\*Current Version' CLAUDE.md`) rather than trusting a
-green gate.
+Of those five, **only `_version.py` and `pyproject.toml` are covered by a CI gate.**
+
+`CLAUDE.md` used to carry a "Current Version" line and was the one that actually got
+forgotten: v11.8.2 shipped without it, nothing failed, and main announced the previous
+version until someone noticed by eye. That line was removed on 2026-09-05 in favour of a
+pointer to CHANGELOG.md, which is the real fix. Do not reintroduce it.
 
 Conditional, and each one is enforced by a CI gate:
 
@@ -117,14 +117,14 @@ git log <last-tag>..HEAD --oneline
 tag `archive/github-workflows-pre-codeberg`.
 
 PR creation, review-comment retrieval, squash-merge, and the release object all run
-against the GitHub REST API via `gh`. The
-release automation carries the concrete calls; there is no `gh`-based path for the
-release itself.
+against the GitHub REST API via `gh`.
 
 ## Merge Discipline
 
-`main` carries no branch-protection rule, so nothing technically blocks a direct push —
-the discipline is convention, not enforcement:
+`main` carries a ruleset named `ProtectMain` that requires changes to arrive through a
+pull request. It required one approving review until 2026-09-05; that was dropped to
+zero, because the author cannot approve their own PR and a solo maintainer is always the
+author, so every PR needed an admin bypass. The PR requirement itself stays:
 
 - Never commit straight to `main`; branch first.
 - Merge through a PR, squash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [11.11.0] - 2026-09-05
+
+MINOR release. Closes three critical advisories reported by alivirgo, and moves development back to GitHub.
+
+The three advisories share a shape worth naming: in each case the guard existed and was simply not reachable from where it was needed. `local_only_tools()` was applied by one transport out of three. The SSE auth check was a closure inside another transport's function. The `client_credentials` hardening from GHSA-5p27-64mv-pr73 checked how a client authenticates but not how it came to exist. Each fix moves the guard to where every caller passes, rather than adding a second copy.
+
+### Security
+
+- **`memory_harvest` and `memory_ingest` were reachable over remote transports** (GHSA-7crr-2r7w-cpfm). Both take a caller-controlled filesystem path. The `local_only_tools()` filter ran only in the FastAPI JSON-RPC shim, so Streamable HTTP and SSE served them to remote callers. The filter now lives in `MemoryServer.list_tools()` and `call_tool()`, which every transport goes through. `call_tool()` refuses before the handler resolves, since hiding a tool from `tools/list` does nothing about a caller that names it directly.
+- **The SSE transport had no authentication at all** (GHSA-2hh8-qjxc-43x3). `/sse` and `/messages/` both reach the full MCP tool surface and neither was gated. The check now lives at module level and both transports call it.
+- **Open Dynamic Client Registration handed out read-write tokens** (GHSA-6mvm-q4j3-27qg). With `MCP_DCR_REGISTRATION_KEY` unset, a caller could register itself as a confidential client, exchange its own credentials, and hold a `read write` token the owner never granted.
+
+### Behaviour changes
+
+Both are deliberate, and both fail loudly rather than degrading quietly.
+
+- **`client_credentials` is refused while Dynamic Client Registration is open.** If you use that grant, set `MCP_DCR_REGISTRATION_KEY` and register with it. `authorization_code` with PKCE is unaffected, which is the flow Claude.ai Remote MCP uses.
+- **An MCP transport refuses to start on a non-loopback bind with no authentication configured.** Set `MCP_API_KEY`, enable OAuth with `MCP_OAUTH_ENABLED=true`, or bind to `127.0.0.1`. This covers Streamable HTTP as well as SSE: its `/mcp` gate is conditional on `OAUTH_ENABLED or API_KEY`, so with neither set it was equally open.
+
+### Infrastructure
+
+- **Development moved back to GitHub.** Issues, pull requests, CI, releases and the wiki are at github.com/doobidoo/mcp-memory-service. The four Forgejo workflows were ported to GitHub Actions and `.forgejo/` removed. Codeberg remains readable as an archive so existing links resolve.
+- Issue and PR numbers below #341 in entries from June to September 2026 are Codeberg numbers. See the note at the top of this file.
+- `claude-hooks` plugin manifest bumped to 1.0.5: its marketplace homepage pointed at the old forge.
+
+
 ## [11.10.0] - 2026-08-28
 
 Special thanks to timkjr for two of the fixes below (#321, #323) and to alivirgo for porting a Stop-hook fix over from the GitHub mirror (#330), which cannot take pull requests directly.

--- a/README.md
+++ b/README.md
@@ -497,19 +497,22 @@ MCP Memory Service is **fully compatible** with the [SHODH Unified Memory API Sp
 
 ---
 
-## Latest Release: **v11.10.0** (August 28, 2026)
+## Latest Release: **v11.11.0** (September 5, 2026)
 
-**MINOR: clustering now fails loudly instead of silently degrading when scikit-learn is missing, plus a consolidation time-horizon fix and three hook fixes (two from external contributor timkjr, one from alivirgo)**
+**MINOR: three critical advisories closed (remote transports served filesystem tools, SSE had no authentication, open DCR handed out read-write tokens), and development moved back to GitHub**
 
 **What's New:**
-- **fix(consolidation): make the configured clustering algorithm the one that runs** (#329). `MCP_CLUSTERING_ALGORITHM` defaulted to `dbscan`, but scikit-learn was declared in no extra, so clustering silently ran the `simple` fallback behind one WARNING line. New `[clustering]` extra, default changed to `auto`; naming `dbscan`/`hierarchical` explicitly without scikit-learn installed now raises `ConsolidationError` instead of degrading silently. Closes #326. **Upgrade note:** if you set `MCP_CLUSTERING_ALGORITHM=dbscan`/`hierarchical` without scikit-learn installed, consolidation now errors — install with `pip install 'mcp-memory-service[clustering]'` or set `MCP_CLUSTERING_ALGORITHM=auto`.
-- **fix(consolidation): make every time horizon mean the window it documents** (#325). Four of the five `memory_consolidate` horizons didn't match their documented window — daily reached 2 days, weekly/monthly applied no age filter at all, quarterly/yearly kept memories OLDER than their window. Closes #324. Known follow-up: no horizon reaches past 365 days any more (#327, not fixed here).
-- **fix(harvest): stop hardcoded 30s/60s wrapper timeouts overriding `HARVEST_LLM_TIMEOUT`** (#321, external contributor timkjr).
-- **fix(hooks): settings.json merge in `configure_claude_settings`** (#323, external contributor timkjr) — a plugin reinstall could wipe a user's own `PreToolUse` hooks.
-- **fix(hooks): pair the last assistant turn with the prompt that preceded it** (#330, authored by alivirgo) — ports a Stop-hook fix from the GitHub mirror, which takes no PRs directly.
-- **claude-hooks: plugin manifest bumped to 1.0.4** so the two hook fixes above reach already-installed users.
+- **fix(security): filesystem tools were reachable over remote transports** (GHSA-7crr-2r7w-cpfm). `memory_harvest` and `memory_ingest` take a caller-controlled path, and the `local_only_tools()` filter ran in only one of three transports. It now lives in `MemoryServer.list_tools()` and `call_tool()`, so every transport inherits it.
+- **fix(security): the SSE transport had no authentication** (GHSA-2hh8-qjxc-43x3). `/sse` and `/messages/` both reach the full tool surface and neither was gated. The check was a closure inside another transport's function and simply not reachable from SSE.
+- **fix(security): open DCR handed out read-write tokens** (GHSA-6mvm-q4j3-27qg). A caller could register itself as a confidential client and exchange its own credentials for a `read write` token without the owner being consulted.
+- **Development moved back to GitHub.** Issues, PRs, CI, releases and the wiki are here again; the Forgejo workflows were ported to GitHub Actions. Codeberg stays readable as an archive so old links resolve.
+
+**Upgrade notes** — two deliberate behaviour changes, both fail loudly rather than degrading quietly:
+- `client_credentials` is refused while Dynamic Client Registration is open. Set `MCP_DCR_REGISTRATION_KEY` and register with it, or use `authorization_code` with PKCE (the flow Claude.ai Remote MCP uses, unaffected).
+- An MCP transport refuses to start on a non-loopback bind with no authentication configured. Set `MCP_API_KEY`, enable OAuth, or bind to `127.0.0.1`.
 
 **Previous Releases** (v11 series — full history for all earlier versions in [CHANGELOG.md](CHANGELOG.md)):
+- **v11.10.0** - MINOR: clustering fails loudly instead of silently degrading without scikit-learn, a consolidation time-horizon fix, three hook fixes (#329, #325, #321, #323, #330) (August 28, 2026)
 - **v11.9.0** - MINOR: transformers 5.x closes two high-severity advisories with no 4.x fix, plus a quality-system bug the new ml-extras CI job caught on day one (#305, #316, #307, #303) (August 27, 2026)
 - **v11.8.5** - PATCH: two Docker fixes reproduced against the published images, plus a timezone-boundary bug in timeframe deletion, external contributor (#295, #297, #237, #298) (August 25, 2026)
 - **v11.8.4** - PATCH: hybrid deployment was burning through Cloudflare's D1 free-tier read allowance, plus three smaller correctness fixes (#289, #290, #287) (August 25, 2026)

--- a/claude-hooks/.claude-plugin/plugin.json
+++ b/claude-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-service",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Automatic memory capture and injection for Claude Code via MCP Memory Service",
   "author": {
     "name": "doobidoo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-memory-service"
-version = "11.10.0"
+version = "11.11.0"
 description = "Semantic memory layer for AI applications. REST API + MCP transport + knowledge graph + autonomous consolidation. Works with 14+ AI clients. Self-host, zero cloud cost."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v11.10.0</title>
+<title>Memory for AI Agents — REST, MCP, OAuth, CLI · mcp-memory-service v11.11.0</title>
 <meta name="description" content="Memory layer for AI agents. REST API + MCP + OAuth + CLI + dashboard — one self-hosted service, every transport. 14+ client integrations, knowledge graph, automatic consolidation. LongMemEval R@5 86%, session ingestion, zero cloud cost.">
-<meta property="og:title" content="MCP Memory Service v11.10.0">
+<meta property="og:title" content="MCP Memory Service v11.11.0">
 <meta property="og:description" content="Consolidation clustering now fails loudly instead of silently degrading, plus a time-horizon fix. Self-hosted AI memory — REST, MCP, OAuth 2.1, CLI. LongMemEval R@5 86%.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://mcpmemory.services/">
@@ -125,7 +125,7 @@ footer a{color:var(--cyan)}
 <!-- Hero -->
 <header class="hero">
   <img src="brain-icon.png" alt="Memory for AI Agents" class="hero-logo">
-  <span class="hero-badge">mcp-memory-service v11.10 &mdash; Now Available</span>
+  <span class="hero-badge">mcp-memory-service v11.11 &mdash; Now Available</span>
   <h1>Memory for AI Agents</h1>
   <p>Persistent memory for AI agents &mdash; REST API, MCP, OAuth, CLI, dashboard. Semantic search, knowledge graph, automatic consolidation. One self-hosted service, every transport.</p>
   <div class="hero-buttons">
@@ -165,23 +165,23 @@ footer a{color:var(--cyan)}
 <!-- Features -->
 <section id="features">
   <div class="container">
-    <h2 class="section-title">What's New in v11.10</h2>
-    <p class="section-subtitle">MINOR release: consolidation clustering now fails loudly instead of silently degrading when scikit-learn is missing, every time horizon means the window it documents, and three hook fixes land — two from external contributor timkjr, one ported from the GitHub mirror. ~3,007 tests.</p>
+    <h2 class="section-title">What's New in v11.11</h2>
+    <p class="section-subtitle">MINOR release: three critical advisories closed. Remote transports served the filesystem tools, the SSE transport had no authentication at all, and open Dynamic Client Registration handed out read-write tokens. Development also moved back to GitHub. ~3,030 tests.</p>
     <div class="features-grid">
       <div class="feature-card" data-delay="0">
         <div class="feature-icon privacy">&#128274;</div>
-        <h3>Clustering Fails Loud Instead of Silently Degrading</h3>
-        <p>MCP_CLUSTERING_ALGORITHM defaulted to dbscan, but scikit-learn was declared in no extra, so clustering silently ran a simple fallback behind one WARNING line. New [clustering] extra, default now auto; naming dbscan/hierarchical explicitly without scikit-learn installed now raises a clear error. (#329)</p>
+        <h3>Filesystem Tools No Longer Reachable Remotely</h3>
+        <p>memory_harvest and memory_ingest take a caller-controlled path. The local_only_tools() filter ran in only one of three transports, so Streamable HTTP and SSE served them to remote callers. It now sits in the shared tool list and dispatch, where every transport passes. (GHSA-7crr-2r7w-cpfm)</p>
       </div>
       <div class="feature-card" data-delay="150">
-        <div class="feature-icon consolidation">&#128295;</div>
-        <h3>Every Consolidation Horizon Means Its Documented Window</h3>
-        <p>Four of the five memory_consolidate time horizons didn't match what the tool description promised — daily reached 2 days, weekly and monthly applied no age filter at all, quarterly and yearly kept memories OLDER than their window. All five now filter to the window they document. (#325)</p>
+        <div class="feature-icon http">&#128273;</div>
+        <h3>The SSE Transport Now Authenticates</h3>
+        <p>/sse and /messages/ both reach the full MCP tool surface, and neither was gated. The check existed but was a closure inside another transport's function. Transports now also refuse to start on a non-loopback bind with no authentication configured. (GHSA-2hh8-qjxc-43x3)</p>
       </div>
       <div class="feature-card" data-delay="300">
-        <div class="feature-icon http">&#128240;</div>
-        <h3>Three Hook Fixes, Two From the Community</h3>
-        <p>External contributor timkjr fixed hardcoded harvest wrapper timeouts and a settings-merge bug that could wipe a user's own hooks; alivirgo ported a Stop-hook transcript-pairing fix from the GitHub mirror. Plugin manifest bumped so installed users actually get them. (#321, #323, #330)</p>
+        <div class="feature-icon consolidation">&#128100;</div>
+        <h3>Self-Registration No Longer Grants Itself Write Access</h3>
+        <p>With open Dynamic Client Registration, a caller could register itself as confidential, exchange its own credentials, and hold a read-write token the owner never granted. Machine-to-machine grants now require gated registration; authorization_code with PKCE is unaffected. (GHSA-6mvm-q4j3-27qg)</p>
       </div>
     </div>
   </div>
@@ -298,7 +298,7 @@ footer a{color:var(--cyan)}
       <a href="blog/remote-mcp-tutorial.html" class="btn btn-secondary">
         Blog: 5-Min claude.ai Setup
       </a>
-      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v11.10.0" class="btn btn-secondary" target="_blank">
+      <a href="https://github.com/doobidoo/mcp-memory-service/releases/tag/v11.11.0" class="btn btn-secondary" target="_blank">
         Release Notes
       </a>
     </div>

--- a/src/mcp_memory_service/_version.py
+++ b/src/mcp_memory_service/_version.py
@@ -1,3 +1,3 @@
 """Version information for MCP Memory Service."""
 
-__version__ = "11.10.0"
+__version__ = "11.11.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "mcp-memory-service"
-version = "11.10.0"
+version = "11.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
MINOR, not PATCH, because two behaviours change. Both fail loudly rather than degrading quietly, which is deliberate: the configurations they break are the vulnerable ones.

- **`client_credentials` is refused while Dynamic Client Registration is open.** Set `MCP_DCR_REGISTRATION_KEY` and register with it, or use `authorization_code` with PKCE. That flow is what Claude.ai Remote MCP uses and is unaffected.
- **An MCP transport refuses to start on a non-loopback bind with no authentication configured.** Set `MCP_API_KEY`, enable OAuth, or bind to `127.0.0.1`.

## Contents

Three critical advisories reported by @alivirgo (#1090), and the move back to GitHub (#1084, #1085).

The advisories share a shape worth naming, and it is in the changelog for that reason: in each case the guard existed and was simply not reachable from where it was needed. `local_only_tools()` was applied by one transport out of three. The SSE auth check was a closure inside another transport's function. The `client_credentials` hardening from GHSA-5p27-64mv-pr73 checked how a client authenticates but not how it came to exist.

## Version files

`_version.py`, `pyproject.toml`, `README.md`, `CHANGELOG.md`, `uv.lock`, and `site/index.html` (required for MINOR, `version-drift-check` enforces it). `check_versions.sh` reports no drift, canonical v11.11.0.

`claude-hooks/.claude-plugin/plugin.json` goes to 1.0.5. The gate requires it because `claude-hooks/` changed this cycle, and the change is real rather than a formality: the marketplace homepage still pointed at the old forge.

`pyproject-lite.toml` deliberately untouched, the publish workflow force-syncs it from `_version.py`.

## Directive corrections

Three claims in `.claude/directives/version-management.md` went stale today and are fixed here, because the next release would follow them:

- It said there is no `gh`-based path for the release itself. Leftover from the forge flip, and it contradicted the sentence immediately before it.
- It said `main` carries no branch-protection rule. There is now a `ProtectMain` ruleset requiring a PR. Required approvals were dropped from 1 to 0 today, because the author cannot approve their own PR and a solo maintainer is always the author.
- It listed a "Current Version" line in `CLAUDE.md` as a required bump and told the reader to grep for it. That line was removed in #1085 in favour of a pointer to CHANGELOG, which is the actual fix for the problem it kept causing.

## After merge

Tag with git, not through the API. The v11.8.1 incident is in the directive: a tag created through the forge is not a push event, `release.yml` never fires, and a release object with notes looks exactly like a finished release.

```
git tag -a v11.11.0 -m "..." <merge-sha>
git push origin refs/tags/v11.11.0
```

Then verify the artifacts rather than the run: PyPI for both distributions, and all four Docker tags.