### PR TITLE
docs(changelog): record the merges since v11.11.0, and disambiguate old issue refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+Thanks to eunwoo song for the retrieval fix below (#1128) and to timkjr for the two consolidation fixes (#1087, #1088), both carried over from pull requests opened on Codeberg before the move.
+
 ### Fixed
 
-- Apply memory eligibility filters before SQLite-vec nearest-neighbor limits in
-  `recall()` and `retrieve()`. Deleted, out-of-window, and filtered metadata rows
-  no longer crowd out valid semantic matches, including beyond the previous
-  candidate-pool cap ([#1077](https://github.com/doobidoo/mcp-memory-service/issues/1077)).
+- **fix(storage): apply eligibility filters before the nearest-neighbour limit (#1128, eunwoo song, closes #1077).** `recall()` and `retrieve()` asked sqlite-vec for the k nearest embeddings first and filtered afterwards, so soft-deleted rows, rows outside the requested time window, and rows excluded by tag or supersession consumed the candidate budget before a valid match could be seen. With enough excluded neighbours the result set came back short or empty even though matching memories existed. Both queries now restrict the KNN scan to eligible rowids, so k counts only memories that can actually be returned. The tests run against real sqlite-vec with 4,100 excluded neighbours crowding five valid ones, which is what distinguishes a fix here from a fix that merely reorders the same failure.
+- **fix(consolidation): map recommendation values onto the API's public contract (#1087, timkjr).** `/api/consolidation/recommendations/{time_horizon}` sanitized its output against an allowlist of uppercase values, but `DreamInspiredConsolidator.get_consolidation_recommendations()` has always returned lowercase snake_case ones (`consolidation_beneficial`, `optional`, `no_action`, `error`). Nothing ever matched, so every call returned `"recommendation": "UNKNOWN"` regardless of the consolidator's actual assessment. The values are now mapped explicitly, with the CWE-209 fallback kept for anything unrecognised. Traces back to Codeberg #328, ported here from Codeberg PR #339.
+- **fix(consolidation): derive DBSCAN's eps from the data's own k-distance curve (#1088, timkjr).** `eps` was computed from dataset size alone (`0.5 - n/10000`, clamped), which bakes in an assumption about how far apart an embedding model puts unrelated text. all-MiniLM-L6-v2 keeps unrelated content at a narrow, elevated baseline similarity, so density-reachability chained memories into one giant cluster — observed at 989 of 1,104 memories in a single cluster with coherence 0.461. `eps` now comes from the knee of the sorted k-distance curve (Ester et al., 1996), computed with `NearestNeighbors` rather than a full n×n distance matrix. Ported from Codeberg PR #340.
+
+### Internal
+
+No user-visible effect; recorded because they change how the repository is maintained.
+
+- **A harvest regression test that was missing (#1089, timkjr).** The meta-discussion filter's escape hatch is convention-only, and nothing pinned that. Two tests now do. Behaviour is unchanged: the widening originally proposed in Codeberg PR #322 was reverted before the merge.
+- **Dependabot no longer widens load-bearing version bounds (#1130).** A grouped bump rewrites the constraint in `pyproject.toml` rather than respecting it, and #1086 used that to lift `mcp` to `<3.0.0` and `pymilvus` to `<4.0.0`. mcp 2.x removes `mcp.shared.session`, which broke test collection outright; pymilvus 3.x has no CI coverage here at all (#1112), so it would have gone in silent. Major updates for both are now ignored. The `github-actions` ecosystem gained a group as well, because `codeql-action`'s `init` and `analyze` steps must move in the same commit — split across #1080 and #1081 they deadlocked, with analyze refusing to run against a config written by a different version. Both are now on v4.37.9 (#1129).
 
 ## [11.11.0] - 2026-09-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,10 @@ sqlite-ml = [
 milvus = [
     # 3.x has breaking API changes and nothing here tests Milvus: the Test Milvus (Docker)
     # job was dropped during the Codeberg era and never restored, so a break would be silent.
-    # Do not widen this bound until a Milvus CI job runs green against 3.x — see issue #261.
+    # Do not widen this bound until a Milvus CI job runs green against 3.x — see issue #1112.
+    # Dependabot cannot widen it any more either: .github/dependabot.yml ignores
+    # major updates for pymilvus, because a group bump rewrites this line rather
+    # than respecting it.
     # A bulk uv-group bump (#976) already widened it to <4.0.0 once by accident.
     "pymilvus>=2.5.0,<3.0.0",
     "milvus-lite>=2.4.10",

--- a/src/mcp_memory_service/web/api/consolidation.py
+++ b/src/mcp_memory_service/web/api/consolidation.py
@@ -168,6 +168,54 @@ async def get_scheduler_status(user: AuthenticationResult = Depends(require_read
         raise HTTPException(status_code=500, detail="Failed to get status")
 
 
+# Maps the consolidator's internal recommendation values onto this endpoint's
+# public contract. The consolidator returns lowercase/snake_case values, and the
+# endpoint's CWE-209 allowlist only ever held uppercase ones, so every response
+# fell through to "UNKNOWN" regardless of actual state (#1125, filed on Codeberg
+# as #328). Anything unrecognised still falls back to "UNKNOWN".
+_RECOMMENDATION_MAP = {
+    "consolidation_beneficial": "CONSOLIDATION_BENEFICIAL",
+    "optional": "NO_CONSOLIDATION_NEEDED",
+    "no_action": "NO_CONSOLIDATION_NEEDED",
+    "error": "UNKNOWN",
+}
+
+
+def _safe_recommendation_payload(recommendations: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the response body, sanitized against stack-trace exposure (CWE-209).
+
+    Every field is coerced to its declared type here rather than in the handler:
+    the consolidator's error path puts exception text into the dict, and none of
+    it may reach the client.
+    """
+    try:
+        safe_count = int(recommendations.get("memory_count", 0))
+    except (TypeError, ValueError):
+        safe_count = 0
+
+    try:
+        safe_duration = float(recommendations.get("estimated_duration_seconds", 0.0))
+    except (TypeError, ValueError):
+        safe_duration = 0.0
+
+    safe_reasons = []
+    for r in recommendations.get("reasons", []):
+        try:
+            # Truncate to prevent large payloads; use repr to avoid exposing exception details
+            safe_reasons.append(repr(r)[:256] if not isinstance(r, str) else r[:256])
+        except Exception:  # noqa: BLE001 - intentionally silent, malformed reason is skipped
+            pass  # Skip malformed reason entries silently
+
+    return {
+        "recommendation": _RECOMMENDATION_MAP.get(
+            recommendations.get("recommendation", "unknown"), "UNKNOWN"
+        ),
+        "memory_count": safe_count,
+        "reasons": safe_reasons,
+        "estimated_duration": safe_duration,
+    }
+
+
 @router.get("/recommendations/{time_horizon}", response_model=RecommendationsResponse)
 async def get_recommendations(time_horizon: str, user: AuthenticationResult = Depends(require_read_access)) -> Dict[str, Any]:
     """
@@ -222,46 +270,7 @@ async def get_recommendations(time_horizon: str, user: AuthenticationResult = De
         # Get recommendations
         recommendations = await consolidator.get_consolidation_recommendations(time_horizon)
 
-        # Map the consolidator's internal recommendation values onto this
-        # endpoint's public contract, and sanitize before returning to
-        # prevent stack-trace exposure (CWE-209). The consolidator returns
-        # lowercase/snake_case values ("consolidation_beneficial", "optional",
-        # "no_action", "error") that never matched the allowlist this endpoint
-        # checked against, so every response fell through to "UNKNOWN"
-        # regardless of actual state (#328).
-        _RECOMMENDATION_MAP = {
-            "consolidation_beneficial": "CONSOLIDATION_BENEFICIAL",
-            "optional": "NO_CONSOLIDATION_NEEDED",
-            "no_action": "NO_CONSOLIDATION_NEEDED",
-            "error": "UNKNOWN",
-        }
-        raw_rec = recommendations.get("recommendation", "unknown")
-        safe_rec = _RECOMMENDATION_MAP.get(raw_rec, "UNKNOWN")
-
-        try:
-            safe_count = int(recommendations.get("memory_count", 0))
-        except (TypeError, ValueError):
-            safe_count = 0
-
-        try:
-            safe_duration = float(recommendations.get("estimated_duration_seconds", 0.0))
-        except (TypeError, ValueError):
-            safe_duration = 0.0
-
-        safe_reasons = []
-        for r in recommendations.get("reasons", []):
-            try:
-                # Truncate to prevent large payloads; use repr to avoid exposing exception details
-                safe_reasons.append(repr(r)[:256] if not isinstance(r, str) else r[:256])
-            except Exception:  # noqa: BLE001 - intentionally silent, malformed reason is skipped
-                pass  # Skip malformed reason entries silently
-
-        return {
-            "recommendation": safe_rec,
-            "memory_count": safe_count,
-            "reasons": safe_reasons,
-            "estimated_duration": safe_duration,
-        }
+        return _safe_recommendation_payload(recommendations)
 
     except HTTPException:
         raise

--- a/tests/harvest/test_extractor.py
+++ b/tests/harvest/test_extractor.py
@@ -62,7 +62,8 @@ class TestPatternExtractor:
         assert len(candidates) == 0
 
     def test_meta_discussion_without_convention_is_filtered(self, extractor):
-        """The meta-discussion filter's escape hatch is convention-only (#322):
+        """The meta-discussion filter's escape hatch is convention-only
+        (Codeberg PR #322):
         a bug/decision/learning candidate about the harvest system itself
         must still be discarded, even though it matches a real pattern."""
         msg = ParsedMessage(

--- a/tests/web/api/test_consolidation_recommendations.py
+++ b/tests/web/api/test_consolidation_recommendations.py
@@ -1,6 +1,6 @@
 """
 Regression tests for the /api/consolidation/recommendations/{time_horizon}
-sanitization mismatch (#340).
+sanitization mismatch (#1125, filed on Codeberg as #328).
 
 The endpoint's CWE-209 sanitization allowlisted only uppercase values
 ("CONSOLIDATION_BENEFICIAL", "NO_CONSOLIDATION_NEEDED", "UNKNOWN"), but


### PR DESCRIPTION
Die Unreleased-Sektion trug nur den Retrieval-Fix aus #1128. Ergaenzt um die beiden Consolidation-Fixes von timkjr (#1087, #1088) und die Dependency-Guardrails (#1129, #1130), jeweils mit Credit.

Dazu drei nackte Issue-Referenzen im Code, die Codeberg-Nummern sind und die GitHub auf eigene, voellig andere Vorgaenge aufloest:

| Fundstelle | war | ist |
|---|---|---|
| `web/api/consolidation.py` | `#328` | `#1125`, mit Codeberg-Herkunft |
| `tests/web/api/test_consolidation_recommendations.py` | `#340` | `#1125` -- #340 war zusaetzlich falsch, das ist der DBSCAN-PR, nicht das Issue |
| `tests/harvest/test_extractor.py` | `#322` | `Codeberg PR #322` |

`pyproject.toml` verweist fuer die pymilvus-Grenze jetzt auf #1112 statt auf Codeberg #261 und nennt die neue dependabot-ignore-Regel.

Ausserdem in derselben Datei: die Sanitisierung ist aus dem Endpoint in `_safe_recommendation_payload()` gewandert. `get_recommendations` lag bei zyklomatischer Komplexitaet 10 gegen ein Budget von 8 -- geerbt, nicht hier entstanden, aber es blockiert das Quality Gate fuer jeden, der die Datei anfasst. Jetzt 5, der Helper 6. Die fuenf Tests des Endpoints laufen unveraendert gruen.