### PR TITLE
chore(ci): stop dependabot from widening load-bearing bounds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
     ignore:
       - dependency-name: "setuptools"
         versions: [">=82"]
+      # The upper bounds on these two are load-bearing, not stale hygiene, and a
+      # group bump rewrites the constraint in pyproject.toml rather than
+      # respecting it. mcp 2.x drops `mcp.shared.session`, which breaks import
+      # of tests/unit/test_lm_studio_compat.py outright; pymilvus 3.x has no CI
+      # coverage here since the Milvus job was dropped, so a break would be
+      # silent (issue #261). Both were widened by accident once before (#976)
+      # and again in #1086. Lift an entry only together with its pyproject bound.
+      - dependency-name: "mcp"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pymilvus"
+        update-types: ["version-update:semver-major"]
     groups:
       uv:
         patterns:
@@ -26,3 +37,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    # codeql-action's init and analyze steps must move in the same commit.
+    # Bumped separately, analyze aborts with "Loaded a configuration file for
+    # version 'X', but running version 'Y'" -- which is how #1080 and #1081
+    # deadlocked each other. Grouping them makes that impossible.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Zwei Dinge, die diese Woche beide aufgeschlagen sind.

**uv-Gruppe.** #1086 hat `mcp<2.0.0` auf `<3.0.0` und `pymilvus<3.0.0` auf `<4.0.0` gehoben. Beide Grenzen stehen mit Begruendung in pyproject.toml, aber ein Gruppen-Bump schreibt das Constraint um statt es zu respektieren. mcp 2.x entfernt `mcp.shared.session` -- genau daran haengt der rote CI-Lauf von #1086:

    ModuleNotFoundError: No module named 'mcp.shared.session'

pymilvus 3.x haette gar keinen Test getroffen, seit der Milvus-Job weg ist (#261). Major-Updates fuer beide sind jetzt ignoriert; das Schliessen des PRs allein haette nichts unterdrueckt, weil die Gruppe aus einem `*`-Pattern gebaut ist.

**github-actions.** Bekommt eine Gruppe, damit `codeql-action/init` und `.../analyze` gemeinsam wandern. Getrennt blockieren sie sich gegenseitig (#1080/#1081), siehe #1129.