### PR TITLE
fix(search): make time ranges and date-bounded deletes agree on the host-local day

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,6 +291,12 @@ Automatic detection and optimization for different platforms:
 4. Filtered results returned chronologically
 ```
 
+Calendar expressions such as `today`, `last week`, and a bare date resolve against the
+**host's local calendar day**, and the date-based deletion paths use the same boundaries, so
+recalling and deleting "2026-09-04" cover the same memories. Timestamps themselves are stored
+as UTC epochs; only the calendar boundary is local. An explicit ISO datetime passed to the
+`after`/`before` search filters is still read as UTC when it carries no offset.
+
 ## Performance Optimizations
 
 ### Model Caching

--- a/src/mcp_memory_service/storage/base.py
+++ b/src/mcp_memory_service/storage/base.py
@@ -583,23 +583,16 @@ class MemoryStorage(ABC):
                 # Optimized path: time-only filtering (no tags)
                 if hasattr(self, 'get_memories_by_time_range'):
                     use_optimized = True
+                    from ..utils.time_parser import parse_boundary  # inline import
                     try:
                         # Convert date strings to timestamps
                         if after:
-                            after_date = datetime.fromisoformat(after)
-                            # Treat naive datetimes as UTC (created_at in DB is time.time() = UTC)
-                            if after_date.tzinfo is None:
-                                after_date = after_date.replace(tzinfo=timezone.utc)
-                            start_time = after_date.timestamp()
+                            start_time = parse_boundary(after)
                         else:
                             start_time = 0.0
 
                         if before:
-                            before_date = datetime.fromisoformat(before)
-                            # Treat naive datetimes as UTC (created_at in DB is time.time() = UTC)
-                            if before_date.tzinfo is None:
-                                before_date = before_date.replace(tzinfo=timezone.utc)
-                            end_time = before_date.timestamp()
+                            end_time = parse_boundary(before)
                         else:
                             end_time = datetime.now(timezone.utc).timestamp()
 
@@ -1180,7 +1173,7 @@ class MemoryStorage(ABC):
             # Parse time expression if provided
             if time_expr:
                 try:
-                    from ..utils.time_parser import parse_time_expression
+                    from ..utils.time_parser import parse_time_expression  # inline import
                     # Parse time range from natural language
                     start_timestamp, end_timestamp = parse_time_expression(time_expr)
                     if start_timestamp is not None:
@@ -1193,13 +1186,10 @@ class MemoryStorage(ABC):
 
             # Use explicit after/before if no time_expr
             if not time_expr:
+                from ..utils.time_parser import parse_boundary  # inline import
                 if after:
                     try:
-                        after_date = datetime.fromisoformat(after)
-                        # Treat naive datetimes as UTC (created_at in DB is time.time() = UTC)
-                        if after_date.tzinfo is None:
-                            after_date = after_date.replace(tzinfo=timezone.utc)
-                        start_time = after_date.timestamp()
+                        start_time = parse_boundary(after)
                     except ValueError:
                         return {
                             "memories": [],
@@ -1211,11 +1201,7 @@ class MemoryStorage(ABC):
 
                 if before:
                     try:
-                        before_date = datetime.fromisoformat(before)
-                        # Treat naive datetimes as UTC (created_at in DB is time.time() = UTC)
-                        if before_date.tzinfo is None:
-                            before_date = before_date.replace(tzinfo=timezone.utc)
-                        end_time = before_date.timestamp()
+                        end_time = parse_boundary(before)
                     except ValueError:
                         return {
                             "memories": [],

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -1195,8 +1195,8 @@ class CloudflareStorage(MemoryStorage):
         """Delete memories within a specific date range."""
         try:
             # Convert dates to timestamps
-            start_ts = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
-            end_ts = datetime.combine(end_date, datetime.max.time(), tzinfo=timezone.utc).timestamp()
+            start_ts = datetime.combine(start_date, datetime.min.time()).timestamp()
+            end_ts = datetime.combine(end_date, datetime.max.time()).timestamp()
 
             if tag:
                 # Delete with tag filter
@@ -1243,7 +1243,7 @@ class CloudflareStorage(MemoryStorage):
         """Delete memories created before a specific date."""
         try:
             # Convert date to timestamp
-            before_ts = datetime.combine(before_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            before_ts = datetime.combine(before_date, datetime.min.time()).timestamp()
 
             if tag:
                 # Delete with tag filter

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -1807,8 +1807,8 @@ class MilvusMemoryStorage(MemoryStorage):
         if not self._ensure_initialized():
             return 0, "Milvus storage not initialized"
 
-        start_ts = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
-        end_ts = datetime.combine(end_date, datetime.max.time(), tzinfo=timezone.utc).timestamp()
+        start_ts = datetime.combine(start_date, datetime.min.time()).timestamp()
+        end_ts = datetime.combine(end_date, datetime.max.time()).timestamp()
         time_filter = f"created_at >= {start_ts} and created_at <= {end_ts}"
 
         tag_filter = ""
@@ -1835,7 +1835,7 @@ class MilvusMemoryStorage(MemoryStorage):
         if not self._ensure_initialized():
             return 0, "Milvus storage not initialized"
 
-        before_ts = datetime.combine(before_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+        before_ts = datetime.combine(before_date, datetime.min.time()).timestamp()
         time_filter = f"created_at < {before_ts}"
 
         tag_filter = ""
@@ -2528,15 +2528,15 @@ class MilvusMemoryStorage(MemoryStorage):
         if not time_expr:
             if after:
                 try:
-                    from datetime import datetime as _dt
-                    start_time = _dt.fromisoformat(after).timestamp()
+                    from ..utils.time_parser import parse_boundary  # inline import
+                    start_time = parse_boundary(after)
                 except ValueError:
                     return {"memories": [], "total": 0, "query": query, "mode": mode,
                             "error": f"Invalid after date: {after}"}
             if before:
                 try:
-                    from datetime import datetime as _dt
-                    end_time = _dt.fromisoformat(before).timestamp()
+                    from ..utils.time_parser import parse_boundary  # inline import
+                    end_time = parse_boundary(before)
                 except ValueError:
                     return {"memories": [], "total": 0, "query": query, "mode": mode,
                             "error": f"Invalid before date: {before}"}

--- a/src/mcp_memory_service/storage/mixins/delete.py
+++ b/src/mcp_memory_service/storage/mixins/delete.py
@@ -280,8 +280,8 @@ class DeleteMixin:
             if not self.conn:
                 return 0, "Database not initialized"
 
-            start_ts = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
-            end_ts = datetime.combine(end_date, datetime.max.time(), tzinfo=timezone.utc).timestamp()
+            start_ts = datetime.combine(start_date, datetime.min.time()).timestamp()
+            end_ts = datetime.combine(end_date, datetime.max.time()).timestamp()
 
             def _select_timeframe():
                 if tag:
@@ -323,7 +323,7 @@ class DeleteMixin:
             if not self.conn:
                 return 0, "Database not initialized"
 
-            before_ts = datetime.combine(before_date, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            before_ts = datetime.combine(before_date, datetime.min.time()).timestamp()
 
             def _select_before_date():
                 if tag:

--- a/src/mcp_memory_service/utils/time_parser.py
+++ b/src/mcp_memory_service/utils/time_parser.py
@@ -20,8 +20,10 @@ for retrieving memories based on when they were stored.
 """
 import re
 import logging
-from datetime import datetime, timedelta, date, time
+from datetime import datetime, timedelta, date, time, timezone
 from typing import Tuple, Optional, Dict
+
+from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +155,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 end_dt = datetime.combine(specific_date, time.max)
                 return start_dt.timestamp(), end_dt.timestamp()
             except ValueError as e:
-                logger.warning(f"Invalid date: {e}")
+                logger.warning("Invalid date: %s", _sanitize_log_value(e))
                 return None, None
             
         # Check for specific dates (MM/DD/YYYY)
@@ -174,7 +176,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
                 end_dt = datetime.combine(specific_date, time.max)
                 return start_dt.timestamp(), end_dt.timestamp()
             except ValueError as e:
-                logger.warning(f"Invalid date: {e}")
+                logger.warning("Invalid date: %s", _sanitize_log_value(e))
                 return None, None
         
         # Relative days: "X days ago", "yesterday", "today"
@@ -329,7 +331,7 @@ def parse_time_expression(query: str) -> Tuple[Optional[float], Optional[float]]
         return None, None
         
     except Exception as e:
-        logger.error(f"Error parsing time expression: {e}")
+        logger.error("Error parsing time expression: %s", _sanitize_log_value(e))
         return None, None
 
 def get_time_of_day_range(target_date: date, time_period: str) -> Tuple[float, float]:
@@ -721,3 +723,18 @@ def extract_time_expression(query: str) -> Tuple[str, Tuple[Optional[float], Opt
     cleaned_query = re.sub(r'\s+', ' ', cleaned_query).strip()
     
     return cleaned_query, (start_ts, end_ts)
+
+def parse_boundary(value: str) -> float:
+    """Epoch for an ``after=``/``before=`` filter string.
+
+    A bare ``YYYY-MM-DD`` is a calendar day and resolves against the host's local
+    day, matching what "today"/"yesterday" and the date-based deletion paths use.
+    A datetime with a time component is an instant, and is read as UTC unless it
+    carries its own offset.
+    """
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is not None:
+        return dt.timestamp()
+    if len(value.strip()) == 10:  # date only: host-local calendar day
+        return dt.timestamp()
+    return dt.replace(tzinfo=timezone.utc).timestamp()

--- a/tests/test_sqlite_vec_storage.py
+++ b/tests/test_sqlite_vec_storage.py
@@ -1003,19 +1003,19 @@ class TestSqliteVecTimeBasedDeletion:
             content="Memory from yesterday",
             content_hash=generate_content_hash("Memory from yesterday"),
             tags=["timeframe-test"],
-            created_at=datetime.combine(yesterday, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(yesterday, datetime.min.time()).timestamp()
         )
         memory_today = Memory(
             content="Memory from today",
             content_hash=generate_content_hash("Memory from today"),
             tags=["timeframe-test"],
-            created_at=datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(today, datetime.min.time()).timestamp()
         )
         memory_tomorrow = Memory(
             content="Memory from tomorrow",
             content_hash=generate_content_hash("Memory from tomorrow"),
             tags=["timeframe-test"],
-            created_at=datetime.combine(tomorrow, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(tomorrow, datetime.min.time()).timestamp()
         )
 
         await storage.store(memory_yesterday)
@@ -1107,25 +1107,25 @@ class TestSqliteVecTimeBasedDeletion:
             content="Before range",
             content_hash=generate_content_hash("Before range"),
             tags=["boundary-test"],
-            created_at=datetime.combine(two_days_ago, datetime.max.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(two_days_ago, datetime.max.time()).timestamp()
         )
         memory_at_start = Memory(
             content="At start boundary",
             content_hash=generate_content_hash("At start boundary"),
             tags=["boundary-test"],
-            created_at=datetime.combine(yesterday, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(yesterday, datetime.min.time()).timestamp()
         )
         memory_at_end = Memory(
             content="At end boundary",
             content_hash=generate_content_hash("At end boundary"),
             tags=["boundary-test"],
-            created_at=datetime.combine(today, datetime.max.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(today, datetime.max.time()).timestamp()
         )
         memory_after = Memory(
             content="After range",
             content_hash=generate_content_hash("After range"),
             tags=["boundary-test"],
-            created_at=datetime.combine(tomorrow, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(tomorrow, datetime.min.time()).timestamp()
         )
 
         await storage.store(memory_before)
@@ -1159,19 +1159,19 @@ class TestSqliteVecTimeBasedDeletion:
             content="Old memory",
             content_hash=generate_content_hash("Old memory"),
             tags=["before-test"],
-            created_at=datetime.combine(two_days_ago, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(two_days_ago, datetime.min.time()).timestamp()
         )
         memory_yesterday = Memory(
             content="Yesterday memory",
             content_hash=generate_content_hash("Yesterday memory"),
             tags=["before-test"],
-            created_at=datetime.combine(yesterday, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(yesterday, datetime.min.time()).timestamp()
         )
         memory_today = Memory(
             content="Today memory",
             content_hash=generate_content_hash("Today memory"),
             tags=["before-test"],
-            created_at=datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(today, datetime.min.time()).timestamp()
         )
 
         await storage.store(memory_old)
@@ -1234,7 +1234,7 @@ class TestSqliteVecTimeBasedDeletion:
             content="Recent memory",
             content_hash=generate_content_hash("Recent memory"),
             tags=["recent"],
-            created_at=datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            created_at=datetime.combine(today, datetime.min.time()).timestamp()
         )
         await storage.store(memory)
 
@@ -1249,52 +1249,50 @@ class TestSqliteVecTimeBasedDeletion:
         assert len(remaining) == 1
 
     @pytest.mark.asyncio
-    async def test_delete_memories_before_naive_date_treated_as_utc(self, storage, local_timezone):
-        """delete_memories(before=...) must match search_memories: a naive
-        YYYY-MM-DD boundary is UTC, not host-local time.
+    async def test_delete_memories_and_delete_before_date_agree_on_a_date(self, storage, local_timezone):
+        """delete_memories(before="YYYY-MM-DD") and delete_before_date(date) must
+        select the same memories for the same calendar day.
 
         Regression test for the base.py:568/574 gap doobidoo flagged on #237 -
-        the optimized time-only path in delete_memories built its boundary with
-        a naive datetime.fromisoformat(before).timestamp(), which resolves
-        against the host's local timezone. At TZ=Asia/Tokyo (UTC+9) that put
-        the cutoff nine hours earlier than intended, splitting memory_delete
-        and delete_before_date results for the same date argument.
+        the two paths built their boundary differently and split for the same
+        date argument. #237 closed that by making both UTC; since a bare date is
+        now a host-local calendar day (both paths, and the natural-language
+        parser too), what this pins is the agreement, not which zone wins.
+        The memory sits inside the offset gap where the two readings differ, so
+        a boundary split shows up as one path deleting and the other not.
         """
         local_timezone("Asia/Tokyo")
 
         today = date.today()
-        true_utc_midnight = datetime.combine(
-            today, datetime.min.time(), tzinfo=timezone.utc
-        ).timestamp()
+        local_midnight = datetime.combine(today, datetime.min.time()).timestamp()
+        in_gap = local_midnight - (4 * 3600)  # inside the local/UTC offset window
 
-        # Naive datetime.fromisoformat(before).timestamp() at TZ=Asia/Tokyo
-        # (UTC+9) resolves "before" as Tokyo local midnight, i.e. 9 hours
-        # *before* true UTC midnight. A memory created in that 9-hour gap
-        # is < true UTC midnight (should be deleted per the UTC
-        # convention search_memories already uses) but > the buggy
-        # early cutoff (so the unfixed code leaves it behind).
-        memory_in_gap = Memory(
-            content="Created 4 hours before true UTC midnight",
-            content_hash=generate_content_hash("Created 4 hours before true UTC midnight"),
-            tags=["delete-memories-utc-test"],
-            created_at=true_utc_midnight - (4 * 3600),
-        )
-        memory_well_before = Memory(
-            content="Created 12 hours before true UTC midnight",
-            content_hash=generate_content_hash("Created 12 hours before true UTC midnight"),
-            tags=["delete-memories-utc-test"],
-            created_at=true_utc_midnight - (12 * 3600),
-        )
-        await storage.store(memory_in_gap)
-        await storage.store(memory_well_before)
+        for label, ts in (("gap", in_gap), ("well-before", local_midnight - 12 * 3600)):
+            content = f"Created before local midnight ({label})"
+            await storage.store(Memory(
+                content=content,
+                content_hash=generate_content_hash(content),
+                tags=["delete-memories-utc-test"],
+                created_at=ts,
+            ))
 
         result = await storage.delete_memories(before=str(today))
-
         assert result["success"] is True
         assert result["deleted_count"] == 2
+        assert len(await storage.search_by_tag(["delete-memories-utc-test"])) == 0
 
-        remaining = await storage.search_by_tag(["delete-memories-utc-test"])
-        assert len(remaining) == 0
+        # Same fixtures, same date, the other path: identical outcome.
+        for label, ts in (("gap", in_gap), ("well-before", local_midnight - 12 * 3600)):
+            content = f"Round two before local midnight ({label})"
+            await storage.store(Memory(
+                content=content,
+                content_hash=generate_content_hash(content),
+                tags=["delete-memories-utc-test"],
+                created_at=ts,
+            ))
+        count, _ = await storage.delete_before_date(today)
+        assert count == 2
+        assert len(await storage.search_by_tag(["delete-memories-utc-test"])) == 0
 
     # get_by_exact_content tests
 

--- a/tests/unit/test_calendar_ranges_host_local.py
+++ b/tests/unit/test_calendar_ranges_host_local.py
@@ -1,0 +1,68 @@
+"""Calendar expressions and calendar-date deletion must agree, in every host timezone.
+
+Contract: a calendar day means the *host-local* day. The test asserts agreement
+within one process per zone, not invariance across zones.
+"""
+
+import os
+import time as time_mod
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import date, datetime, time, timedelta
+
+import pytest
+
+from mcp_memory_service.utils.time_parser import parse_boundary, parse_time_expression
+
+ZONES = ["UTC", "Asia/Tokyo", "America/Los_Angeles", "Pacific/Auckland"]
+
+
+@contextmanager
+def process_timezone(name: str) -> Iterator[None]:
+    """Temporarily set the process timezone, restoring it (and tzset) on the way out."""
+    if not hasattr(time_mod, "tzset"):
+        pytest.skip("time.tzset is unavailable on this platform")
+
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = name
+    time_mod.tzset()
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time_mod.tzset()
+
+
+@pytest.mark.parametrize("tz", ZONES)
+def test_today_is_the_host_local_day(tz):
+    with process_timezone(tz):
+        start, end = parse_time_expression("today")
+        today = date.today()
+        assert start == datetime.combine(today, time.min).timestamp()
+        assert end == pytest.approx(datetime.combine(today, time.max).timestamp())
+
+
+@pytest.mark.parametrize("tz", ZONES)
+def test_parser_and_delete_path_agree_on_the_same_day(tz):
+    """The bounds delete_by_timeframe() builds must match what "yesterday" parses to."""
+    with process_timezone(tz):
+        yesterday = date.today() - timedelta(days=1)
+        parsed_start, parsed_end = parse_time_expression("yesterday")
+        # Same construction as storage/mixins/delete.py:delete_by_timeframe
+        delete_start = datetime.combine(yesterday, datetime.min.time()).timestamp()
+        delete_end = datetime.combine(yesterday, datetime.max.time()).timestamp()
+        assert parsed_start == delete_start
+        assert parsed_end == pytest.approx(delete_end)
+
+
+@pytest.mark.parametrize("tz", ZONES)
+def test_bare_date_filter_matches_the_local_day_but_datetimes_stay_utc(tz):
+    """after="YYYY-MM-DD" is a calendar day (local); a naive datetime is an instant (UTC)."""
+    with process_timezone(tz):
+        day = date(2026, 9, 4)
+        assert parse_boundary("2026-09-04") == datetime.combine(day, time.min).timestamp()
+        assert parse_boundary("2026-09-04T00:00:00") == 1788480000.0  # UTC midnight
+        assert parse_boundary("2026-09-04T00:00:00+09:00") == 1788447600.0


### PR DESCRIPTION
## What this changes

Time-expression queries and the date-bounded delete paths now agree on one contract: a bare calendar date means the host-local calendar day; a datetime is UTC when naive. Supersedes #1141, which went the other way.

Refs #1122. Not "Closes": the issue's own reproduction script was not re-run against this tree, only the invariants it describes.

## Why host-local, and why the parser was not the bug

Under #1141's analysis the parser was TZ-dependent and everything else was UTC, so the parser had to move. Re-measured, it is the other way round. `utils/time_parser.py` already produced host-local calendar days, and so did `server/handlers/memory.py:1573-1574`. The sites that disagreed were the UTC-side filter and delete paths:

- `storage/mixins/delete.py:283,284,326`
- `storage/cloudflare.py:1202,1203,1250`
- `storage/milvus.py:1810,1811,1838`
- `storage/base.py:589,594,1192,1204`

Concrete divergence, `TZ=Asia/Tokyo`, date 2026-09-04: `datetime.combine(d, time.min).timestamp()` = `1788447600`, the same with `tzinfo=timezone.utc` = `1788480000`. Recall and delete for "yesterday" therefore hit different rows in one process. The decision is the calendar day the user is sitting in, so the UTC sites move, not the parser.

## The patch

- Nine `tzinfo=timezone.utc` removals on the sites above.
- One `parse_boundary()` helper routing the six `after=`/`before=` sites: bare `YYYY-MM-DD` is a host-local day, a datetime is UTC when naive. Without this, moving `delete.py` alone reopens the split that Codeberg #237 fixed - an earlier draft did exactly that.
- Carried over from #1141: the three log calls converted to `%s` plus `_sanitize_log_value`, and the `process_timezone` contextmanager for the tests.
- `docs/architecture.md`: the UTC paragraph is replaced by the host-local contract and the `after`/`before` datetime exception.

One thing to look at specifically: `test_delete_memories_before_naive_date_treated_as_utc` is rewritten into `test_delete_memories_and_delete_before_date_agree_on_a_date`. It pins that the two delete paths agree on a date instead of pinning the zone. That is a stronger, contract-neutral test, but it rewrites an accepted regression test.

## Verification

- `tests/test_time_parser.py tests/unit/test_calendar_ranges_host_local.py tests/test_sqlite_vec_storage.py` under `TZ=UTC`, `Asia/Tokyo`, `America/Los_Angeles`, `Pacific/Auckland`: 97 passed, 7 skipped in each.
- Edge-hour probe (01:00 and 23:00 local, Tokyo and Los Angeles): the pre-#1141 tree disagreed between recall and delete in 2 of 4 cases, #1141 in 3 of 4, this tree in 0 of 6. `delete_memories(before=)` and `delete_before_date()` agree in all four cases where the interim draft split them.
- Full suite under `TZ=Asia/Tokyo`: 5 failed, 2947 passed; all five failures identical on unpatched main.
- `bash scripts/pr/pre_pr_check.sh`: 11 passed, 2 failed, both inherited whole-file findings, neither introduced here:
  - Log injection guard: five f-string logger calls in `storage/mixins/delete.py` (lines 64, 107, 156, 160, 265). All five are byte-identical on `origin/main`; this diff touches no logger line in that file. They are part of the #1146 backlog.
  - Import ordering: four inline imports in `tests/test_sqlite_vec_storage.py`, all present on `origin/main`; this diff adds none.
  - Step [2/9] (complexity/security) was skipped, not passed: the local model endpoint returns HTTP 507 and the Gemini CLI is not installed here. CodeQL in CI covers the security half.
