### PR TITLE
fix: scope memory_explore entities to query

### DIFF
--- a/docs/guides/token-efficient-retrieval.md
+++ b/docs/guides/token-efficient-retrieval.md
@@ -114,19 +114,14 @@ each truncated to 150 characters. Chunk content itself is capped at 500 characte
 snippet concatenation, useful for deciding where to drill in — not a summarization of the
 entity.
 
-### Known limitations
+### Query-scoped entity selection
 
-- **Entity selection is not query-scoped.** `memory_explore` takes the first
-  `max_entities` entities the graph returns and uses your query only to choose which chunks
-  hang off them. On a store with more entities than `max_entities`, it will not reliably
-  surface the ones relevant to your query. Tracked as
-  [#220](https://codeberg.org/doobidoo/mcp-memory-service/issues/220).
-- **An entity with no chunk matching your query inherits the query's top chunks**, and its
-  `summary` is built from them, with nothing in the response marking it as a fallback. Same
-  issue.
-
-Until #220 is resolved, treat `memory_explore` as "what do I know about, broadly" rather
-than "what do I know about X".
+`memory_explore` selects entities linked to the retrieved query chunks, starting with the
+highest-relevance chunks and stopping at `max_entities`. If none of those chunks has an
+entity link, it falls back to the graph's global entity list so partially populated graphs
+remain discoverable. A fallback entity receives an empty `top_chunks` list and summary
+unless one of its linked memories is present in the query results; unrelated query chunks
+are never attached to it.
 
 ## Which to reach for
 

--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -711,7 +711,7 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
 
         # Opt-in composite scoring (Issue #55)
         if scoring == "composite":
-            entity_degree = ent.get("count", profile.get("count", 0))
+            entity_degree = ent.get("count", profile.get("memory_count", 0))
             # Batch proximity: one find_connected per entity (not per chunk)
             proximity_map = {}
             if graph and top_chunks:
@@ -745,7 +745,7 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
             "name": name,
             "entity_type": entity_types[0] if entity_types else "",
             "summary": summary,
-            "relation_count": ent.get("count", profile.get("count", 0)),
+            "relation_count": ent.get("count", profile.get("memory_count", 0)),
             "top_chunks": top_chunks,
         })
     return knowledge_map

--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -23,7 +23,7 @@ Provides graph database operations including:
 
 import json
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from mcp import types
 from ...scoring import composite_score, score_components
@@ -640,6 +640,47 @@ async def _retrieve_candidates(storage, query: str, n_results: int, tags, store)
     return await storage.retrieve(query, **kwargs)
 
 
+async def _select_explore_entities(
+    graph: Any,
+    chunk_pool: List[Dict[str, Any]],
+    max_entities: int,
+) -> List[Dict[str, Any]]:
+    """Select entities linked to the highest-relevance retrieved chunks.
+
+    Keep the historical global list as a fallback for stores whose retrieved
+    memories have no entity links yet. The knowledge-map builder still leaves
+    those fallback entities' chunks empty instead of implying a false link.
+    """
+    if not graph or max_entities <= 0:
+        return []
+
+    entities = []
+    seen = set()
+    ranked_chunks = sorted(
+        chunk_pool,
+        key=lambda chunk: chunk.get("relevance") or 0.0,
+        reverse=True,
+    )
+    for chunk in ranked_chunks:
+        memory_hash = chunk.get("hash")
+        if not memory_hash:
+            continue
+        for name in await graph.get_entities_for_memory(memory_hash):
+            if not name:
+                continue
+            entity_id = normalize_entity_id(name)
+            if entity_id in seen:
+                continue
+            seen.add(entity_id)
+            entities.append({"entity_name": name})
+            if len(entities) >= max_entities:
+                return entities
+
+    if entities:
+        return entities
+    return await graph.list_entities(limit=max_entities)
+
+
 async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entity, scoring=None):
     """Assemble the memory_explore response shape from discovered entities.
 
@@ -664,17 +705,13 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
             entity_hashes = await graph.find_memories_by_entity(name)
             entity_chunks = [chunk_by_hash[h] for h in entity_hashes if h in chunk_by_hash]
 
-        # Fallback: use full chunk_pool if no entity-specific chunks found
-        if not entity_chunks:
-            entity_chunks = chunk_pool
-
         # Rank by relevance descending, take top N
         ranked = sorted(entity_chunks, key=lambda c: c.get("relevance") or 0.0, reverse=True)
         top_chunks = ranked[:chunks_per_entity]
 
         # Opt-in composite scoring (Issue #55)
         if scoring == "composite":
-            entity_degree = ent.get("count", 0)
+            entity_degree = ent.get("count", profile.get("count", 0))
             # Batch proximity: one find_connected per entity (not per chunk)
             proximity_map = {}
             if graph and top_chunks:
@@ -708,7 +745,7 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
             "name": name,
             "entity_type": entity_types[0] if entity_types else "",
             "summary": summary,
-            "relation_count": ent.get("count", 0),
+            "relation_count": ent.get("count", profile.get("count", 0)),
             "top_chunks": top_chunks,
         })
     return knowledge_map
@@ -756,9 +793,11 @@ async def handle_memory_explore(server, arguments: dict) -> List[types.TextConte
             if r.relevance_score >= min_score
         ]
 
-        # 2. Entity discovery (real graph degree) — None when backend has no graph.
+        # 2. Entity discovery — scoped to entities linked from retrieved chunks.
         graph = await get_graph_storage()
-        entities_raw = await graph.list_entities(limit=max_entities) if graph else []
+        entities_raw = await _select_explore_entities(
+            graph, chunk_pool, max_entities
+        )
 
         knowledge_map = await _build_knowledge_map(
             graph, entities_raw, chunk_pool, chunks_per_entity, scoring=scoring

--- a/src/mcp_memory_service/tools/registry.py
+++ b/src/mcp_memory_service/tools/registry.py
@@ -1264,9 +1264,6 @@ memory_quality {"action": "maintain", "dry_run": false} (dry_run defaults to tru
 stores nothing). Unavailable on the Cloudflare backend.
 Guide: docs/guides/token-efficient-retrieval.md
 
-KNOWN LIMITATION: entity selection is not query-scoped — the first max_entities entities in
-the graph are used, and your query only decides which chunks hang off them (#220).
-
 USE THIS WHEN:
 - User wants a high-level overview ("what do I know about X", "map out", "explore")
 - Need entities + their relationships rather than raw memory chunks

--- a/tests/test_two_phase_aggregation.py
+++ b/tests/test_two_phase_aggregation.py
@@ -11,7 +11,7 @@ def mock_graph():
     g.common_neighbors = AsyncMock(return_value=[])
     g.get_entities_for_memory = AsyncMock(return_value=[])
     g.find_connected = AsyncMock(return_value=[])
-    g.get_entity_profile = AsyncMock(return_value={"count": 5, "memory_count": 5})
+    g.get_entity_profile = AsyncMock(return_value={"memory_count": 5})
     g.list_entities = AsyncMock(return_value=[
         {"entity_name": "python", "count": 10},
         {"entity_name": "testing", "count": 5},
@@ -97,7 +97,7 @@ class TestBuildKnowledgeMap:
         from mcp_memory_service.server.handlers.graph import _build_knowledge_map
         graph = AsyncMock()
         graph.find_memories_by_entity = AsyncMock(return_value=["hash1"])
-        graph.get_entity_profile = AsyncMock(return_value={"count": 10, "entity_types": ["language"]})
+        graph.get_entity_profile = AsyncMock(return_value={"memory_count": 10, "entity_types": ["language"]})
         entities = [{"entity_name": "python", "count": 10}]
         chunks = [{"hash": "hash1", "content": "about python", "relevance": 0.9}]
         result = await _build_knowledge_map(graph, entities, chunk_pool=chunks, chunks_per_entity=3)
@@ -111,7 +111,7 @@ class TestBuildKnowledgeMap:
 
         graph = AsyncMock()
         graph.find_memories_by_entity = AsyncMock(return_value=["other-hash"])
-        graph.get_entity_profile = AsyncMock(return_value={"count": 2})
+        graph.get_entity_profile = AsyncMock(return_value={"memory_count": 2})
         entities = [{"entity_name": "unrelated"}]
         chunks = [{"hash": "query-hash", "content": "query result", "relevance": 0.9}]
 
@@ -182,7 +182,7 @@ class TestMemoryExploreEntitySelection:
         graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global"}])
         graph.find_memories_by_entity = AsyncMock(return_value=["query-hash"])
         graph.get_entity_profile = AsyncMock(
-            return_value={"count": 1, "entity_types": ["topic"]}
+            return_value={"memory_count": 1, "entity_types": ["topic"]}
         )
         monkeypatch.setattr(
             graph_handlers, "get_graph_storage", AsyncMock(return_value=graph)

--- a/tests/test_two_phase_aggregation.py
+++ b/tests/test_two_phase_aggregation.py
@@ -1,4 +1,6 @@
 """Tests for two-phase aggregation logic (PR #78)."""
+import json
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
@@ -102,6 +104,98 @@ class TestBuildKnowledgeMap:
         assert len(result) == 1
         assert result[0]["entity_id"] == "python"
         assert result[0]["name"] == "python"
+
+    @pytest.mark.asyncio
+    async def test_unmatched_entity_does_not_inherit_query_chunks(self):
+        from mcp_memory_service.server.handlers.graph import _build_knowledge_map
+
+        graph = AsyncMock()
+        graph.find_memories_by_entity = AsyncMock(return_value=["other-hash"])
+        graph.get_entity_profile = AsyncMock(return_value={"count": 2})
+        entities = [{"entity_name": "unrelated"}]
+        chunks = [{"hash": "query-hash", "content": "query result", "relevance": 0.9}]
+
+        result = await _build_knowledge_map(graph, entities, chunks, chunks_per_entity=3)
+
+        assert result[0]["top_chunks"] == []
+        assert result[0]["summary"] == ""
+        assert result[0]["relation_count"] == 2
+
+
+class TestSelectExploreEntities:
+    @pytest.mark.asyncio
+    async def test_uses_entities_linked_to_highest_relevance_chunks(self):
+        from mcp_memory_service.server.handlers.graph import _select_explore_entities
+
+        graph = AsyncMock()
+        graph.get_entities_for_memory = AsyncMock(
+            side_effect=lambda memory_hash: {
+                "high": ["Python", "Testing"],
+                "low": ["Testing", "python", "SQLite"],
+            }[memory_hash]
+        )
+        graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global"}])
+        chunks = [
+            {"hash": "low", "relevance": 0.2},
+            {"hash": "high", "relevance": 0.9},
+        ]
+
+        result = await _select_explore_entities(graph, chunks, max_entities=4)
+
+        assert result == [
+            {"entity_name": "Python"},
+            {"entity_name": "Testing"},
+            {"entity_name": "SQLite"},
+        ]
+        graph.list_entities.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_global_entities_when_chunks_have_no_links(self):
+        from mcp_memory_service.server.handlers.graph import _select_explore_entities
+
+        graph = AsyncMock()
+        graph.get_entities_for_memory = AsyncMock(return_value=[])
+        graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global", "count": 3}])
+
+        result = await _select_explore_entities(
+            graph, [{"hash": "query-hash", "relevance": 0.9}], max_entities=1
+        )
+
+        assert result == [{"entity_name": "Global", "count": 3}]
+        graph.list_entities.assert_awaited_once_with(limit=1)
+
+
+class TestMemoryExploreEntitySelection:
+    @pytest.mark.asyncio
+    async def test_handler_uses_entities_linked_to_retrieved_chunks(self, monkeypatch):
+        from mcp_memory_service.server.handlers import graph as graph_handlers
+
+        candidate = MagicMock()
+        candidate.memory.content_hash = "query-hash"
+        candidate.memory.content = "A query-matching memory."
+        candidate.relevance_score = 0.9
+        server = MagicMock()
+        server.storage.retrieve = AsyncMock(return_value=[candidate])
+
+        graph = AsyncMock()
+        graph.get_entities_for_memory = AsyncMock(return_value=["Relevant"])
+        graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global"}])
+        graph.find_memories_by_entity = AsyncMock(return_value=["query-hash"])
+        graph.get_entity_profile = AsyncMock(
+            return_value={"count": 1, "entity_types": ["topic"]}
+        )
+        monkeypatch.setattr(
+            graph_handlers, "get_graph_storage", AsyncMock(return_value=graph)
+        )
+
+        response = await graph_handlers.handle_memory_explore(
+            server, {"query": "relevant query", "max_entities": 5}
+        )
+        payload = json.loads(response[0].text)
+
+        assert [entity["name"] for entity in payload["entities"]] == ["Relevant"]
+        assert payload["entities"][0]["top_chunks"][0]["hash"] == "query-hash"
+        graph.list_entities.assert_not_awaited()
 
 
 class TestHydrateChunks:


### PR DESCRIPTION
Closes #1104

## Summary
- select explore entities from the highest-relevance retrieved chunks
- keep global fallback entities empty unless they truly match a query chunk
- document the query-scoped behavior

## Validation
- `ruff check` on changed Python files
- 42 focused graph tests passed, 1 skipped
- mutation checks proved both regressions
- full suite: 2,942 passed; 8 unrelated existing failures
