### PR TITLE
chore(quality): clear the safe CodeQL note backlog

### DIFF
--- a/src/mcp_memory_service/bootstrap/formatter.py
+++ b/src/mcp_memory_service/bootstrap/formatter.py
@@ -3,7 +3,7 @@
 import os
 import re
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 
 class BootstrapFormatter:

--- a/src/mcp_memory_service/config/base.py
+++ b/src/mcp_memory_service/config/base.py
@@ -25,7 +25,6 @@ Licensed under the Apache License, Version 2.0
 """
 import os
 import sys
-import secrets
 from pathlib import Path
 from typing import Optional
 import time

--- a/src/mcp_memory_service/consolidation/belief_service.py
+++ b/src/mcp_memory_service/consolidation/belief_service.py
@@ -15,7 +15,6 @@ from typing import List, Optional
 from .belief import (
     CONFIDENCE_FLOOR,
     LAMBDA,
-    PROVENANCE_FLOOR,
     derive_confidence,
     should_promote,
     should_supersede,

--- a/src/mcp_memory_service/extraction/multilingual.py
+++ b/src/mcp_memory_service/extraction/multilingual.py
@@ -4,7 +4,7 @@ Applies locale-driven NER patterns from YAML configuration files.
 All patterns are pre-compiled at init time for performance.
 """
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 from ..config.locale import get_active_locales

--- a/src/mcp_memory_service/harvest/bootstrap_utils.py
+++ b/src/mcp_memory_service/harvest/bootstrap_utils.py
@@ -1,7 +1,7 @@
 """Utilities for bootstrap profile generation — dedup and ranking."""
 
 import time
-from typing import Callable, Dict, List, Optional
+from typing import Dict, List, Optional
 
 
 def _simple_similarity(a: str, b: str) -> float:

--- a/src/mcp_memory_service/harvest/rewriter.py
+++ b/src/mcp_memory_service/harvest/rewriter.py
@@ -229,7 +229,7 @@ class HarvestRewriter:
     def rewrite_sync(self, text: str, suggested_type: str = "observation", already_extracted: list = None) -> Optional[RewriteResult]:
         """Synchronous wrapper for rewrite (works inside running event loop)."""
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor() as pool:
                 future = pool.submit(asyncio.run, self.rewrite(text, suggested_type, already_extracted))
                 # Must exceed the actual per-request HTTP timeout times the
@@ -271,7 +271,7 @@ class HarvestRewriter:
     def rewrite_batch_sync(self, items: list) -> list:
         """Synchronous wrapper for rewrite_batch."""
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor() as pool:
                 future = pool.submit(asyncio.run, self.rewrite_batch(items))
                 # See rewrite_sync: must exceed the per-call timeout times

--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -11,7 +11,6 @@ Install with `pip install .[nli]` when the transformers backend lands.
 
 import logging
 import os
-import re
 from dataclasses import dataclass
 from typing import List, Tuple
 

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2202,12 +2202,6 @@ class MemoryServer:
         from .server.handlers import mistake_notes as mistake_handlers
         return await mistake_handlers.handle_mistake_note_delete(self, arguments)
 
-        """Delete a mistake note by content hash."""
-        await self._ensure_storage_initialized()
-        result = await self.memory_service.mistake_note_delete(
-            content_hash=arguments.get("content_hash", ""),
-        )
-        return [types.TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
     # ─── Session Legacy & Bootstrap Profile Handlers ──────────────
 
     async def handle_commit_session_legacy(self, arguments: dict) -> List[types.TextContent]:

--- a/src/mcp_memory_service/storage/mixins/base.py
+++ b/src/mcp_memory_service/storage/mixins/base.py
@@ -6,22 +6,18 @@ import logging
 import os
 import sys
 import platform
-import re
 import time
 import random
 import threading
 import asyncio
-from pathlib import Path
-from typing import List, Dict, Any, Optional, Set, Callable
+from typing import List, Any, Optional, Set, Callable
 
 try:
     import sqlite_vec
-    from sqlite_vec import serialize_float32
     SQLITE_VEC_AVAILABLE = True
 except ImportError:
     SQLITE_VEC_AVAILABLE = False
 
-from ..base import MemoryStorage
 from ...models.memory import Memory
 from ...config import SQLITEVEC_MAX_CONTENT_LENGTH
 

--- a/src/mcp_memory_service/storage/mixins/delete.py
+++ b/src/mcp_memory_service/storage/mixins/delete.py
@@ -3,11 +3,9 @@
 import sqlite3
 import logging
 import time
-import traceback
 from datetime import datetime, date, timezone
 from typing import List, Tuple, Optional
 
-from ...models.memory import Memory
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_memory_service/storage/mixins/embeddings.py
+++ b/src/mcp_memory_service/storage/mixins/embeddings.py
@@ -7,7 +7,7 @@ import os
 import struct
 import sys
 import traceback
-from typing import List, Optional
+from typing import List
 
 try:
     from sentence_transformers import SentenceTransformer

--- a/src/mcp_memory_service/storage/mixins/migrations.py
+++ b/src/mcp_memory_service/storage/mixins/migrations.py
@@ -4,7 +4,6 @@ import sqlite3
 import logging
 import re
 import traceback
-import time
 import os
 import asyncio
 from pathlib import Path

--- a/src/mcp_memory_service/web/api/backup.py
+++ b/src/mcp_memory_service/web/api/backup.py
@@ -23,7 +23,6 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
-from mcp_memory_service.config import OAUTH_ENABLED
 
 # OAuth authentication imports
 from ..oauth.middleware import require_read_access, require_write_access, AuthenticationResult


### PR DESCRIPTION
## What this changes

Clears the part of the CodeQL note backlog that is genuinely dead: 18 unused imports and unused locals across 12 files, plus the unreachable block in `handle_mistake_note_delete` (alert 543, `py/unreachable-statement`). That block is six statements after an unconditional `return`, left behind when the `e9f169b7` rebase reintroduced the old body; the delegated handler in `handlers/mistake_notes.py:56-62` already does the same thing. 13 files, `+7/-24`.

What is deliberately not touched, because those alerts are intentional and were dismissed with a reason instead:

- the 13 `config/__init__.py` polluting-imports - the documented re-export facade, 138 call sites
- the 5 "unused" imports in `sqlite_vec.py` / `milvus.py` - backward-compat and test-patch re-exports; `clear_model_caches` is imported from there by `web/api/health.py:325` and `server_impl.py:3029/3124`, deleting it would be a production `ImportError`
- the optional-dependency `ImportError` guards in the mixins
- `rewriter.py` keeps the `asyncio.get_running_loop()` call - it is the `RuntimeError` probe that picks the sync path - and drops only the unused `loop =` binding

Left open on purpose: `migrations.py` 13/14 (an `ImportError` guard, no value in touching it), `graph.py` 548/549 (want a `logger.debug`, tracked in #1154), and the real defects behind alerts 550, 497, 556, 498-500 (#1148, #1149, #1150, #1156). CodeQL closes the 19 alerts this diff fixes on its next scan of main; nothing was dismissed for them.

## Verification

- Per deleted name: `grep -cw <name> <file>` residual 0; 14/14 smoke imports of the touched modules; `pyflakes` clean of undefined names.
- `tests/consolidation/test_belief_service.py`, `tests/harvest/`, sqlite-vec KNN tests: 53 + 3 passed in the worktree venv.
- `bash scripts/pr/pre_pr_check.sh`: 10 passed, 3 failed, all three inherited whole-file findings. The diff adds exactly seven lines (five trimmed `from ... import` lines, two `asyncio.get_running_loop()` calls with the unused binding dropped); none contains a logger call, an inline import, or a debug statement. Every line the gate named exists byte-identical on `origin/main`:
  - Log injection guard: `config/base.py`, `belief_service.py`, `nli.py`, `mixins/base.py`, `mixins/delete.py`, `mixins/embeddings.py` - part of the #1146 backlog.
  - Import ordering: `harvest/bootstrap_utils.py` (3 inline imports on main), `mixins/base.py` (5), `mixins/migrations.py` (4).
  - Debug code: `mixins/base.py`, same pre-existing content.
  - Step [2/9] (complexity, security, and the check-3 cleanup rule from #1147) was skipped, not passed: the local model endpoint returns HTTP 507 and the Gemini CLI is not installed here, and `quality_gate.sh` exits before check 3 when it has no backend. CodeQL in CI covers security; for a deletion-only diff there is nothing for complexity to score.

This is the change #1147 was needed for - before it, check 3 blocked this diff with "No test files added/modified despite 13 code file(s) changed".
