### PR TITLE
harvest: remove dead cross-session dedup gate (#1148)

### DIFF
--- a/src/mcp_memory_service/harvest/harvester.py
+++ b/src/mcp_memory_service/harvest/harvester.py
@@ -110,20 +110,6 @@ class SessionHarvester:
 
         return kept
 
-    async def _is_duplicate_of_existing(self, content: str) -> bool:
-        """Check if content is semantically similar to existing memories."""
-        if not self._memory_service:
-            return False
-        try:
-            results = await self._memory_service.search(query=content, limit=1)
-            if results and len(results) > 0:
-                top = results[0]
-                similarity = top.get("similarity", top.get("score", 0))
-                return similarity > 0.85
-        except Exception:
-            pass
-        return False
-
     def harvest(self, config: HarvestConfig) -> List[HarvestResult]:
         """Parse sessions and extract candidates (synchronous, no storage)."""
         session_files = self._resolve_sessions(config)

--- a/tests/test_harvest_pipeline_v2.py
+++ b/tests/test_harvest_pipeline_v2.py
@@ -128,47 +128,6 @@ class TestBugConsolidation:
         assert len(result) == 2
 
 
-@pytest.mark.skipif(
-    not SENTENCE_TRANSFORMERS_AVAILABLE,
-    reason="Requires real embedding model for semantic dedup"
-)
-class TestDedupSemantic:
-    """Passo 4: dedup com memórias existentes no banco."""
-
-    def _get_harvester(self):
-        from mcp_memory_service.harvest.harvester import SessionHarvester
-        return SessionHarvester(Path("/tmp/fake"))
-
-    def test_is_duplicate_of_existing_method_exists(self):
-        """Método _is_duplicate_of_existing deve existir."""
-        h = self._get_harvester()
-        assert hasattr(h, "_is_duplicate_of_existing"), \
-            "SessionHarvester deve ter método _is_duplicate_of_existing"
-
-    @pytest.mark.asyncio
-    async def test_rejects_if_similar_exists_in_db(self):
-        """Candidato similar a memória existente → rejeitado."""
-        h = self._get_harvester()
-        # Mock storage que retorna memória similar
-        mock_storage = AsyncMock()
-        mock_storage.search.return_value = [
-            {"content": "Seguir padrão spec → tdd para desenvolvimento", "similarity": 0.92}
-        ]
-        h._memory_service = mock_storage
-        result = await h._is_duplicate_of_existing("convenção: Seguir spec → tdd para garantir clareza")
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_accepts_if_no_similar_in_db(self):
-        """Candidato sem similar no banco → aceito."""
-        h = self._get_harvester()
-        mock_storage = AsyncMock()
-        mock_storage.search.return_value = []
-        h._memory_service = mock_storage
-        result = await h._is_duplicate_of_existing("MIR nunca se comunica diretamente com Inji")
-        assert result is False
-
-
 class TestMultiProvider:
     """Passo 5: Multi-provider LLM com fallback."""
 


### PR DESCRIPTION
Closes #1148.

## What this does

Deletes `SessionHarvester._is_duplicate_of_existing` (and the tests that certified it). As the issue notes, the method is unreachable and could not work — but the fix is **delete**, not wire, and the reason is architectural.

## Why delete, not wire

The cross-session semantic dedup this method was meant to provide **already exists**, and better, in `_try_evolve()` — which is the method the store path (`harvest_and_store`) actually calls:

| | `_is_duplicate_of_existing` (dead) | `_try_evolve` (live, called) |
|---|---|---|
| store API | `self._memory_service.search(...)` — **does not exist** on `MemoryService` | `self.memory_service.storage.retrieve(query, n_results, min_confidence)` — real |
| result field | `top.get("similarity")` — assumes a dict | `similar[0].relevance_score` — real attribute |
| threshold | `0.85` hard-coded | `config.similarity_threshold` — configurable |
| on match | **reject** the candidate | **evolve** the existing memory (versioned update) |
| invoked? | no call-site | yes, from `harvest_and_store` |

Verified on `main` (`c81e10a`):

```
$ grep -rn "_is_duplicate_of_existing" src        # only the definition, no caller
$ python -c "from mcp_memory_service.services.memory_service import MemoryService; print(hasattr(MemoryService,'search'))"
False
```

So this isn't a gate that needs rewiring — it's a predecessor of `_try_evolve` that was left behind. **Wiring a reject-gate back into the store loop would actively regress P4 Evolution**: it would drop a near-duplicate candidate *before* `_try_evolve` gets the chance to evolve the existing memory from it. Removing it (and the bare `except`, per the issue and CodeQL alert 550) is the correct resolution.

## Tests removed, and why

`TestDedupSemantic` (3 tests in `tests/test_harvest_pipeline_v2.py`) asserted the dead method's behaviour by handing it an `AsyncMock` whose `.search()` returned `[{"content": ..., "similarity": 0.92}]`. That mock *supplies the exact API production lacks* — a `search()` method returning a dict with `"similarity"` — so the tests were green against a contract the codebase never honours. They tested the shape of the bug, not real behaviour, and go with the method.

The **live** dedup behaviour stays fully covered by `tests/harvest/test_harvester.py`: `test_evolve_similar_memory`, `test_store_novel_content`, `test_below_threshold_similarity_stores_new`, `test_skip_evolve_stale_memory`, `test_superseded_memory_not_evolved`, `test_fallback_when_no_storage`.

## Verification

- `pytest tests/harvest/test_harvester.py tests/test_harvest_pipeline_v2.py` → **28 passed, 3 skipped** (was 28 passed, 6 skipped; the 3 removed tests were among the ML-skipped set).
- Full CI-mirror run (`pytest tests/ --ignore=consolidation --ignore=benchmarks --ignore=integration -m "not benchmark"`) → **2404 passed, 94 skipped, 0 failed**.
- `scripts/pr/pre_pr_check.sh` → **12/13 pass**. The one failing check ("Log injection guard") flags `logger.warning(f"...{e}")` at `harvester.py:165` — a line that is **pre-existing on `main`** (line 179 there), inside `harvest_and_store`, which this diff does not touch (the diff is 55 deletions, 0 additions). I left it out to keep the change scoped to #1148; happy to wrap it with `_sanitize_log_value()` in this PR or a follow-up if you'd prefer.

## Agent Disclosure
This PR was generated by DIADE, an autonomous coding agent. The submitting account (massimiliano1991) is operated by Massimiliano Guidi.
Human review of this PR: no — fully automated. Every claim above was verified at the source before submitting (grep for call-sites, `hasattr` for the missing API, full local test run); the maintainer's own review is the intended check on the architectural judgment.
