### PR TITLE
docs(site): redraw the deployment diagram for the GitHub topology

### DIFF
--- a/site/deployment/index.html
+++ b/site/deployment/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="generator" content="archify 2.16.0-dev.0">
-  <title>MCP Memory Service — Deployment Landscape Diagram</title>
+  <title>mcp-memory-service — release and mirror topology Diagram</title>
   <script>
     // Resolve the theme before first paint so light-preference users don't
     // see a dark flash. The toolbar script below re-applies with UI state.
@@ -4948,12 +4948,13 @@
            data-preset-badge-blueprint="BLUEPRINT / REV 01"
            data-preset-badge-editorial="EDITORIAL / FIELD NOTE">
         <div class="pulse-dot"></div>
-        <h1>MCP Memory Service — Deployment Landscape</h1>
+        <h1>mcp-memory-service — release and mirror topology</h1>
       </div>
+      <p class="subtitle">GitHub is origin, CI, releases and wiki since 5 September 2026</p>
     </div>
 
-    <script id="archify-guided-views-data" type="application/json">[{"id":"release-pfad","label":"Release path","focus":["mac","codeberg","runner","pypi","dockerhub"],"note":"A tag push to Codeberg starts release.yml on the Hetzner runner, which publishes to PyPI and Docker Hub."},{"id":"mirror-pfad","label":"Mirror path","focus":["codeberg","gitea","github","ghpages"],"note":"Both mirrors are one-way streets: Gitea pulls, and GitHub only ever receives a fast-forwarded main, never tags."},{"id":"site-pfad","label":"Site path","focus":["codeberg","runner","cfpages","ghpages"],"note":"A merge to main touching site/** deploys through wrangler to Cloudflare Pages; GitHub Pages only redirects there."}]</script>
-
+    <script id="archify-guided-views-data" type="application/json">[{"id":"release-path","label":"Release path","focus":["mac","github","ghactions","pypi","dockerhub"],"note":"A tag pushed with git starts release.yml on a GitHub-hosted runner, which publishes both distributions and the images."},{"id":"site-path","label":"Site path","focus":["github","ghactions","ghpages","cfpages"],"note":"A merge to main touching site/** deploys through wrangler. GitHub Pages only redirects to the same domain."},{"id":"copies","label":"Second copies","focus":["mac","gitlab","codeberg","gitea"],"note":"GitLab receives a fast-forwarded main and never tags. Codeberg is a frozen archive that nothing pushes to."}]</script>
+    <script id="archify-source-evidence-data" type="application/json">{"schemaVersion":1,"verified":true,"repository":{"url":"https://github.com/doobidoo/mcp-memory-service","revision":"cf728da4499763b15f759104a81fe17c63b26eba","shortRevision":"cf728da"},"referenceCount":4,"nodes":{"ghactions":[{"path":".github/workflows/release.yml","label":"release pipeline","href":"https://github.com/doobidoo/mcp-memory-service/blob/cf728da4499763b15f759104a81fe17c63b26eba/.github/workflows/release.yml"},{"path":".github/workflows/ci.yml","label":"CI","href":"https://github.com/doobidoo/mcp-memory-service/blob/cf728da4499763b15f759104a81fe17c63b26eba/.github/workflows/ci.yml"}],"ghpages":[{"path":"docs/index.html","label":"redirect stub","href":"https://github.com/doobidoo/mcp-memory-service/blob/cf728da4499763b15f759104a81fe17c63b26eba/docs/index.html"}],"cfpages":[{"path":".github/workflows/deploy-site.yml","label":"wrangler deploy","href":"https://github.com/doobidoo/mcp-memory-service/blob/cf728da4499763b15f759104a81fe17c63b26eba/.github/workflows/deploy-site.yml"}]}}</script>
     <script id="archify-i18n-data" type="application/json">{"locale":"en","messages":{"viewer.kind.frontend":"Frontend","viewer.kind.backend":"Backend","viewer.kind.database":"Database","viewer.kind.cloud":"Cloud","viewer.kind.security":"Security","viewer.kind.messagebus":"Message bus","viewer.kind.external":"External","viewer.kind.neutral":"Neutral","viewer.kind.node":"Node","viewer.kind.start":"Start","viewer.kind.active":"Active","viewer.kind.waiting":"Waiting","viewer.kind.decision":"Decision","viewer.kind.success":"Success","viewer.kind.failure":"Failure","viewer.toolbar.actions":"Diagram actions","viewer.theme.toggle.title":"Toggle theme (T)","viewer.theme.toggle":"Toggle color theme","viewer.theme.dark":"Dark","viewer.theme.light":"Light","viewer.preset.choose.title":"Choose visual style (S cycles)","viewer.preset.choose":"Choose visual style","viewer.preset.style":"Style","viewer.preset.menu":"Visual style","viewer.preset.identity":"Visual identity","viewer.preset.cycles":"S cycles","viewer.preset.classic":"Classic","viewer.preset.classic.short":"Classic","viewer.preset.classic.hint":"Stable technical default","viewer.preset.flow":"Signal Flow","viewer.preset.flow.short":"Flow","viewer.preset.flow.hint":"Motion-forward presentation","viewer.preset.blueprint":"Blueprint","viewer.preset.blueprint.hint":"Engineering review","viewer.preset.editorial":"Editorial","viewer.preset.editorial.hint":"Publication and launch notes","viewer.preset.badge.signalFlow":"SIGNAL FLOW","viewer.preset.badge.blueprint":"BLUEPRINT / REV 01","viewer.preset.badge.editorial":"EDITORIAL / FIELD NOTE","viewer.preset.badge.editorialPlate":"ARCHIFY / PLATE 04","viewer.preset.current":"Visual style: {style}. Choose visual style","viewer.motion.live":"Live","viewer.motion.still":"Still","viewer.motion.pause":"Pause motion","viewer.motion.resume":"Resume motion","viewer.motion.reduced":"Motion paused by reduced-motion preference","viewer.motion.hidden":"Motion paused while this page is hidden","viewer.motion.yielding":"Pause motion; currently yielding to {owner}","viewer.motion.yielding.title":"Live preview enabled · yielding to {owner}","viewer.owner.story":"the guided story","viewer.owner.chapter":"the active chapter","viewer.owner.chapterPreview":"the chapter delta preview","viewer.owner.handoff":"the chapter handoff","viewer.owner.route":"Route Probe","viewer.owner.lens":"Semantic Lens","viewer.owner.relationship":"Relationship Preview","viewer.owner.intent":"Intent Trace","viewer.owner.focus":"semantic focus","viewer.owner.legend":"legend preview","viewer.owner.reader":"reader interaction","viewer.present.enter":"Enter presentation stage","viewer.present.enter.title":"Presentation stage (F)","viewer.present.exit":"Exit presentation stage","viewer.present.exit.title":"Exit presentation stage (F or Escape)","viewer.present.present":"Present","viewer.present.exit.label":"Exit","viewer.export.button":"Export","viewer.export.button.title":"Export diagram (E)","viewer.export.diagram":"Export diagram","viewer.export.menu":"Export","viewer.export.subtitle":"Portable, clean outputs","viewer.export.share":"Share","viewer.export.shareCard":"Share Card","viewer.export.routeShareCard":"Route Share Card","viewer.export.reachShareCard":"Reach Share Card","viewer.export.copyShareCard":"Copy Share Card","viewer.export.copyDiagram":"Copy diagram","viewer.export.clipboardPng":"PNG to clipboard","viewer.export.raster":"Raster images","viewer.export.image":"Image","viewer.export.lossless":"Lossless image","viewer.export.compact":"Compact image","viewer.export.modern":"Modern image","viewer.export.vectorMotion":"Vector and motion","viewer.export.vectorMotion.heading":"Vector \u0026 motion","viewer.export.editable":"Editable vector","viewer.export.motion6s":"6s motion","viewer.export.unsupported":"Not supported by this browser","viewer.export.clipboardUnsupported":"Clipboard image write not supported by this browser","viewer.export.clipboardUnsupported.period":"Clipboard image write not supported by this browser.","viewer.export.clipboardUnsupported.short":"Clipboard image write not supported in this browser.","viewer.export.motionUnavailable":"Motion capture unavailable in this browser","viewer.export.webmUnavailable":"WebM unavailable in this browser","viewer.export.failed":"Export failed: {message}","viewer.export.unknownVariant":"Unknown Share Card variant: {variant}","viewer.export.routeRequired":"Trace a route before exporting a Route Share Card","viewer.export.reachRequired":"Trace authored reach before exporting a Reach Share Card","viewer.export.unknown":"unknown","viewer.export.routeFailed":"Route Share Card export failed: {message}","viewer.export.reachFailed":"Reach Share Card export failed: {message}","viewer.export.copyFailed":"Copy failed: {message}","viewer.export.copiedPng":"Copied PNG to clipboard","viewer.export.copiedShare":"Copied Share Card","viewer.export.downloadedShare":"Downloaded Share Card","viewer.export.downloadedRoute":"Downloaded Route Share Card","viewer.export.downloadedReach":"Downloaded Reach Share Card","viewer.export.downloadedWebm":"Downloaded WebM","viewer.export.recording":"Recording 6 seconds of motion…","viewer.export.card.routeSummary.one":"Route: {source} → {target} · {count} directed hop","viewer.export.card.routeSummary.other":"Route: {source} → {target} · {count} directed hops","viewer.export.card.reachSummary":"Authored {direction} from {origin} · {nodes} · {links} · max {hops}","viewer.export.card.node.one":"{count} node","viewer.export.card.node.other":"{count} nodes","viewer.export.card.link.one":"{count} link","viewer.export.card.link.other":"{count} links","viewer.export.card.hop.one":"{count} hop","viewer.export.card.hop.other":"{count} hops","viewer.export.card.routeBadge":"ARCHIFY · ROUTE · {hops}","viewer.export.card.reachBadge":"ARCHIFY · {direction} REACH","viewer.export.card.defaultBadge":"ARCHIFY · {preset} · {theme}","viewer.export.direction.upstream":"Upstream","viewer.export.direction.downstream":"Downstream","viewer.export.error.canvasUnavailable":"Canvas unavailable for {label}","viewer.export.error.contextUnavailable":"2D canvas context unavailable for {label}","viewer.export.error.toBlobUnavailable":"canvas.toBlob unavailable for {label}","viewer.export.error.toBlobNull":"canvas.toBlob returned no data for {label}","viewer.export.error.variantsCombined":"Share Card variants cannot be combined","viewer.export.error.viewerState":"Share Card export could not remove temporary viewer state","viewer.export.error.routeState":"Route Card export could not preserve the resolved route safely","viewer.export.error.reachState":"Reach Card export could not preserve authored reach safely","viewer.export.error.webmRequirements":"WebM motion export requires a trace animation and browser MediaRecorder support","viewer.export.error.mediaRecorder":"MediaRecorder failed","viewer.export.error.emptyWebm":"MediaRecorder produced an empty WebM","viewer.export.error.webmBackground":"SVG background could not be loaded for WebM export","viewer.guided.region":"Guided diagram views","viewer.guided.previous":"Previous guided view","viewer.guided.previous.title":"Previous guided view ([)","viewer.guided.next":"Next guided view","viewer.guided.next.title":"Next guided view (])","viewer.guided.views":"Guided views","viewer.guided.explore":"Explore this system","viewer.guided.intro":"Step through curated paths without changing the source diagram.","viewer.guided.trail":"Story trail","viewer.guided.beat":"Beat","viewer.guided.nextBeat":"Next","viewer.guided.play":"Play guided story","viewer.guided.play.title":"Play guided story (P)","viewer.guided.pause":"Pause guided story","viewer.guided.pause.title":"Pause guided story (P)","viewer.guided.replay":"Replay guided story","viewer.guided.replay.title":"Replay guided story (P)","viewer.guided.playStory":"Play story","viewer.guided.pauseStory":"Pause","viewer.guided.replayStory":"Replay story","viewer.guided.motionUnavailable":"Story playback unavailable while motion is Still","viewer.guided.enableMotion":"Switch motion to Live to play the guided story","viewer.guided.selectBeatLink":"Select a Story Beat to copy its exact link","viewer.guided.copyMoment":"Copy moment","viewer.guided.momentCopied":"Moment link copied","viewer.guided.momentCopyFailed":"Could not copy story moment link","viewer.guided.copied":"Copied","viewer.guided.copyFailed":"Copy failed","viewer.guided.showAll":"Show all","viewer.guided.showAll.aria":"Show entire diagram","viewer.guided.chapters":"Story chapters","viewer.guided.storyTrail":"Story trail for {label}: {count} beats","viewer.guided.chapter.open":"Open chapter {index} of {total}: {label}, {count} stops","viewer.guided.chapter.current":"Current chapter {index} of {total}: {label}, {count} stops","viewer.guided.chapter.selectedNodes":"{count} selected nodes","viewer.guided.chapter.stops":"{count} stops","viewer.guided.chapter.stop.one":"{count} stop","viewer.guided.chapter.stop.other":"{count} stops","viewer.guided.chapter.current.title":"{label} — current chapter, {count} stops","viewer.guided.chapter.delta.expanded":"{stay} stay, {enter} enter, {leave} leave","viewer.guided.chapter.delta.aria":"Open chapter {index} of {total}: {label}. Chapter focus delta: {delta}","viewer.guided.chapter.delta.title":"{label} — {delta} chapter focus","viewer.guided.handoff":"{from} → {to} · via {label}","viewer.guided.share.chapter":"Chapter {index} / {total}","viewer.guided.share.initial":"Chapter 01 / 01","viewer.guided.share.default":"Guided chapter","viewer.guided.state.ready":"Ready","viewer.guided.state.playing":"Playing","viewer.guided.state.settled":"Settled","viewer.guided.state.paused":"Paused","viewer.guided.state.pinned":"Pinned","viewer.guided.state.still":"Still","viewer.guided.share.step":"Step {index} / {total} · {label}","viewer.guided.share.staticMoment":"{step} · Static moment","viewer.guided.share.complete":"{count} steps complete · {note}","viewer.guided.share.settled":"Path settled for reading.","viewer.guided.share.staticPath":"{count} steps · Static path","viewer.guided.share.ready":"{count} steps · Ready","viewer.guided.share.aria":"{state} chapter {index} of {total}: {label}. {beat}. {route}","viewer.guided.beat.start":"Beat {index} / {total} · {label} · starting point","viewer.guided.beat.forward":"Beat {index} / {total} · {from} → {to}","viewer.guided.beat.reverse":"Beat {index} / {total} · {from} → {to} · reverse authored link","viewer.guided.beat.multiple":"Beat {index} / {total} · {from} ⇄ {to} · {count} authored links","viewer.guided.beat.group":"Beat {index} / {total} · {from} · {to} · grouped · no direct link","viewer.guided.beat.aria.prefix":"Story beat {index} of {total}: {label}. ","viewer.guided.beat.aria.start":"Starting point.","viewer.guided.beat.aria.forward":"From {from} through one authored forward relationship.","viewer.guided.beat.aria.reverse":"From {from}; the authored relationship points from {to} to {from}.","viewer.guided.beat.aria.multiple":"From {from} through {count} authored relationships; shown without arbitrary motion.","viewer.guided.beat.aria.group":"Grouped from {from} with no direct authored relationship.","viewer.guided.caption.start":"Starting point","viewer.guided.caption.grouped":"Grouped transition · no direct authored link","viewer.guided.caption.more":" +{count} more","viewer.guided.caption.reverse":"Reverse authored relationship","viewer.guided.caption.relationships":"{count} authored relationships","viewer.guided.caption.relationship":"Authored relationship","viewer.guided.caption.direction":"authored direction: {from} → {to}","viewer.guided.caption.starting":"Authored starting point","viewer.guided.beatLink":"Copy link to current story moment: Beat {index} of {total}: {label}","viewer.guided.noStory":"This diagram has no authored guided story.","viewer.guide.eyebrow":"Diagram guide","viewer.guide.close":"Close diagram guide","viewer.guide.inspecting":"Inspecting compiled semantics","viewer.guide.actions":"Diagram exploration actions","viewer.guide.find":"Find any node","viewer.guide.find.hint":"Search labels, responsibilities, kinds, and stable IDs.","viewer.guide.route":"Trace a route","viewer.guide.route.aria":"Trace a directed route","viewer.guide.route.hint":"Ask how two semantic nodes connect in authored direction.","viewer.guide.map":"See the whole system","viewer.guide.map.hint":"Open Semantic Radar with a live viewport and stable nodes.","viewer.guide.lens":"Compare semantic kinds","viewer.guide.lens.hint":"Count roles, reveal their traffic, and compare direct authored links.","viewer.guide.story":"Play the guided story","viewer.guide.story.hint":"Walk the authored chapters and real relationships.","viewer.guide.present":"Enter Presentation Stage","viewer.guide.present.hint":"Give the live diagram the viewport without changing export.","viewer.guide.shortcuts":"Additional keyboard shortcuts","viewer.guide.shortcut.export":"Export","viewer.guide.shortcut.theme":"Theme","viewer.guide.shortcut.style":"Style","viewer.guide.shortcut.reset":"Reset","viewer.guide.shortcut.zoomIn":"Zoom in","viewer.guide.shortcut.zoomOut":"Zoom out","viewer.guide.shortcut.close":"Close","viewer.guide.facts":"{nodes} · {relationships} · {views}","viewer.guide.fact.node.one":"{count} semantic node","viewer.guide.fact.node.other":"{count} semantic nodes","viewer.guide.fact.relationship.one":"{count} relationship","viewer.guide.fact.relationship.other":"{count} relationships","viewer.guide.fact.view.one":"{count} guided view","viewer.guide.fact.view.other":"{count} guided views","viewer.guide.story.available.one":"Walk {count} authored chapter and its real relationships.","viewer.guide.story.available.other":"Walk {count} authored chapters and their real relationships.","viewer.guide.story.unavailable":"No authored guided story in this diagram.","viewer.guide.open":"Open diagram guide","viewer.guide.noStory":"This diagram has no authored guided story.","viewer.finder.title":"Find a node","viewer.finder.close":"Close node finder","viewer.finder.placeholder":"Search labels or IDs","viewer.finder.search":"Search diagram nodes","viewer.finder.results":"Diagram nodes","viewer.finder.empty":"No matching nodes","viewer.finder.result.focus":"Focus {label}","viewer.finder.result.routeStart":"Choose {label} as route start","viewer.finder.result.routeTarget":"Choose {label} as route destination, {links}","viewer.finder.status.empty":"No matching nodes","viewer.finder.status.count.one":"{count} matching node","viewer.finder.status.count.other":"{count} matching nodes","viewer.finder.noun.nodes":"nodes","viewer.finder.link.one":"{count} link","viewer.finder.link.other":"{count} links","viewer.finder.result.focus.one":"Focus {label}, {count} related connection","viewer.finder.result.focus.other":"Focus {label}, {count} related connections","viewer.finder.status.filtered":"{visible} of {available} {noun}","viewer.finder.status.all":"{available} {noun}","viewer.passport.eyebrow":"Semantic passport","viewer.passport.metadata":"Node metadata","viewer.passport.evidence":"Verified source evidence","viewer.passport.verified":"Verified source","viewer.passport.reach":"Authored reach","viewer.passport.reach.trace":"Trace authored reachability","viewer.passport.upstream":"Upstream","viewer.passport.downstream":"Downstream","viewer.passport.upstream.trace":"Trace upstream authored reachability","viewer.passport.downstream.trace":"Trace downstream authored reachability","viewer.passport.close":"Close semantic passport","viewer.passport.copy":"Copy link","viewer.passport.copy.focus":"Copy link to focused node","viewer.passport.relations":"Relations","viewer.passport.relations.show":"Show connected relationships","viewer.passport.relations.hide":"Hide connected relationships","viewer.passport.relations.list":"Connected relationships","viewer.passport.copyRelation":"Copy relation","viewer.passport.copyNode":"Copy node","viewer.passport.copyPinned":"Copy link to pinned relationship","viewer.passport.copySource":"Copy link to source node","viewer.passport.copy.focused.success":"Focused node link copied","viewer.passport.copy.pinned.success":"Pinned relationship link copied","viewer.passport.copy.focused.failed":"Could not copy focused node link","viewer.passport.copy.pinned.failed":"Could not copy pinned relationship link","viewer.passport.relationship.none":"No connected relationships","viewer.passport.relationship.count.one":"{count} relation","viewer.passport.relationship.count.other":"{count} relations","viewer.passport.relationship.show.one":"Show {count} connected relationship","viewer.passport.relationship.show.other":"Show {count} connected relationships","viewer.passport.relationship.summary":"{out} outgoing · {in} incoming{loops}","viewer.passport.relationship.loops":" · {count} loop","viewer.passport.relationship.explorer":"Direct relationship explorer","viewer.passport.relationship.help":"Use arrow keys to explore relationships. Press Enter or Space to pin details; Escape clears.","viewer.passport.relationship.loopsBack":"loops back","viewer.passport.relationship.connectsTo":"connects to","viewer.passport.relationship.connectsFrom":"connects from","viewer.passport.relationship.pinned":"Pinned relationship · {from} → {to} · {label}","viewer.passport.relationship.inspect":"Inspect relationship {index} of {total}: {from} to {to}, {label}. Press Enter for details.","viewer.passport.relationship.group.out":"Outgoing","viewer.passport.relationship.group.in":"Incoming","viewer.passport.relationship.group.loop":"Self loops","viewer.passport.relationship.row":"{group}: {relationship}, {neighbor}","viewer.passport.relationship.direction.out":"OUT →","viewer.passport.relationship.direction.in":"← IN","viewer.passport.relationship.direction.loop":"LOOP","viewer.passport.sourceCount.one":"{count} verified source reference","viewer.passport.sourceCount.other":"{count} verified source references","viewer.passport.sourceMarker":"SRC","viewer.passport.beacon.one":"{count} verified source; focus this node to inspect","viewer.passport.beacon.other":"{count} verified sources; focus this node to inspect","viewer.passport.repository.open":"Open verified repository revision {revision}","viewer.passport.source.open":"Open verified source {path} at revision {revision}","viewer.passport.source.openLink":"Open ↗","viewer.passport.reach.upstream.one":"Trace {count} upstream authored node","viewer.passport.reach.upstream.other":"Trace {count} upstream authored nodes","viewer.passport.reach.downstream.one":"Trace {count} downstream authored node","viewer.passport.reach.downstream.other":"Trace {count} downstream authored nodes","viewer.passport.reach.noUpstream":"No upstream authored nodes","viewer.passport.reach.noDownstream":"No downstream authored nodes","viewer.passport.reach.status":"{direction} · {nodes} nodes · {links} links · max {hops} hops","viewer.route.eyebrow":"Route probe","viewer.route.start":"Choose a start node","viewer.route.start.find":"Find start","viewer.route.start.find.aria":"Find a route start","viewer.route.copy":"Copy link","viewer.route.copy.aria":"Copy link to traced route","viewer.route.clear":"Clear","viewer.route.clear.aria":"Clear route probe","viewer.route.traced":"Traced route","viewer.route.pickTwo":"Pick two semantic nodes on the diagram","viewer.route.pickOne":"Pick a semantic node on the diagram","viewer.route.controls":"Route journey controls","viewer.route.previous":"Previous route position","viewer.route.play":"Play route journey","viewer.route.pause":"Pause route journey","viewer.route.replay":"Replay route journey","viewer.route.next":"Next route position","viewer.route.journey":"Journey","viewer.route.pause.label":"Pause","viewer.route.replay.label":"Replay","viewer.route.overview":"Overview","viewer.route.overview.aria":"Show complete route overview","viewer.route.instructions":"Choose the source, then the destination. Direction matters.","viewer.route.destination":"Choose a destination from {label}","viewer.route.destination.find":"Find target","viewer.route.destination.find.aria":"Find a reachable route destination","viewer.route.differentDestination":"Choose a different destination","viewer.route.distinct":"A route needs two distinct semantic nodes.","viewer.route.unreachable":"No directed route to {label}","viewer.route.unreachable.detail":"{target} is not reachable from {source}. Pick a highlighted destination.","viewer.route.start.instructions":"Select the source. The next step will reveal only directed destinations.","viewer.route.copy.success":"Traced route link copied","viewer.route.copy.failed":"Could not copy traced route link","viewer.route.position":"Route position {index} of {total}: {label}","viewer.route.step":"Step {index} of {total} · {phase} · {label}","viewer.route.motionRequired":"Automatic journey requires Live motion","viewer.route.trigger.clear":"Clear traced route","viewer.route.overview.status":"{nodes} · {hops} · shortest authored route","viewer.route.overview.node.one":"{count} node","viewer.route.overview.node.other":"{count} nodes","viewer.route.overview.hop.one":"{count} directed hop","viewer.route.overview.hop.other":"{count} directed hops","viewer.route.phase.playing":"Playing","viewer.route.phase.complete":"Complete","viewer.route.phase.inspecting":"Inspecting","viewer.route.destination.count.one":"{count} directed destination available. Pick a highlighted node.","viewer.route.destination.count.other":"{count} directed destinations available. Pick a highlighted node.","viewer.route.noOutgoing":"No outgoing route starts here. Clear and choose another source.","viewer.route.result.title":"{source} to {target}","viewer.route.finder.source.title":"Choose route start","viewer.route.finder.source.placeholder":"Search route sources","viewer.route.finder.source.empty":"No matching route sources","viewer.route.finder.source.results":"Nodes that can start a route","viewer.route.finder.source.noun":"route sources","viewer.route.finder.source.badge":"start","viewer.route.finder.target.title":"Destination from {label}","viewer.route.finder.target.placeholder":"Search reachable destinations","viewer.route.finder.target.empty":"No matching reachable destinations","viewer.route.finder.target.results":"Reachable route destinations","viewer.route.finder.target.noun":"reachable destinations","viewer.route.hop.one":"{count} hop","viewer.route.hop.other":"{count} hops","viewer.lens.eyebrow":"Semantic lens","viewer.lens.title":"Compare system roles","viewer.lens.close":"Close semantic lens","viewer.lens.instruction":"Choose up to two semantic kinds. One reveals its real traffic; two compare only direct authored relationships.","viewer.lens.kinds":"Semantic kinds","viewer.lens.choose":"Choose a kind to inspect its nodes and touching relationships.","viewer.lens.copy":"Copy link to semantic lens","viewer.lens.clear":"Clear semantic lens","viewer.lens.open":"Open semantic lens","viewer.lens.openActive":"Open active semantic lens","viewer.lens.legend":"Semantic legend","viewer.lens.legend.inspect.one":"Inspect {label}, {count} node","viewer.lens.legend.inspect.other":"Inspect {label}, {count} nodes","viewer.lens.kind.count.one":"{label}, {count} node","viewer.lens.kind.count.other":"{label}, {count} nodes","viewer.lens.compare.one":"{first} → {second}: {forward} · {second} → {first}: {reverse} · {count} direct relationship","viewer.lens.compare.other":"{first} → {second}: {forward} · {second} → {first}: {reverse} · {count} direct relationships","viewer.lens.single":"{nodes} · {relationships} · connected peers remain visible","viewer.lens.node.one":"{count} {label} node","viewer.lens.node.other":"{count} {label} nodes","viewer.lens.relationship.one":"{count} touching relationship","viewer.lens.relationship.other":"{count} touching relationships","viewer.radar.title":"Semantic radar","viewer.radar.building":"Building overview","viewer.radar.openFull":"Open full semantic radar","viewer.radar.open":"Open radar","viewer.radar.close":"Close semantic radar","viewer.radar.surface":"Diagram overview. Click a node to focus it, or use arrow keys to pan.","viewer.radar.click":"Click node","viewer.radar.drag":"Drag to pan","viewer.radar.space":"Semantic radar needs more MAP space.","viewer.radar.nodes":"Semantic diagram radar nodes","viewer.radar.focus":"Focus {label} from Semantic Radar","viewer.radar.status":"{count} nodes · {viewport}","viewer.radar.fullMap":"{count} nodes · full map","viewer.radar.compacted":"Radar compacted to avoid covering the Semantic Passport or MAP controls.","viewer.radar.cancelWaiting":"Cancel semantic radar waiting for more MAP space","viewer.radar.needsSpace":"Semantic radar needs more visible MAP space","viewer.radar.viewport.full":"full map","viewer.radar.viewport.width":"{percent}% width","viewer.radar.viewport.scale":"{percent}% viewport","viewer.nav.controls":"Diagram view controls","viewer.nav.route":"Trace a directed route","viewer.nav.route.title":"Trace route (R)","viewer.nav.route.short":"PATH","viewer.nav.radar":"Open semantic radar","viewer.nav.radar.title":"Semantic radar (M)","viewer.nav.radar.short":"MAP","viewer.nav.lens":"Open semantic lens","viewer.nav.lens.title":"Semantic lens (L)","viewer.nav.lens.short":"LENS","viewer.nav.find":"Find a node","viewer.nav.find.title":"Find a node (/)","viewer.nav.guide":"Open diagram guide","viewer.nav.guide.title":"Diagram guide (?)","viewer.nav.zoomOut":"Zoom out","viewer.nav.zoomOut.title":"Zoom out (-)","viewer.nav.reset":"Reset diagram view","viewer.nav.reset.title":"Reset view (0)","viewer.nav.read":"READ","viewer.nav.zoomIn":"Zoom in","viewer.nav.zoomIn.title":"Zoom in (+)","viewer.nav.camera":"{hint}. Reset diagram view","viewer.nav.camera.title":"{semantic}{hint} · reset view (0)","viewer.nav.camera.semantic":"Semantic camera active · ","viewer.nav.level.map":"MAP","viewer.nav.level.read":"READ","viewer.nav.level.full":"FULL","viewer.nav.level.auto":"AUTO","viewer.nav.detail.map":"Zoom in to reveal relationship labels and node context","viewer.nav.detail.read":"Zoom in again to reveal tags and annotations","viewer.nav.detail.full":"Full diagram detail","viewer.intent.summary":"{label}. {out} outgoing, {in} incoming{loops}. {total} connections. Press Enter for details.","viewer.intent.loops":", {count} self loop","viewer.common.copied":"Copied","viewer.common.copyFailed":"Copy failed","viewer.common.copyLink":"Copy link","viewer.common.clear":"Clear","viewer.common.close":"Close"}}</script>
     <div class="guided-views no-print" id="guided-views" hidden aria-label="Guided diagram views">
       <button id="guided-view-prev" type="button" aria-label="Previous guided view" title="Previous guided view ([)">&#8592;</button>
@@ -4997,9 +4998,9 @@
     <!-- Main Diagram -->
     <div class="diagram-container" data-detail-level="read"
          data-preset-badge-editorial-plate="ARCHIFY / PLATE 04">
-      <svg viewBox="0 0 1200 500" role="img" lang="en" aria-labelledby="archify-diagram-title archify-diagram-description" data-preset="classic" data-quality-profile="showcase">
-        <title id="archify-diagram-title">MCP Memory Service — Deployment Landscape</title>
-        <desc id="archify-diagram-description">An architecture diagram generated by Archify.</desc>
+      <svg viewBox="0 0 1340 585" role="img" lang="en" aria-labelledby="archify-diagram-title archify-diagram-description" data-preset="classic" data-engineering-profile="deployment-ownership" data-quality-profile="showcase">
+        <title id="archify-diagram-title">mcp-memory-service — release and mirror topology</title>
+        <desc id="archify-diagram-description">GitHub is origin, CI, releases and wiki since 5 September 2026</desc>
         <!-- Definitions -->
         <defs>
           <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
@@ -5023,175 +5024,211 @@
         <rect width="100%" height="100%" fill="url(#grid)" />
 
         <!-- Boundaries (behind everything) -->
-        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="0" data-composition-frame-label="Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1)" x="568" y="94" width="204" height="310" rx="12" class="c-region" stroke-width="1"/>
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="0" data-composition-frame-label="github.com" x="228" y="208" width="444" height="244" rx="12" class="c-region" stroke-width="1"/>
 
-        <rect data-graph-role="structural-frame" data-composition-frame-kind="security-group" data-composition-frame-id="1" data-composition-frame-label="reachable only over the Tailnet" x="576" y="296" width="188" height="108" rx="8" class="c-security-group" stroke-width="1"/>
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="security-group" data-composition-frame-id="1" data-composition-frame-label="the only place repository secrets live" x="238" y="226" width="424" height="106" rx="8" class="c-security-group" stroke-width="1"/>
+
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="2" data-composition-frame-label="Cloudflare" x="734" y="346" width="192" height="106" rx="12" class="c-region" stroke-width="1"/>
+
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="3" data-composition-frame-label="gitlab.com / private" x="234" y="466" width="182" height="106" rx="12" class="c-region" stroke-width="1"/>
+
+        <rect data-graph-role="structural-frame" data-composition-frame-kind="region" data-composition-frame-id="4" data-composition-frame-label="tinyclaw · Hetzner VM" x="1134" y="466" width="182" height="106" rx="12" class="c-region" stroke-width="1"/>
 
         <!-- Connection paths (before components for correct z-order) -->
-        <path data-edge-from="mac" data-edge-to="codeberg" data-edge-label="git push + tag" data-edge-key="0" data-composition-points="180,255;300,255" d="M 180 255 L 300 255" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path data-edge-from="codeberg" data-edge-to="runner" data-edge-label="Forgejo Actions" data-edge-key="1" data-composition-points="460,255;525,255;525,150;590,150" d="M 460 255 L 517 255 Q 525 255 525 247 L 525 158 Q 525 150 533 150 L 590 150" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path data-edge-from="codeberg" data-edge-to="gitea" data-edge-label="pulls every 8h" data-edge-key="2" data-composition-points="460,269;525,269;525,352;590,352" d="M 460 269 L 517 269 Q 525 269 525 277 L 525 344 Q 525 352 533 352 L 590 352" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
-        <path data-edge-from="runner" data-edge-to="pypi" data-edge-label="tag v* → publish-pypi" data-edge-key="3" data-composition-points="750,136;875,136;875,71;1000,71" d="M 750 136 L 867 136 Q 875 136 875 128 L 875 79 Q 875 71 883 71 L 1000 71" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-        <path data-edge-from="runner" data-edge-to="dockerhub" data-edge-label="tag v* → buildx push" data-edge-key="4" data-composition-points="750,150;875,150;875,191;1000,191" d="M 750 150 L 867 150 Q 875 150 875 158 L 875 183 Q 875 191 883 191 L 1000 191" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-        <path data-edge-from="runner" data-edge-to="cfpages" data-edge-label="site/** → wrangler" data-edge-key="5" data-composition-points="750,164;875,164;875,345;1000,345" d="M 750 164 L 867 164 Q 875 164 875 172 L 875 337 Q 875 345 883 345 L 1000 345" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
-        <path data-edge-from="mac" data-edge-to="github" data-edge-label="fast-forward main, never tags" data-edge-key="6" data-composition-points="180,269;240,269;240,452;300,452" d="M 180 269 L 232 269 Q 240 269 240 277 L 240 444 Q 240 452 248 452 L 300 452" class="a-security" stroke-width="1.5" marker-end="url(#arrowhead-security)"/>
-        <path data-edge-from="github" data-edge-to="ghpages" data-edge-label="serves docs/" data-edge-key="7" data-composition-points="460,452;590,452" d="M 460 452 L 590 452" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
-        <path data-edge-from="ghpages" data-edge-to="cfpages" data-edge-label="redirect" data-edge-key="8" data-composition-points="750,452;875,452;875,359;1000,359" d="M 750 452 L 867 452 Q 875 452 875 444 L 875 367 Q 875 359 883 359 L 1000 359" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
+        <path data-edge-from="mac" data-edge-to="github" data-edge-label="git push + tag" data-edge-key="0" data-composition-points="172,274;250,274" d="M 172 274 L 250 274" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path data-edge-from="github" data-edge-to="ghactions" data-edge-label="push · tag v*" data-edge-key="1" data-composition-points="400,274;500,274" d="M 400 274 L 500 274" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path data-edge-from="ghactions" data-edge-to="pypi" data-edge-label="release.yml" data-edge-key="2" data-composition-points="650,267;795,267;795,171;940,171" d="M 650 267 L 787 267 Q 795 267 795 259 L 795 179 Q 795 171 803 171 L 940 171" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <path data-edge-from="ghactions" data-edge-to="dockerhub" data-edge-label="buildx push" data-edge-key="3" data-composition-points="650,281;940,281" d="M 650 281 L 940 281" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <path data-edge-from="ghactions" data-edge-to="cfpages" data-edge-label="site/** → wrangler" data-edge-key="4" data-composition-points="650,295;700,295;700,394;750,394" d="M 650 295 L 692 295 Q 700 295 700 303 L 700 386 Q 700 394 708 394 L 750 394" class="a-default" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+        <path data-edge-from="github" data-edge-to="ghpages" data-edge-label="serves docs/" data-edge-key="5" data-composition-points="400,288;450,288;450,401;500,401" d="M 400 288 L 442 288 Q 450 288 450 296 L 450 393 Q 450 401 458 401 L 500 401" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
+        <path data-edge-from="ghpages" data-edge-to="cfpages" data-edge-label="redirect" data-edge-key="6" data-composition-points="650,408;750,408" d="M 650 408 L 750 408" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
+        <path data-edge-from="mac" data-edge-to="gitlab" data-edge-label="fast-forward main, never tags" data-edge-key="7" data-composition-points="172,288;211,288;211,521;250,521" d="M 172 288 L 203 288 Q 211 288 211 296 L 211 513 Q 211 521 219 521 L 250 521" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
+        <path data-edge-from="codeberg" data-edge-to="gitea" data-edge-label="pulled every 8h" data-edge-key="8" data-composition-points="1010,521;1150,521" d="M 1010 521 L 1150 521" class="a-dashed" stroke-width="1.5" marker-end="url(#arrowhead-dashed)"/>
 
         <!-- Components -->
-        <g id="node-mac" data-node-id="mac" data-node-label="Developer Mac" tabindex="0" role="button" aria-label="Focus Developer Mac, local work, manual pushes, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="local work, manual pushes" data-node-context="Architecture component">
-          <title>Developer Mac · local work, manual pushes · Architecture component</title>
-          <rect x="30" y="230" width="150" height="64" rx="6" class="c-mask"/>
-          <rect x="30" y="230" width="150" height="64" rx="6" class="c-external" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(36 236) scale(0.6875)">
+        <g id="node-mac" data-node-id="mac" data-node-label="Developer Mac" tabindex="0" role="button" aria-label="Focus Developer Mac, manual pushes, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="manual pushes" data-node-context="Architecture component">
+          <title>Developer Mac · manual pushes · Architecture component</title>
+          <rect x="40" y="250" width="132" height="62" rx="6" class="c-mask"/>
+          <rect x="40" y="250" width="132" height="62" rx="6" class="c-external" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(46 256) scale(0.6875)">
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-node-label data-detail-anchor x="105" y="260" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Developer Mac</text>
-        <text data-detail="context" x="105" y="276" class="t-muted" font-size="9" text-anchor="middle">local work, manual pushes</text>
+          <text data-node-label data-detail-anchor x="106" y="279" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Developer Mac</text>
+        <text data-detail="context" x="106" y="295" class="t-muted" font-size="9" text-anchor="middle">manual pushes</text>
         </g>
 
-        <g id="node-codeberg" data-node-id="codeberg" data-node-label="Codeberg" tabindex="0" role="button" aria-label="Focus Codeberg, origin · issues · PRs · releases, Architecture component" aria-pressed="false" data-node-kind="backend" data-node-sublabel="origin · issues · PRs · releases" data-node-tag="leading" data-node-context="Architecture component">
-          <title>Codeberg · origin · issues · PRs · releases · Architecture component · leading</title>
-          <rect x="300" y="230" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="300" y="230" width="160" height="64" rx="6" class="c-backend" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(306 236) scale(0.6875)">
+        <g id="node-github" data-node-id="github" data-node-label="GitHub" tabindex="0" role="button" aria-label="Focus GitHub, origin · issues · PRs, github.com › the only place repository secrets live" aria-pressed="false" data-node-kind="backend" data-node-sublabel="origin · issues · PRs" data-node-tag="leading" data-node-context="github.com › the only place repository secrets live">
+          <title>GitHub · origin · issues · PRs · github.com › the only place repository secrets live · leading</title>
+          <rect x="250" y="250" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="250" y="250" width="150" height="62" rx="6" class="c-backend" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(256 256) scale(0.6875)">
             <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
           </g>
-          <text data-node-label data-detail-anchor x="380" y="260" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Codeberg</text>
-        <text data-detail="context" x="380" y="276" class="t-muted" font-size="7.9" text-anchor="middle">origin · issues · PRs · releases</text>
-        <text data-detail="fine" x="380" y="286" class="t-backend" font-size="7" text-anchor="middle">leading</text>
+          <text data-node-label data-detail-anchor x="325" y="279" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitHub</text>
+        <text data-detail="context" x="325" y="295" class="t-muted" font-size="9" text-anchor="middle">origin · issues · PRs</text>
+        <text data-detail="fine" x="325" y="304" class="t-backend" font-size="7" text-anchor="middle">leading</text>
         </g>
 
-        <g id="node-runner" data-node-id="runner" data-node-label="Forgejo Runner" tabindex="0" role="button" aria-label="Focus Forgejo Runner, self-hosted, label docker, Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1)" aria-pressed="false" data-node-kind="backend" data-node-sublabel="self-hosted, label docker" data-node-tag="CI" data-node-context="Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1)">
-          <title>Forgejo Runner · self-hosted, label docker · Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1) · CI</title>
-          <rect x="590" y="118" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="590" y="118" width="160" height="64" rx="6" class="c-backend" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(596 124) scale(0.6875)">
-            <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
-          </g>
-          <text data-node-label data-detail-anchor x="670" y="148" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Forgejo Runner</text>
-        <text data-detail="context" x="670" y="164" class="t-muted" font-size="9" text-anchor="middle">self-hosted, label docker</text>
-        <text data-detail="fine" x="670" y="174" class="t-backend" font-size="7" text-anchor="middle">CI</text>
-        </g>
-
-        <g id="node-gitea" data-node-id="gitea" data-node-label="Gitea 1.26.4" tabindex="0" role="button" aria-label="Focus Gitea 1.26.4, pull mirror, every 8 hours, Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1) › reachable only over the Tailnet" aria-pressed="false" data-node-kind="backend" data-node-sublabel="pull mirror, every 8 hours" data-node-tag="mirror" data-node-context="Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1) › reachable only over the Tailnet">
-          <title>Gitea 1.26.4 · pull mirror, every 8 hours · Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1) › reachable only over the Tailnet · mirror</title>
-          <rect x="590" y="320" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="590" y="320" width="160" height="64" rx="6" class="c-backend" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(596 326) scale(0.6875)">
-            <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
-          </g>
-          <text data-node-label data-detail-anchor x="670" y="350" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Gitea 1.26.4</text>
-        <text data-detail="context" x="670" y="366" class="t-muted" font-size="9" text-anchor="middle">pull mirror, every 8 hours</text>
-        <text data-detail="fine" x="670" y="376" class="t-backend" font-size="7" text-anchor="middle">mirror</text>
-        </g>
-
-        <g id="node-pypi" data-node-id="pypi" data-node-label="PyPI" tabindex="0" role="button" aria-label="Focus PyPI, mcp-memory-service, Architecture component" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="mcp-memory-service" data-node-context="Architecture component">
-          <title>PyPI · mcp-memory-service · Architecture component</title>
-          <rect x="1000" y="40" width="150" height="62" rx="6" class="c-mask"/>
-          <rect x="1000" y="40" width="150" height="62" rx="6" class="c-cloud" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(1006 46) scale(0.6875)">
+        <g id="node-ghactions" data-node-id="ghactions" data-node-label="GitHub Actions" tabindex="0" role="button" aria-label="Focus GitHub Actions, ubuntu-latest, hosted, github.com › the only place repository secrets live" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="ubuntu-latest, hosted" data-node-tag="CI" data-node-context="github.com › the only place repository secrets live">
+          <title>GitHub Actions · ubuntu-latest, hosted · github.com › the only place repository secrets live · CI</title>
+          <rect x="500" y="250" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="500" y="250" width="150" height="62" rx="6" class="c-cloud" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(506 256) scale(0.6875)">
             <path d="M4.3 12.5h7.3a2.4 2.4 0 0 0 .2-4.8 4 4 0 0 0-7.5-1.3A3.1 3.1 0 0 0 4.3 12.5Z"/>
           </g>
-          <text data-node-label data-detail-anchor x="1075" y="69" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">PyPI</text>
-        <text data-detail="context" x="1075" y="85" class="t-muted" font-size="9" text-anchor="middle">mcp-memory-service</text>
+          <text data-node-label data-detail-anchor x="575" y="279" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitHub Actions</text>
+        <text data-detail="context" x="575" y="295" class="t-muted" font-size="9" text-anchor="middle">ubuntu-latest, hosted</text>
+        <text data-detail="fine" x="575" y="304" class="t-cloud" font-size="7" text-anchor="middle">CI</text>
         </g>
 
-        <g id="node-dockerhub" data-node-id="dockerhub" data-node-label="Docker Hub" tabindex="0" role="button" aria-label="Focus Docker Hub, doobidoo/mcp-memory-service, Architecture component" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="doobidoo/mcp-memory-service" data-node-context="Architecture component">
+        <g id="node-pypi" data-node-id="pypi" data-node-label="PyPI" tabindex="0" role="button" aria-label="Focus PyPI, main + lite, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="main + lite" data-node-context="Architecture component">
+          <title>PyPI · main + lite · Architecture component</title>
+          <rect x="940" y="140" width="140" height="62" rx="6" class="c-mask"/>
+          <rect x="940" y="140" width="140" height="62" rx="6" class="c-external" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(946 146) scale(0.6875)">
+            <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
+            <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
+          </g>
+          <text data-node-label data-detail-anchor x="1010" y="169" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">PyPI</text>
+        <text data-detail="context" x="1010" y="185" class="t-muted" font-size="9" text-anchor="middle">main + lite</text>
+        </g>
+
+        <g id="node-dockerhub" data-node-id="dockerhub" data-node-label="Docker Hub" tabindex="0" role="button" aria-label="Focus Docker Hub, doobidoo/mcp-memory-service, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="doobidoo/mcp-memory-service" data-node-context="Architecture component">
           <title>Docker Hub · doobidoo/mcp-memory-service · Architecture component</title>
-          <rect x="1000" y="160" width="150" height="62" rx="6" class="c-mask"/>
-          <rect x="1000" y="160" width="150" height="62" rx="6" class="c-cloud" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(1006 166) scale(0.6875)">
-            <path d="M4.3 12.5h7.3a2.4 2.4 0 0 0 .2-4.8 4 4 0 0 0-7.5-1.3A3.1 3.1 0 0 0 4.3 12.5Z"/>
-          </g>
-          <text data-node-label data-detail-anchor x="1075" y="189" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Docker Hub</text>
-        <text data-detail="context" x="1075" y="205" class="t-muted" font-size="8.7" text-anchor="middle">doobidoo/mcp-memory-service</text>
-        </g>
-
-        <g id="node-cfpages" data-node-id="cfpages" data-node-label="Cloudflare Pages" tabindex="0" role="button" aria-label="Focus Cloudflare Pages, mcpmemory.services, Architecture component" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="mcpmemory.services" data-node-tag="canonical" data-node-context="Architecture component">
-          <title>Cloudflare Pages · mcpmemory.services · Architecture component · canonical</title>
-          <rect x="1000" y="320" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="1000" y="320" width="160" height="64" rx="6" class="c-cloud" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(1006 326) scale(0.6875)">
-            <path d="M4.3 12.5h7.3a2.4 2.4 0 0 0 .2-4.8 4 4 0 0 0-7.5-1.3A3.1 3.1 0 0 0 4.3 12.5Z"/>
-          </g>
-          <text data-node-label data-detail-anchor x="1080" y="350" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Cloudflare Pages</text>
-        <text data-detail="context" x="1080" y="366" class="t-muted" font-size="9" text-anchor="middle">mcpmemory.services</text>
-        <text data-detail="fine" x="1080" y="376" class="t-cloud" font-size="7" text-anchor="middle">canonical</text>
-        </g>
-
-        <g id="node-github" data-node-id="github" data-node-label="GitHub Mirror" tabindex="0" role="button" aria-label="Focus GitHub Mirror, Actions off, CodeQL only, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="Actions off, CodeQL only" data-node-context="Architecture component">
-          <title>GitHub Mirror · Actions off, CodeQL only · Architecture component</title>
-          <rect x="300" y="420" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="300" y="420" width="160" height="64" rx="6" class="c-external" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(306 426) scale(0.6875)">
+          <rect x="940" y="250" width="200" height="62" rx="6" class="c-mask"/>
+          <rect x="940" y="250" width="200" height="62" rx="6" class="c-external" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(946 256) scale(0.6875)">
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-node-label data-detail-anchor x="380" y="450" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitHub Mirror</text>
-        <text data-detail="context" x="380" y="466" class="t-muted" font-size="9" text-anchor="middle">Actions off, CodeQL only</text>
+          <text data-node-label data-detail-anchor x="1040" y="279" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Docker Hub</text>
+        <text data-detail="context" x="1040" y="295" class="t-muted" font-size="9" text-anchor="middle">doobidoo/mcp-memory-service</text>
         </g>
 
-        <g id="node-ghpages" data-node-id="ghpages" data-node-label="GitHub Pages" tabindex="0" role="button" aria-label="Focus GitHub Pages, docs/ redirect stub, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="docs/ redirect stub" data-node-context="Architecture component">
-          <title>GitHub Pages · docs/ redirect stub · Architecture component</title>
-          <rect x="590" y="420" width="160" height="64" rx="6" class="c-mask"/>
-          <rect x="590" y="420" width="160" height="64" rx="6" class="c-external" stroke-width="1.5"/>
-          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(596 426) scale(0.6875)">
+        <g id="node-ghpages" data-node-id="ghpages" data-node-label="GitHub Pages" tabindex="0" role="button" aria-label="Focus GitHub Pages, docs/ redirect stub, github.com" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="docs/ redirect stub" data-node-tag="maintainer" data-node-context="github.com">
+          <title>GitHub Pages · docs/ redirect stub · github.com · maintainer</title>
+          <rect x="500" y="370" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="500" y="370" width="150" height="62" rx="6" class="c-cloud" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(506 376) scale(0.6875)">
+            <path d="M4.3 12.5h7.3a2.4 2.4 0 0 0 .2-4.8 4 4 0 0 0-7.5-1.3A3.1 3.1 0 0 0 4.3 12.5Z"/>
+          </g>
+          <text data-node-label data-detail-anchor x="575" y="399" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitHub Pages</text>
+        <text data-detail="context" x="575" y="415" class="t-muted" font-size="9" text-anchor="middle">docs/ redirect stub</text>
+        <text data-detail="fine" x="575" y="424" class="t-cloud" font-size="7" text-anchor="middle">maintainer</text>
+        </g>
+
+        <g id="node-cfpages" data-node-id="cfpages" data-node-label="Cloudflare Pages" tabindex="0" role="button" aria-label="Focus Cloudflare Pages, mcpmemory.services, Cloudflare" aria-pressed="false" data-node-kind="cloud" data-node-sublabel="mcpmemory.services" data-node-tag="canonical" data-node-context="Cloudflare">
+          <title>Cloudflare Pages · mcpmemory.services · Cloudflare · canonical</title>
+          <rect x="750" y="370" width="160" height="62" rx="6" class="c-mask"/>
+          <rect x="750" y="370" width="160" height="62" rx="6" class="c-cloud" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="cloud" class="semantic-sigil s-cloud" transform="translate(756 376) scale(0.6875)">
+            <path d="M4.3 12.5h7.3a2.4 2.4 0 0 0 .2-4.8 4 4 0 0 0-7.5-1.3A3.1 3.1 0 0 0 4.3 12.5Z"/>
+          </g>
+          <text data-node-label data-detail-anchor x="830" y="399" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Cloudflare Pages</text>
+        <text data-detail="context" x="830" y="415" class="t-muted" font-size="9" text-anchor="middle">mcpmemory.services</text>
+        <text data-detail="fine" x="830" y="424" class="t-cloud" font-size="7" text-anchor="middle">canonical</text>
+        </g>
+
+        <g id="node-gitlab" data-node-id="gitlab" data-node-label="GitLab" tabindex="0" role="button" aria-label="Focus GitLab, private push mirror, gitlab.com / private" aria-pressed="false" data-node-kind="backend" data-node-sublabel="private push mirror" data-node-tag="mirror" data-node-context="gitlab.com / private">
+          <title>GitLab · private push mirror · gitlab.com / private · mirror</title>
+          <rect x="250" y="490" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="250" y="490" width="150" height="62" rx="6" class="c-backend" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(256 496) scale(0.6875)">
+            <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
+          </g>
+          <text data-node-label data-detail-anchor x="325" y="519" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitLab</text>
+        <text data-detail="context" x="325" y="535" class="t-muted" font-size="9" text-anchor="middle">private push mirror</text>
+        <text data-detail="fine" x="325" y="544" class="t-backend" font-size="7" text-anchor="middle">mirror</text>
+        </g>
+
+        <g id="node-codeberg" data-node-id="codeberg" data-node-label="Codeberg" tabindex="0" role="button" aria-label="Focus Codeberg, frozen archive, Architecture component" aria-pressed="false" data-node-kind="external" data-node-sublabel="frozen archive" data-node-tag="archive" data-node-context="Architecture component">
+          <title>Codeberg · frozen archive · Architecture component · archive</title>
+          <rect x="860" y="490" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="860" y="490" width="150" height="62" rx="6" class="c-external" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="external" class="semantic-sigil s-external" transform="translate(866 496) scale(0.6875)">
             <rect x="2.5" y="5" width="8.5" height="8" rx="1.5"/>
             <path d="M8 2.5h5.5V8M13.5 2.5 7.5 8.5"/>
           </g>
-          <text data-node-label data-detail-anchor x="670" y="450" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">GitHub Pages</text>
-        <text data-detail="context" x="670" y="466" class="t-muted" font-size="9" text-anchor="middle">docs/ redirect stub</text>
+          <text data-node-label data-detail-anchor x="935" y="519" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Codeberg</text>
+        <text data-detail="context" x="935" y="535" class="t-muted" font-size="9" text-anchor="middle">frozen archive</text>
+        <text data-detail="fine" x="935" y="544" class="t-external" font-size="7" text-anchor="middle">archive</text>
+        </g>
+
+        <g id="node-gitea" data-node-id="gitea" data-node-label="Gitea 1.26.4" tabindex="0" role="button" aria-label="Focus Gitea 1.26.4, pull mirror, tinyclaw · Hetzner VM" aria-pressed="false" data-node-kind="backend" data-node-sublabel="pull mirror" data-node-tag="unverified" data-node-context="tinyclaw · Hetzner VM">
+          <title>Gitea 1.26.4 · pull mirror · tinyclaw · Hetzner VM · unverified</title>
+          <rect x="1150" y="490" width="150" height="62" rx="6" class="c-mask"/>
+          <rect x="1150" y="490" width="150" height="62" rx="6" class="c-backend" stroke-width="1.5"/>
+          <g aria-hidden="true" data-semantic-sigil="backend" class="semantic-sigil s-backend" transform="translate(1156 496) scale(0.6875)">
+            <path d="M6 3 3 8l3 5M10 3l3 5-3 5"/>
+          </g>
+          <text data-node-label data-detail-anchor x="1225" y="519" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Gitea 1.26.4</text>
+        <text data-detail="context" x="1225" y="535" class="t-muted" font-size="9" text-anchor="middle">pull mirror</text>
+        <text data-detail="fine" x="1225" y="544" class="t-backend" font-size="7" text-anchor="middle">unverified</text>
         </g>
 
         <!-- Connection labels -->
-        <g data-detail="context" data-edge-from="mac" data-edge-to="codeberg" data-edge-label="git push + tag" data-edge-key="0">
-          <rect x="201.4" y="235" width="77.2" height="14" rx="3" class="c-mask"/>
-          <text x="240" y="245" class="t-backend" font-size="8" text-anchor="middle">git push + tag</text>
+        <g data-detail="context" data-edge-from="mac" data-edge-to="github" data-edge-label="git push + tag" data-edge-key="0">
+          <rect x="172.4" y="254" width="77.2" height="14" rx="3" class="c-mask"/>
+          <text x="211" y="264" class="t-backend" font-size="8" text-anchor="middle">git push + tag</text>
         </g>
-        <g data-detail="context" data-edge-from="codeberg" data-edge-to="runner" data-edge-label="Forgejo Actions" data-edge-key="1">
-          <rect x="484" y="182.5" width="82" height="14" rx="3" class="c-mask"/>
-          <text x="525" y="192.5" class="t-backend" font-size="8" text-anchor="middle">Forgejo Actions</text>
+        <g data-detail="context" data-edge-from="github" data-edge-to="ghactions" data-edge-label="push · tag v*" data-edge-key="1">
+          <rect x="413.8" y="254" width="72.4" height="14" rx="3" class="c-mask"/>
+          <text x="450" y="264" class="t-backend" font-size="8" text-anchor="middle">push · tag v*</text>
         </g>
-        <g data-detail="context" data-edge-from="codeberg" data-edge-to="gitea" data-edge-label="pulls every 8h" data-edge-key="2">
-          <rect x="486.4" y="290.5" width="77.2" height="14" rx="3" class="c-mask"/>
-          <text x="525" y="300.5" class="t-messagebus" font-size="8" text-anchor="middle">pulls every 8h</text>
+        <g data-detail="context" data-edge-from="ghactions" data-edge-to="pypi" data-edge-label="release.yml" data-edge-key="2">
+          <rect x="763.6" y="199" width="62.8" height="14" rx="3" class="c-mask"/>
+          <text x="795" y="209" class="t-muted" font-size="8" text-anchor="middle">release.yml</text>
         </g>
-        <g data-detail="context" data-edge-from="runner" data-edge-to="pypi" data-edge-label="tag v* → publish-pypi" data-edge-key="3">
-          <rect x="882.1" y="51" width="110.8" height="14" rx="3" class="c-mask"/>
-          <text x="937.5" y="61" class="t-muted" font-size="8" text-anchor="middle">tag v* → publish-pypi</text>
+        <g data-detail="context" data-edge-from="ghactions" data-edge-to="dockerhub" data-edge-label="buildx push" data-edge-key="3">
+          <rect x="763.6" y="277" width="62.8" height="14" rx="3" class="c-mask"/>
+          <text x="795" y="287" class="t-muted" font-size="8" text-anchor="middle">buildx push</text>
         </g>
-        <g data-detail="context" data-edge-from="runner" data-edge-to="dockerhub" data-edge-label="tag v* → buildx push" data-edge-key="4">
-          <rect x="884.5" y="171" width="106" height="14" rx="3" class="c-mask"/>
-          <text x="937.5" y="181" class="t-muted" font-size="8" text-anchor="middle">tag v* → buildx push</text>
+        <g data-detail="context" data-edge-from="ghactions" data-edge-to="cfpages" data-edge-label="site/** → wrangler" data-edge-key="4">
+          <rect x="651.8" y="324.5" width="96.39999999999999" height="14" rx="3" class="c-mask"/>
+          <text x="700" y="334.5" class="t-muted" font-size="8" text-anchor="middle">site/** → wrangler</text>
         </g>
-        <g data-detail="context" data-edge-from="runner" data-edge-to="cfpages" data-edge-label="site/** → wrangler" data-edge-key="5">
-          <rect x="889.3" y="325" width="96.39999999999999" height="14" rx="3" class="c-mask"/>
-          <text x="937.5" y="335" class="t-muted" font-size="8" text-anchor="middle">site/** → wrangler</text>
+        <g data-detail="context" data-edge-from="github" data-edge-to="ghpages" data-edge-label="serves docs/" data-edge-key="5">
+          <rect x="416.2" y="324.5" width="67.6" height="14" rx="3" class="c-mask"/>
+          <text x="450" y="334.5" class="t-messagebus" font-size="8" text-anchor="middle">serves docs/</text>
         </g>
-        <g data-detail="context" data-edge-from="mac" data-edge-to="github" data-edge-label="fast-forward main, never tags" data-edge-key="6">
-          <rect x="165.4" y="340.5" width="149.2" height="14" rx="3" class="c-mask"/>
-          <text x="240" y="350.5" class="t-security" font-size="8" text-anchor="middle">fast-forward main, never tags</text>
+        <g data-detail="context" data-edge-from="ghpages" data-edge-to="cfpages" data-edge-label="redirect" data-edge-key="6">
+          <rect x="675.8" y="410" width="48.4" height="14" rx="3" class="c-mask"/>
+          <text x="700" y="420" class="t-messagebus" font-size="8" text-anchor="middle">redirect</text>
         </g>
-        <g data-detail="context" data-edge-from="github" data-edge-to="ghpages" data-edge-label="serves docs/" data-edge-key="7">
-          <rect x="491.2" y="432" width="67.6" height="14" rx="3" class="c-mask"/>
-          <text x="525" y="442" class="t-messagebus" font-size="8" text-anchor="middle">serves docs/</text>
+        <g data-detail="context" data-edge-from="mac" data-edge-to="gitlab" data-edge-label="fast-forward main, never tags" data-edge-key="7">
+          <rect x="136.4" y="384.5" width="149.2" height="14" rx="3" class="c-mask"/>
+          <text x="211" y="394.5" class="t-messagebus" font-size="8" text-anchor="middle">fast-forward main, never tags</text>
         </g>
-        <g data-detail="context" data-edge-from="ghpages" data-edge-to="cfpages" data-edge-label="redirect" data-edge-key="8">
-          <rect x="850.8" y="385.5" width="48.4" height="14" rx="3" class="c-mask"/>
-          <text x="875" y="395.5" class="t-messagebus" font-size="8" text-anchor="middle">redirect</text>
+        <g data-detail="context" data-edge-from="codeberg" data-edge-to="gitea" data-edge-label="pulled every 8h" data-edge-key="8">
+          <rect x="1039" y="501" width="82" height="14" rx="3" class="c-mask"/>
+          <text x="1080" y="511" class="t-messagebus" font-size="8" text-anchor="middle">pulled every 8h</text>
         </g>
 
         <!-- Boundary labels (foreground masks keep routes out of titles) -->
-        <g data-graph-role="structural-frame-label" data-composition-frame-id="0" data-composition-frame-kind="region" data-composition-frame-label="Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1)">
-          <rect data-graph-role="structural-frame-label-mask" x="572" y="98" width="196" height="16" rx="3" class="c-mask"/>
-          <text data-boundary-label x="576" y="109.94871794871796" class="t-cloud" font-size="7.948717948717949" font-weight="600">Hetzner VM tinyclaw (ubuntu-4gb-nbg1-1)</text>
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="0" data-composition-frame-kind="region" data-composition-frame-label="github.com">
+          <rect data-graph-role="structural-frame-label-mask" x="232" y="212" width="64" height="16" rx="3" class="c-mask"/>
+          <text data-boundary-label x="236" y="225" class="t-cloud" font-size="9" font-weight="600">github.com</text>
         </g>
 
-        <g data-graph-role="structural-frame-label" data-composition-frame-id="1" data-composition-frame-kind="security-group" data-composition-frame-label="reachable only over the Tailnet">
-          <rect data-graph-role="structural-frame-label-mask" x="580" y="300" width="177.4" height="16" rx="3" class="c-mask"/>
-          <text data-boundary-label x="584" y="313" class="t-security" font-size="9" font-weight="600">reachable only over the Tailnet</text>
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="1" data-composition-frame-kind="security-group" data-composition-frame-label="the only place repository secrets live">
+          <rect data-graph-role="structural-frame-label-mask" x="242" y="230" width="215.2" height="16" rx="3" class="c-mask"/>
+          <text data-boundary-label x="246" y="243" class="t-security" font-size="9" font-weight="600">the only place repository secrets live</text>
+        </g>
+
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="2" data-composition-frame-kind="region" data-composition-frame-label="Cloudflare">
+          <rect data-graph-role="structural-frame-label-mask" x="738" y="350" width="64" height="16" rx="3" class="c-mask"/>
+          <text data-boundary-label x="742" y="363" class="t-cloud" font-size="9" font-weight="600">Cloudflare</text>
+        </g>
+
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="3" data-composition-frame-kind="region" data-composition-frame-label="gitlab.com / private">
+          <rect data-graph-role="structural-frame-label-mask" x="238" y="470" width="118" height="16" rx="3" class="c-mask"/>
+          <text data-boundary-label x="242" y="483" class="t-cloud" font-size="9" font-weight="600">gitlab.com / private</text>
+        </g>
+
+        <g data-graph-role="structural-frame-label" data-composition-frame-id="4" data-composition-frame-kind="region" data-composition-frame-label="tinyclaw · Hetzner VM">
+          <rect data-graph-role="structural-frame-label-mask" x="1138" y="470" width="123.39999999999999" height="16" rx="3" class="c-mask"/>
+          <text data-boundary-label x="1142" y="483" class="t-cloud" font-size="9" font-weight="600">tinyclaw · Hetzner VM</text>
         </g>
 
         <!-- Legend -->
@@ -5385,12 +5422,12 @@
       <div class="card">
         <div class="card-header">
           <div class="card-dot cyan"></div>
-          <h3>One machine, two roles</h3>
+          <h3>Exactly one publisher</h3>
         </div>
         <ul>
-          <li>&bull; tinyclaw runs the Forgejo runner that feeds PyPI, Docker Hub and Cloudflare Pages</li>
-          <li>&bull; The same VM hosts the Gitea mirror, reachable only over the Tailnet</li>
-          <li>&bull; If that VM goes down, releases and the mirror stop together</li>
+          <li>&bull; release.yml on a GitHub-hosted runner owns PyPI and Docker Hub</li>
+          <li>&bull; Codeberg lost its Actions secrets on 5 September 2026 and can no longer publish</li>
+          <li>&bull; A tag must be pushed with git; one created through a forge API fires nothing</li>
         </ul>
       </div>
 
@@ -5400,21 +5437,21 @@
           <h3>One-way streets</h3>
         </div>
         <ul>
-          <li>&bull; GitHub only ever receives a fast-forwarded main, and never tags</li>
-          <li>&bull; Gitea pulls from Codeberg; it never pushes back</li>
+          <li>&bull; GitLab only ever receives a fast-forwarded main, and never tags</li>
           <li>&bull; GitHub Pages serves a redirect stub, not content</li>
+          <li>&bull; Nothing pushes to Codeberg any more; it stays readable so old links resolve</li>
         </ul>
       </div>
 
       <div class="card">
         <div class="card-header">
-          <div class="card-dot emerald"></div>
-          <h3>Exactly one publisher</h3>
+          <div class="card-dot amber"></div>
+          <h3>What the move retired</h3>
         </div>
         <ul>
-          <li>&bull; Only release.yml on the Hetzner runner publishes packages</li>
-          <li>&bull; The mirror holds no secrets, so it cannot publish anything</li>
-          <li>&bull; Hand-authored snapshot of 2026-08-28, not generated from repository state</li>
+          <li>&bull; Releases no longer depend on one Hetzner VM; hosted runners replaced it</li>
+          <li>&bull; The Forgejo runner on tinyclaw still exists but has no job</li>
+          <li>&bull; The Gitea mirror still points at Codeberg; its state is unverified since the move</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Die Seite unter mcpmemory.services/deployment zeigte weiterhin Codeberg in der Mitte: origin, issues, PRs und releases, mit einem Forgejo-Runner auf der Hetzner-VM, und GitHub als Mirror, der nur ein fast-forwarded main bekommt. Jede einzelne dieser Aussagen hat sich am 5. September umgedreht.

## Neu generiert statt von Hand geschnitten

Das HTML ist ein Archify-Artefakt mit fest gesetzter SVG-Geometrie. Kanten dort blind umzuhängen hätte niemand verifizieren können, also habe ich die Spezifikation neu geschrieben und das Artefakt neu erzeugt.

## Was das Bild jetzt sagt

- GitHub ist origin. Ein mit git gepushter Tag startet `release.yml` auf einem GitHub-gehosteten Runner, der PyPI und Docker Hub bedient.
- GitLab ist der Mirror, der ein fast-forwarded main bekommt und nie Tags. Dieser Satz ist unverändert von GitHub zu GitLab gewandert.
- Codeberg ist ein eingefrorenes Archiv, in das nichts mehr pusht.
- Eine Security-Group um GitHub und GitHub Actions trägt den Ein-Publisher-Invariant jetzt **visuell**: das ist der einzige Ort, an dem Repository-Secrets liegen.

## Zwei Dinge sind gezeichnet wie sie sind, nicht wie sie sein sollten

Der Forgejo-Runner auf tinyclaw existiert noch, hat aber keine Aufgabe. Und der Gitea-Pull-Mirror zeigt weiter auf Codeberg, sein Zustand ist seit dem Umzug ungeprüft. Beides steht als Text in der Karte, statt dass das Diagramm eine funktionierende Verbindung suggeriert.

## Verifikation

Nicht nur Validierung, sondern angesehen:

- `archify validate --quality showcase`: ok, 9/9 Artefakt-Checks, 0 Kompositionsfehler, 0 Warnungen
- `archify visual-check`: pass für containment, readability und viewer chrome bei 1440x900, 1600x1000, 1920x1080 und 2048x1320, jeweils hell und dunkel
- Das gerenderte PNG habe ich mir angesehen

Die vom Visual-Check erzeugten PNG- und Sidecar-Dateien sind wieder entfernt und nicht Teil des Commits.

## Hinweis

`scripts/pr/pre_pr_check.sh` habe ich **nicht** ausgeführt. Der Index dieses Working Trees trägt gerade gestagete Arbeit einer parallelen Session (CHANGELOG, pyproject, consolidation.py, zwei Tests), und das Gate liest den Index — es hätte fremde Dateien mitbewertet. Diese Änderung ist eine einzelne generierte HTML-Datei unter `site/`, kein Code; die CI auf diesem PR ist die zuständige Prüfung.