### PR TITLE
chore(storage): drop the timezone import #1157 left unused in the delete mixin

### DIFF
--- a/src/mcp_memory_service/storage/mixins/delete.py
+++ b/src/mcp_memory_service/storage/mixins/delete.py
@@ -3,7 +3,7 @@
 import sqlite3
 import logging
 import time
-from datetime import datetime, date, timezone
+from datetime import datetime, date
 from typing import List, Tuple, Optional
 
 


### PR DESCRIPTION
#1157 removed the `tzinfo=timezone.utc` pins from `storage/mixins/delete.py` and left the `timezone` import behind; CodeQL flagged it as alert 560 on the next scan of main. One line.

`bash scripts/pr/pre_pr_check.sh`: 11 passed, 1 failed - the log-injection guard on the same five pre-existing f-string logger calls in this file (lines 62-263), byte-identical on `origin/main` and part of #1146; this diff touches no logger line. Step [2/9] skipped for lack of a local model backend, as on the other PRs today.
