### PR TITLE
chore(deps): bump github/codeql-action to v4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,13 +45,13 @@ jobs:
         pip install -e ".[sqlite]"
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: python
         queries: security-and-quality
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         category: "/language:python"


### PR DESCRIPTION
Dependabot hat den Bump auf zwei PRs aufgeteilt, #1080 fuer `init` und #1081 fuer `analyze`. Einzeln angewandt geht das nicht: #1080 laeuft rot mit

    Loaded a configuration file for version '4.37.9', but running version '4.37.8'

init und analyze muessen im selben Commit wandern. Dieser PR macht beides und ersetzt die zwei; die schliesse ich nach dem Merge.

Der Pin ist gegen die Forge geprueft, nicht gegen den Kommentar dahinter: `v4.37.9` ist ein annotated tag, dereferenziert auf `cdf488f595d80d6e07e03d4674febd5ab45fa938`.