### PR TITLE
fix(quality): stop the gate demanding tests for dead-code removal

### DIFF
--- a/scripts/pr/lib/is_cleanup_only.py
+++ b/scripts/pr/lib/is_cleanup_only.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Decide whether a unified diff only removes code rather than adding behavior.
+
+The test-coverage check in quality_gate.sh demands a test file whenever Python
+files change. Dead-code removal cannot satisfy that: there is no new behavior to
+cover, so the gate was unpassable for exactly the cleanup it keeps asking for.
+
+A change counts as cleanup-only when every added line is either an import, or a
+trimmed form of a line removed in the same hunk -- which is what shortening an
+import list or dropping an unused binding looks like:
+
+    -from typing import Dict, List, Optional      -    loop = asyncio.get_running_loop()
+    +from typing import List                      +    asyncio.get_running_loop()
+
+Anything else -- a genuinely new statement, a changed condition -- is a behavior
+change and still needs a test.
+
+Reads a unified diff on stdin. Exit 0 = cleanup-only, 1 = adds behavior.
+"""
+import re
+import sys
+
+FILE_RE = re.compile(r"^\+\+\+ b/(.*)$")
+IMPORT_RE = re.compile(r"^(import |from \S+ import )")
+
+
+def is_cleanup_only(diff: str) -> bool:
+    in_python = False
+    removed: list[str] = []
+    added: list[str] = []
+    verdict = True
+
+    def flush() -> bool:
+        # Every added line must be an import, or contained in something removed.
+        for line in added:
+            if IMPORT_RE.match(line):
+                continue
+            if any(line in r for r in removed):
+                continue
+            return False
+        return True
+
+    for raw in diff.splitlines():
+        m = FILE_RE.match(raw)
+        if m:
+            verdict = verdict and flush()
+            removed, added = [], []
+            in_python = m.group(1).endswith(".py")
+            continue
+        if raw.startswith("@@"):
+            verdict = verdict and flush()
+            removed, added = [], []
+            continue
+        if not in_python:
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            stripped = raw[1:].strip()
+            if stripped and not stripped.startswith("#"):
+                added.append(stripped)
+        elif raw.startswith("-") and not raw.startswith("---"):
+            stripped = raw[1:].strip()
+            if stripped:
+                removed.append(stripped)
+
+    return verdict and flush()
+
+
+if __name__ == "__main__":
+    sys.exit(0 if is_cleanup_only(sys.stdin.read()) else 1)

--- a/scripts/pr/pre_pr_check.sh
+++ b/scripts/pr/pre_pr_check.sh
@@ -94,15 +94,15 @@ bash scripts/pr/quality_gate.sh --staged --with-pyscn
 QUALITY_GATE_EXIT=$?
 set -e
 if [ $QUALITY_GATE_EXIT -eq 0 ]; then
-    check_status "Quality gate (complexity ≤8, no security issues)" 0
+    check_status "Quality gate (complexity, security, test coverage, breaking changes)" 0
 elif [ $QUALITY_GATE_EXIT -eq 3 ]; then
     # Gemini CLI missing — the gate ran nothing. Reporting this as a pass made
     # the whole check meaningless on machines without the CLI.
-    check_status "Quality gate (complexity ≤8, no security issues)" 3
+    check_status "Quality gate (complexity, security, test coverage, breaking changes)" 3
     echo -e "${YELLOW}   Complexity and security were not evaluated locally — CI still checks them${NC}"
 else
-    check_status "Quality gate (complexity ≤8, no security issues)" 1
-    echo -e "${RED}   Fix high-complexity functions or security issues before creating PR${NC}"
+    check_status "Quality gate (complexity, security, test coverage, breaking changes)" 1
+    echo -e "${RED}   See the FINDINGS list above - it names the check that failed${NC}"
 fi
 
 # Check 3: Run test suite with coverage

--- a/scripts/pr/quality_gate.sh
+++ b/scripts/pr/quality_gate.sh
@@ -205,7 +205,20 @@ test_files=$(echo "$all_changed" | grep -Ec '^tests/.*\.(py|sh)$' || true)
 # Count code files directly from changed_files
 code_files=$(echo "$changed_files" | grep -c '\.py$' || true)
 
-if [ $code_files -gt 0 ] && [ $test_files -eq 0 ]; then
+# Dead-code removal has no new behavior to cover, so demanding a test file for it
+# made the gate unpassable for exactly the cleanup it keeps asking for. Anything
+# that adds real behavior still needs a test -- see lib/is_cleanup_only.py.
+if [ "$MODE" = "staged" ]; then
+    py_diff=$(git diff --cached -- '*.py')
+else
+    py_diff=$(gh pr diff $PR_NUMBER)
+fi
+cleanup_only=false
+if [ -n "$py_diff" ] && printf '%s' "$py_diff" | python3 "$SCRIPT_DIR/lib/is_cleanup_only.py"; then
+    cleanup_only=true
+fi
+
+if [ $code_files -gt 0 ] && [ $test_files -eq 0 ] && [ "$cleanup_only" = false ]; then
     warnings+=("No test files added/modified despite $code_files code file(s) changed")
     if [ $exit_code -eq 0 ]; then
         exit_code=1
@@ -213,6 +226,9 @@ if [ $code_files -gt 0 ] && [ $test_files -eq 0 ]; then
 fi
 echo "Code files changed: $code_files"
 echo "Test files changed: $test_files"
+if [ $code_files -gt 0 ] && [ "$cleanup_only" = true ]; then
+    echo "Cleanup-only change (no added behavior) - test requirement not applied"
+fi
 echo ""
 
 # Check 4: Breaking changes

--- a/tests/ci/test_is_cleanup_only.sh
+++ b/tests/ci/test_is_cleanup_only.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Covers scripts/pr/lib/is_cleanup_only.py, the rule that lets the quality gate's
+# test-coverage check pass a dead-code removal while still blocking added behavior.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/pr/lib/is_cleanup_only.py"
+failures=0
+
+check() {
+    local name="$1" expected="$2" diff="$3"
+    printf '%s' "$diff" | python3 "$HELPER"
+    local actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        echo "PASS - $name"
+    else
+        echo "FAIL - $name (expected exit $expected, got $actual)"
+        failures=$((failures + 1))
+    fi
+}
+
+# Shortening an import list: the added line is an import.
+check "trimmed import list" 0 '--- a/x.py
++++ b/x.py
+@@ -1,1 +1,1 @@
+-from typing import Dict, List, Optional
++from typing import List
+'
+
+# Dropping an unused binding: the added line is contained in the removed one.
+check "dropped unused binding" 0 '--- a/x.py
++++ b/x.py
+@@ -1,1 +1,1 @@
+-            loop = asyncio.get_running_loop()
++            asyncio.get_running_loop()
+'
+
+# Pure deletion.
+check "pure deletion" 0 '--- a/x.py
++++ b/x.py
+@@ -1,2 +1,0 @@
+-import traceback
+-import os
+'
+
+# A genuinely new statement must still demand a test.
+check "new statement" 1 '--- a/x.py
++++ b/x.py
+@@ -1,1 +1,2 @@
+ def f():
++    return compute_something()
+'
+
+# A changed condition is a behavior change, not cleanup.
+check "changed condition" 1 '--- a/x.py
++++ b/x.py
+@@ -1,1 +1,1 @@
+-    if a > b:
++    if a >= b:
+'
+
+# The same edit in a non-Python file must not make a Python change look clean.
+check "non-python ignored" 0 '--- a/x.md
++++ b/x.md
+@@ -1,1 +1,1 @@
+-old prose
++entirely new prose
+'
+
+# A cleanup hunk plus a behavior hunk in one diff is still a behavior change.
+check "mixed diff blocks" 1 '--- a/x.py
++++ b/x.py
+@@ -1,1 +1,1 @@
+-from typing import Dict, List
++from typing import List
+@@ -20,1 +20,2 @@
+ def f():
++    side_effect()
+'
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures test(s) failed"
+    exit 1
+fi
+echo "All tests passed"


### PR DESCRIPTION
## What this changes

Check 3 of `quality_gate.sh` flags any Python change that touches no test file. A dead-code removal cannot satisfy that - there is no new behavior to cover - so the gate was unpassable for exactly the cleanup it keeps asking for. Found while trying to land the CodeQL note backlog: 13 files, `+7/-24`, blocked with "No test files added/modified", and the FAIL headline blamed complexity and security, neither of which had fired.

The new rule in `scripts/pr/lib/is_cleanup_only.py`: an added line counts as cleanup when it is an import, or a trimmed form of a line removed in the same hunk. That is what shortening an import list or dropping an unused binding looks like:

```
-from typing import Dict, List, Optional      -    loop = asyncio.get_running_loop()
+from typing import List                      +    asyncio.get_running_loop()
```

A new statement or a changed condition still demands a test. The `pre_pr_check.sh` headline now names all the checks the gate runs and points at the FINDINGS list instead of guessing at the cause.

## Verification

- `tests/ci/test_is_cleanup_only.sh`: 7 cases (trimmed import, dropped binding, pure deletion, new statement, changed condition, non-Python ignored, mixed hunks) - all pass.
- Against the two real diffs that motivated it: the cleanup commit classifies as cleanup-only (exit 0); the `memory_count` fix from #1144 classifies as behavior (exit 1).
- Check 3 end to end with the cleanup diff staged: 13 code files, 0 test files, no finding, "Cleanup-only change" printed. Same diff plus one new function: finding reinstated, `exit_code=1`.
- `bash scripts/pr/pre_pr_check.sh`: 11/13 passed. Step [2/9] (complexity/security) was skipped, not passed: the local model endpoint returns HTTP 507 on completions and the Gemini CLI is not installed on this machine. CodeQL in CI covers the security half.

Note: `tests/ci/*.sh` is not wired into any workflow, so CI does not run the new test. That is a pre-existing gap and gets its own issue.
