### PR TITLE
chore(release): verify published artifacts by content, not status code

### DIFF
--- a/.claude/directives/version-management.md
+++ b/.claude/directives/version-management.md
@@ -54,17 +54,23 @@ A release is done when it is installable, not when the tag exists. After the tag
 check the publish endpoints directly:
 
 ```bash
-# both distributions, not just the main one
-curl -s https://pypi.org/pypi/mcp-memory-service/json      | jq -r .info.version
-curl -s https://pypi.org/pypi/mcp-memory-service-lite/json | jq -r .info.version
-
-# all four image tags: X.Y.Z, X.Y.Z-slim, X.Y, X.Y-slim
-curl -s -o /dev/null -w '%{http_code}\n' \
-  https://hub.docker.com/v2/repositories/doobidoo/mcp-memory-service/tags/X.Y.Z
+bash scripts/release/verify_artifacts.sh X.Y.Z
 ```
 
-PyPI's JSON endpoint lags the upload by a minute or two, so a stale version there right
-after a green publish job is cache, not failure — re-check before concluding anything.
+It verifies both PyPI distributions by `.info.version`, all four image tags
+(`X.Y.Z`, `X.Y.Z-slim`, `X.Y`, `X.Y-slim`) by tag name, and that `X.Y`, `X.Y-slim` and
+`latest` resolve to the same **digests** as the exact version tags. Nothing in it treats
+an HTTP status code as evidence. It is read-only, so re-running it is free and is the
+intended way to confirm a `gh run rerun --failed` actually recovered the release.
+
+Pending checks are polled until a deadline (`--timeout`, default 600s) because PyPI's
+JSON endpoint lags the upload by a minute or two — a stale version there right after a
+green publish job is cache, not failure. Docker Hub also rate-limits anonymous callers,
+and a throttled response looks exactly like a missing tag, which is the other reason the
+checks retry instead of concluding on a single probe.
+
+Exit 0 means every artifact is present and consistent. Exit 1 prints each unmet check
+with what was actually observed — do not create the release object until it is 0.
 
 ### A release can publish half of itself
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ scripts/
 ├── linux/           # Linux service management shortcuts (v7.5.1+)
 ├── maintenance/     # Database cleanup and repair operations
 ├── migration/       # Data migration and schema updates
+├── release/         # Post-tag release artifact verification
 ├── server/          # Server runtime and operational scripts
 ├── service/         # Service management and deployment
 ├── sync/            # Backend synchronization utilities
@@ -188,6 +189,18 @@ Handle database migrations and data transformations.
 | `migrate_timestamps.py` | Fix timestamp issues | `python migration/migrate_timestamps.py` |
 | `cleanup_mcp_timestamps.py` | Clean timestamp proliferation | `python migration/cleanup_mcp_timestamps.py` |
 | `verify_mcp_timestamps.py` | Verify timestamp consistency | `python migration/verify_mcp_timestamps.py` |
+
+### 📦 **release/** - Release Artifact Verification
+Prove a release is installable after the tag push, before the release object exists.
+
+| Script | Purpose | Quick Usage |
+|--------|---------|-------------|
+| `verify_artifacts.sh` | Verify PyPI (main + lite) by version and all four Docker tags plus `latest` by digest | `bash release/verify_artifacts.sh 11.11.0` |
+
+Read-only and idempotent; polls until `--timeout` (default 600s) to absorb PyPI's cache
+lag and Docker Hub's anonymous rate limit. Exit 0 means published, exit 1 prints each
+unmet check with what was observed. Never treats an HTTP status code as proof. See
+[`.claude/directives/version-management.md`](../.claude/directives/version-management.md).
 
 ### 🏠 **installation/** - Setup & Installation
 Platform-specific installation and setup scripts.

--- a/scripts/release/verify_artifacts.sh
+++ b/scripts/release/verify_artifacts.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Release Artifact Verification
+#
+# Proves a release is actually installable. Checks published content, never HTTP
+# status codes: PyPI is verified by the version string in its JSON metadata, Docker
+# Hub by the tag name and image digest returned for each tag.
+#
+# Checks performed for version X.Y.Z:
+#   1. PyPI mcp-memory-service       .info.version == X.Y.Z
+#   2. PyPI mcp-memory-service-lite  .info.version == X.Y.Z
+#   3. Docker tags X.Y.Z, X.Y.Z-slim, X.Y, X.Y-slim all exist (by .name)
+#   4. X.Y      resolves to the same digest as X.Y.Z
+#      X.Y-slim resolves to the same digest as X.Y.Z-slim
+#      latest   resolves to the same digest as X.Y.Z
+#
+# Check 4 is the v11.11.0 failure mode: the Docker job died at `docker login`, so
+# `latest` kept serving the previous build while the release looked finished.
+#
+# Read-only and therefore idempotent: re-running never changes anything, and a
+# re-run after a `gh run rerun --failed` is the intended way to confirm recovery.
+# Pending checks are polled until the deadline, because PyPI's JSON endpoint lags
+# an upload by a minute or two and Docker Hub rate-limits anonymous callers.
+#
+# Usage:
+#   scripts/release/verify_artifacts.sh 11.11.0
+#   scripts/release/verify_artifacts.sh 11.11.0 --timeout 60   # fail fast
+#
+# Exit codes:
+#   0 - every artifact verified
+#   1 - at least one artifact missing, stale, or unverifiable before the deadline
+#   2 - bad usage
+
+set -euo pipefail
+
+DOCKER_REPO="${MCS_DOCKER_REPO:-doobidoo/mcp-memory-service}"
+PYPI_PROJECTS=("mcp-memory-service" "mcp-memory-service-lite")
+TIMEOUT=600
+INTERVAL=15
+
+usage() {
+  echo "usage: $0 <X.Y.Z> [--timeout SECONDS]" >&2
+  exit 2
+}
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || usage
+shift
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "FAIL  version must be X.Y.Z, got: $VERSION" >&2
+  exit 2
+fi
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --timeout) TIMEOUT="${2:-}"; [ -n "$TIMEOUT" ] || usage; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+MINOR="${VERSION%.*}"          # 11.11.0 -> 11.11
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+
+# ---------------------------------------------------------------- fetch helpers
+
+# Echoes the value of a top-level JSON string field, or nothing on any failure.
+# Silence here is deliberate: the caller decides whether an empty result is a
+# missing artifact or a transient error, and reports it at the deadline.
+json_field() {
+  local url="$1" field="$2"
+  curl -sf --max-time 20 "$url" 2>/dev/null \
+    | python3 -c "
+import json,sys
+try:
+    print(json.load(sys.stdin).get('$field',''))
+except Exception:
+    pass
+" 2>/dev/null
+}
+
+pypi_version() {
+  curl -sf --max-time 20 "https://pypi.org/pypi/$1/json" 2>/dev/null \
+    | python3 -c "
+import json,sys
+try:
+    print(json.load(sys.stdin)['info']['version'])
+except Exception:
+    pass
+" 2>/dev/null
+}
+
+docker_digest() {
+  json_field "https://hub.docker.com/v2/repositories/$DOCKER_REPO/tags/$1" digest
+}
+
+# ------------------------------------------------------------------- the checks
+#
+# Each check name maps to a probe. A probe echoes the observed value and exits 0
+# when the artifact is verified, or echoes what it saw and exits 1 when it is not.
+
+CHECKS=(
+  "pypi:mcp-memory-service"
+  "pypi:mcp-memory-service-lite"
+  "docker:$VERSION"
+  "docker:$VERSION-slim"
+  "docker:$MINOR"
+  "docker:$MINOR-slim"
+  "digest:$MINOR:$VERSION"
+  "digest:$MINOR-slim:$VERSION-slim"
+  "digest:latest:$VERSION"
+)
+
+probe() {
+  local check="$1" kind="${1%%:*}" rest="${1#*:}"
+  case "$kind" in
+    pypi)
+      local found; found="$(pypi_version "$rest")"
+      echo "${found:-<unreachable>}"
+      [ "$found" = "$VERSION" ]
+      ;;
+    docker)
+      local name
+      name="$(json_field "https://hub.docker.com/v2/repositories/$DOCKER_REPO/tags/$rest" name)"
+      echo "${name:-<absent>}"
+      [ "$name" = "$rest" ]
+      ;;
+    digest)
+      local tag="${rest%%:*}" ref="${rest#*:}" a b
+      a="$(docker_digest "$tag")"; b="$(docker_digest "$ref")"
+      echo "${a:-<absent>} vs ${b:-<absent>}"
+      [ -n "$a" ] && [ "$a" = "$b" ]
+      ;;
+    *) echo "<unknown check>"; return 1 ;;
+  esac
+}
+
+describe() {
+  local kind="${1%%:*}" rest="${1#*:}"
+  case "$kind" in
+    pypi)   echo "PyPI $rest == $VERSION" ;;
+    docker) echo "Docker tag $rest exists" ;;
+    digest) echo "Docker ${rest%%:*} digest == ${rest#*:} digest" ;;
+  esac
+}
+
+# ------------------------------------------------------------------------ poll
+
+echo "Verifying mcp-memory-service v$VERSION (timeout ${TIMEOUT}s)"
+echo
+
+# Parallel indexed arrays of fixed length, one slot per check: macOS ships bash
+# 3.2, which has no associative arrays and errors on ${#empty[@]} under `set -u`.
+NCHECKS=${#CHECKS[@]}
+DONE=(); LAST_SEEN=()
+for (( i = 0; i < NCHECKS; i++ )); do DONE[$i]=0; LAST_SEEN[$i]="<not probed>"; done
+
+while :; do
+  pending=0
+  for (( i = 0; i < NCHECKS; i++ )); do
+    [ "${DONE[$i]}" -eq 0 ] || continue
+    check="${CHECKS[$i]}"
+    observed="$(probe "$check")" && status=0 || status=$?
+    LAST_SEEN[$i]="$observed"
+    if [ "$status" -eq 0 ]; then
+      DONE[$i]=1
+      printf 'PASS  %-42s %s\n' "$(describe "$check")" "$observed"
+    else
+      pending=$(( pending + 1 ))
+    fi
+    sleep 1   # Docker Hub rate-limits anonymous callers; back-to-back calls
+              # return an error body that looks exactly like a missing tag.
+  done
+
+  [ "$pending" -gt 0 ] || break
+
+  remaining=$(( DEADLINE - $(date +%s) ))
+  if [ "$remaining" -le 0 ]; then
+    break
+  fi
+  printf '...   %d check(s) pending, retrying in %ds (%ds left)\n' \
+    "$pending" "$INTERVAL" "$remaining"
+  sleep "$INTERVAL"
+done
+
+if [ "$pending" -gt 0 ]; then
+  echo
+  for (( i = 0; i < NCHECKS; i++ )); do
+    [ "${DONE[$i]}" -eq 0 ] || continue
+    printf 'FAIL  %-42s %s\n' "$(describe "${CHECKS[$i]}")" "${LAST_SEEN[$i]}"
+  done
+  echo
+  echo "v$VERSION is NOT fully published. Do not create the release object yet."
+  echo "If release.yml has a failed job, recover with:"
+  echo "  gh run rerun <run-id> --failed        # never workflow_dispatch"
+  exit 1
+fi
+
+echo
+echo "v$VERSION verified on PyPI (main + lite) and Docker Hub (4 tags + latest)."


### PR DESCRIPTION
## What

`scripts/release/verify_artifacts.sh <X.Y.Z>` — proves a tagged release is actually installable, before the release object goes up.

Nine checks:

- PyPI `mcp-memory-service` and `mcp-memory-service-lite` by `.info.version`
- Docker tags `X.Y.Z`, `X.Y.Z-slim`, `X.Y`, `X.Y-slim` by tag name
- `X.Y`, `X.Y-slim` and `latest` resolve to the same **digests** as the exact version tags

The digest check is the part that did not exist anywhere. It is the v11.11.0 failure mode: PyPI green, the Docker job dead at `docker login`, and `latest` still serving the previous build — a version with three open critical advisories — while the release looked finished.

## Why now

The procedure has existed as prose in `.claude/directives/version-management.md` since v11.8.1 and has been executed by hand every release. Its own snippet used `curl -o /dev/null -w '%{http_code}'`, which is precisely the status-code check the same rule set forbids ("Never treat an HTTP 200 as proof of deployment"). That is replaced.

Nothing else about the release flow is automated here. Merge decisions, bump type and release notes stay with the release manager, where the judgment is.

## Notes

Read-only and idempotent, so re-running costs nothing and is the intended way to confirm a `gh run rerun --failed` actually recovered a half-published release.

Pending checks are polled until `--timeout` (default 600s) rather than concluding on a single probe: PyPI's JSON endpoint lags an upload by a minute or two, and Docker Hub rate-limits anonymous callers — a throttled response is byte-for-byte indistinguishable from a missing tag. I hit that while building this, which is why the retry is in there.

Written for bash 3.2 (no associative arrays), since that is what macOS ships.

## Testing

```
$ ./scripts/release/verify_artifacts.sh 11.11.0 --timeout 60
PASS  PyPI mcp-memory-service == 11.11.0         11.11.0
PASS  PyPI mcp-memory-service-lite == 11.11.0    11.11.0
PASS  Docker tag 11.11.0 exists                  11.11.0
PASS  Docker tag 11.11.0-slim exists             11.11.0-slim
PASS  Docker tag 11.11 exists                    11.11
PASS  Docker tag 11.11-slim exists               11.11-slim
PASS  Docker 11.11 digest == 11.11.0 digest      sha256:bd89d3f6... vs sha256:bd89d3f6...
PASS  Docker 11.11-slim digest == 11.11.0-slim digest sha256:54a633f8... vs sha256:54a633f8...
PASS  Docker latest digest == 11.11.0 digest     sha256:bd89d3f6... vs sha256:bd89d3f6...

v11.11.0 verified on PyPI (main + lite) and Docker Hub (4 tags + latest).
EXIT=0

$ ./scripts/release/verify_artifacts.sh 99.99.99 --timeout 1
FAIL  (all nine, each printing what was observed)
v99.99.99 is NOT fully published. Do not create the release object yet.
EXIT=1

$ ./scripts/release/verify_artifacts.sh v11.11.0   -> EXIT=2, version must be X.Y.Z
$ ./scripts/release/verify_artifacts.sh            -> EXIT=2, usage
```

Incidental finding from the dry run: v11.11.0 is fully published on Docker Hub, so the `gh run rerun --failed` after the 2026-09-05 login failure did land. `latest` is correct.

`bash scripts/pr/pre_pr_check.sh`: ALL CHECKS PASSED (11/13). The two skips are the quality gate and coverage, both skipped because no local analysis model was reachable in this environment — not evaluated, not failed.