### PR TITLE
fix(search): use UTC for time expression ranges

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,6 +291,10 @@ Automatic detection and optimization for different platforms:
 4. Filtered results returned chronologically
 ```
 
+Calendar expressions such as `today`, `last week`, and explicit dates use UTC
+boundaries, matching the UTC epoch timestamps stored by every backend and making
+results independent of the server host's local timezone.
+
 ## Performance Optimizations
 
 ### Model Caching

--- a/src/mcp_memory_service/utils/time_parser.py
+++ b/src/mcp_memory_service/utils/time_parser.py
@@ -16,12 +16,15 @@
 Natural language time expression parser for MCP Memory Service.
 
 This module provides utilities to parse and understand various time expressions
-for retrieving memories based on when they were stored.
+for retrieving memories based on when they were stored. Calendar boundaries are
+interpreted in UTC to match stored epoch timestamps.
 """
-import re
 import logging
-from datetime import datetime, timedelta, date, time
-from typing import Tuple, Optional, Dict
+import re
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Dict, Optional, Tuple
+
+from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +79,25 @@ PATTERNS = {
 }
 
 _MAX_TIME_QUERY_LEN = 500  # guard against ReDoS on user-supplied input
+
+
+def _utc_now() -> datetime:
+    """Return the current instant with an explicit UTC timezone."""
+    return datetime.now(timezone.utc)
+
+
+def _utc_today() -> date:
+    """Return the current UTC calendar date."""
+    return _utc_now().date()
+
+
+def _timestamp_range(start_dt: datetime, end_dt: datetime) -> Tuple[float, float]:
+    """Convert calendar boundaries to epochs using UTC for naive values."""
+    if start_dt.tzinfo is None:
+        start_dt = start_dt.replace(tzinfo=timezone.utc)
+    if end_dt.tzinfo is None:
+        end_dt = end_dt.replace(tzinfo=timezone.utc)
+    return start_dt.timestamp(), end_dt.timestamp()
 
 def _calculate_season_date_range(
     period: str,
@@ -151,9 +173,9 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 specific_date = date(int(year), int(month), int(day))
                 start_dt = datetime.combine(specific_date, time.min)
                 end_dt = datetime.combine(specific_date, time.max)
-                return start_dt.timestamp(), end_dt.timestamp()
+                return _timestamp_range(start_dt, end_dt)
             except ValueError as e:
-                logger.warning(f"Invalid date: {e}")
+                logger.warning("Invalid date: %s", _sanitize_log_value(e))
                 return None, None
             
         # Check for specific dates (MM/DD/YYYY)
@@ -162,7 +184,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
             month, day, year = specific_date_match.groups()
             month = int(month)
             day = int(day)
-            current_year = datetime.now().year
+            current_year = _utc_now().year
             year = int(year) if year else current_year
             # Handle 2-digit years
             if year and year < 100:
@@ -172,9 +194,9 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 specific_date = date(year, month, day)
                 start_dt = datetime.combine(specific_date, time.min)
                 end_dt = datetime.combine(specific_date, time.max)
-                return start_dt.timestamp(), end_dt.timestamp()
+                return _timestamp_range(start_dt, end_dt)
             except ValueError as e:
-                logger.warning(f"Invalid date: {e}")
+                logger.warning("Invalid date: %s", _sanitize_log_value(e))
                 return None, None
         
         # Relative days: "X days ago", "yesterday", "today"
@@ -187,7 +209,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
             else:
                 days = int(days_ago_match.group(1))
                 
-            target_date = date.today() - timedelta(days=days)
+            target_date = _utc_today() - timedelta(days=days)
             
             # Check for time of day modifiers
             time_of_day_match = PATTERNS["time_of_day"].search(query)
@@ -198,25 +220,25 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 # Return the full day
                 start_dt = datetime.combine(target_date, time.min)
                 end_dt = datetime.combine(target_date, time.max)
-                return start_dt.timestamp(), end_dt.timestamp()
+                return _timestamp_range(start_dt, end_dt)
         
         # Relative weeks: "X weeks ago"
         weeks_ago_match = PATTERNS["relative_weeks"].search(query)
         if weeks_ago_match:
             weeks = int(weeks_ago_match.group(1))
-            target_date = date.today() - timedelta(weeks=weeks)
+            target_date = _utc_today() - timedelta(weeks=weeks)
             # Get the start of the week (Monday)
             start_date = target_date - timedelta(days=target_date.weekday())
             end_date = start_date + timedelta(days=6)
             start_dt = datetime.combine(start_date, time.min)
             end_dt = datetime.combine(end_date, time.max)
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
         
         # Relative months: "X months ago"
         months_ago_match = PATTERNS["relative_months"].search(query)
         if months_ago_match:
             months = int(months_ago_match.group(1))
-            current = datetime.now()
+            current = _utc_now()
             # Calculate target month
             year = current.year
             month = current.month - months
@@ -235,17 +257,17 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 
             start_dt = datetime.combine(first_day, time.min)
             end_dt = datetime.combine(last_day, time.max)
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
         
         # Relative years: "X years ago"
         years_ago_match = PATTERNS["relative_years"].search(query)
         if years_ago_match:
             years = int(years_ago_match.group(1))
-            current_year = datetime.now().year
+            current_year = _utc_now().year
             target_year = current_year - years
             start_dt = datetime(target_year, 1, 1, 0, 0, 0)
             end_dt = datetime(target_year, 12, 31, 23, 59, 59)
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
 
         # "Last N X" expressions (e.g., "last 3 days", "last 2 weeks")
         # Check this BEFORE "last_period" to match more specific pattern first
@@ -284,7 +306,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
         if half_year_match:
             half = half_year_match.group(1)
             year_str = half_year_match.group(2)
-            year = int(year_str) if year_str else datetime.now().year
+            year = int(year_str) if year_str else _utc_now().year
             
             if half.lower() == "first":
                 start_dt = datetime(year, 1, 1, 0, 0, 0)
@@ -293,14 +315,14 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 start_dt = datetime(year, 7, 1, 0, 0, 0)
                 end_dt = datetime(year, 12, 31, 23, 59, 59)
                 
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
         
         # Quarter expressions
         quarter_match = PATTERNS["quarter"].search(query)
         if quarter_match:
             quarter = quarter_match.group(1).lower()
             year_str = quarter_match.group(2)
-            year = int(year_str) if year_str else datetime.now().year
+            year = int(year_str) if year_str else _utc_now().year
             
             # Map textual quarter to number
             quarter_num = {"first": 1, "1st": 1, "second": 2, "2nd": 2, 
@@ -315,21 +337,21 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
             else:
                 end_dt = datetime(year, quarter_month + 3, 1, 0, 0, 0) - timedelta(seconds=1)
                 
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
         
         # Recent/fuzzy time expressions
         recent_match = PATTERNS["recent"].search(query)
         if recent_match:
             # Default to last 7 days for "recent"
-            end_dt = datetime.now()
+            end_dt = _utc_now()
             start_dt = end_dt - timedelta(days=7)
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
             
         # If no time expression is found, return None for both timestamps
         return None, None
         
     except Exception as e:
-        logger.error(f"Error parsing time expression: {e}")
+        logger.error("Error parsing time expression: %s", _sanitize_log_value(e))
         return None, None
 
 def get_time_of_day_range(target_date: date, time_period: str) -> Tuple[float, float]:
@@ -355,17 +377,17 @@ def get_time_of_day_range(target_date: date, time_period: str) -> Tuple[float, f
             else:
                 end_dt = datetime.combine(target_date, time(end_hour, 59, 59))
                 
-        return start_dt.timestamp(), end_dt.timestamp()
+        return _timestamp_range(start_dt, end_dt)
     else:
         # Fallback to full day
         start_dt = datetime.combine(target_date, time.min)
         end_dt = datetime.combine(target_date, time.max)
-        return start_dt.timestamp(), end_dt.timestamp()
+        return _timestamp_range(start_dt, end_dt)
 
 def get_last_period_range(period: str) -> Tuple[float, float]:
     """Get timestamp range for 'last X' expressions."""
-    now = datetime.now()
-    today = date.today()
+    now = _utc_now()
+    today = _utc_today()
     
     if period == "day":
         # Last day = yesterday
@@ -436,12 +458,12 @@ def get_last_period_range(period: str) -> Tuple[float, float]:
         end_dt = now
         start_dt = end_dt - timedelta(days=1)
         
-    return start_dt.timestamp(), end_dt.timestamp()
+    return _timestamp_range(start_dt, end_dt)
 
 def get_last_n_periods_range(n: int, period: str) -> Tuple[float, float]:
     """Get timestamp range for 'last N X' expressions (e.g., 'last 3 days')."""
-    now = datetime.now()
-    today = date.today()
+    now = _utc_now()
+    today = _utc_today()
 
     # Normalize period to singular form
     period = period.rstrip('s')  # Remove trailing 's' if present
@@ -460,7 +482,7 @@ def get_last_n_periods_range(n: int, period: str) -> Tuple[float, float]:
         end_dt = now
     elif period == "month":
         # Last N months means from N months ago first day 00:00 until now
-        current = datetime.now()
+        current = _utc_now()
         year = current.year
         month = current.month - n
 
@@ -483,12 +505,12 @@ def get_last_n_periods_range(n: int, period: str) -> Tuple[float, float]:
         start_dt = datetime.combine(start_date, time.min)
         end_dt = now
 
-    return start_dt.timestamp(), end_dt.timestamp()
+    return _timestamp_range(start_dt, end_dt)
 
 def get_this_period_range(period: str) -> Tuple[float, float]:
     """Get timestamp range for 'this X' expressions."""
-    now = datetime.now()
-    today = date.today()
+    now = _utc_now()
+    today = _utc_today()
     
     if period == "day":
         # This day = today
@@ -529,7 +551,7 @@ def get_this_period_range(period: str) -> Tuple[float, float]:
         end_dt = now
         start_dt = datetime.combine(today, time.min)
         
-    return start_dt.timestamp(), end_dt.timestamp()
+    return _timestamp_range(start_dt, end_dt)
 
 def get_month_range(month_name: str) -> Tuple[float, float]:
     """Get timestamp range for a named month."""
@@ -542,10 +564,10 @@ def get_month_range(month_name: str) -> Tuple[float, float]:
     
     if month_name in month_map:
         month_num = month_map[month_name]
-        current_year = datetime.now().year
+        current_year = _utc_now().year
         
         # If the month is in the future for this year, use last year
-        current_month = datetime.now().month
+        current_month = _utc_now().month
         year = current_year if month_num <= current_month else current_year - 1
         
         # Get first and last day of the month
@@ -557,16 +579,17 @@ def get_month_range(month_name: str) -> Tuple[float, float]:
             
         start_dt = datetime.combine(first_day, time.min)
         end_dt = datetime.combine(last_day, time.max)
-        return start_dt.timestamp(), end_dt.timestamp()
+        return _timestamp_range(start_dt, end_dt)
     else:
         return None, None
 
 def get_named_period_range(period_name: str) -> Tuple[Optional[float], Optional[float]]:
     """Get timestamp range for named periods like holidays."""
     period_name = period_name.lower().replace("_", " ")
-    current_year = datetime.now().year
-    current_month = datetime.now().month
-    current_day = datetime.now().day
+    current = _utc_now()
+    current_year = current.year
+    current_month = current.month
+    current_day = current.day
     
     if period_name in NAMED_PERIODS:
         info = NAMED_PERIODS[period_name]
@@ -601,7 +624,7 @@ def get_named_period_range(period_name: str) -> Tuple[Optional[float], Optional[
             
             start_dt = datetime.combine(start_date, time.min)
             end_dt = datetime.combine(end_date, time.max)
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
             
         elif "start_month" in info and "end_month" in info:
             # Season or date range
@@ -653,7 +676,7 @@ def get_named_period_range(period_name: str) -> Tuple[Optional[float], Optional[
                         start_dt = datetime(current_year - 1, start_month, start_day)
                         end_dt = datetime(current_year - 1, end_month, end_day, 23, 59, 59)
             
-            return start_dt.timestamp(), end_dt.timestamp()
+            return _timestamp_range(start_dt, end_dt)
     
     # If no match found
     return None, None

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -1,22 +1,23 @@
 """
 Unit tests for time_parser module
 """
-import pytest
-from datetime import datetime, date, timedelta
-import time
-
-import sys
 import os
+import sys
+import time
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from mcp_memory_service.utils.time_parser import (
-    parse_time_expression,
     extract_time_expression,
-    get_time_of_day_range,
     get_last_period_range,
-    get_this_period_range,
     get_month_range,
-    get_named_period_range
+    get_named_period_range,
+    get_this_period_range,
+    get_time_of_day_range,
+    parse_time_expression,
 )
 
 
@@ -30,9 +31,9 @@ class TestTimeParser:
         assert start_ts is not None
         assert end_ts is not None
         
-        yesterday = date.today() - timedelta(days=1)
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         assert start_dt.date() == yesterday
         assert end_dt.date() == yesterday
@@ -42,14 +43,14 @@ class TestTimeParser:
         
         # Test "3 days ago"
         start_ts, end_ts = parse_time_expression("3 days ago")
-        three_days_ago = date.today() - timedelta(days=3)
-        start_dt = datetime.fromtimestamp(start_ts)
+        three_days_ago = datetime.now(timezone.utc).date() - timedelta(days=3)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
         assert start_dt.date() == three_days_ago
         
         # Test "today"
         start_ts, end_ts = parse_time_expression("today")
-        start_dt = datetime.fromtimestamp(start_ts)
-        assert start_dt.date() == date.today()
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        assert start_dt.date() == datetime.now(timezone.utc).date()
     
     def test_relative_weeks(self):
         """Test parsing relative week expressions"""
@@ -57,15 +58,15 @@ class TestTimeParser:
         assert start_ts is not None
         assert end_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         # Should be a Monday to Sunday range
         assert start_dt.weekday() == 0  # Monday
         assert end_dt.weekday() == 6    # Sunday
         
         # Should be roughly 2 weeks ago
-        days_ago = (date.today() - start_dt.date()).days
+        days_ago = (datetime.now(timezone.utc).date() - start_dt.date()).days
         assert 14 <= days_ago <= 20  # Allow some flexibility for week boundaries
     
     def test_relative_months(self):
@@ -74,8 +75,8 @@ class TestTimeParser:
         assert start_ts is not None
         assert end_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         # Should be first to last day of the month
         assert start_dt.day == 1
@@ -87,7 +88,7 @@ class TestTimeParser:
         start_ts, end_ts = parse_time_expression("03/15/2024")
         assert start_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
         assert start_dt.year == 2024
         assert start_dt.month == 3
         assert start_dt.day == 15
@@ -95,17 +96,17 @@ class TestTimeParser:
         # Test YYYY-MM-DD format
         start_ts, end_ts = parse_time_expression("2024-06-15")
         assert start_ts is not None
-        start_dt = datetime.fromtimestamp(start_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
         assert start_dt.date() == date(2024, 6, 15)
     
     def test_month_names(self):
         """Test parsing month names"""
-        current_year = datetime.now().year
-        current_month = datetime.now().month
+        current_year = datetime.now(timezone.utc).year
+        current_month = datetime.now(timezone.utc).month
         
         # Test a past month
         start_ts, end_ts = parse_time_expression("january")
-        start_dt = datetime.fromtimestamp(start_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
 
         # Should be this year's January if we're in/past January, otherwise last year's
         # Matches implementation logic: month_num <= current_month
@@ -120,8 +121,8 @@ class TestTimeParser:
         assert start_ts is not None
         assert end_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         # Summer is roughly June 21 to September 22
         assert start_dt.month == 6
@@ -133,8 +134,8 @@ class TestTimeParser:
         start_ts, end_ts = parse_time_expression("christmas")
         assert start_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         # Christmas window should include Dec 25 +/- a few days
         assert start_dt.month == 12
@@ -145,10 +146,10 @@ class TestTimeParser:
         """Test time of day parsing"""
         # Test "yesterday morning"
         start_ts, end_ts = parse_time_expression("yesterday morning")
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
-        yesterday = date.today() - timedelta(days=1)
+        yesterday = datetime.now(timezone.utc).date() - timedelta(days=1)
         assert start_dt.date() == yesterday
         assert 5 <= start_dt.hour <= 6  # Morning starts at 5 AM
         assert 11 <= end_dt.hour <= 12  # Morning ends before noon
@@ -159,8 +160,8 @@ class TestTimeParser:
         assert start_ts is not None
         assert end_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         assert start_dt.month == 1
         assert end_dt.month == 3
@@ -170,10 +171,10 @@ class TestTimeParser:
         start_ts, end_ts = parse_time_expression("first quarter of 2024")
         assert start_ts is not None
         
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
-        assert start_dt == datetime(2024, 1, 1, 0, 0, 0)
+        assert start_dt == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         assert end_dt.year == 2024
         assert end_dt.month == 3
         assert end_dt.day == 31
@@ -221,18 +222,18 @@ class TestTimeParser:
         """Test 'this X' period expressions"""
         # This week
         start_ts, end_ts = parse_time_expression("this week")
-        start_dt = datetime.fromtimestamp(start_ts)
-        end_dt = datetime.fromtimestamp(end_ts)
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end_ts, tz=timezone.utc)
         
         # Should include today
-        today = date.today()
+        today = datetime.now(timezone.utc).date()
         assert start_dt.date() <= today <= end_dt.date()
         
         # This month
         start_ts, end_ts = parse_time_expression("this month")
-        start_dt = datetime.fromtimestamp(start_ts)
-        assert start_dt.month == datetime.now().month
-        assert start_dt.year == datetime.now().year
+        start_dt = datetime.fromtimestamp(start_ts, tz=timezone.utc)
+        assert start_dt.month == datetime.now(timezone.utc).month
+        assert start_dt.year == datetime.now(timezone.utc).year
     
     def test_recent_expressions(self):
         """Test 'recent' and similar expressions"""

--- a/tests/unit/test_time_parser_utc.py
+++ b/tests/unit/test_time_parser_utc.py
@@ -1,0 +1,79 @@
+"""Timezone invariants for natural-language time ranges."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import date, datetime, timezone
+
+import pytest
+
+from mcp_memory_service.utils.time_parser import (
+    get_time_of_day_range,
+    parse_time_expression,
+)
+
+
+@contextmanager
+def process_timezone(name: str) -> Iterator[None]:
+    """Temporarily set the process timezone for timestamp regression coverage."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset is unavailable on this platform")
+
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time.tzset()
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "2024-06-15",
+        "03/15/2024",
+        "first half of 2024",
+        "third quarter of 2024",
+        "today",
+        "yesterday",
+        "last week",
+        "this month",
+    ],
+)
+def test_calendar_ranges_are_independent_of_host_timezone(expression: str) -> None:
+    results = []
+    for timezone_name in ("Asia/Tokyo", "Europe/Berlin", "America/Los_Angeles"):
+        with process_timezone(timezone_name):
+            results.append(parse_time_expression(expression))
+
+    assert results[0] == results[1] == results[2]
+
+
+def test_explicit_day_uses_utc_boundaries() -> None:
+    with process_timezone("America/Los_Angeles"):
+        start, end = parse_time_expression("2024-06-15")
+
+    assert start == datetime(2024, 6, 15, tzinfo=timezone.utc).timestamp()
+    assert (
+        end
+        == datetime(2024, 6, 15, 23, 59, 59, 999999, tzinfo=timezone.utc).timestamp()
+    )
+
+
+def test_time_of_day_uses_utc_boundaries() -> None:
+    expected = (
+        datetime(2024, 6, 15, 5, tzinfo=timezone.utc).timestamp(),
+        datetime(2024, 6, 15, 11, 59, 59, tzinfo=timezone.utc).timestamp(),
+    )
+
+    for timezone_name in ("Asia/Tokyo", "America/Los_Angeles"):
+        with process_timezone(timezone_name):
+            assert get_time_of_day_range(date(2024, 6, 15), "morning") == expected


### PR DESCRIPTION
## What this changes

Natural-language calendar ranges now use UTC for both the current calendar date and conversion to stored epoch timestamps. A shared conversion boundary covers explicit dates, relative periods, named periods, seasons, quarters, and time-of-day ranges, and the architecture documentation now records that contract.

The parser's existing exception logs also use the repository's shared log-value sanitizer so the staged file passes the log-injection guard.

## Why

Fixes #1122.

Naive `datetime.timestamp()` values were interpreted in the server host's local timezone even though memory timestamps are stored as UTC epochs. The same query could therefore shift by the host UTC offset and select a different interval after deployment or migration.

## How it was verified

- Added an invariant test that failed before the fix for eight calendar expressions under `Asia/Tokyo`, `Europe/Berlin`, and `America/Los_Angeles`.
- `uv run pytest tests/unit/test_time_parser_utc.py tests/test_time_parser.py -q` — 24 passed.
- The existing Issue #396 time-expression regression passed independently under all three timezones above.
- `bash scripts/pr/pre_pr_check.sh` — passed 11/13 checks. The repository's optional local AI analyzer was unavailable and the 80% coverage target was reported as advisory; the CI-selected test suite and all enforced checks passed. Reported overall coverage was 61.24%.
- `uv run ruff check --select I src/mcp_memory_service/utils/time_parser.py tests/test_time_parser.py tests/unit/test_time_parser_utc.py` — passed.
- `git diff --check` — passed.

## Notes for the reviewer

Calendar words such as `today` now deliberately mean the UTC calendar day. This matches the stored UTC epoch contract and the deletion path described in the issue, and makes results independent of host configuration.

## Agent Disclosure
This PR was generated by OpenAI Codex. The submitting account is operated by the GitHub user @be-student.
Human review of this PR: no — fully automated
