### PR TITLE
fix(embeddings): read the process-level hash-fallback warning flag

### DIFF
--- a/src/mcp_memory_service/storage/mixins/embeddings.py
+++ b/src/mcp_memory_service/storage/mixins/embeddings.py
@@ -261,7 +261,7 @@ class EmbeddingsMixin:
             _st_flag = getattr(_st_mod, 'SENTENCE_TRANSFORMERS_AVAILABLE', False) if _st_mod else SENTENCE_TRANSFORMERS_AVAILABLE
             _st_available = _st_flag or SentenceTransformer is not None
             if not _st_available:
-                if not getattr(self, '_hash_fallback_warned', False):
+                if not (_HASH_FALLBACK_WARNED or getattr(self, '_hash_fallback_warned', False)):
                     logger.warning(
                         "No embedding backend available; using hash embeddings (reduced quality). "
                         "Install ML dependencies for semantic search: pip install mcp-memory-service[ml]. "
@@ -372,7 +372,7 @@ class EmbeddingsMixin:
         except Exception as e:
             logger.error(f"Failed to initialize embedding model: {str(e)}")
             logger.error(traceback.format_exc())
-            if not getattr(self, '_hash_fallback_warned', False):
+            if not (_HASH_FALLBACK_WARNED or getattr(self, '_hash_fallback_warned', False)):
                 logger.warning(
                     "No embedding backend available; using hash embeddings (reduced quality). "
                     "Install ML dependencies for semantic search: pip install mcp-memory-service[ml]. "

--- a/tests/test_torch_optional.py
+++ b/tests/test_torch_optional.py
@@ -432,3 +432,58 @@ class TestRuntimeWarning:
         assert quality_warnings_second == [], (
             f"Should not repeat fallback warning on second init, got: {quality_warnings_second}"
         )
+
+    def test_warning_emitted_once_per_process_not_once_per_instance(self, monkeypatch, caplog):
+        """A second, freshly built mixin must not repeat the fallback warning.
+
+        The module comment promises the warning fires once per process, but the
+        guard only consulted the per-instance flag, so the module-level
+        `_HASH_FALLBACK_WARNED` was written and never read. Production never
+        noticed, because `_STORAGE_CACHE` yields one instance per process --
+        this pins the documented behaviour for the case where it does not.
+        """
+        from mcp_memory_service.storage.mixins.embeddings import EmbeddingsMixin
+
+        monkeypatch.setattr(
+            "mcp_memory_service.storage.mixins.embeddings.SENTENCE_TRANSFORMERS_AVAILABLE",
+            False,
+        )
+        monkeypatch.setattr(
+            "mcp_memory_service.storage.mixins.embeddings.SentenceTransformer", None
+        )
+        monkeypatch.delenv("MCP_EXTERNAL_EMBEDDING_URL", raising=False)
+        monkeypatch.setenv("MCP_MEMORY_USE_ONNX", "0")
+
+        def build_mixin():
+            mixin = EmbeddingsMixin()
+            mixin.embedding_model_name = "all-MiniLM-L6-v2"
+            mixin.embedding_dimension = 384
+            mixin.embedding_model = None
+            mixin.enable_cache = False
+            mixin.conn = None
+            mixin._run_in_thread = AsyncMock(return_value=None)
+            return mixin
+
+        import asyncio
+
+        def fallback_warnings():
+            return [
+                r for r in caplog.records
+                if r.levelno >= logging.WARNING
+                and ("hash" in r.message.lower() or "quality" in r.message.lower())
+            ]
+
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(build_mixin()._initialize_embedding_model())
+        assert fallback_warnings(), "Should warn on the first instance"
+
+        caplog.clear()
+
+        # A different instance, with no per-instance flag set on it.
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(build_mixin()._initialize_embedding_model())
+
+        assert fallback_warnings() == [], (
+            "Fallback warning must not repeat for a second instance in the same "
+            f"process, got: {fallback_warnings()}"
+        )


### PR DESCRIPTION
Closes #1156. Option B from the issue — 4 changed lines in one file, plus the test that makes the distinction observable.

Both guards read only the per-instance flag:

```python
if not getattr(self, '_hash_fallback_warned', False):
```

so `_HASH_FALLBACK_WARNED` was written at lines 271 and 382 and never read, and the comment at line 28 ("only once per process") described something the code did not do. Both now consult the global as well.

Production behaviour is unchanged: `_STORAGE_CACHE` yields one storage instance per process and `HybridMemoryStorage` is not an `EmbeddingsMixin`, so per-instance and per-process already coincide. What changes is that the flag now means what it says if a second instance ever appears — `clear_all_caches()` plus re-init, or a second backend path.

### The test

`test_warning_emitted_only_on_first_init` calls `_initialize_embedding_model` twice on the *same* mixin, so it passes under either semantics. The new `test_warning_emitted_once_per_process_not_once_per_instance` builds a second, fresh mixin, which is the case that separates them.

### Verified

- Red before green: with the test in place and `embeddings.py` reverted, the new test fails on the second instance's warning; with the fix, it passes.
- `pytest tests/test_torch_optional.py` — 16 passed.
- `pytest tests/test_torch_optional.py tests/test_embedding_dimension_cache.py` — 16 passed, 4 skipped.
- The `tests/conftest.py` resets at 112 and 119 are now load-bearing, as the issue predicted. Deleting them on this branch gives **4 failed, 12 passed** (the issue's 3, plus the new test). I left conftest untouched.
