### PR TITLE
docs: record the partial-release failure mode

### DIFF
--- a/.claude/directives/version-management.md
+++ b/.claude/directives/version-management.md
@@ -66,6 +66,32 @@ curl -s -o /dev/null -w '%{http_code}\n' \
 PyPI's JSON endpoint lags the upload by a minute or two, so a stale version there right
 after a green publish job is cache, not failure — re-check before concluding anything.
 
+### A release can publish half of itself
+
+v11.11.0 on 2026-09-05: `Test` and `Publish to PyPI (main + lite)` green, `Publish
+Docker images` red at `docker login` with `unauthorized: incorrect username or
+password`. Both secrets were set (masked as `***` in the log, so neither was empty);
+the values were wrong. `DOCKER_PASSWORD` has to be a Docker Hub **access token**, not
+the account password.
+
+This looks nothing like the v11.8.1 failure above — there is a run, and two of three
+jobs are green — but for Docker users the effect is the same, and worse in one respect:
+`latest` kept pointing at the previous build, so the most-used tag served a version with
+three open critical advisories and nothing about the tag said so.
+
+Recover with a job re-run, never a dispatch:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+That repeats only the failed job and keeps `github.ref_name` at the tag, so the image
+tags still derive correctly. A `workflow_dispatch` from `main` would push junk `main`
+tags and clobber `latest`.
+
+**Create the release object last**, after the artifacts are verified. A release with
+notes looks finished, which is exactly what hid v11.8.1 for a day.
+
 `release.yml` has a `workflow_dispatch` fallback, but it is **PyPI catch-up only**: the
 Docker job derives its image tags from `github.ref_name`, so a manual dispatch from
 `main` pushes junk `main` tags and clobbers `latest`.


### PR DESCRIPTION
v11.11.0 published PyPI successfully and failed at the Docker Hub login. The directive only covered the total failure (a forge-API tag means `release.yml` never fires), which looks completely different in the run list but has the same effect for Docker users.

Records three things:

- The failure signature: two of three jobs green, `unauthorized: incorrect username or password`, both secrets set but wrong. `DOCKER_PASSWORD` has to be an access token, not the account password.
- Why it is worse than it looks: `latest` kept pointing at the previous build, so the most-used tag served a version with three open critical advisories and nothing about the tag said so.
- The recovery is `gh run rerun --failed`, not a dispatch. The job re-run keeps `github.ref_name` at the tag, which is what the image tags derive from; a dispatch from `main` pushes junk `main` tags and clobbers `latest`.

Plus the rule that fell out of it: create the release object **last**, after verifying artifacts. A release with notes looks finished, which is what hid v11.8.1 for a day.