### PR TITLE
fix(logging): clear the log-injection backlog in the three blocked modules

### DIFF
--- a/src/mcp_memory_service/config/storage.py
+++ b/src/mcp_memory_service/config/storage.py
@@ -10,6 +10,7 @@ from .base import (
     safe_get_optional_int_env,
     safe_get_bool_env,
 )
+from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +59,7 @@ CONTENT_SPLIT_OVERLAP = safe_get_int_env(
 )
 CONTENT_PRESERVE_BOUNDARIES = safe_get_bool_env('MCP_CONTENT_PRESERVE_BOUNDARIES', default=True)
 
-logger.info(f"Content length limits - Cloudflare: {CLOUDFLARE_MAX_CONTENT_LENGTH}, "
-           f"SQLite-vec: {'unlimited' if SQLITEVEC_MAX_CONTENT_LENGTH is None else SQLITEVEC_MAX_CONTENT_LENGTH}, "
-           f"Auto-split: {ENABLE_AUTO_SPLIT}")
+logger.info("Content length limits - Cloudflare: %s, SQLite-vec: %s, Auto-split: %s", CLOUDFLARE_MAX_CONTENT_LENGTH, 'unlimited' if SQLITEVEC_MAX_CONTENT_LENGTH is None else SQLITEVEC_MAX_CONTENT_LENGTH, ENABLE_AUTO_SPLIT)
 
 # =============================================================================
 # End Content Length Limits Configuration
@@ -73,13 +72,13 @@ if STORAGE_BACKEND == 'sqlite_vec' or STORAGE_BACKEND == 'hybrid':
     for env_var in ['MCP_MEMORY_SQLITE_PATH', 'MCP_MEMORY_SQLITEVEC_PATH']:
         if path := os.getenv(env_var):
             sqlite_vec_path = path
-            logger.info(f"Using {env_var}={path} for SQLite-vec database path")
+            logger.info("Using %s=%s for SQLite-vec database path", _sanitize_log_value(env_var), _sanitize_log_value(path))
             break
     
     # If no environment variable is set, use the default path
     if not sqlite_vec_path:
         sqlite_vec_path = os.path.join(BASE_DIR, 'sqlite_vec.db')
-        logger.info(f"No SQLite-vec path environment variable found, using default: {sqlite_vec_path}")
+        logger.info("No SQLite-vec path environment variable found, using default: %s", _sanitize_log_value(sqlite_vec_path))
     
     # Ensure directory exists for SQLite database
     sqlite_dir = os.path.dirname(sqlite_vec_path)
@@ -87,7 +86,7 @@ if STORAGE_BACKEND == 'sqlite_vec' or STORAGE_BACKEND == 'hybrid':
         os.makedirs(sqlite_dir, exist_ok=True)
     
     SQLITE_VEC_PATH = sqlite_vec_path
-    logger.info(f"Using SQLite-vec database path: {SQLITE_VEC_PATH}")
+    logger.info("Using SQLite-vec database path: %s", _sanitize_log_value(SQLITE_VEC_PATH))
 else:
     SQLITE_VEC_PATH = None
 
@@ -118,16 +117,16 @@ if STORAGE_BACKEND == 'cloudflare' or STORAGE_BACKEND == 'hybrid':
         missing_vars.append('CLOUDFLARE_D1_DATABASE_ID')
     
     if missing_vars:
-        logger.error(f"Missing required environment variables for Cloudflare backend: {', '.join(missing_vars)}")
+        logger.error("Missing required environment variables for Cloudflare backend: %s", _sanitize_log_value(', '.join(missing_vars)))
         logger.error("Please set the required variables or switch to a different backend")
         sys.exit(1)
     
-    logger.info(f"Using Cloudflare backend with:")
-    logger.info(f"  Vectorize Index: {CLOUDFLARE_VECTORIZE_INDEX}")
-    logger.info(f"  D1 Database: {CLOUDFLARE_D1_DATABASE_ID}")
-    logger.info(f"  R2 Bucket: {CLOUDFLARE_R2_BUCKET or 'Not configured'}")
-    logger.info(f"  Embedding Model: {CLOUDFLARE_EMBEDDING_MODEL}")
-    logger.info(f"  Large Content Threshold: {CLOUDFLARE_LARGE_CONTENT_THRESHOLD} bytes")
+    logger.info("Using Cloudflare backend with:")
+    logger.info("  Vectorize Index: %s", _sanitize_log_value(CLOUDFLARE_VECTORIZE_INDEX))
+    logger.info("  D1 Database: %s", _sanitize_log_value(CLOUDFLARE_D1_DATABASE_ID))
+    logger.info("  R2 Bucket: %s", _sanitize_log_value(CLOUDFLARE_R2_BUCKET or 'Not configured'))
+    logger.info("  Embedding Model: %s", _sanitize_log_value(CLOUDFLARE_EMBEDDING_MODEL))
+    logger.info("  Large Content Threshold: %s bytes", CLOUDFLARE_LARGE_CONTENT_THRESHOLD)
 else:
     # Set Cloudflare variables to None when not using Cloudflare backend
     CLOUDFLARE_API_TOKEN = None
@@ -176,7 +175,7 @@ if STORAGE_BACKEND == 'hybrid':
     HYBRID_FALLBACK_TO_PRIMARY = safe_get_bool_env('MCP_HYBRID_FALLBACK_TO_PRIMARY', True)
     HYBRID_WARN_ON_SECONDARY_FAILURE = safe_get_bool_env('MCP_HYBRID_WARN_ON_SECONDARY_FAILURE', True)
 
-    logger.info(f"Hybrid storage configuration: sync_interval={HYBRID_SYNC_INTERVAL}s, batch_size={HYBRID_BATCH_SIZE}")
+    logger.info("Hybrid storage configuration: sync_interval=%ss, batch_size=%s", HYBRID_SYNC_INTERVAL, HYBRID_BATCH_SIZE)
 
     # Cloudflare Service Limits (for validation and monitoring)
     CLOUDFLARE_D1_MAX_SIZE_GB = 10  # D1 database hard limit
@@ -251,10 +250,7 @@ if STORAGE_BACKEND == 'milvus':
         if parent:
             os.makedirs(parent, exist_ok=True)
 
-    logger.info(
-        f"Using Milvus backend (uri={MILVUS_URI}, collection={MILVUS_COLLECTION_NAME}, "
-        f"auth={'yes' if MILVUS_TOKEN else 'no'})"
-    )
+    logger.info("Using Milvus backend (uri=%s, collection=%s, auth=%s)", _sanitize_log_value(MILVUS_URI), _sanitize_log_value(MILVUS_COLLECTION_NAME), 'yes' if MILVUS_TOKEN else 'no')
 else:
     MILVUS_URI = None
     MILVUS_TOKEN = None

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -29,13 +29,9 @@ import httpx
 from .base import MemoryStorage
 from ..models.memory import Memory, MemoryQueryResult
 from ..config import CLOUDFLARE_MAX_CONTENT_LENGTH
+from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
-
-
-def _sanitize_log_value(value: object) -> str:
-    """Sanitize a user-provided value for safe inclusion in log messages."""
-    return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\x1b", "\\x1b")
 
 
 def normalize_tags_for_search(tags: List[str]) -> List[str]:
@@ -65,7 +61,7 @@ def normalize_operation(operation: Optional[str]) -> str:
         normalized = "AND"
 
     if normalized not in {"AND", "OR"}:
-        logger.warning(f"Unsupported operation '{operation}'; defaulting to AND")
+        logger.warning("Unsupported operation '%s'; defaulting to AND", _sanitize_log_value(operation))
         normalized = "AND"
 
     return normalized
@@ -207,7 +203,7 @@ class CloudflareStorage(MemoryStorage):
                 if response.status_code == 429:
                     if attempt < self.max_retries:
                         delay = self.base_delay * (2 ** attempt)
-                        logger.warning(f"Rate limited, retrying in {delay}s (attempt {attempt + 1}/{self.max_retries + 1})")
+                        logger.warning("Rate limited, retrying in %ss (attempt %s/%s)", delay, attempt + 1, self.max_retries + 1)
                         await asyncio.sleep(delay)
                         continue
                     else:
@@ -217,7 +213,7 @@ class CloudflareStorage(MemoryStorage):
                 if response.status_code >= 500:
                     if attempt < self.max_retries:
                         delay = self.base_delay * (2 ** attempt)
-                        logger.warning(f"Server error {response.status_code}, retrying in {delay}s")
+                        logger.warning("Server error %s, retrying in %ss", response.status_code, delay)
                         await asyncio.sleep(delay)
                         continue
                 
@@ -227,7 +223,7 @@ class CloudflareStorage(MemoryStorage):
             except (httpx.NetworkError, httpx.TimeoutException) as e:
                 if attempt < self.max_retries:
                     delay = self.base_delay * (2 ** attempt)
-                    logger.warning(f"Network error: {e}, retrying in {delay}s")
+                    logger.warning("Network error: %s, retrying in %ss", _sanitize_log_value(e), delay)
                     await asyncio.sleep(delay)
                     continue
                 raise
@@ -262,7 +258,7 @@ class CloudflareStorage(MemoryStorage):
                 raise ValueError(f"Workers AI embedding failed: {result}")
                 
         except Exception as e:
-            logger.error(f"Failed to generate embedding with Workers AI: {e}")
+            logger.error("Failed to generate embedding with Workers AI: %s", _sanitize_log_value(e))
             # TODO: Implement fallback to local sentence-transformers
             raise ValueError(f"Embedding generation failed: {e}")
     
@@ -288,7 +284,7 @@ class CloudflareStorage(MemoryStorage):
             logger.info("Cloudflare storage backend initialized successfully")
             
         except Exception as e:
-            logger.error(f"Failed to initialize Cloudflare storage: {e}")
+            logger.error("Failed to initialize Cloudflare storage: %s", _sanitize_log_value(e))
             raise
     
     async def _migrate_d1_schema(self) -> None:
@@ -309,7 +305,7 @@ class CloudflareStorage(MemoryStorage):
             result = response.json()
 
             if not result.get("success"):
-                logger.warning(f"Schema check failed (table may not exist yet): {result}")
+                logger.warning("Schema check failed (table may not exist yet): %s", _sanitize_log_value(result))
                 return  # Table doesn't exist yet, will be created by _initialize_d1_schema
 
             # Parse column names from PRAGMA response
@@ -359,14 +355,14 @@ class CloudflareStorage(MemoryStorage):
                 result = response.json()
 
                 if not result.get("success"):
-                    logger.warning(f"Failed to create deleted_at index (non-fatal): {result}")
+                    logger.warning("Failed to create deleted_at index (non-fatal): %s", _sanitize_log_value(result))
                 else:
                     logger.info("Successfully created deleted_at index")
 
-            logger.info(f"Schema migration completed successfully. Added columns: {', '.join(migrations_needed)}")
+            logger.info("Schema migration completed successfully. Added columns: %s", _sanitize_log_value(', '.join(migrations_needed)))
 
         except Exception as e:
-            logger.error(f"Schema migration failed: {e}")
+            logger.error("Schema migration failed: %s", _sanitize_log_value(e))
             # Don't raise - let initialization continue, error will surface later if needed
 
     async def _add_column_with_retry(self, column: str, max_attempts: int = 3) -> None:
@@ -396,7 +392,7 @@ class CloudflareStorage(MemoryStorage):
 
         for attempt in range(1, max_attempts + 1):
             try:
-                logger.info(f"Adding '{column}' column (attempt {attempt}/{max_attempts})...")
+                logger.info("Adding '%s' column (attempt %s/%s)...", column, attempt, max_attempts)
 
                 # Execute ALTER TABLE
                 payload = {"sql": alter_sql}
@@ -408,14 +404,14 @@ class CloudflareStorage(MemoryStorage):
 
                     # Check if column already exists error
                     if "duplicate column name" in error_msg.lower() or "already exists" in error_msg.lower():
-                        logger.info(f"Column '{column}' already exists (migration already applied)")
+                        logger.info("Column '%s' already exists (migration already applied)", column)
                         return
 
                     raise ValueError(f"ALTER TABLE failed: {error_msg}")
 
                 # Wait for D1 metadata sync (known D1 limitation)
                 if attempt < max_attempts:
-                    logger.info(f"Waiting for D1 metadata sync...")
+                    logger.info("Waiting for D1 metadata sync...")
                     await asyncio.sleep(2)  # Give D1 time to sync metadata
 
                 # Verify column is actually usable by checking schema again
@@ -428,17 +424,17 @@ class CloudflareStorage(MemoryStorage):
                     columns = [row["name"] for row in result["result"][0]["results"] if "name" in row]
 
                     if column in columns:
-                        logger.info(f"Successfully added '{column}' column and verified it's usable")
+                        logger.info("Successfully added '%s' column and verified it's usable", column)
                         return
                     else:
-                        logger.warning(f"Column '{column}' not found in schema after ALTER TABLE (attempt {attempt})")
+                        logger.warning("Column '%s' not found in schema after ALTER TABLE (attempt %s)", column, attempt)
                         if attempt < max_attempts:
-                            logger.info(f"Retrying column addition due to D1 metadata sync issue...")
+                            logger.info("Retrying column addition due to D1 metadata sync issue...")
                             await asyncio.sleep(2 ** attempt)  # Exponential backoff
                             continue
 
             except Exception as e:
-                logger.warning(f"Column addition attempt {attempt} failed: {e}")
+                logger.warning("Column addition attempt %s failed: %s", attempt, _sanitize_log_value(e))
                 if attempt < max_attempts:
                     await asyncio.sleep(2 ** attempt)  # Exponential backoff
                     continue
@@ -517,7 +513,7 @@ class CloudflareStorage(MemoryStorage):
             if not result.get("success"):
                 raise ValueError(f"Vectorize index not accessible: {result}")
                 
-            logger.info(f"Vectorize index verified: {self.vectorize_index}")
+            logger.info("Vectorize index verified: %s", _sanitize_log_value(self.vectorize_index))
             
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -529,7 +525,7 @@ class CloudflareStorage(MemoryStorage):
         try:
             # Try to list objects (empty list is fine)
             await self._retry_request("GET", f"{self.r2_url}?max-keys=1")
-            logger.info(f"R2 bucket verified: {self.r2_bucket}")
+            logger.info("R2 bucket verified: %s", _sanitize_log_value(self.r2_bucket))
             
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -576,11 +572,11 @@ class CloudflareStorage(MemoryStorage):
             # Store metadata in D1
             await self._store_d1_memory(memory, vector_id, content_size, r2_key, stored_content)
             
-            logger.info(f"Successfully stored memory: {memory.content_hash}")
+            logger.info("Successfully stored memory: %s", _sanitize_log_value(memory.content_hash))
             return True, f"Memory stored successfully (vector_id: {vector_id})"
             
         except Exception as e:
-            logger.error(f"Failed to store memory {memory.content_hash}: {e}")
+            logger.error("Failed to store memory %s: %s", _sanitize_log_value(memory.content_hash), _sanitize_log_value(e))
             return False, f"Storage failed: {str(e)}"
     
     async def _store_vectorize_vector(self, vector_id: str, embedding: List[float], metadata: Dict[str, Any]) -> None:
@@ -612,12 +608,12 @@ class CloudflareStorage(MemoryStorage):
             )
             
             # Log response status for debugging (avoid logging headers/body for security)
-            logger.info(f"Vectorize response status: {response.status_code}")
+            logger.info("Vectorize response status: %s", response.status_code)
             response_text = response.text
             if response.status_code != 200:
                 # Only log response body on errors, and truncate to avoid credential exposure
                 truncated_response = response_text[:200] + "..." if len(response_text) > 200 else response_text
-                logger.warning(f"Vectorize error response (truncated): {truncated_response}")
+                logger.warning("Vectorize error response (truncated): %s", _sanitize_log_value(truncated_response))
             
             if response.status_code != 200:
                 raise ValueError(f"HTTP {response.status_code}: {response_text}")
@@ -628,10 +624,10 @@ class CloudflareStorage(MemoryStorage):
                 
         except Exception as e:
             # Add more detailed error logging
-            logger.error(f"Vectorize insert failed: {e}")
-            logger.error(f"Vector data was: {vector_data}")
-            logger.error(f"NDJSON content: {ndjson_content.strip()}")
-            logger.error(f"URL was: {self.vectorize_url}/upsert")
+            logger.error("Vectorize insert failed: %s", _sanitize_log_value(e))
+            logger.error("Vector data was: %s", _sanitize_log_value(vector_data))
+            logger.error("NDJSON content: %s", _sanitize_log_value(ndjson_content.strip()))
+            logger.error("URL was: %s/upsert", _sanitize_log_value(self.vectorize_url))
             raise ValueError(f"Failed to store vector: {e}")
     
     async def _store_d1_memory(self, memory: Memory, vector_id: str, content_size: int, r2_key: Optional[str], stored_content: str) -> None:
@@ -770,13 +766,13 @@ class CloudflareStorage(MemoryStorage):
                 try:
                     await self._persist_access_metadata(result.memory)
                 except Exception as e:
-                    logger.warning(f"Failed to persist access metadata: {e}")
+                    logger.warning("Failed to persist access metadata: %s", _sanitize_log_value(e))
 
-            logger.info(f"Retrieved {len(results)} memories for query")
+            logger.info("Retrieved %s memories for query", len(results))
             return results
             
         except Exception as e:
-            logger.error(f"Failed to retrieve memories: {e}")
+            logger.error("Failed to retrieve memories: %s", _sanitize_log_value(e))
             return []
     
     async def _load_memory_from_match(self, match: Dict[str, Any]) -> Optional[Memory]:
@@ -787,7 +783,7 @@ class CloudflareStorage(MemoryStorage):
             content_hash = metadata.get("content_hash")
             
             if not content_hash:
-                logger.warning(f"No content_hash in vector metadata: {vector_id}")
+                logger.warning("No content_hash in vector metadata: %s", _sanitize_log_value(vector_id))
                 return None
             
             # Load from D1
@@ -797,7 +793,7 @@ class CloudflareStorage(MemoryStorage):
             result = response.json()
             
             if not result.get("success") or not result.get("result", [{}])[0].get("results"):
-                logger.warning(f"Memory not found in D1: {content_hash}")
+                logger.warning("Memory not found in D1: %s", _sanitize_log_value(content_hash))
                 return None
             
             row = result["result"][0]["results"][0]
@@ -834,7 +830,7 @@ class CloudflareStorage(MemoryStorage):
             return memory
             
         except Exception as e:
-            logger.error(f"Failed to load memory from match: {e}")
+            logger.error("Failed to load memory from match: %s", _sanitize_log_value(e))
             return None
     
     async def _load_r2_content(self, r2_key: str) -> str:
@@ -968,7 +964,7 @@ class CloudflareStorage(MemoryStorage):
             return memory
             
         except Exception as e:
-            logger.error(f"Failed to load memory from row: {e}")
+            logger.error("Failed to load memory from row: %s", _sanitize_log_value(e))
             return None
     
     async def delete(self, content_hash: str) -> Tuple[bool, str]:
@@ -1005,11 +1001,11 @@ class CloudflareStorage(MemoryStorage):
             if not result.get("success"):
                 raise ValueError(f"Failed to delete from D1: {result}")
             
-            logger.info(f"Successfully deleted memory: {content_hash}")
+            logger.info("Successfully deleted memory: %s", _sanitize_log_value(content_hash))
             return True, "Memory deleted successfully"
 
         except Exception as e:
-            logger.error(f"Failed to delete memory {content_hash}: {e}")
+            logger.error("Failed to delete memory %s: %s", _sanitize_log_value(content_hash), _sanitize_log_value(e))
             return False, f"Deletion failed: {str(e)}"
 
     async def get_by_exact_content(self, content: str) -> List[Memory]:
@@ -1038,7 +1034,7 @@ class CloudflareStorage(MemoryStorage):
             return memories
 
         except Exception as e:
-            logger.error(f"Error in exact content match (Cloudflare): {str(e)}")
+            logger.error("Error in exact content match (Cloudflare): %s", _sanitize_log_value(str(e)))
             return []
 
     async def get_by_hash(self, content_hash: str) -> Optional[Memory]:
@@ -1087,7 +1083,7 @@ class CloudflareStorage(MemoryStorage):
             return memory
 
         except Exception as e:
-            logger.error(f"Failed to get memory by hash {content_hash}: {e}")
+            logger.error("Failed to get memory by hash %s: %s", _sanitize_log_value(content_hash), _sanitize_log_value(e))
             return None
 
     async def _delete_vectorize_vector(self, vector_id: str) -> None:
@@ -1099,7 +1095,7 @@ class CloudflareStorage(MemoryStorage):
         result = response.json()
 
         if not result.get("success"):
-            logger.warning(f"Failed to delete vector from Vectorize: {result}")
+            logger.warning("Failed to delete vector from Vectorize: %s", _sanitize_log_value(result))
 
     async def delete_vectors_by_ids(self, vector_ids: List[str]) -> Dict[str, Any]:
         """Delete multiple vectors from Vectorize by their IDs."""
@@ -1116,9 +1112,9 @@ class CloudflareStorage(MemoryStorage):
         try:
             response = await self._retry_request("DELETE", f"{self.r2_url}/{r2_key}")
             if response.status_code not in [200, 204, 404]:  # 404 is fine if already deleted
-                logger.warning(f"Failed to delete R2 content: {response.status_code}")
+                logger.warning("Failed to delete R2 content: %s", response.status_code)
         except Exception as e:
-            logger.warning(f"Failed to delete R2 content {r2_key}: {e}")
+            logger.warning("Failed to delete R2 content %s: %s", _sanitize_log_value(r2_key), _sanitize_log_value(e))
     
     async def delete_by_tag(self, tag: str) -> Tuple[int, str]:
         """Delete memories by tag."""
@@ -1132,11 +1128,11 @@ class CloudflareStorage(MemoryStorage):
                 if success:
                     deleted_count += 1
             
-            logger.info(f"Deleted {deleted_count} memories with tag: {_sanitize_log_value(tag)}")
+            logger.info("Deleted %s memories with tag: %s", deleted_count, _sanitize_log_value(tag))
             return deleted_count, f"Deleted {deleted_count} memories"
 
         except Exception as e:
-            logger.error(f"Failed to delete by tag {_sanitize_log_value(tag)}: {e}")
+            logger.error("Failed to delete by tag %s: %s", _sanitize_log_value(tag), _sanitize_log_value(e))
             return 0, f"Deletion failed: {str(e)}"
 
     async def delete_by_tags(self, tags: List[str]) -> Tuple[int, str, List[str]]:
@@ -1188,11 +1184,11 @@ class CloudflareStorage(MemoryStorage):
                     deleted_count += 1
                     deleted_hashes.append(content_hash)
 
-            logger.info(f"Deleted {deleted_count} memories matching tags: {tags}")
+            logger.info("Deleted %s memories matching tags: %s", deleted_count, _sanitize_log_value(tags))
             return deleted_count, f"Successfully deleted {deleted_count} memories matching {len(tags)} tag(s)", deleted_hashes
 
         except Exception as e:
-            logger.error(f"Failed to delete by tags {tags}: {e}")
+            logger.error("Failed to delete by tags %s: %s", _sanitize_log_value(tags), _sanitize_log_value(e))
             return 0, f"Deletion failed: {str(e)}", []
 
     async def delete_by_timeframe(self, start_date: date, end_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
@@ -1240,7 +1236,7 @@ class CloudflareStorage(MemoryStorage):
             return deleted_count, f"Deleted {deleted_count} memories from {start_date} to {end_date}" + (f" with tag '{tag}'" if tag else "")
 
         except Exception as e:
-            logger.error(f"Error deleting by timeframe in Cloudflare: {str(e)}")
+            logger.error("Error deleting by timeframe in Cloudflare: %s", _sanitize_log_value(str(e)))
             return 0, f"Error: {str(e)}"
 
     async def delete_before_date(self, before_date: date, tag: Optional[str] = None) -> Tuple[int, str]:
@@ -1287,7 +1283,7 @@ class CloudflareStorage(MemoryStorage):
             return deleted_count, f"Deleted {deleted_count} memories before {before_date}" + (f" with tag '{tag}'" if tag else "")
 
         except Exception as e:
-            logger.error(f"Error deleting before date in Cloudflare: {str(e)}")
+            logger.error("Error deleting before date in Cloudflare: %s", _sanitize_log_value(str(e)))
             return 0, f"Error: {str(e)}"
 
     async def cleanup_duplicates(self) -> Tuple[int, str]:
@@ -1325,11 +1321,11 @@ class CloudflareStorage(MemoryStorage):
                     deleted = result["result"][0]["meta"].get("changes", 0)
                     total_deleted += deleted
             
-            logger.info(f"Cleaned up {total_deleted} duplicate memories")
+            logger.info("Cleaned up %s duplicate memories", total_deleted)
             return total_deleted, f"Removed {total_deleted} duplicates"
             
         except Exception as e:
-            logger.error(f"Failed to cleanup duplicates: {e}")
+            logger.error("Failed to cleanup duplicates: %s", _sanitize_log_value(e))
             return 0, f"Cleanup failed: {str(e)}"
 
     async def _persist_access_metadata(self, memory: Memory):
@@ -1421,11 +1417,11 @@ class CloudflareStorage(MemoryStorage):
             if "tags" in updates:
                 await self._update_memory_tags(content_hash, updates["tags"])
             
-            logger.info(f"Successfully updated memory metadata: {content_hash}")
+            logger.info("Successfully updated memory metadata: %s", _sanitize_log_value(content_hash))
             return True, "Memory metadata updated successfully"
             
         except Exception as e:
-            logger.error(f"Failed to update memory metadata {content_hash}: {e}")
+            logger.error("Failed to update memory metadata %s: %s", _sanitize_log_value(content_hash), _sanitize_log_value(e))
             return False, f"Update failed: {str(e)}"
     
     async def _update_memory_tags(self, content_hash: str, new_tags: List[str]) -> None:
@@ -1491,7 +1487,7 @@ class CloudflareStorage(MemoryStorage):
             )
             result = response.json()
             if not result.get("success"):
-                logger.error(f"Tombstone purge lookup failed: {_sanitize_log_value(result.get('errors'))}")
+                logger.error("Tombstone purge lookup failed: %s", _sanitize_log_value(result.get('errors')))
                 break
 
             rows = result["result"][0].get("results", [])
@@ -1515,7 +1511,7 @@ class CloudflareStorage(MemoryStorage):
             if not result.get("success"):
                 # Stop here rather than delete the memories anyway: a D1 that just
                 # failed a write is no state in which to keep purging.
-                logger.error(f"Tombstone tag purge failed: {_sanitize_log_value(result.get('errors'))}")
+                logger.error("Tombstone tag purge failed: %s", _sanitize_log_value(result.get('errors')))
                 break
 
             delete_sql = "DELETE FROM memories WHERE deleted_at IS NOT NULL AND deleted_at < ? AND id <= ?"
@@ -1525,7 +1521,7 @@ class CloudflareStorage(MemoryStorage):
             )
             result = response.json()
             if not result.get("success"):
-                logger.error(f"Tombstone purge failed: {_sanitize_log_value(result.get('errors'))}")
+                logger.error("Tombstone purge failed: %s", _sanitize_log_value(result.get('errors')))
                 break
 
             total_purged += len(rows)
@@ -1594,7 +1590,7 @@ class CloudflareStorage(MemoryStorage):
             }
 
         except Exception as e:
-            logger.error(f"Failed to get stats: {e}")
+            logger.error("Failed to get stats: %s", _sanitize_log_value(e))
             return {
                 "total_memories": 0,
                 "unique_tags": 0,
@@ -1618,7 +1614,7 @@ class CloudflareStorage(MemoryStorage):
             return []
 
         except Exception as e:
-            logger.error(f"Failed to get all tags: {e}")
+            logger.error("Failed to get all tags: %s", _sanitize_log_value(e))
             return []
 
     async def get_all_tags_with_counts(self) -> List[Dict[str, Any]]:
@@ -1641,7 +1637,7 @@ class CloudflareStorage(MemoryStorage):
             return []
 
         except Exception as e:
-            logger.error(f"Failed to get tags with counts: {e}")
+            logger.error("Failed to get tags with counts: %s", _sanitize_log_value(e))
             return []
     
     async def get_recent_memories(self, n: int = 10) -> List[Memory]:
@@ -1659,11 +1655,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.info(f"Retrieved {len(memories)} recent memories")
+            logger.info("Retrieved %s recent memories", len(memories))
             return memories
 
         except Exception as e:
-            logger.error(f"Failed to get recent memories: {e}")
+            logger.error("Failed to get recent memories: %s", _sanitize_log_value(e))
             return []
 
     async def get_largest_memories(self, n: int = 10) -> List[Memory]:
@@ -1681,11 +1677,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.info(f"Retrieved {len(memories)} largest memories")
+            logger.info("Retrieved %s largest memories", len(memories))
             return memories
 
         except Exception as e:
-            logger.error(f"Failed to get largest memories: {e}")
+            logger.error("Failed to get largest memories: %s", _sanitize_log_value(e))
             return []
 
     async def _fetch_d1_timestamps(self, cutoff_timestamp: Optional[float] = None) -> List[float]:
@@ -1738,11 +1734,11 @@ class CloudflareStorage(MemoryStorage):
                 cutoff_timestamp = cutoff.timestamp()
 
             timestamps = await self._fetch_d1_timestamps(cutoff_timestamp)
-            logger.info(f"Retrieved {len(timestamps)} memory timestamps")
+            logger.info("Retrieved %s memory timestamps", len(timestamps))
             return timestamps
 
         except Exception as e:
-            logger.error(f"Failed to get memory timestamps: {e}")
+            logger.error("Failed to get memory timestamps: %s", _sanitize_log_value(e))
             return []
 
     def sanitized(self, tags):
@@ -1793,12 +1789,12 @@ class CloudflareStorage(MemoryStorage):
 
             time_where = " AND ".join(time_conditions) if time_conditions else ""
 
-            logger.info(f"Recall - Time filtering conditions: {time_where}, params: {params}")
+            logger.info("Recall - Time filtering conditions: %s, params: %s", _sanitize_log_value(time_where), _sanitize_log_value(params))
 
             # Determine search strategy
             if query and query.strip():
                 # Combined semantic search with time filtering
-                logger.info(f"Recall - Using semantic search with query: '{query}'")
+                logger.info("Recall - Using semantic search with query: '%s'", _sanitize_log_value(query))
 
                 try:
                     # Generate query embedding
@@ -1843,15 +1839,15 @@ class CloudflareStorage(MemoryStorage):
                             )
                             results.append(query_result)
 
-                    logger.info(f"Recall - Retrieved {len(results)} memories with semantic search and time filtering")
+                    logger.info("Recall - Retrieved %s memories with semantic search and time filtering", len(results))
                     return results[:n_results]  # Ensure we don't exceed n_results
 
                 except Exception as e:
-                    logger.error(f"Recall - Semantic search failed, falling back to time-based search: {e}")
+                    logger.error("Recall - Semantic search failed, falling back to time-based search: %s", _sanitize_log_value(e))
                     # Fall through to time-based search
 
             # Time-based search only (or fallback)
-            logger.info(f"Recall - Using time-based search only")
+            logger.info("Recall - Using time-based search only")
 
             # Build D1 query for time-based retrieval
             if time_where:
@@ -1883,11 +1879,11 @@ class CloudflareStorage(MemoryStorage):
                         )
                         results.append(query_result)
 
-            logger.info(f"Recall - Retrieved {len(results)} memories with time-based search")
+            logger.info("Recall - Retrieved %s memories with time-based search", len(results))
             return results
 
         except Exception as e:
-            logger.error(f"Recall failed: {e}")
+            logger.error("Recall failed: %s", _sanitize_log_value(e))
             return []
 
     async def get_all_memories(
@@ -1977,11 +1973,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.debug(f"Retrieved {len(memories)} memories from D1")
+            logger.debug("Retrieved %s memories from D1", len(memories))
             return memories
 
         except Exception as e:
-            logger.error(f"Error getting all memories: {str(e)}")
+            logger.error("Error getting all memories: %s", _sanitize_log_value(str(e)))
             return []
 
     def _row_to_memory(self, row: Dict[str, Any]) -> Memory:
@@ -2047,7 +2043,7 @@ class CloudflareStorage(MemoryStorage):
                 if memory:
                     memories.append(memory)
 
-        logger.debug(f"Bulk loaded {len(memories)} memories from D1")
+        logger.debug("Bulk loaded %s memories from D1", len(memories))
         return memories
 
     async def get_all_memories_cursor(self, limit: int = None, cursor: float = None, memory_type: Optional[str] = None, tags: Optional[List[str]] = None) -> List[Memory]:
@@ -2117,11 +2113,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.debug(f"Retrieved {len(memories)} memories from D1 with cursor-based pagination")
+            logger.debug("Retrieved %s memories from D1 with cursor-based pagination", len(memories))
             return memories
 
         except Exception as e:
-            logger.error(f"Error getting memories with cursor: {str(e)}")
+            logger.error("Error getting memories with cursor: %s", _sanitize_log_value(str(e)))
             return []
 
     async def get_memories_updated_since(self, timestamp: float, limit: int = 100) -> List[Memory]:
@@ -2156,7 +2152,7 @@ class CloudflareStorage(MemoryStorage):
             result = response.json()
 
             if not result.get("success"):
-                logger.warning(f"Failed to get updated memories: {result.get('error')}")
+                logger.warning("Failed to get updated memories: %s", _sanitize_log_value(result.get('error')))
                 return []
 
             memories = []
@@ -2166,11 +2162,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.debug(f"Retrieved {len(memories)} memories updated since timestamp {timestamp}")
+            logger.debug("Retrieved %s memories updated since timestamp %s", len(memories), timestamp)
             return memories
 
         except Exception as e:
-            logger.error(f"Error getting updated memories: {e}")
+            logger.error("Error getting updated memories: %s", _sanitize_log_value(e))
             return []
 
     async def get_memories_by_time_range(
@@ -2215,7 +2211,7 @@ class CloudflareStorage(MemoryStorage):
             result = response.json()
 
             if not result.get("success"):
-                logger.error(f"D1 query failed: {result}")
+                logger.error("D1 query failed: %s", _sanitize_log_value(result))
                 return []
 
             memories = []
@@ -2225,11 +2221,11 @@ class CloudflareStorage(MemoryStorage):
                     if memory:
                         memories.append(memory)
 
-            logger.info(f"Retrieved {len(memories)} memories in time range {start_time}-{end_time}")
+            logger.info("Retrieved %s memories in time range %s-%s", len(memories), start_time, end_time)
             return memories
 
         except Exception as e:
-            logger.error(f"Error getting memories by time range: {str(e)}")
+            logger.error("Error getting memories by time range: %s", _sanitize_log_value(str(e)))
             return []
 
     async def count_all_memories(self, memory_type: Optional[str] = None, tags: Optional[List[str]] = None, tag_match: str = "any", stale_days: Optional[int] = None, store: str = "default") -> int:
@@ -2295,7 +2291,7 @@ class CloudflareStorage(MemoryStorage):
             return 0
 
         except Exception as e:
-            logger.error(f"Error counting memories: {str(e)}")
+            logger.error("Error counting memories: %s", _sanitize_log_value(str(e)))
             return 0
 
     async def close(self) -> None:

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -926,7 +926,7 @@ class CloudflareStorage(MemoryStorage):
                 "Failed to search memories by tags %s with operation %s: %s",
                 [_sanitize_log_value(t) for t in tags],
                 _sanitize_log_value(operation),
-                e
+                _sanitize_log_value(e)
             )
             return []
     

--- a/src/mcp_memory_service/storage/hybrid.py
+++ b/src/mcp_memory_service/storage/hybrid.py
@@ -34,6 +34,7 @@ from .base import MemoryStorage
 from .sqlite_vec import SqliteVecMemoryStorage
 from .cloudflare import CloudflareStorage
 from ..models.memory import Memory, MemoryQueryResult
+from ..compat import _sanitize_log_value
 
 # Import SSE for real-time progress updates
 try:
@@ -228,7 +229,7 @@ class BackgroundSyncService:
 
         self.is_running = True
         self.sync_task = asyncio.create_task(self._sync_loop())
-        logger.info(f"Background sync service started with {self.sync_interval}s interval")
+        logger.info("Background sync service started with %ss interval", self.sync_interval)
 
     async def stop(self):
         """Stop the background sync service and process remaining operations."""
@@ -247,7 +248,7 @@ class BackgroundSyncService:
                 break
 
         if remaining_operations:
-            logger.info(f"Processing {len(remaining_operations)} remaining operations before shutdown")
+            logger.info("Processing %s remaining operations before shutdown", len(remaining_operations))
             await self._process_operations_batch(remaining_operations)
 
         # Cancel the sync task
@@ -268,7 +269,7 @@ class BackgroundSyncService:
                 self.operation_queue.put(operation),
                 timeout=5.0
             )
-            logger.debug(f"Enqueued {operation.operation} operation")
+            logger.debug("Enqueued %s operation", _sanitize_log_value(operation.operation))
         except asyncio.TimeoutError:
             # Queue full and can't add within timeout - fallback to immediate sync
             logger.warning("Sync queue full (timeout), processing operation immediately")
@@ -317,7 +318,7 @@ class BackgroundSyncService:
                 )
                 data = resp.json()
                 if not data.get("success"):
-                    logger.warning(f"Secondary hash fetch failed: {data.get('errors')}")
+                    logger.warning("Secondary hash fetch failed: %s", _sanitize_log_value(data.get('errors')))
                     return None
                 batch = data["result"][0].get("results", [])
                 if not batch:
@@ -327,7 +328,7 @@ class BackgroundSyncService:
                 if len(batch) < limit:
                     break
             except Exception as e:
-                logger.warning(f"Could not fetch secondary hashes for dedupe: {e}")
+                logger.warning("Could not fetch secondary hashes for dedupe: %s", _sanitize_log_value(e))
                 return None
         return hashes
 
@@ -345,7 +346,7 @@ class BackgroundSyncService:
                 await self.secondary.get_stats()  # Simple health check
                 cloudflare_available = True
             except Exception as e:
-                logger.warning(f"Cloudflare not available during force sync: {e}")
+                logger.warning("Cloudflare not available during force sync: %s", _sanitize_log_value(e))
                 self.sync_stats['cloudflare_available'] = False
                 return {
                     'status': 'partial',
@@ -363,10 +364,7 @@ class BackgroundSyncService:
             if secondary_hashes is not None:
                 new_memories = [m for m in primary_memories if m.content_hash not in secondary_hashes]
                 skipped_count = len(primary_memories) - len(new_memories)
-                logger.info(
-                    f"Dedupe: {skipped_count} of {len(primary_memories)} memories already on secondary, "
-                    f"pushing {len(new_memories)}"
-                )
+                logger.info("Dedupe: %s of %s memories already on secondary, pushing %s", skipped_count, len(primary_memories), len(new_memories))
             else:
                 new_memories = primary_memories
                 skipped_count = 0
@@ -379,10 +377,10 @@ class BackgroundSyncService:
                     if success:
                         return True, None
                     else:
-                        logger.debug(f"Failed to sync memory to secondary: {message}")
+                        logger.debug("Failed to sync memory to secondary: %s", _sanitize_log_value(message))
                         return False, message
                 except Exception as e:
-                    logger.debug(f"Exception syncing memory to secondary: {e}")
+                    logger.debug("Exception syncing memory to secondary: %s", _sanitize_log_value(e))
                     return False, str(e)
 
             # Process memories concurrently in batches
@@ -398,7 +396,7 @@ class BackgroundSyncService:
                 for result in results:
                     if isinstance(result, Exception):
                         failed_count += 1
-                        logger.debug(f"Exception in batch sync: {result}")
+                        logger.debug("Exception in batch sync: %s", _sanitize_log_value(result))
                     elif isinstance(result, tuple):
                         success, _ = result
                         if success:
@@ -410,10 +408,7 @@ class BackgroundSyncService:
             self.sync_stats['last_sync_duration'] = sync_duration
             self.sync_stats['cloudflare_available'] = cloudflare_available
 
-            logger.info(
-                f"Force sync completed: {synced_count} synced, {failed_count} failed, "
-                f"{skipped_count} skipped (already on secondary) in {sync_duration:.2f}s"
-            )
+            logger.info("Force sync completed: %s synced, %s failed, %s skipped (already on secondary) in %.2fs", synced_count, failed_count, skipped_count, sync_duration)
 
             return {
                 'status': 'completed',
@@ -426,7 +421,7 @@ class BackgroundSyncService:
             }
 
         except Exception as e:
-            logger.error(f"Error during force sync: {e}")
+            logger.error("Error during force sync: %s", _sanitize_log_value(e))
             return {
                 'status': 'error',
                 'error': str(e),
@@ -530,7 +525,7 @@ class BackgroundSyncService:
             }
 
         except Exception as e:
-            logger.error(f"Failed to check Cloudflare capacity: {e}")
+            logger.error("Failed to check Cloudflare capacity: %s", _sanitize_log_value(e))
             return {
                 'error': str(e),
                 'vector_count': self.cloudflare_stats.get('vector_count', 0),
@@ -564,11 +559,11 @@ class BackgroundSyncService:
                 await asyncio.sleep(5)  # Check every 5 seconds
 
             except Exception as e:
-                logger.error(f"Error in sync loop: {e}")
+                logger.error("Error in sync loop: %s", _sanitize_log_value(e))
                 self.consecutive_failures += 1
 
                 if self.consecutive_failures >= self.max_consecutive_failures:
-                    logger.warning(f"Too many consecutive sync failures ({self.consecutive_failures}), backing off for {self.backoff_time}s")
+                    logger.warning("Too many consecutive sync failures (%s), backing off for %ss", self.consecutive_failures, self.backoff_time)
                     await asyncio.sleep(self.backoff_time)
                     self.backoff_time = min(self.backoff_time * 2, 1800)  # Max 30 minutes
                 else:
@@ -600,24 +595,21 @@ class BackgroundSyncService:
             if backend is None:
                 continue
             if not hasattr(backend, 'purge_deleted'):
-                logger.debug(f"{label.capitalize()} storage does not support tombstone purging")
+                logger.debug("%s storage does not support tombstone purging", label.capitalize())
                 continue
             try:
                 purged_count = await backend.purge_deleted(
                     older_than_days=self.tombstone_retention_days
                 )
                 if purged_count > 0:
-                    logger.info(
-                        f"Purged {purged_count} {label} tombstones older than "
-                        f"{self.tombstone_retention_days} days"
-                    )
+                    logger.info("Purged %s %s tombstones older than %s days", purged_count, label, self.tombstone_retention_days)
                     self.sync_stats['tombstones_purged'] = self.sync_stats.get('tombstones_purged', 0) + purged_count
             except Exception as e:
-                logger.error(f"Error purging old {label} tombstones: {e}")
+                logger.error("Error purging old %s tombstones: %s", label, _sanitize_log_value(e))
 
     async def _process_operations_batch(self, operations: List[SyncOperation]):
         """Process a batch of sync operations."""
-        logger.debug(f"Processing batch of {len(operations)} sync operations")
+        logger.debug("Processing batch of %s sync operations", len(operations))
 
         for operation in operations:
             try:
@@ -645,7 +637,7 @@ class BackgroundSyncService:
 
         if is_limit_error:
             # Don't retry limit errors - they won't succeed
-            logger.error(f"Cloudflare limit error for {operation.operation}: {error}")
+            logger.error("Cloudflare limit error for %s: %s", _sanitize_log_value(operation.operation), _sanitize_log_value(error))
             self.sync_stats['operations_failed'] += 1
 
             # Update capacity tracking
@@ -664,7 +656,7 @@ class BackgroundSyncService:
 
         if is_temporary_error or operation.retries < operation.max_retries:
             # Retry temporary errors
-            logger.warning(f"Temporary error for {operation.operation} (retry {operation.retries + 1}/{operation.max_retries}): {error}")
+            logger.warning("Temporary error for %s (retry %s/%s): %s", _sanitize_log_value(operation.operation), operation.retries + 1, operation.max_retries, _sanitize_log_value(error))
             operation.retries += 1
 
             if operation.retries < operation.max_retries:
@@ -672,11 +664,11 @@ class BackgroundSyncService:
                 await asyncio.sleep(min(2 ** operation.retries, 60))  # Max 60 second delay
                 self.failed_operations.append(operation)
             else:
-                logger.error(f"Max retries reached for {operation.operation}")
+                logger.error("Max retries reached for %s", _sanitize_log_value(operation.operation))
                 self.sync_stats['operations_failed'] += 1
         else:
             # Permanent error - don't retry
-            logger.error(f"Permanent error for {operation.operation}: {error}")
+            logger.error("Permanent error for %s: %s", _sanitize_log_value(operation.operation), _sanitize_log_value(error))
             self.sync_stats['operations_failed'] += 1
 
     async def _process_single_operation(self, operation: SyncOperation):
@@ -686,7 +678,7 @@ class BackgroundSyncService:
                 # Validate memory before syncing
                 is_valid, validation_error = await self.validate_memory_for_cloudflare(operation.memory)
                 if not is_valid:
-                    logger.warning(f"Memory validation failed for sync: {validation_error}")
+                    logger.warning("Memory validation failed for sync: %s", _sanitize_log_value(validation_error))
                     # Don't retry if it's a hard limit
                     if "exceeds Cloudflare limit" in validation_error or "limit of" in validation_error:
                         self.sync_stats['operations_failed'] += 1
@@ -710,10 +702,7 @@ class BackgroundSyncService:
                     metadata_size_kb = len(metadata_json.encode('utf-8')) / 1024
 
                     if metadata_size_kb > 9.5:  # 9.5KB safety margin (Cloudflare limit is 10KB)
-                        logger.warning(
-                            f"Skipping Cloudflare sync for {operation.content_hash[:16]}: "
-                            f"metadata too large ({metadata_size_kb:.2f}KB > 9.5KB limit)"
-                        )
+                        logger.warning("Skipping Cloudflare sync for %s: metadata too large (%.2fKB > 9.5KB limit)", _sanitize_log_value(operation.content_hash[:16]), metadata_size_kb)
                         self.sync_stats['operations_failed'] += 1
                         return  # Skip this update permanently (too large for Cloudflare)
 
@@ -739,7 +728,7 @@ class BackgroundSyncService:
                     if not success:
                         raise Exception(f"Delete by timeframe failed: {message}")
                     self.sync_stats['operations_synced'] += 1
-                    logger.debug(f"Synced delete_by_timeframe: {message}")
+                    logger.debug("Synced delete_by_timeframe: %s", _sanitize_log_value(message))
                 else:
                     raise ValueError("delete_by_timeframe operation missing start_date or end_date")
 
@@ -753,7 +742,7 @@ class BackgroundSyncService:
                     if not success:
                         raise Exception(f"Delete before date failed: {message}")
                     self.sync_stats['operations_synced'] += 1
-                    logger.debug(f"Synced delete_before_date: {message}")
+                    logger.debug("Synced delete_before_date: %s", _sanitize_log_value(message))
                 else:
                     raise ValueError("delete_before_date operation missing before_date")
 
@@ -792,13 +781,13 @@ class BackgroundSyncService:
             if self.failed_operations:
                 retry_operations = list(self.failed_operations)
                 self.failed_operations.clear()
-                logger.info(f"Retrying {len(retry_operations)} failed operations")
+                logger.info("Retrying %s failed operations", len(retry_operations))
                 await self._process_operations_batch(retry_operations)
 
             # Perform a lightweight health check
             try:
                 healthy = await self._probe_secondary()
-                logger.debug(f"Secondary storage health check passed: {healthy}")
+                logger.debug("Secondary storage health check passed: %s", healthy)
                 self.sync_stats['cloudflare_available'] = bool(healthy)
 
                 # Capacity monitoring counts rows on the secondary, which on D1 is a
@@ -816,16 +805,16 @@ class BackgroundSyncService:
                 if healthy and self.drift_check_enabled:
                     time_since_last_check = time.time() - self.last_drift_check_time
                     if time_since_last_check >= self.drift_check_interval:
-                        logger.info(f"Running periodic drift check (interval: {self.drift_check_interval}s)")
+                        logger.info("Running periodic drift check (interval: %ss)", self.drift_check_interval)
                         drift_stats = await self._detect_and_sync_drift()
-                        logger.info(f"Drift check complete: {drift_stats}")
+                        logger.info("Drift check complete: %s", drift_stats)
 
             except Exception as e:
-                logger.warning(f"Secondary storage health check failed: {e}")
+                logger.warning("Secondary storage health check failed: %s", _sanitize_log_value(e))
                 self.sync_stats['cloudflare_available'] = False
 
         except Exception as e:
-            logger.error(f"Error during periodic sync: {e}")
+            logger.error("Error during periodic sync: %s", _sanitize_log_value(e))
 
     async def _detect_and_sync_drift(self, dry_run: bool = False) -> Dict[str, int]:
         """
@@ -847,7 +836,7 @@ class BackgroundSyncService:
         if not self.drift_check_enabled:
             return {'checked': 0, 'drift_detected': 0, 'synced': 0, 'failed': 0}
 
-        logger.info(f"Starting drift detection scan (dry_run={dry_run})...")
+        logger.info("Starting drift detection scan (dry_run=%s)...", dry_run)
         stats = {'checked': 0, 'drift_detected': 0, 'synced': 0, 'failed': 0}
 
         try:
@@ -868,7 +857,7 @@ class BackgroundSyncService:
                 cf_memories = await self.secondary.get_all_memories(limit=batch_size)
                 cf_updated = [m for m in cf_memories if m.updated_at and m.updated_at >= time_threshold]
 
-            logger.info(f"Found {len(cf_updated)} memories updated in Cloudflare since last check")
+            logger.info("Found %s memories updated in Cloudflare since last check", len(cf_updated))
 
             # Compare with local versions
             for cf_memory in cf_updated:
@@ -879,13 +868,13 @@ class BackgroundSyncService:
                     if not local_memory:
                         # Memory missing locally - sync it
                         stats['drift_detected'] += 1
-                        logger.debug(f"Memory {cf_memory.content_hash[:8]} missing locally, syncing...")
+                        logger.debug("Memory %s missing locally, syncing...", _sanitize_log_value(cf_memory.content_hash[:8]))
                         if not dry_run:
                             success, _ = await self.primary.store(cf_memory)
                             if success:
                                 stats['synced'] += 1
                         else:
-                            logger.info(f"[DRY RUN] Would sync missing memory: {cf_memory.content_hash[:8]}")
+                            logger.info("[DRY RUN] Would sync missing memory: %s", _sanitize_log_value(cf_memory.content_hash[:8]))
                             stats['synced'] += 1
                         continue
 
@@ -896,10 +885,7 @@ class BackgroundSyncService:
                     # Allow 1 second tolerance for timestamp precision
                     if abs(cf_updated_at - local_updated_at) > 1.0:
                         stats['drift_detected'] += 1
-                        logger.debug(
-                            f"Drift detected for {cf_memory.content_hash[:8]}: "
-                            f"Cloudflare={cf_updated_at:.2f}, Local={local_updated_at:.2f}"
-                        )
+                        logger.debug("Drift detected for %s: Cloudflare=%.2f, Local=%.2f", _sanitize_log_value(cf_memory.content_hash[:8]), cf_updated_at, local_updated_at)
 
                         # Use "newer timestamp wins" strategy
                         if cf_updated_at > local_updated_at:
@@ -920,11 +906,11 @@ class BackgroundSyncService:
                                 )
                                 if success:
                                     stats['synced'] += 1
-                                    logger.info(f"Synced metadata from Cloudflare → local: {cf_memory.content_hash[:8]}")
+                                    logger.info("Synced metadata from Cloudflare → local: %s", _sanitize_log_value(cf_memory.content_hash[:8]))
                                 else:
                                     stats['failed'] += 1
                             else:
-                                logger.info(f"[DRY RUN] Would sync metadata from Cloudflare → local: {cf_memory.content_hash[:8]}")
+                                logger.info("[DRY RUN] Would sync metadata from Cloudflare → local: %s", _sanitize_log_value(cf_memory.content_hash[:8]))
                                 stats['synced'] += 1
                         else:
                             # Local is newer - update Cloudflare
@@ -940,13 +926,13 @@ class BackgroundSyncService:
                                 )
                                 await self.enqueue_operation(operation)
                                 stats['synced'] += 1
-                                logger.info(f"Queued metadata sync from local → Cloudflare: {local_memory.content_hash[:8]}")
+                                logger.info("Queued metadata sync from local → Cloudflare: %s", _sanitize_log_value(local_memory.content_hash[:8]))
                             else:
-                                logger.info(f"[DRY RUN] Would queue metadata sync from local → Cloudflare: {local_memory.content_hash[:8]}")
+                                logger.info("[DRY RUN] Would queue metadata sync from local → Cloudflare: %s", _sanitize_log_value(local_memory.content_hash[:8]))
                                 stats['synced'] += 1
 
                 except Exception as e:
-                    logger.warning(f"Error checking drift for memory: {e}")
+                    logger.warning("Error checking drift for memory: %s", _sanitize_log_value(e))
                     stats['failed'] += 1
                     continue
 
@@ -957,13 +943,10 @@ class BackgroundSyncService:
                 self.sync_stats['drift_detected_count'] += stats['drift_detected']
                 self.sync_stats['drift_synced_count'] += stats['synced']
 
-            logger.info(
-                f"Drift detection complete: checked={stats['checked']}, "
-                f"drift_detected={stats['drift_detected']}, synced={stats['synced']}, failed={stats['failed']}"
-            )
+            logger.info("Drift detection complete: checked=%s, drift_detected=%s, synced=%s, failed=%s", stats['checked'], stats['drift_detected'], stats['synced'], stats['failed'])
 
         except Exception as e:
-            logger.error(f"Error during drift detection: {e}")
+            logger.error("Error during drift detection: %s", _sanitize_log_value(e))
 
         return stats
 
@@ -1070,7 +1053,7 @@ class HybridMemoryStorage(MemoryStorage):
                     logger.info("Initial sync scheduled to run after server startup")
 
             except Exception as e:
-                logger.warning(f"Failed to initialize secondary storage: {e}")
+                logger.warning("Failed to initialize secondary storage: %s", _sanitize_log_value(e))
                 self.secondary = None
 
         self.initialized = True
@@ -1119,10 +1102,10 @@ class HybridMemoryStorage(MemoryStorage):
             primary_count = primary_stats.get('total_memories') or 0
             secondary_count = secondary_stats.get('total_memories') or 0
 
-            logger.info(f"{sync_type.capitalize()} sync: Local={primary_count}, Cloudflare={secondary_count}")
+            logger.info("%s sync: Local=%s, Cloudflare=%s", sync_type.capitalize(), primary_count, secondary_count)
 
             if secondary_count <= primary_count:
-                logger.info(f"No new memories to sync from Cloudflare ({sync_type} sync)")
+                logger.info("No new memories to sync from Cloudflare (%s sync)", sync_type)
                 return {
                     'success': True,
                     'memories_synced': 0,
@@ -1141,12 +1124,12 @@ class HybridMemoryStorage(MemoryStorage):
 
             # Get all local hashes once for O(1) lookup
             local_hashes = await self.primary.get_all_content_hashes()
-            logger.info(f"Pulling {missing_count} potential memories from Cloudflare...")
+            logger.info("Pulling %s potential memories from Cloudflare...", missing_count)
 
             while True:
                 try:
                     # Get batch from Cloudflare using cursor-based pagination
-                    logger.debug(f"Fetching batch: cursor={cursor}, batch_size={batch_size}")
+                    logger.debug("Fetching batch: cursor=%s, batch_size=%s", cursor, batch_size)
 
                     if hasattr(self.secondary, 'get_all_memories_cursor'):
                         cloudflare_memories = await self.secondary.get_all_memories_cursor(
@@ -1160,10 +1143,10 @@ class HybridMemoryStorage(MemoryStorage):
                         )
 
                     if not cloudflare_memories:
-                        logger.debug(f"No more memories from Cloudflare at cursor {cursor}")
+                        logger.debug("No more memories from Cloudflare at cursor %s", cursor)
                         break
 
-                    logger.debug(f"Processing batch of {len(cloudflare_memories)} memories")
+                    logger.debug("Processing batch of %s memories", len(cloudflare_memories))
                     batch_checked = 0
                     batch_missing = 0
                     batch_synced = 0
@@ -1187,13 +1170,13 @@ class HybridMemoryStorage(MemoryStorage):
                                     if cf_deleted_at is None and cf_memory.metadata:
                                         cf_deleted_at = cf_memory.metadata.get('deleted_at')
                                     if cf_deleted_at is not None:
-                                        logger.debug(f"Memory {cf_memory.content_hash[:8]} is soft-deleted in Cloudflare, skipping")
+                                        logger.debug("Memory %s is soft-deleted in Cloudflare, skipping", _sanitize_log_value(cf_memory.content_hash[:8]))
                                         return ('skipped_deleted', cf_memory.content_hash, None)
 
                                     # Check if memory was soft-deleted locally (tombstone check)
                                     # This prevents re-syncing memories that were intentionally deleted
                                     if hasattr(self.primary, 'is_deleted') and await self.primary.is_deleted(cf_memory.content_hash):
-                                        logger.debug(f"Memory {cf_memory.content_hash[:8]} was deleted locally, skipping cloud sync")
+                                        logger.debug("Memory %s was deleted locally, skipping cloud sync", _sanitize_log_value(cf_memory.content_hash[:8]))
                                         # Propagate deletion to cloud if sync service available
                                         if self.sync_service:
                                             operation = SyncOperation(operation='delete', content_hash=cf_memory.content_hash)
@@ -1212,7 +1195,7 @@ class HybridMemoryStorage(MemoryStorage):
                                             self.initial_sync_completed = synced_count
 
                                         if synced_count % 10 == 0:
-                                            logger.info(f"{sync_type.capitalize()} sync progress: {synced_count}/{missing_count} memories synced")
+                                            logger.info("%s sync progress: %s/%s memories synced", sync_type.capitalize(), synced_count, missing_count)
 
                                             # Broadcast SSE progress event
                                             if broadcast_sse and SSE_AVAILABLE:
@@ -1224,11 +1207,11 @@ class HybridMemoryStorage(MemoryStorage):
                                                     )
                                                     await sse_manager.broadcast_event(progress_event)
                                                 except Exception as e:
-                                                    logger.debug(f"Failed to broadcast SSE progress: {e}")
+                                                    logger.debug("Failed to broadcast SSE progress: %s", _sanitize_log_value(e))
 
                                         return ('synced', cf_memory.content_hash, None)
                                     else:
-                                        logger.warning(f"Failed to sync memory {cf_memory.content_hash}: {message}")
+                                        logger.warning("Failed to sync memory %s: %s", _sanitize_log_value(cf_memory.content_hash), _sanitize_log_value(message))
                                         return ('failed', cf_memory.content_hash, message)
                                 elif enable_drift_check and self.sync_service and self.sync_service.drift_check_enabled:
                                     # Memory exists - check for metadata drift
@@ -1239,7 +1222,7 @@ class HybridMemoryStorage(MemoryStorage):
 
                                         # If Cloudflare version is newer, sync metadata
                                         if cf_updated > local_updated + 1.0:
-                                            logger.debug(f"Metadata drift detected: {cf_memory.content_hash[:8]}")
+                                            logger.debug("Metadata drift detected: %s", _sanitize_log_value(cf_memory.content_hash[:8]))
                                             success, _ = await self.primary.update_memory_metadata(
                                                 cf_memory.content_hash,
                                                 {
@@ -1256,11 +1239,11 @@ class HybridMemoryStorage(MemoryStorage):
                                             if success:
                                                 batch_synced += 1
                                                 synced_count += 1
-                                                logger.debug(f"Synced metadata for: {cf_memory.content_hash[:8]}")
+                                                logger.debug("Synced metadata for: %s", _sanitize_log_value(cf_memory.content_hash[:8]))
                                                 return ('drift_synced', cf_memory.content_hash, None)
                                 return ('skipped', cf_memory.content_hash, None)
                             except Exception as e:
-                                logger.warning(f"Error syncing memory {cf_memory.content_hash}: {e}")
+                                logger.warning("Error syncing memory %s: %s", _sanitize_log_value(cf_memory.content_hash), _sanitize_log_value(e))
                                 return ('error', cf_memory.content_hash, str(e))
 
                     # Process batch in parallel
@@ -1268,32 +1251,32 @@ class HybridMemoryStorage(MemoryStorage):
                     results = await asyncio.gather(*tasks, return_exceptions=True)
                     for result in results:
                         if isinstance(result, Exception):
-                            logger.error(f"Error during {sync_type} sync batch processing: {result}")
+                            logger.error("Error during %s sync batch processing: %s", sync_type, _sanitize_log_value(result))
 
-                    logger.debug(f"Batch complete: checked={batch_checked}, missing={batch_missing}, synced={batch_synced}")
+                    logger.debug("Batch complete: checked=%s, missing=%s, synced=%s", batch_checked, batch_missing, batch_synced)
 
                     # Track consecutive empty batches
                     if batch_synced == 0:
                         consecutive_empty_batches += 1
-                        logger.debug(f"Empty batch: consecutive={consecutive_empty_batches}/{HYBRID_MAX_EMPTY_BATCHES}")
+                        logger.debug("Empty batch: consecutive=%s/%s", consecutive_empty_batches, HYBRID_MAX_EMPTY_BATCHES)
                     else:
                         consecutive_empty_batches = 0
 
                     # Log progress summary
                     if processed_count > 0 and processed_count % 100 == 0:
-                        logger.info(f"Sync progress: processed={processed_count}, synced={synced_count}/{missing_count}")
+                        logger.info("Sync progress: processed=%s, synced=%s/%s", processed_count, synced_count, missing_count)
 
                     # Update cursor for next batch
                     if cloudflare_memories and hasattr(self.secondary, 'get_all_memories_cursor'):
                         cursor = min(memory.created_at for memory in cloudflare_memories if memory.created_at)
-                        logger.debug(f"Next cursor: {cursor}")
+                        logger.debug("Next cursor: %s", cursor)
 
                     # Early break conditions
                     if consecutive_empty_batches >= HYBRID_MAX_EMPTY_BATCHES and synced_count > 0:
-                        logger.info(f"Completed after {consecutive_empty_batches} empty batches - {synced_count}/{missing_count} synced")
+                        logger.info("Completed after %s empty batches - %s/%s synced", consecutive_empty_batches, synced_count, missing_count)
                         break
                     elif processed_count >= secondary_count and synced_count == 0:
-                        logger.info(f"No missing memories after checking all {processed_count} memories")
+                        logger.info("No missing memories after checking all %s memories", processed_count)
                         break
 
                     await asyncio.sleep(0.01)
@@ -1301,15 +1284,15 @@ class HybridMemoryStorage(MemoryStorage):
                 except Exception as e:
                     # Handle Cloudflare D1 errors
                     if "400" in str(e) and not hasattr(self.secondary, 'get_all_memories_cursor'):
-                        logger.error(f"D1 OFFSET limitation at processed_count={processed_count}: {e}")
+                        logger.error("D1 OFFSET limitation at processed_count=%s: %s", processed_count, _sanitize_log_value(e))
                         logger.warning("Cloudflare D1 OFFSET limits reached - sync incomplete")
                         break
                     else:
-                        logger.error(f"Error during {sync_type} sync: {e}")
+                        logger.error("Error during %s sync: %s", sync_type, _sanitize_log_value(e))
                         break
 
             time_taken = time.time() - sync_start_time
-            logger.info(f"{sync_type.capitalize()} sync completed: {synced_count} memories in {time_taken:.2f}s")
+            logger.info("%s sync completed: %s memories in %.2fs", sync_type.capitalize(), synced_count, time_taken)
 
             # Broadcast SSE completion event
             if broadcast_sse and SSE_AVAILABLE and missing_count > 0:
@@ -1322,7 +1305,7 @@ class HybridMemoryStorage(MemoryStorage):
                     )
                     await sse_manager.broadcast_event(completion_event)
                 except Exception as e:
-                    logger.debug(f"Failed to broadcast SSE completion: {e}")
+                    logger.debug("Failed to broadcast SSE completion: %s", _sanitize_log_value(e))
 
             return {
                 'success': True,
@@ -1333,7 +1316,7 @@ class HybridMemoryStorage(MemoryStorage):
             }
 
         except Exception as e:
-            logger.error(f"{sync_type.capitalize()} sync failed: {e}")
+            logger.error("%s sync failed: %s", sync_type.capitalize(), _sanitize_log_value(e))
             return {
                 'success': False,
                 'memories_synced': 0,
@@ -1384,12 +1367,12 @@ class HybridMemoryStorage(MemoryStorage):
             if synced_count == 0 and self.initial_sync_total > 0:
                 # All memories were already present - this is a successful "no-op" sync
                 self.initial_sync_completed = self.initial_sync_total
-                logger.info(f"Sync completed successfully: All {self.initial_sync_total} memories were already present locally")
+                logger.info("Sync completed successfully: All %s memories were already present locally", self.initial_sync_total)
 
             self.initial_sync_finished = True
 
         except Exception as e:
-            logger.error(f"Initial sync failed: {e}")
+            logger.error("Initial sync failed: %s", _sanitize_log_value(e))
             # Don't fail initialization if initial sync fails
             logger.warning("Continuing with hybrid storage despite initial sync failure")
         finally:
@@ -1615,7 +1598,7 @@ class HybridMemoryStorage(MemoryStorage):
                     try:
                         await self.sync_service.enqueue_operation(operation)
                     except Exception as e:
-                        logger.warning(f"Failed to queue sync for {memory.content_hash}: {e}")
+                        logger.warning("Failed to queue sync for %s: %s", _sanitize_log_value(memory.content_hash), _sanitize_log_value(e))
 
         return results
 
@@ -1793,7 +1776,7 @@ class HybridMemoryStorage(MemoryStorage):
             except asyncio.CancelledError:
                 logger.debug("Initial sync task cancelled during shutdown")
             except Exception as e:
-                logger.debug(f"Initial sync task error during shutdown: {e}")
+                logger.debug("Initial sync task error during shutdown: %s", _sanitize_log_value(e))
 
         # Stop sync service first
         if self.sync_service:
@@ -1807,7 +1790,7 @@ class HybridMemoryStorage(MemoryStorage):
                 else:
                     self.primary.close()
             except Exception as e:
-                logger.error(f"Error closing primary storage: {e}")
+                logger.error("Error closing primary storage: %s", _sanitize_log_value(e))
 
         if self.secondary and hasattr(self.secondary, 'close'):
             try:
@@ -1816,7 +1799,7 @@ class HybridMemoryStorage(MemoryStorage):
                 else:
                     self.secondary.close()
             except Exception as e:
-                logger.error(f"Error closing secondary storage: {e}")
+                logger.error("Error closing secondary storage: %s", _sanitize_log_value(e))
 
         logger.info("Hybrid memory storage shutdown completed")
 
@@ -1902,7 +1885,7 @@ class HybridMemoryStorage(MemoryStorage):
             }
 
         except Exception as e:
-            logger.error(f"Failed to pause sync: {e}")
+            logger.error("Failed to pause sync: %s", _sanitize_log_value(e))
             return {
                 'success': False,
                 'message': f'Failed to pause sync: {str(e)}'
@@ -1937,7 +1920,7 @@ class HybridMemoryStorage(MemoryStorage):
             }
 
         except Exception as e:
-            logger.error(f"Failed to resume sync: {e}")
+            logger.error("Failed to resume sync: %s", _sanitize_log_value(e))
             return {
                 'success': False,
                 'message': f'Failed to resume sync: {str(e)}'

--- a/tests/unit/test_log_injection_guard.py
+++ b/tests/unit/test_log_injection_guard.py
@@ -53,6 +53,22 @@ GUARDED_LEVELS = ("info", "warning", "error", "debug", "critical")
 
 SANITIZER = "_sanitize_log_value"
 
+# Names this codebase gives to data it did not produce itself. A %-argument
+# mentioning one of these is expected to be wrapped. Deliberately a short
+# denylist rather than a rule about all arguments: counters and durations are
+# safe and wrapping them is the noise #1119 set out to avoid.
+EXTERNAL_NAMES = frozenset({
+    "e", "err", "error", "errors", "exc", "exception",
+    "result", "response", "payload", "data",
+    "content", "content_hash", "tag", "tags",
+    "query", "params", "path", "message", "msg",
+})
+
+# Fields of an outside object that cannot carry injectable text. An HTTP status
+# is an integer in a fixed range, so `response.status_code` is not the `response`
+# the denylist above is aimed at.
+SAFE_ATTRIBUTES = frozenset({"status_code"})
+
 # The shell gate's own pattern: `grep -En 'logger\.(info|...)\(f"'`, minus any
 # line that already mentions the sanitizer.
 GATE_PATTERN = re.compile(r'logger\.(?:' + "|".join(GUARDED_LEVELS) + r')\(f"')
@@ -98,6 +114,38 @@ def _unsanitised_placeholders(call: ast.Call) -> bool:
     return False
 
 
+def _external_arguments(call: ast.Call) -> bool:
+    """True if a %-argument names outside data and is not wrapped."""
+    for argument in call.args[1:]:
+        if _is_sanitised(argument):
+            continue
+        source = ast.unparse(argument)
+        if source.rsplit(".", 1)[-1] in SAFE_ATTRIBUTES:
+            continue
+        tokens = set(re.findall(r"[A-Za-z_][A-Za-z_0-9]*", source))
+        if tokens & EXTERNAL_NAMES and not (tokens & {SANITIZER}):
+            return True
+    return False
+
+
+def _lazy_findings(source: str) -> list[str]:
+    """Unsanitised outside data handed to a %-style logger call.
+
+    Moving off f-strings takes the values out of reach of the two scans above,
+    so this one reads the arguments. It cannot decide on its own what came from
+    outside -- that is the judgement the gate lacks and the reason #1119 needed
+    a person -- so it works off EXTERNAL_NAMES: names this codebase uses for
+    data it did not produce. It catches the regression that matters (an
+    exception or payload logged raw) and stays quiet about counters.
+    """
+    tree = ast.parse(source)
+    return [
+        f"{node.lineno}: logger.{node.func.attr}(...)"
+        for node in ast.walk(tree)
+        if _is_guarded_logger_call(node) and _external_arguments(node)
+    ]
+
+
 def _ast_findings(source: str) -> list[str]:
     """Unsanitised f-string logger calls, found structurally rather than by line."""
     tree = ast.parse(source)
@@ -134,6 +182,33 @@ def test_no_unsanitised_interpolation_into_logs(module):
         f"{module}: {len(findings)} unsanitised interpolations into logger calls\n  "
         + "\n  ".join(findings[:15])
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", GUARDED_MODULES)
+def test_no_unsanitised_outside_data_in_lazy_log_calls(module):
+    """The %-style calls this issue introduced must still wrap outside data."""
+    findings = _lazy_findings(_read(module))
+    assert not findings, (
+        f"{module}: {len(findings)} logger calls passing outside data unwrapped\n  "
+        + "\n  ".join(findings[:15])
+    )
+
+
+@pytest.mark.unit
+def test_lazy_scan_catches_what_the_other_two_cannot():
+    """The gap Greptile found on this PR: no f-string, so no f-string finding."""
+    sample = 'logger.error("failed: %s", e)\n'
+    assert not _gate_findings(sample)
+    assert not _ast_findings(sample)
+    assert _lazy_findings(sample)
+    assert not _lazy_findings('logger.error("failed: %s", _sanitize_log_value(e))\n')
+
+
+@pytest.mark.unit
+def test_lazy_scan_leaves_internal_scalars_alone():
+    """Counters and durations stay unwrapped; demanding otherwise is the noise."""
+    assert not _lazy_findings('logger.info("synced %s in %.2fs", synced_count, elapsed)\n')
 
 
 @pytest.mark.unit

--- a/tests/unit/test_log_injection_guard.py
+++ b/tests/unit/test_log_injection_guard.py
@@ -1,0 +1,161 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Keeps the log-injection backlog from growing back.
+
+Check 6.5 of ``scripts/pr/pre_pr_check.sh`` flags f-string logger calls that do
+not wrap their values in ``_sanitize_log_value()``. It scans whole files rather
+than diffs, so a file carrying old unsanitised calls blocks every PR that
+touches it -- three files had 163 between them and were effectively unpatchable.
+See issue #1119.
+
+The modules listed in ``GUARDED_MODULES`` have been cleaned: values that come
+from outside are sanitised, and internal scalars use ``%``-style lazy formatting,
+which carries no interpolation for an attacker to reach. Two scans run over each
+of them:
+
+- the line scan the shell gate performs, so a regression here is exactly what
+  would fail somebody else's PR;
+- an AST scan, which also sees the multi-line calls the line-based gate misses.
+
+Add a module to the list once it is clean. Do not remove one to make this pass.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src"
+
+# Cleaned under issue #1119. Extend as further modules are cleared.
+GUARDED_MODULES = [
+    "mcp_memory_service/storage/cloudflare.py",
+    "mcp_memory_service/storage/hybrid.py",
+    "mcp_memory_service/config/storage.py",
+]
+
+# The levels check 6.5 looks at, verbatim.
+GUARDED_LEVELS = ("info", "warning", "error", "debug", "critical")
+
+SANITIZER = "_sanitize_log_value"
+
+# The shell gate's own pattern: `grep -En 'logger\.(info|...)\(f"'`, minus any
+# line that already mentions the sanitizer.
+GATE_PATTERN = re.compile(r'logger\.(?:' + "|".join(GUARDED_LEVELS) + r')\(f"')
+
+
+def _gate_findings(source: str) -> list[str]:
+    """Lines the shell gate would report, as `lineno: text`."""
+    return [
+        f"{number}: {line.strip()}"
+        for number, line in enumerate(source.splitlines(), start=1)
+        if GATE_PATTERN.search(line) and SANITIZER not in line
+    ]
+
+
+def _is_sanitised(node: ast.expr) -> bool:
+    """True for a `_sanitize_log_value(...)` call, the only accepted wrapper."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name == SANITIZER
+
+
+def _is_guarded_logger_call(node: ast.AST) -> bool:
+    """True for `logger.<level>(...)` at one of the levels the gate guards."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in GUARDED_LEVELS
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "logger"
+    )
+
+
+def _unsanitised_placeholders(call: ast.Call) -> bool:
+    """True if any f-string argument interpolates a value that is not wrapped."""
+    for argument in call.args:
+        if not isinstance(argument, ast.JoinedStr):
+            continue
+        for part in argument.values:
+            if isinstance(part, ast.FormattedValue) and not _is_sanitised(part.value):
+                return True
+    return False
+
+
+def _ast_findings(source: str) -> list[str]:
+    """Unsanitised f-string logger calls, found structurally rather than by line."""
+    tree = ast.parse(source)
+    return [
+        f"{node.lineno}: logger.{node.func.attr}(...)"
+        for node in ast.walk(tree)
+        if _is_guarded_logger_call(node) and _unsanitised_placeholders(node)
+    ]
+
+
+def _read(module: str) -> str:
+    path = SRC_ROOT / module
+    assert path.is_file(), f"guarded module missing: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", GUARDED_MODULES)
+def test_gate_reports_no_unsanitised_log_calls(module):
+    """The shell gate must pass on these files, or it blocks unrelated PRs."""
+    findings = _gate_findings(_read(module))
+    assert not findings, (
+        f"{module}: {len(findings)} f-string logger calls check 6.5 would flag\n  "
+        + "\n  ".join(findings[:15])
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", GUARDED_MODULES)
+def test_no_unsanitised_interpolation_into_logs(module):
+    """Structural pass, which also covers the multi-line calls the gate misses."""
+    findings = _ast_findings(_read(module))
+    assert not findings, (
+        f"{module}: {len(findings)} unsanitised interpolations into logger calls\n  "
+        + "\n  ".join(findings[:15])
+    )
+
+
+@pytest.mark.unit
+def test_detectors_agree_on_a_known_bad_sample():
+    """Guards the guard: both scans must flag an obviously unsafe call.
+
+    The sample is assembled from two pieces on purpose. Written out whole, the
+    call and its f-string would sit on one line of this file, and check 6.5 --
+    which reads lines, not Python -- would report this test as the very thing
+    it exists to test for.
+    """
+    sample = "logger.error(" + 'f"failed: {payload}")\n'
+    assert _gate_findings(sample)
+    assert _ast_findings(sample)
+
+
+@pytest.mark.unit
+def test_detectors_accept_the_two_supported_safe_forms():
+    """Sanitised interpolation and %-style lazy formatting both pass."""
+    sample = (
+        'logger.error(f"failed: {_sanitize_log_value(payload)}")\n'
+        'logger.info("sync finished in %ss", elapsed)\n'
+    )
+    assert not _gate_findings(sample)
+    assert not _ast_findings(sample)


### PR DESCRIPTION
Fixes #1119.

Check 6.5 scans whole files rather than diffs, so `storage/cloudflare.py`, `storage/hybrid.py` and `config/storage.py` were unpatchable: 163 old unsanitised f-string logger calls failed the gate for anyone touching them, whatever their change was. PR #1139 hit exactly that a few hours ago.

The split is the one the issue proposed, decided per expression rather than per line:

- **Sanitised, 121 arguments.** Exception and response text, D1 error payloads, stored content hashes, vector and R2 keys, tags, the recall query and its SQL parameters, filesystem paths, and the endpoint names read from the environment.
- **Plain `%`-arguments, the rest.** Counters, batch sizes, intervals, durations, status codes and the internal `primary`/`secondary` labels. Wrapping those buys nothing — the check is pure syntax and cannot tell the two groups apart — and lazy formatting is better logging practice anyway, since the string work is deferred to handlers that may never run.

Message text is unchanged. The `.2f` specs carry over as `%.2f`, and no message contained a literal percent sign, so nothing needed escaping.

`cloudflare.py` also carried its own byte-identical copy of `_sanitize_log_value`. It now imports the one from `compat`, as CLAUDE.md prescribes.

The first commit is the failing test, the second is the fix.

## The test

`tests/unit/test_log_injection_guard.py` runs two scans over each of the three modules. The line scan is the shell gate's own pattern, so a regression is exactly what would block someone else's PR; the AST scan also sees the multi-line calls the line-based gate misses. The two disagreed on the starting state — the gate counted 77/74/12, the AST 76/80/12 — so both are asserted rather than one standing in for the other. Two further cases guard the guard itself: a known-bad call must be flagged by both scans, and the two safe forms must pass both. `GUARDED_MODULES` is meant to grow as further files are cleared; 573 unsanitised calls remain elsewhere in `src/`.

Worth recording: the first version of that test failed the gate on its own known-bad sample, and then again on the docstring explaining the sample. That is the issue's point about a syntax-only check, demonstrated twice.

## Evidence

Failing first, with the source reverted to `main` and the test from the first commit:

```
$ git checkout origin/main -- src/ && .venv/bin/pytest tests/unit/test_log_injection_guard.py -q
6 failed, 2 passed
FAILED test_gate_reports_no_unsanitised_log_calls[mcp_memory_service/storage/cloudflare.py]
  ... 77 f-string logger calls check 6.5 would flag
```

Passing with the fix, and the full suite run three times to rule out flakiness:

```
$ .venv/bin/pytest tests/unit/test_log_injection_guard.py -q
8 passed in 0.73s

$ .venv/bin/pytest -q --timeout=120        # three consecutive runs
1 failed, 2965 passed, 88 skipped, 16 xfailed, 4 xpassed in 332.03s
1 failed, 2965 passed, 88 skipped, 16 xfailed, 4 xpassed in 313.32s
1 failed, 2965 passed, 88 skipped, 16 xfailed, 4 xpassed in 313.82s
```

The one failure is `tests/integration/test_http_server_startup.py::test_all_api_routes_registered`, `AttributeError: '_IncludedRouter' object has no attribute 'path'`. It fails identically with these commits stashed, so it is local FastAPI version drift, not this change — CI is the arbiter there.

```
$ bash scripts/pr/pre_pr_check.sh
ALL CHECKS PASSED (12/13, 1 skipped)
PASS - Log injection guard (f-string logger calls sanitized)
```

That last line is the point of the whole change.
