### PR TITLE
docs(cloudflare): correct the D1 foreign key comment in the tombstone purge

### DIFF
--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -1499,8 +1499,10 @@ class CloudflareStorage(MemoryStorage):
                 break
             max_id = rows[-1]["id"]
 
-            # Join rows first: D1 does not guarantee the schema's ON DELETE CASCADE
-            # is enforced, and an orphaned memory_tags row would outlive its memory.
+            # Join rows first. D1 enforces foreign keys the way `PRAGMA foreign_keys = on`
+            # does, so the schema's ON DELETE CASCADE would take these rows with the
+            # memories below; deleting them explicitly keeps the purge from depending on
+            # that, and bounds the work each batch does.
             tags_sql = (
                 "DELETE FROM memory_tags WHERE memory_id IN "
                 "(SELECT id FROM memories WHERE deleted_at IS NOT NULL AND deleted_at < ? AND id <= ?)"
@@ -1511,8 +1513,8 @@ class CloudflareStorage(MemoryStorage):
             )
             result = response.json()
             if not result.get("success"):
-                # Stop here rather than delete the memories anyway: that would leave
-                # behind exactly the orphaned join rows this ordering exists to avoid.
+                # Stop here rather than delete the memories anyway: a D1 that just
+                # failed a write is no state in which to keep purging.
                 logger.error(f"Tombstone tag purge failed: {_sanitize_log_value(result.get('errors'))}")
                 break
 


### PR DESCRIPTION
Follow-up to #1136.

That PR added a tombstone cleanup in `_store_d1_memory` that leans on the schema's `ON DELETE CASCADE` to drop obsolete `memory_tags` links. The purge path a thousand lines further down carried a comment asserting the opposite - that D1 does not guarantee the cascade is enforced - so the file ended up stating both positions.

The cascade side is the correct one. Cloudflare's documentation: "By default, D1 enforces that foreign key constraints are valid within all queries and migrations. This is identical to the behaviour you would observe when setting `PRAGMA foreign_keys = on` in SQLite for every transaction." (https://developers.cloudflare.com/d1/sql-api/foreign-keys/)

The purge still deletes the join rows explicitly. That is worth keeping - it bounds the work each batch does rather than handing an unbounded cascade to D1 - but the reason recorded for it is now the real one, and the follow-on comment about aborting on failure no longer rests on a false premise.

Comments only. No SQL, no behaviour, no test changes.

## Checks

`bash scripts/pr/pre_pr_check.sh`: 12 of 13 pass, 2 skips. The one failure is check 6.5, the log-injection guard, reporting five f-string logger calls in `cloudflare.py` at lines 68, 210, 220, 230 and 265. All five are byte-identical on `origin/main` at the same line numbers, and this branch changes ten lines, none of them a logger call. That check scans the whole file rather than the diff; it is the inherited state tracked in #1119.
