### PR TITLE
ci: run the shell tests and the dead-reference check

### DIFF
--- a/.claude/hooks/worktree_guard.sh
+++ b/.claude/hooks/worktree_guard.sh
@@ -106,6 +106,12 @@ cmd_prepare() {
   br="$(git -C "$r" branch --show-current 2>/dev/null)"
   br="${br:-HEAD}"
   stamp="$(date +%y%m%d-%H%M%S)"
+  # Two prepares inside one second collided on the branch name and the second
+  # one failed silently; suffix until both the branch and the path are free.
+  local base="$stamp" n=0
+  while git -C "$r" show-ref -q --verify "refs/heads/wt/$stamp" || [ -e "$(dirname "$r")/$(basename "$r")--wt-$stamp" ]; do
+    n=$((n + 1)); stamp="$base-$n"
+  done
   dest="$(dirname "$r")/$(basename "$r")--wt-$stamp"
   git -C "$r" worktree add -q -b "wt/$stamp" "$dest" "$br" >&2 2>/dev/null || return 1
   # Heavy/secret untracked deps are gitignored -> absent in a fresh worktree.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,31 @@ jobs:
     - name: Run the JS test suites
       run: bash scripts/ci/run_hooks_tests.sh
 
+  shell-tests:
+    runs-on: ubuntu-latest
+    name: Shell Tests (tests/ci/) + Dead Refs (docs/)
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    # tests/ci/*.sh are the tests for the gate scripts themselves and ran in no
+    # workflow at all until this job existed, so a gate change passed check 3 with
+    # a test CI never executed (issue #1153). They fake pyscn and tolerate a
+    # missing gh, so the runner image is enough.
+    - name: Run the shell test suites
+      run: |
+        status=0
+        for t in tests/ci/*.sh; do
+          echo "::group::$t"
+          bash "$t" || { echo "FAILED: $t"; status=1; }
+          echo "::endgroup::"
+        done
+        exit $status
+    # check_dead_refs.sh was documented as a CI gate and wired nowhere
+    # (issue #1121). It scans docs/ and README.md for references to removed
+    # features, ports and commands.
+    - name: Check active docs for dead references
+      run: bash scripts/ci/check_dead_refs.sh
+
   test:
     runs-on: ubuntu-latest
     name: Tests + Coverage

--- a/scripts/ci/check_versions.sh
+++ b/scripts/ci/check_versions.sh
@@ -101,7 +101,9 @@ for target in "${SCAN_TARGETS[@]}"; do
       DRIFT_LINES+=("$line  →  expected v$CANONICAL (or excluded path)")
       FOUND=1
     fi
-  done < <(grep -rEn 'v?[0-9]+\.[0-9]+\.[0-9]+' "$target" --include='*.md' --include='*.html' 2>/dev/null || true)
+  # -H: GNU grep omits the filename when -r lands on a single file, so `file`
+  # became the line number on Linux and the path excludes never matched there.
+  done < <(grep -rHEn 'v?[0-9]+\.[0-9]+\.[0-9]+' "$target" --include='*.md' --include='*.html' 2>/dev/null || true)
 done
 
 if [ $FOUND -eq 0 ]; then


### PR DESCRIPTION
## What this changes

One new CI job, `shell-tests`, runs every `tests/ci/*.sh` and then `scripts/ci/check_dead_refs.sh`. Closes #1121 (dead-refs check documented as a gate, wired nowhere) and #1153 (the ten shell test suites for the gate scripts ran in no workflow, so a gate change could pass check 3 with a test CI never executed).

Also fixes the one red case those tests had: `.claude/hooks/worktree_guard.sh` stamped worktrees to the second, so two `prepare` calls inside one second collided on `wt/<stamp>` and the second failed silently. The stamp now takes a `-N` suffix until both branch and path are free.

## Verification

- All ten `tests/ci/*.sh` plus `check_dead_refs.sh` run green locally with the venv off `PATH` (the shell tests fake `pyscn` and tolerate a missing `gh`, so the plain runner image is enough). `test_worktree_guard.sh` was 7/8 before the hook fix and is 8/8 on three consecutive runs after it.
- Stamp collision reproduced in an isolated temp repo before the fix: two back-to-back `prepare` calls in one second returned an empty path for the second.
- `bash scripts/pr/pre_pr_check.sh`: 12/13 passed, the skip is the unenforced coverage target. Local model backend was up; complexity and security ran (no Python files changed).
- `uses:` line is the existing `actions/checkout` SHA pin, copied verbatim.

After merge I will confirm the job actually ran on main via the run list, not by assuming the trigger.
