### PR TITLE
fix(plugins): fire retrieval hook for memory_search

### DIFF
--- a/src/mcp_memory_service/plugins/context.py
+++ b/src/mcp_memory_service/plugins/context.py
@@ -11,6 +11,8 @@ HookName = Literal["on_store", "on_delete", "on_retrieve", "on_consolidate"]
 # on_store(memory_dict: dict) -> None
 # on_delete(content_hash: str) -> None
 # on_retrieve(query: str, results: list[dict]) -> list[dict]  (can rerank)
+# Retrieval entry points fire this after their filters and fallbacks, so the
+# callback receives the exact result set that will be formatted for the caller.
 # on_consolidate(report: dict) -> None
 HookFn = Callable[..., Awaitable[Any]]
 

--- a/src/mcp_memory_service/server/handlers/memory.py
+++ b/src/mcp_memory_service/server/handlers/memory.py
@@ -991,7 +991,7 @@ async def _format_beliefs_section(arguments: dict, storage) -> str:
 async def handle_memory_search(server, arguments: dict) -> List[types.TextContent]:
     """Unified handler for memory search with flexible modes and filters."""
     import json
-    from ...services.memory_service import normalize_tags
+    from ...services.memory_service import MemoryService, normalize_tags
 
     try:
         # Initialize storage lazily when needed
@@ -1128,6 +1128,16 @@ async def handle_memory_search(server, arguments: dict) -> List[types.TextConten
             # unfiltered results for an explicit filter would be a silent lie;
             # an empty result set is the honest answer.
             memories = [m for m in memories if m.get("content_hash") in entity_hashes]
+            total = len(memories)
+            result["memories"] = memories
+            result["total"] = total
+
+        # Plugins must see the final unified-search result after fallback and
+        # entity filtering, matching the legacy MemoryService retrieval path.
+        if isinstance(server.memory_service, MemoryService):
+            memories = await server.memory_service.apply_retrieve_plugins(
+                query, memories
+            )
             total = len(memories)
             result["memories"] = memories
             result["total"] = total

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -272,6 +272,19 @@ class MemoryService:
         self._plugin_registry = PluginRegistry(PluginContext(storage=storage, service=self))
         self._plugin_registry.discover_and_register()
 
+    async def apply_retrieve_plugins(
+        self, query: Optional[str], results: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Apply retrieval plugins through the shared result boundary.
+
+        Every retrieval entry point must call this after completing its own
+        filtering and fallback work so plugins observe the final result set.
+        """
+        modified = await self._plugin_registry.fire(
+            "on_retrieve", query or "", results
+        )
+        return modified if isinstance(modified, list) else results
+
     async def list_memories(
         self,
         page: int = 1,
@@ -597,9 +610,7 @@ class MemoryService:
                     except Exception as e:
                         logger.debug(f"Background quality scoring for retrieved memory failed silently: {e}")
 
-            modified = await self._plugin_registry.fire('on_retrieve', query, results)
-            if isinstance(modified, list):
-                results = modified
+            results = await self.apply_retrieve_plugins(query, results)
 
             return {
                 "memories": results,

--- a/tests/plugins/test_wiring.py
+++ b/tests/plugins/test_wiring.py
@@ -1,8 +1,10 @@
 """Tests that plugin hooks are fired from MemoryService methods."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from mcp_memory_service.server.handlers.memory import handle_memory_search
 from mcp_memory_service.services.memory_service import MemoryService
 
 
@@ -84,11 +86,84 @@ class TestDeleteHookFired:
 class TestRetrieveHookFired:
     @pytest.mark.asyncio
     async def test_on_retrieve_fired(self, service):
-        result = await service.retrieve_memories("test query")
+        await service.retrieve_memories("test query")
         calls = [c for c in service._plugin_registry.fire.call_args_list if c[0][0] == "on_retrieve"]
         assert len(calls) == 1
         assert calls[0][0][1] == "test query"  # query passed
         assert isinstance(calls[0][0][2], list)  # results passed
+
+
+class TestUnifiedSearchRetrieveHook:
+    @pytest.mark.asyncio
+    async def test_on_retrieve_reranks_final_fallback_results(
+        self, service, mock_storage
+    ):
+        """The primary search tool exposes its complete result set to plugins."""
+        mock_storage.search_memories = AsyncMock(
+            side_effect=[
+                {
+                    "memories": [
+                        {
+                            "content": "semantic result",
+                            "content_hash": "semantic",
+                            "similarity_score": 0.2,
+                            "tags": [],
+                            "created_at_iso": "2026-01-01T00:00:00Z",
+                        }
+                    ],
+                    "total": 1,
+                    "query": "plugin query",
+                    "mode": "semantic",
+                },
+                {
+                    "memories": [
+                        {
+                            "content": "exact result",
+                            "content_hash": "exact",
+                            "tags": [],
+                            "created_at_iso": "2026-01-02T00:00:00Z",
+                        }
+                    ],
+                    "total": 1,
+                    "mode": "exact",
+                },
+                {
+                    "memories": [
+                        {
+                            "content": "tag result",
+                            "content_hash": "tag",
+                            "tags": ["plugin"],
+                            "created_at_iso": "2026-01-03T00:00:00Z",
+                        }
+                    ],
+                    "total": 1,
+                    "mode": "semantic",
+                },
+            ]
+        )
+        service._plugin_registry.fire = AsyncMock(
+            side_effect=lambda hook, query, results: list(reversed(results))
+        )
+        server = MagicMock()
+        server.memory_service = service
+        server._ensure_storage_initialized = AsyncMock(return_value=mock_storage)
+
+        response = await handle_memory_search(
+            server, {"query": "plugin query", "fallback": True}
+        )
+
+        service._plugin_registry.fire.assert_awaited_once()
+        hook, query, results = service._plugin_registry.fire.await_args.args
+        assert hook == "on_retrieve"
+        assert query == "plugin query"
+        assert [item["content_hash"] for item in results] == [
+            "semantic",
+            "exact",
+            "tag",
+        ]
+        assert response[0].text.index("tag result") < response[0].text.index(
+            "semantic result"
+        )
 
 
 class TestConsolidateHookFired:


### PR DESCRIPTION
## Summary

`memory_search`, the primary retrieval tool, called storage directly and never fired the plugin `on_retrieve` hook. Plugins could observe legacy retrieval but could not augment or rerank unified search results.

This change adds a shared `MemoryService.apply_retrieve_plugins` boundary and routes both legacy retrieval and the final unified-search result through it. Unified search fires the hook after fallback and entity filtering, then updates the result list and total before formatting.

## Validation

- regression reproduced first: the unified-search test observed zero hook calls
- 116 unified-search, plugin, fallback, and MemoryService tests passed
- critical Ruff checks (`E9`, `F63`, `F7`, `F82`) passed
- changed modules compile successfully
- `git diff --check` passed

Closes #1109
