### PR TITLE
fix(quality): read pyscn metrics from JSON

### DIFF
--- a/docs/development/code-quality-workflow.md
+++ b/docs/development/code-quality-workflow.md
@@ -149,7 +149,7 @@ bash scripts/pr/quality_gate.sh <PR_NUMBER> --with-pyscn
 - Dead code detection
 - Code duplication analysis
 - Coupling metrics (CBO)
-- Architecture violations
+- Architecture score
 
 **Duration:** ~30-60 seconds
 
@@ -239,7 +239,7 @@ bash scripts/quality/track_pyscn_metrics.sh
 
 **Output:**
 - CSV file: `.pyscn/history/metrics.csv`
-- HTML report: `.pyscn/reports/analyze_*.html`
+- JSON report: `.pyscn/reports/analyze_*.json`
 
 **Example Output:**
 ```
@@ -366,15 +366,15 @@ pip install pyscn
 pyscn analyze .
 ```
 
-**View Report:**
+**Generate and view the machine-readable report:**
 ```bash
-open .pyscn/reports/analyze_*.html
+pyscn analyze --json --no-open .
+python3 -m json.tool "$(ls -t .pyscn/reports/analyze_*.json | head -1)" | less
 ```
 
-**JSON Output:**
-```bash
-pyscn analyze . --format json > /tmp/metrics.json
-```
+The PR and trend scripts read metrics from the JSON `summary` contract through
+`scripts/quality/read_pyscn_summary.py`. They deliberately reject missing or
+non-numeric metrics instead of recording a misleading zero score.
 
 ### Report Interpretation
 
@@ -525,6 +525,7 @@ pyscn analyze --exclude "tests/*,scripts/*"
 | `scripts/pr/quality_gate.sh` | PR quality gates | `bash scripts/pr/quality_gate.sh <PR>` |
 | `scripts/pr/run_pyscn_analysis.sh` | pyscn PR analysis | `bash scripts/pr/run_pyscn_analysis.sh --pr <PR>` |
 | `scripts/quality/track_pyscn_metrics.sh` | Metrics tracking | `bash scripts/quality/track_pyscn_metrics.sh` |
+| `scripts/quality/read_pyscn_summary.py` | Validate and extract pyscn JSON metrics | Called by both pyscn scripts |
 | `scripts/quality/weekly_quality_review.sh` | Weekly review | `bash scripts/quality/weekly_quality_review.sh` |
 
 ### Configuration Files
@@ -533,7 +534,7 @@ pyscn analyze --exclude "tests/*,scripts/*"
 |------|---------|
 | `.pyscn/.gitignore` | Ignore pyscn reports and history |
 | `.pyscn/history/metrics.csv` | Historical quality metrics |
-| `.pyscn/reports/*.html` | pyscn HTML reports |
+| `.pyscn/reports/*.json` | pyscn machine-readable reports |
 | `.claude/agents/code-quality-guard.md` | Code quality agent specification |
 
 ### Related Documentation

--- a/scripts/pr/run_pyscn_analysis.sh
+++ b/scripts/pr/run_pyscn_analysis.sh
@@ -14,6 +14,7 @@
 #   bash scripts/pr/run_pyscn_analysis.sh --threshold 70     # Require health score ≥70
 
 set -e
+set -o pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -65,34 +66,31 @@ mkdir -p .pyscn/reports
 echo "Running pyscn analysis (this may take 30-60 seconds)..."
 echo ""
 
-# Generate timestamp for report
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-REPORT_FILE=".pyscn/reports/analyze_${TIMESTAMP}.html"
-JSON_FILE=".pyscn/reports/analyze_${TIMESTAMP}.json"
+# Mark the start so stale reports from previous runs cannot be selected.
+RUN_MARKER=$(mktemp)
 
-# Run analysis (HTML report)
-if pyscn analyze . --output "$REPORT_FILE" 2>&1 | tee /tmp/pyscn_output.log; then
+# Run analysis using pyscn's stable machine-readable format.
+if pyscn analyze --json --no-open . 2>&1 | tee /tmp/pyscn_output.log; then
     echo -e "${GREEN}✓${NC} Analysis complete"
 else
+    rm -f "$RUN_MARKER"
     echo -e "${RED}❌ Analysis failed${NC}"
     cat /tmp/pyscn_output.log
     exit 1
 fi
 
-# Extract metrics from HTML report using grep/sed
-# Note: This is a simple parser - adjust patterns if pyscn output format changes
-HEALTH_SCORE=$(grep -o 'Health Score: [0-9]*' "$REPORT_FILE" | head -1 | grep -o '[0-9]*' || echo "0")
-COMPLEXITY_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | head -1 | sed 's/<[^>]*>//g' || echo "0")
-DEAD_CODE_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '2p' | sed 's/<[^>]*>//g' || echo "0")
-DUPLICATION_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
+JSON_FILE=$(find .pyscn/reports -type f -name 'analyze_*.json' -newer "$RUN_MARKER" -print | sort | tail -1)
+rm -f "$RUN_MARKER"
+if [ -z "$JSON_FILE" ]; then
+    echo -e "${RED}❌ Analysis produced no new JSON report${NC}"
+    exit 1
+fi
 
-# Extract detailed metrics
-TOTAL_FUNCTIONS=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | head -1 | sed 's/<[^>]*>//g' || echo "0")
-AVG_COMPLEXITY=$(grep -o '<div class="metric-value">[0-9.]*</div>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
-MAX_COMPLEXITY=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
-DUPLICATION_PCT=$(grep -o '<div class="metric-value">[0-9.]*%</div>' "$REPORT_FILE" | head -1 | sed 's/<[^>]*>//g' || echo "0%")
-DEAD_CODE_ISSUES=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | sed -n '4p' | sed 's/<[^>]*>//g' || echo "0")
-ARCHITECTURE_VIOLATIONS=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | tail -2 | head -1 | sed 's/<[^>]*>//g' || echo "0")
+METRICS=$(python3 "$(dirname "$0")/../quality/read_pyscn_summary.py" "$JSON_FILE") || exit 1
+IFS=$'\t' read -r HEALTH_SCORE COMPLEXITY_SCORE DEAD_CODE_SCORE DUPLICATION_SCORE \
+    _COUPLING_SCORE _DEPENDENCIES_SCORE ARCHITECTURE_SCORE AVG_COMPLEXITY \
+    MAX_COMPLEXITY DUPLICATION_NUM DEAD_CODE_ISSUES <<< "$METRICS"
+DUPLICATION_PCT="${DUPLICATION_NUM}%"
 
 echo ""
 echo -e "${BLUE}=== Analysis Results ===${NC}"
@@ -104,7 +102,7 @@ echo "  - Complexity: $COMPLEXITY_SCORE/100 (Avg: $AVG_COMPLEXITY, Max: $MAX_COM
 echo "  - Dead Code: $DEAD_CODE_SCORE/100 ($DEAD_CODE_ISSUES issues)"
 echo "  - Duplication: $DUPLICATION_SCORE/100 ($DUPLICATION_PCT duplication)"
 echo ""
-echo "📄 Report: $REPORT_FILE"
+echo "📄 Report: $JSON_FILE"
 echo ""
 
 # Determine status
@@ -152,7 +150,6 @@ if [ "$MAX_COMPLEXITY" -gt 10 ]; then
 fi
 
 CRITICAL_DUPLICATION=""
-DUPLICATION_NUM=$(echo "$DUPLICATION_PCT" | sed 's/%//')
 if (( $(echo "$DUPLICATION_NUM > 5.0" | bc -l) )); then
     CRITICAL_DUPLICATION="- ⚠️  Code duplication above 5% threshold ($DUPLICATION_PCT)
 "
@@ -176,7 +173,7 @@ if [ -n "$PR_NUMBER" ]; then
 | 🔢 Complexity | $COMPLEXITY_SCORE/100 | Avg: $AVG_COMPLEXITY, Max: $MAX_COMPLEXITY |
 | 💀 Dead Code | $DEAD_CODE_SCORE/100 | $DEAD_CODE_ISSUES issues |
 | 📋 Duplication | $DUPLICATION_SCORE/100 | $DUPLICATION_PCT code duplication |
-| 🏗️  Architecture | N/A | $ARCHITECTURE_VIOLATIONS violations |
+| 🏗️  Architecture | $ARCHITECTURE_SCORE/100 | pyscn architecture score |
 
 ### Status
 
@@ -186,7 +183,7 @@ ${CRITICAL_COMPLEXITY}${CRITICAL_DUPLICATION}${RECOMMENDATIONS}
 
 ### Full Report
 
-View detailed analysis: [HTML Report](.pyscn/reports/analyze_${TIMESTAMP}.html)
+View detailed analysis: [JSON Report]($JSON_FILE)
 
 ---
 
@@ -224,7 +221,7 @@ else
     echo "Health score ($HEALTH_SCORE) below threshold ($THRESHOLD)"
     echo ""
     echo "Action required before merging:"
-    echo "  1. Review full report: open $REPORT_FILE"
+    echo "  1. Review full report: $JSON_FILE"
     echo "  2. Address high-complexity functions (complexity >10)"
     echo "  3. Remove dead code ($DEAD_CODE_ISSUES issues)"
     echo "  4. Reduce duplication where feasible"

--- a/scripts/quality/read_pyscn_summary.py
+++ b/scripts/quality/read_pyscn_summary.py
@@ -1,0 +1,61 @@
+"""Read the stable metric contract from a pyscn JSON report."""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def require_number(mapping: dict[str, Any], key: str) -> float:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"missing or invalid numeric metric: {key}")
+    if not math.isfinite(value):
+        raise ValueError(f"non-finite numeric metric: {key}")
+    return float(value)
+
+
+def format_number(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} REPORT.json", file=sys.stderr)
+        return 2
+
+    try:
+        report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+        summary = report["summary"]
+        complexity = report["complexity"]["summary"]
+        if not isinstance(summary, dict) or not isinstance(complexity, dict):
+            raise TypeError("summary objects must be mappings")
+
+        metrics = [
+            require_number(summary, "health_score"),
+            require_number(summary, "complexity_score"),
+            require_number(summary, "dead_code_score"),
+            require_number(summary, "duplication_score"),
+            require_number(summary, "coupling_score"),
+            require_number(summary, "dependency_score"),
+            require_number(summary, "architecture_score"),
+            require_number(summary, "average_complexity"),
+            require_number(complexity, "max_complexity"),
+            require_number(summary, "code_duplication_percentage"),
+            require_number(summary, "dead_code_count"),
+        ]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        print(f"invalid pyscn JSON report: {exc}", file=sys.stderr)
+        return 1
+
+    print("\t".join(format_number(metric) for metric in metrics))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quality/track_pyscn_metrics.sh
+++ b/scripts/quality/track_pyscn_metrics.sh
@@ -38,29 +38,29 @@ DATE_READABLE=$(date +"%Y-%m-%d %H:%M:%S")
 
 # Run pyscn analysis
 echo "Running pyscn analysis..."
-REPORT_FILE=".pyscn/reports/analyze_${TIMESTAMP}.html"
+RUN_MARKER=$(mktemp)
 
-if pyscn analyze . --output "$REPORT_FILE" > /tmp/pyscn_metrics.log 2>&1; then
+if pyscn analyze --json --no-open . > /tmp/pyscn_metrics.log 2>&1; then
     echo -e "${GREEN}✓${NC} Analysis complete"
 else
+    rm -f "$RUN_MARKER"
     echo -e "${RED}❌ Analysis failed${NC}"
     cat /tmp/pyscn_metrics.log
     exit 1
 fi
 
-# Extract metrics from HTML report
-HEALTH_SCORE=$(grep -o 'Health Score: [0-9]*' "$REPORT_FILE" | head -1 | grep -o '[0-9]*' || echo "0")
-COMPLEXITY_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | head -1 | sed 's/<[^>]*>//g' || echo "0")
-DEAD_CODE_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '2p' | sed 's/<[^>]*>//g' || echo "0")
-DUPLICATION_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
-COUPLING_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '4p' | sed 's/<[^>]*>//g' || echo "100")
-DEPENDENCIES_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '5p' | sed 's/<[^>]*>//g' || echo "0")
-ARCHITECTURE_SCORE=$(grep -o '<span class="score-value">[0-9]*</span>' "$REPORT_FILE" | sed -n '6p' | sed 's/<[^>]*>//g' || echo "0")
+JSON_FILE=$(find .pyscn/reports -type f -name 'analyze_*.json' -newer "$RUN_MARKER" -print | sort | tail -1)
+rm -f "$RUN_MARKER"
+if [ -z "$JSON_FILE" ]; then
+    echo -e "${RED}❌ Analysis produced no new JSON report${NC}"
+    exit 1
+fi
 
-AVG_COMPLEXITY=$(grep -o '<div class="metric-value">[0-9.]*</div>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
-MAX_COMPLEXITY=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | sed -n '3p' | sed 's/<[^>]*>//g' || echo "0")
-DUPLICATION_PCT=$(grep -o '<div class="metric-value">[0-9.]*%</div>' "$REPORT_FILE" | head -1 | sed 's/<[^>]*>//g' || echo "0%")
-DEAD_CODE_ISSUES=$(grep -o '<div class="metric-value">[0-9]*</div>' "$REPORT_FILE" | sed -n '4p' | sed 's/<[^>]*>//g' || echo "0")
+METRICS=$(python3 "$(dirname "$0")/read_pyscn_summary.py" "$JSON_FILE") || exit 1
+IFS=$'\t' read -r HEALTH_SCORE COMPLEXITY_SCORE DEAD_CODE_SCORE DUPLICATION_SCORE \
+    COUPLING_SCORE DEPENDENCIES_SCORE ARCHITECTURE_SCORE AVG_COMPLEXITY \
+    MAX_COMPLEXITY DUPLICATION_NUM DEAD_CODE_ISSUES <<< "$METRICS"
+DUPLICATION_PCT="${DUPLICATION_NUM}%"
 
 echo ""
 echo -e "${BLUE}=== Metrics Extracted ===${NC}"
@@ -110,7 +110,7 @@ if [ $(wc -l < "$CSV_FILE") -gt 2 ]; then
             echo ""
             echo "Recommended actions:"
             echo "  1. Review recent changes: git log --since='$PREV_DATE'"
-            echo "  2. Compare reports: open $REPORT_FILE"
+            echo "  2. Compare reports: $JSON_FILE"
             echo "  3. Create GitHub issue to track regression"
         fi
     else

--- a/tests/ci/test_pyscn_json_scripts.sh
+++ b/tests/ci/test_pyscn_json_scripts.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMPDIR_LOCAL="$(mktemp -d)"
+FAKEBIN="$TMPDIR_LOCAL/bin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/pyscn" <<'EOF'
+#!/usr/bin/env bash
+set -e
+if [ "${PYSCN_FAKE_FAIL:-}" = "1" ]; then
+  echo "simulated analyzer failure" >&2
+  exit 9
+fi
+mkdir -p .pyscn/reports
+timestamp="$(date +%Y%m%d_%H%M%S)"
+cat > ".pyscn/reports/analyze_${timestamp}.json" <<'JSON'
+{
+  "summary": {
+    "health_score": 83,
+    "complexity_score": 71,
+    "dead_code_score": 82,
+    "duplication_score": 93,
+    "coupling_score": 84,
+    "dependency_score": 75,
+    "architecture_score": 96,
+    "average_complexity": 3.5,
+    "total_functions": 42,
+    "dead_code_count": 7,
+    "code_duplication_percentage": 2.5
+  },
+  "complexity": {"summary": {"max_complexity": 11}}
+}
+JSON
+printf '<html><body>Current report layout without legacy score markup</body></html>\n' \
+  > ".pyscn/reports/analyze_${timestamp}.html"
+EOF
+chmod +x "$FAKEBIN/pyscn"
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@" 2>&1; then
+    echo "ok - $name"
+    PASS=$((PASS + 1))
+  else
+    echo "not ok - $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+reset_reports() {
+  rm -rf "$TMPDIR_LOCAL/work/.pyscn"
+  mkdir -p "$TMPDIR_LOCAL/work"
+}
+
+test_pr_gate_reads_json_summary() {
+  reset_reports
+  local out
+  out="$(cd "$TMPDIR_LOCAL/work" && PATH="$FAKEBIN:$PATH" \
+    bash "$REPO_ROOT/scripts/pr/run_pyscn_analysis.sh" --threshold 80 2>&1)" || {
+      echo "$out"
+      return 1
+    }
+  [[ "$out" == *"Overall Health Score: 83/100"* ]] || return 1
+  [[ "$out" == *"Avg: 3.5, Max: 11"* ]] || return 1
+  [[ "$out" == *"analyze_"*".json"* ]]
+}
+
+test_tracker_reads_same_json_contract() {
+  reset_reports
+  local out
+  out="$(cd "$TMPDIR_LOCAL/work" && PATH="$FAKEBIN:$PATH" \
+    bash "$REPO_ROOT/scripts/quality/track_pyscn_metrics.sh" 2>&1)" || {
+      echo "$out"
+      return 1
+    }
+  [[ "$out" == *"Health Score: 83/100"* ]] || return 1
+  [[ "$out" == *"Coupling: 84/100"* ]] || return 1
+  grep -q ',83,71,82,93,84,75,96,3.5,11,2.5%,7$' \
+    "$TMPDIR_LOCAL/work/.pyscn/history/metrics.csv"
+}
+
+test_reader_rejects_incomplete_reports() {
+  printf '{"summary": {"health_score": 83}, "complexity": {"summary": {}}}\n' \
+    > "$TMPDIR_LOCAL/incomplete.json"
+  local out
+  if out="$(python3 "$REPO_ROOT/scripts/quality/read_pyscn_summary.py" \
+    "$TMPDIR_LOCAL/incomplete.json" 2>&1)"; then
+    return 1
+  fi
+  [[ "$out" == *"missing or invalid numeric metric"* ]]
+}
+
+test_pr_gate_propagates_analyzer_failure() {
+  reset_reports
+  local out
+  if out="$(cd "$TMPDIR_LOCAL/work" && PATH="$FAKEBIN:$PATH" PYSCN_FAKE_FAIL=1 \
+    bash "$REPO_ROOT/scripts/pr/run_pyscn_analysis.sh" 2>&1)"; then
+    return 1
+  fi
+  [[ "$out" == *"Analysis failed"* ]] && [[ "$out" == *"simulated analyzer failure"* ]]
+}
+
+run_test "PR gate reads the current pyscn JSON summary" test_pr_gate_reads_json_summary
+run_test "trend tracker reads the same JSON contract" test_tracker_reads_same_json_contract
+run_test "reader rejects incomplete reports instead of recording zero" test_reader_rejects_incomplete_reports
+run_test "PR gate propagates analyzer failures through tee" test_pr_gate_propagates_analyzer_failure
+
+rm -rf "$TMPDIR_LOCAL"
+
+echo ""
+echo "passed: $PASS, failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What this changes

Both pyscn workflows now invoke the current `--json --no-open` interface and read one validated `summary` contract through a shared Python helper. Missing or malformed metrics fail loudly, analyzer failures propagate through `tee`, and PR comments and trend CSVs use the same values.

## Why

Fixes #1127. The HTML layout is not a stable interface, so the existing grep/sed extraction now reports false zero scores with current pyscn releases.

## How it was verified

- The two-script regression failed before the fix and now passes four cases, including incomplete JSON and analyzer failure
- Current pyscn 1.30.1 executed end to end through both scripts
- CI-equivalent test selection: 2,378 passed, 90 skipped, 8 deselected, 8 xfailed, 2 xpassed
- `bash scripts/pr/pre_pr_check.sh`: passed 11/13; local model analysis and the advisory 80% coverage target were skipped, with measured coverage 61.25%
- Ruff, Black, shell syntax, and `git diff --check` passed

## Notes for the reviewer

The report remains a generated local artifact under `.pyscn/reports/`; the scripts select only a JSON report created after the current analysis begins, so stale reports cannot be recorded.

## Agent Disclosure
This PR was generated by OpenAI Codex. The submitting account is operated by the GitHub user @be-student.
Human review of this PR: no — fully automated
