### PR TITLE
fix(quality-gate): score the diff, not the file, and stop mislabelling findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,13 @@ a weekly pyscn review with trend tracking. Health score below 50 blocks a releas
 50-69 means refactor within two weeks, 70 and up is fine. Complexity target is grade
 A-B, meaning 8 or lower.
 
+The PR gate's complexity check is scoped to the diff: a finding counts only when it
+names a function the change actually touched (`scripts/pr/lib/touched_functions.py`).
+An untouched function above the budget in the same file is the file's pre-existing
+state and does not block — it used to, which made the gate unpassable for anyone
+working in `storage/hybrid.py` or `storage/base.py`. Everything the gate does report
+blocks; there is no "warning" tier below it.
+
 ### Log injection guard (v10.68.0, from CodeQL GHSA-84hp-mqvj-3p8h)
 
 User-provided values in raw f-string log calls trigger CodeQL `py/log-injection`.

--- a/scripts/pr/lib/scope_findings.py
+++ b/scripts/pr/lib/scope_findings.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Keep only the complexity findings that name a function the diff touched.
+
+Reads the model's report on stdin and the touched-function names as arguments
+(as produced by touched_functions.py). Prints the findings that survive, one
+per line, and exits 1 when none do -- so the caller can branch on the exit
+status instead of testing for an empty string.
+
+The model is asked for `FunctionName: Score X - Reason` but does not always
+comply exactly: it prefixes bullets, wraps names in backticks, and sometimes
+qualifies them as `Class.method`. Matching is therefore on the last dotted
+segment, case-insensitively, which is the part both sides agree on.
+"""
+
+import re
+import sys
+
+SCORE = re.compile(r"score\s*(9|10)\b", re.IGNORECASE)
+NAME = re.compile(r"^[\s\-*>`]*([A-Za-z_][A-Za-z0-9_.]*)\s*[:(]")
+
+
+def leaf(name: str) -> str:
+    return name.rsplit(".", 1)[-1].lower()
+
+
+def main() -> int:
+    touched = {leaf(n) for n in sys.argv[1:] if n}
+    if not touched:
+        return 1
+
+    kept = []
+    for line in sys.stdin.read().splitlines():
+        if not SCORE.search(line):
+            continue
+        m = NAME.match(line)
+        if not m:
+            # A finding we cannot attribute to a name is reported rather than
+            # dropped: silently swallowing it would turn a parsing gap into a
+            # clean gate.
+            kept.append(line.strip())
+            continue
+        if leaf(m.group(1)) in touched:
+            kept.append(line.strip())
+
+    for line in kept:
+        print(line)
+    return 0 if kept else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr/lib/touched_functions.py
+++ b/scripts/pr/lib/touched_functions.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Print the names of the functions a diff actually touches.
+
+The quality gate scores whole files, so any change to a file that already
+contains a function above the complexity budget failed the gate regardless of
+what the change did -- it punished proximity rather than the change (#1118).
+This narrows it: a finding only counts when the diff touched the function it
+names.
+
+Usage:
+    touched_functions.py --staged <file.py>
+    touched_functions.py --range <base>...<head> <file.py>
+
+Prints one name per line. A change outside any function (imports, module-level
+constants, a new decorator) prints the sentinel ``__module__`` so the caller can
+tell "nothing touched" from "module scope touched" -- the latter still deserves
+a look, it just cannot be attributed to a function.
+
+Exits 0 with no output when the file has no touched function, and also when the
+file cannot be parsed: a syntax error is the compiler's job to report, not this
+helper's, and failing the gate on it would only hide the real message.
+"""
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+
+HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def changed_lines(diff: str) -> set[int]:
+    """Line numbers touched on the new side of a unified diff."""
+    lines: set[int] = set()
+    new_lineno = 0
+    in_hunk = False
+    for line in diff.splitlines():
+        m = HUNK.match(line)
+        if m:
+            new_lineno = int(m.group(1))
+            in_hunk = True
+            continue
+        if not in_hunk:
+            continue
+        if line.startswith("+"):
+            lines.add(new_lineno)
+            new_lineno += 1
+        elif line.startswith("-"):
+            # Deleted lines have no position on the new side. The line that
+            # follows them does, and it is already covered by the context or
+            # addition that comes next.
+            continue
+        elif line.startswith("\\"):
+            continue
+        else:
+            new_lineno += 1
+    return lines
+
+
+def function_ranges(source: str) -> list[tuple[str, int, int]]:
+    """(qualified name, first line, last line) for every function in the file.
+
+    The first line is the decorator when there is one: changing a decorator
+    changes the function's behaviour, so it belongs to the function's range.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    ranges: list[tuple[str, int, int]] = []
+
+    def walk(node, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                start = min(
+                    [child.lineno] + [d.lineno for d in child.decorator_list]
+                )
+                ranges.append((prefix + child.name, start, child.end_lineno))
+                walk(child, prefix + child.name + ".")
+            elif isinstance(child, ast.ClassDef):
+                walk(child, prefix + child.name + ".")
+
+    walk(tree, "")
+    return ranges
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--staged", action="store_true")
+    group.add_argument("--range", dest="rev_range")
+    parser.add_argument("path")
+    args = parser.parse_args()
+
+    cmd = ["git", "diff", "--unified=0"]
+    if args.staged:
+        cmd.append("--cached")
+    else:
+        cmd.append(args.rev_range)
+    cmd += ["--", args.path]
+
+    diff = subprocess.run(cmd, capture_output=True, text=True).stdout
+    touched = changed_lines(diff)
+    if not touched:
+        return 0
+
+    try:
+        with open(args.path, encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError:
+        return 0
+
+    names = []
+    covered: set[int] = set()
+    for name, start, end in function_ranges(source):
+        span = set(range(start, end + 1))
+        covered |= span
+        if span & touched:
+            names.append(name)
+
+    if touched - covered:
+        names.append("__module__")
+
+    for name in names:
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr/quality_gate.sh
+++ b/scripts/pr/quality_gate.sh
@@ -101,10 +101,12 @@ critical_issues=()
 
 # Get changed files
 echo "Fetching changed files..."
+pr_head_branch=""
 if [ "$MODE" = "staged" ]; then
     all_changed=$(git diff --cached --name-only --diff-filter=ACMR)
 else
     all_changed=$(gh pr diff $PR_NUMBER --name-only)
+    pr_head_branch=$(gh pr view $PR_NUMBER --json headRefName --jq '.headRefName')
 fi
 changed_files=$(echo "$all_changed" | grep '\.py$' || echo "")
 
@@ -132,18 +134,33 @@ while IFS= read -r file; do
         continue
     fi
 
+    # Which functions does this change actually touch? The model scores the whole
+    # file, so without this every change to a file that already holds a complex
+    # function failed the gate -- proximity, not the change (#1118).
+    if [ "$MODE" = "staged" ]; then
+        touched=$(python3 "$SCRIPT_DIR/lib/touched_functions.py" --staged "$file")
+    else
+        touched=$(python3 "$SCRIPT_DIR/lib/touched_functions.py" --range "origin/main...origin/$pr_head_branch" "$file")
+    fi
+
+    if [ -z "$touched" ]; then
+        echo "Skipping $file (no function bodies touched)"
+        continue
+    fi
+
     echo "Analyzing: $file"
     result=$(analyze "Analyze code complexity. Rate each function 1-10 (1=simple, 10=very complex). Report ONLY functions with score >7 in format 'FunctionName: Score X - Reason'. File content:
 
 $(cat "$file")")
 
     # The documented budget is grade A-B, complexity <= 8, so 8 is acceptable and
-    # only 9 and 10 are findings. The old pattern also matched 8 and would have
-    # flagged code that meets the standard.
-    if echo "$result" | grep -qi "score 9\|score 10"; then
-        warnings+=("High complexity in $file: $result")
+    # only 9 and 10 are findings. Findings on functions this diff did not touch
+    # are dropped: they are the file's pre-existing state, and the author of an
+    # unrelated change is not the person to refactor them.
+    scoped=$(printf '%s' "$result" | python3 "$SCRIPT_DIR/lib/scope_findings.py" $touched) && {
+        warnings+=("High complexity in $file: $scoped")
         exit_code=1
-    fi
+    }
 done < <(echo "$changed_files")
 echo ""
 
@@ -205,19 +222,29 @@ api_paths=(src/mcp_memory_service/tools src/mcp_memory_service/web/api)
 if [ "$MODE" = "staged" ]; then
     api_changes=$(git diff --cached -- "${api_paths[@]}" 2>/dev/null || echo "")
 else
-    head_branch=$(gh pr view $PR_NUMBER --json headRefName --jq '.headRefName')
-    api_changes=$(git diff origin/main...origin/$head_branch -- "${api_paths[@]}" 2>/dev/null || echo "")
+    api_changes=$(git diff "origin/main...origin/$pr_head_branch" -- "${api_paths[@]}" 2>/dev/null || echo "")
 fi
 
 if [ ! -z "$api_changes" ]; then
     echo "Analyzing API changes..."
     # Truncate to 200 lines to bound the prompt. Large diffs still lose context,
     # which is an accepted trade-off here.
-    breaking_result=$(analyze "Analyze for breaking changes. Breaking changes include: removed functions/endpoints, changed signatures (parameters removed/reordered), changed return types, renamed public APIs, changed HTTP paths/methods. Report ONLY if breaking changes found with severity (CRITICAL/HIGH/MEDIUM). Changes:
+    # The marker is required for the same reason the security check has one: the
+    # old pattern grepped for the word "breaking", which matches the model's own
+    # "No breaking changes found." Every API change reported a finding whose text
+    # said there was none.
+    breaking_result=$(analyze "Analyze for breaking changes. Breaking changes include: removed functions/endpoints, changed signatures (parameters removed/reordered), changed return types, renamed public APIs, changed HTTP paths/methods.
+
+IMPORTANT: Output format:
+- If ANY breaking change is found, start the response with: BREAKING_CHANGE_DETECTED: [severity CRITICAL/HIGH/MEDIUM]
+- If there are none, start the response with: NO_BREAKING_CHANGES
+- Then provide details
+
+Changes:
 
 $(echo "$api_changes" | head -200)")
 
-    if echo "$breaking_result" | grep -qi "breaking\|CRITICAL\|HIGH"; then
+    if echo "$breaking_result" | grep -q "^BREAKING_CHANGE_DETECTED:"; then
         warnings+=("Potential breaking changes detected: $breaking_result")
         if [ $exit_code -eq 0 ]; then
             exit_code=1
@@ -317,7 +344,10 @@ Run \`bash scripts/security/scan_vulnerabilities.sh\` locally and fix all securi
     fi
 
 else
-    echo "WARNINGS (non-blocking)"
+    # These block: exit 1 is what pre_pr_check.sh reads to fail check 2. The
+    # heading used to say "non-blocking", so the gate contradicted itself in the
+    # same breath (#1118).
+    echo "FINDINGS (blocking)"
     echo ""
     for warning in "${warnings[@]}"; do
         echo "- $warning"
@@ -327,14 +357,13 @@ else
     if [ "$MODE" = "pr" ]; then
         warnings_md=$(printf '%s\n' "${warnings[@]}" | sed 's/^/- /')
 
-        gh pr comment $PR_NUMBER --body "**Quality Gate WARNINGS**
+        gh pr comment $PR_NUMBER --body "**Quality Gate FAILED**
 
-Some checks require attention (non-blocking):
+These findings block the gate:
 
 $warnings_md
 
-**Recommendation:**
-Consider addressing these issues before requesting review to improve code quality."
+Each names a function this change touched. Findings on untouched functions in the same file are not reported."
     fi
 
 fi

--- a/tests/ci/test_quality_gate.sh
+++ b/tests/ci/test_quality_gate.sh
@@ -11,12 +11,19 @@
 #   2. `grep -c ... || echo 0` produced "0\n0" and killed the arithmetic test
 #      in check 3 under set -e
 #   3. the complexity pattern matched score 8, which the documented budget allows
+#   4. complexity was scored per file, so a change to a file holding an unrelated
+#      complex function failed the gate on proximity (#1118)
+#   5. check 4 grepped for the word "breaking", which matches the model's own
+#      "No breaking changes found."
+#   6. the findings that set exit 1 were printed under "WARNINGS (non-blocking)"
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 GATE="$REPO_ROOT/scripts/pr/quality_gate.sh"
 HELPER="$REPO_ROOT/scripts/pr/lib/llm_prompt.py"
+SCOPE="$REPO_ROOT/scripts/pr/lib/scope_findings.py"
+TOUCHED="$REPO_ROOT/scripts/pr/lib/touched_functions.py"
 
 PASS=0
 FAIL=0
@@ -70,8 +77,60 @@ test_file_counts_use_grep_exit_only() {
 
 # --- Test: complexity 8 is within budget and must not be flagged ---
 test_complexity_threshold_allows_8() {
-  grep -qF 'grep -qi "score 9\|score 10"' "$GATE" \
-    || { echo "   complexity pattern does not match only 9 and 10"; return 1; }
+  local out
+  out=$(printf 'handler: Score 8 - borderline\n' | python3 "$SCOPE" handler) && {
+    echo "   score 8 was reported as a finding: $out"; return 1
+  }
+  out=$(printf 'handler: Score 9 - too much\n' | python3 "$SCOPE" handler) \
+    || { echo "   score 9 was not reported"; return 1; }
+  [[ "$out" == *"Score 9"* ]] || { echo "   finding text lost: $out"; return 1; }
+}
+
+# --- Test: a finding on a function the diff did not touch is dropped (#1118) ---
+test_findings_scoped_to_touched_functions() {
+  printf 'untouched_helper: Score 10 - pre-existing\n' | python3 "$SCOPE" the_one_i_edited && {
+    echo "   a finding on an untouched function still blocks"; return 1
+  }
+  local out
+  out=$(printf 'MyClass.the_one_i_edited: Score 9 - mine\n' | python3 "$SCOPE" the_one_i_edited) \
+    || { echo "   a qualified name did not match its own leaf"; return 1; }
+  [[ "$out" == *"Score 9"* ]] || { echo "   qualified-name finding lost: $out"; return 1; }
+}
+
+# --- Test: touched_functions attributes a change to the function that holds it ---
+test_touched_functions_maps_lines_to_functions() {
+  local tmp
+  tmp=$(mktemp -d)
+  (
+    cd "$tmp" || exit 1
+    git init -q . && git config user.email t@example.com && git config user.name t
+    printf 'def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n' > m.py
+    git add m.py && git commit -qm base
+    printf 'def alpha():\n    return 1\n\n\ndef beta():\n    return 22\n' > m.py
+    git add m.py
+    python3 "$TOUCHED" --staged m.py
+  ) > "$tmp/out" 2>/dev/null
+  local out
+  out=$(cat "$tmp/out")
+  rm -rf "$tmp"
+  [[ "$out" == *"beta"* ]] || { echo "   the edited function was not reported: $out"; return 1; }
+  [[ "$out" != *"alpha"* ]] || { echo "   an untouched function was reported: $out"; return 1; }
+}
+
+# --- Test: the breaking-change check needs a marker, not the word "breaking" ---
+test_breaking_change_needs_marker() {
+  grep -q 'grep -q "\^BREAKING_CHANGE_DETECTED:"' "$GATE" \
+    || { echo "   check 4 does not key off a machine marker"; return 1; }
+  ! grep -q 'grep -qi "breaking\\|CRITICAL\\|HIGH"' "$GATE" \
+    || { echo "   the old pattern remains and matches \"No breaking changes found\""; return 1; }
+}
+
+# --- Test: findings that set exit 1 are not labelled non-blocking ---
+test_blocking_findings_are_labelled_blocking() {
+  grep -q 'echo "FINDINGS (blocking)"' "$GATE" \
+    || { echo "   the failing summary does not say it blocks"; return 1; }
+  ! grep -q 'WARNINGS (non-blocking)' "$GATE" \
+    || { echo "   the gate still calls its blocking findings non-blocking"; return 1; }
 }
 
 # --- Test: the helper reports an unusable endpoint as no-backend, not as a reply ---
@@ -99,6 +158,10 @@ run_test "file counts rely on grep's own output" test_file_counts_use_grep_exit_
 run_test "complexity threshold allows a score of 8" test_complexity_threshold_allows_8
 run_test "helper exits 3 when the endpoint is unusable" test_helper_signals_no_backend
 run_test "skipped pyscn is not summarised as OK" test_pyscn_skip_not_reported_as_ok
+run_test "findings are scoped to the functions the diff touched" test_findings_scoped_to_touched_functions
+run_test "touched_functions maps changed lines to their function" test_touched_functions_maps_lines_to_functions
+run_test "breaking-change check needs a marker" test_breaking_change_needs_marker
+run_test "blocking findings are labelled blocking" test_blocking_findings_are_labelled_blocking
 
 echo ""
 echo "passed: $PASS, failed: $FAIL"


### PR DESCRIPTION
Closes #1118.

Drei Stellen, an denen das Pflicht-Gate etwas anderes gesagt hat, als es tat.

**1. Komplexitaet wurde pro Datei bewertet.** Wer eine Datei anfasste, die schon eine Funktion ueber dem Budget enthielt, fiel durch -- egal was die Aenderung tat. `storage/hybrid.py` haelt vier solche Funktionen, `storage/base.py` zwei, also war das Gate fuer den grossen Teil der Storage-Arbeit unpassierbar. Heute ist mir dasselbe bei einer reinen Kommentaraenderung passiert.

Ein Fund zaehlt jetzt nur noch, wenn er eine Funktion nennt, die der Diff wirklich beruehrt hat. `scripts/pr/lib/touched_functions.py` loest die Diff-Hunks gegen den AST der Datei auf, `scripts/pr/lib/scope_findings.py` filtert damit den Modell-Report. Eine Aenderung, die keinen Funktionsrumpf trifft -- Importe, Konstanten, ein Kommentar -- ueberspringt die Datei ganz.

Bewusst konservativ: ein Fund, dessen Funktionsnamen sich nicht parsen laesst, wird behalten statt verworfen. Eine Parsing-Luecke soll kein gruenes Gate erzeugen.

**2. Check 4 hat sein eigenes Modell-Ergebnis nach dem Wort "breaking" durchsucht.** Das matcht "No breaking changes found." Jede API-Aenderung erzeugte damit einen Fund, dessen Text sagte, es gebe keinen -- genau so stand es heute in meinem Gate-Lauf. Jetzt derselbe Marker-Mechanismus, den der Security-Check schon immer hatte.

**3. Die Funde, die `exit 1` setzen, standen unter `WARNINGS (non-blocking)`.** `pre_pr_check.sh` liest genau diesen Exit-Code als FAIL. Die Ueberschrift sagt jetzt, was der Exit-Code tut.

**Tests.** Vier neue Faelle in `tests/ci/test_quality_gate.sh`, der bestehende Score-8-Fall greift jetzt den Filter statt eines Literals ab. 11 von 11 gruen. Die beiden Behauptungen ueber den Text des Gates schlagen gegen `origin/main` fehl -- ohne diesen Gegenbeweis waeren es Tests, die nichts pruefen.

`bash scripts/pr/pre_pr_check.sh`: ALL CHECKS PASSED (12/13, einer uebersprungen).