### PR TITLE
fix(memory_explore): keep the chunk that selected an entity in its chunks

### DIFF
--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -736,8 +736,11 @@ async def _build_knowledge_map(
                     try:
                         connected = await graph.find_connected(first_hash, max_hops=3)
                         proximity_map = {h: d for h, d in connected}
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        # Proximity is the opt-in composite term; hop=None is
+                        # handled below, so only the term is lost (#1154).
+                        logger.debug("find_connected failed for entity %s: %s",
+                                     _sanitize_log_value(name), _sanitize_log_value(e))
             for c in top_chunks:
                 rel = c.get("relevance") or 0.0
                 hop = proximity_map.get(c.get("hash"))
@@ -881,8 +884,11 @@ async def _hydrate_chunks(storage, memory_hashes, scoring=None, graph=None, enti
             try:
                 connected = await graph.find_connected(chunks[0]["hash"], max_hops=3)
                 proximity_map = {h: d for h, d in connected}
-            except Exception:
-                pass
+            except Exception as e:
+                # No entity name in scope here; the seed hash identifies the
+                # batch. Only the proximity term is lost (#1154).
+                logger.debug("find_connected failed from %s: %s",
+                             _sanitize_log_value(chunks[0]["hash"]), _sanitize_log_value(e))
         for c in chunks:
             rel = c["relevance"] if c["relevance"] is not None else 0.0
             hop = proximity_map.get(c["hash"])

--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -644,18 +644,25 @@ async def _select_explore_entities(
     graph: Any,
     chunk_pool: List[Dict[str, Any]],
     max_entities: int,
-) -> List[Dict[str, Any]]:
+) -> tuple[List[Dict[str, Any]], Dict[str, set]]:
     """Select entities linked to the highest-relevance retrieved chunks.
 
     Keep the historical global list as a fallback for stores whose retrieved
     memories have no entity links yet. The knowledge-map builder still leaves
     those fallback entities' chunks empty instead of implying a false link.
+
+    Also return the entity-to-memory links discovered on the way, keyed by
+    normalized entity id. Selecting an entity means one of the retrieved chunks
+    is linked to it, so the builder needs those links to guarantee that chunk
+    ends up among the entity's chunks. Empty for the fallback path, which has
+    no retrieved-chunk link to report.
     """
     if not graph or max_entities <= 0:
-        return []
+        return [], {}
 
     entities = []
     seen = set()
+    hashes_by_entity: Dict[str, set] = {}
     ranked_chunks = sorted(
         chunk_pool,
         key=lambda chunk: chunk.get("relevance") or 0.0,
@@ -669,19 +676,22 @@ async def _select_explore_entities(
             if not name:
                 continue
             entity_id = normalize_entity_id(name)
+            hashes_by_entity.setdefault(entity_id, set()).add(memory_hash)
             if entity_id in seen:
                 continue
             seen.add(entity_id)
             entities.append({"entity_name": name})
             if len(entities) >= max_entities:
-                return entities
+                return entities, hashes_by_entity
 
     if entities:
-        return entities
-    return await graph.list_entities(limit=max_entities)
+        return entities, hashes_by_entity
+    return await graph.list_entities(limit=max_entities), {}
 
 
-async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entity, scoring=None):
+async def _build_knowledge_map(
+    graph, entities_raw, chunk_pool, chunks_per_entity, scoring=None, hashes_by_entity=None
+):
     """Assemble the memory_explore response shape from discovered entities.
 
     Phase-1 aggregation (standalone, no composite scoring):
@@ -702,7 +712,13 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
         # Entity-specific chunk filtering
         entity_chunks = []
         if graph:
-            entity_hashes = await graph.find_memories_by_entity(name)
+            # find_memories_by_entity is capped (limit=20) and ordered oldest
+            # first, so an entity with more links than that can come back
+            # without the very chunk that caused it to be selected -- leaving
+            # top_chunks empty and summary blank. Union in the links found
+            # while selecting, which are retrieved chunks by construction.
+            entity_hashes = set(await graph.find_memories_by_entity(name))
+            entity_hashes |= (hashes_by_entity or {}).get(normalize_entity_id(name), set())
             entity_chunks = [chunk_by_hash[h] for h in entity_hashes if h in chunk_by_hash]
 
         # Rank by relevance descending, take top N
@@ -795,12 +811,17 @@ async def handle_memory_explore(server, arguments: dict) -> List[types.TextConte
 
         # 2. Entity discovery — scoped to entities linked from retrieved chunks.
         graph = await get_graph_storage()
-        entities_raw = await _select_explore_entities(
+        entities_raw, hashes_by_entity = await _select_explore_entities(
             graph, chunk_pool, max_entities
         )
 
         knowledge_map = await _build_knowledge_map(
-            graph, entities_raw, chunk_pool, chunks_per_entity, scoring=scoring
+            graph,
+            entities_raw,
+            chunk_pool,
+            chunks_per_entity,
+            scoring=scoring,
+            hashes_by_entity=hashes_by_entity,
         )
         knowledge_map = knowledge_map[:max_entities]
 

--- a/tests/test_two_phase_aggregation.py
+++ b/tests/test_two_phase_aggregation.py
@@ -121,6 +121,57 @@ class TestBuildKnowledgeMap:
         assert result[0]["summary"] == ""
         assert result[0]["relation_count"] == 2
 
+    @pytest.mark.asyncio
+    async def test_selecting_chunk_survives_the_capped_entity_lookup(self):
+        """#1152: a hot entity's selecting chunk must not fall off the limit=20 window.
+
+        find_memories_by_entity is capped and ordered oldest first, so an entity
+        with more links than the cap comes back without its newest ones. If the
+        chunk that caused the entity to be selected is one of those, the entity
+        was returned with no chunks and a blank summary.
+        """
+        from mcp_memory_service.server.handlers.graph import _build_knowledge_map
+
+        graph = AsyncMock()
+        # The 20 oldest links, none of which is the retrieved chunk.
+        graph.find_memories_by_entity = AsyncMock(
+            return_value=[f"old-{i}" for i in range(20)]
+        )
+        graph.get_entity_profile = AsyncMock(return_value={"memory_count": 25})
+        entities = [{"entity_name": "hot-entity"}]
+        chunks = [{"hash": "query-hash", "content": "The matching memory.", "relevance": 0.9}]
+
+        result = await _build_knowledge_map(
+            graph,
+            entities,
+            chunks,
+            chunks_per_entity=3,
+            hashes_by_entity={"hot-entity": {"query-hash"}},
+        )
+
+        assert [c["hash"] for c in result[0]["top_chunks"]] == ["query-hash"]
+        assert result[0]["summary"] != ""
+
+    @pytest.mark.asyncio
+    async def test_unlinked_entity_still_gets_no_chunks_with_the_map(self):
+        """The union must not hand an entity a chunk it was never linked to."""
+        from mcp_memory_service.server.handlers.graph import _build_knowledge_map
+
+        graph = AsyncMock()
+        graph.find_memories_by_entity = AsyncMock(return_value=["other-hash"])
+        graph.get_entity_profile = AsyncMock(return_value={"memory_count": 2})
+
+        result = await _build_knowledge_map(
+            graph,
+            [{"entity_name": "unrelated"}],
+            [{"hash": "query-hash", "content": "query result", "relevance": 0.9}],
+            chunks_per_entity=3,
+            hashes_by_entity={"someone-else": {"query-hash"}},
+        )
+
+        assert result[0]["top_chunks"] == []
+        assert result[0]["summary"] == ""
+
 
 class TestSelectExploreEntities:
     @pytest.mark.asyncio
@@ -140,7 +191,7 @@ class TestSelectExploreEntities:
             {"hash": "high", "relevance": 0.9},
         ]
 
-        result = await _select_explore_entities(graph, chunks, max_entities=4)
+        result, hashes_by_entity = await _select_explore_entities(graph, chunks, max_entities=4)
 
         assert result == [
             {"entity_name": "Python"},
@@ -148,6 +199,13 @@ class TestSelectExploreEntities:
             {"entity_name": "SQLite"},
         ]
         graph.list_entities.assert_not_awaited()
+        # The links walked on the way out are reported, so the builder can
+        # guarantee the selecting chunk is among each entity's chunks (#1152).
+        assert hashes_by_entity == {
+            "python": {"high", "low"},
+            "testing": {"high", "low"},
+            "sqlite": {"low"},
+        }
 
     @pytest.mark.asyncio
     async def test_falls_back_to_global_entities_when_chunks_have_no_links(self):
@@ -157,12 +215,15 @@ class TestSelectExploreEntities:
         graph.get_entities_for_memory = AsyncMock(return_value=[])
         graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global", "count": 3}])
 
-        result = await _select_explore_entities(
+        result, hashes_by_entity = await _select_explore_entities(
             graph, [{"hash": "query-hash", "relevance": 0.9}], max_entities=1
         )
 
         assert result == [{"entity_name": "Global", "count": 3}]
         graph.list_entities.assert_awaited_once_with(limit=1)
+        # The fallback path has no retrieved-chunk link to report, so the
+        # builder still leaves those entities' chunks empty.
+        assert hashes_by_entity == {}
 
 
 class TestMemoryExploreEntitySelection:


### PR DESCRIPTION
Closes #1152.

`_select_explore_entities` selects entities by walking the entity links of the retrieved chunks — correct, and what #1144 established. `_build_knowledge_map` then went back to `graph.find_memories_by_entity(name)`, which is `limit=20` and ordered oldest first. For an entity with more links than that, the newest are exactly the ones missing, so an entity selected *because of* a recent chunk could come back with `top_chunks=[]` and `summary=''`. The global fallback #1144 removed used to hide this by attaching the query chunk regardless.

### Approach

The map the issue points at is already built during selection — the loop calls `get_entities_for_memory` per chunk and discards the result. `_select_explore_entities` now returns it alongside the entity list, and `_build_knowledge_map` unions it into the lookup.

I kept the capped query rather than replacing it outright. Selection returns early once `max_entities` is reached, so links for an already-selected entity that only appear in lower-ranked chunks are not in the map; the query still contributes those. Union gets the guarantee the issue asks for without giving anything up.

The fallback path (`graph.list_entities`, for stores whose retrieved memories have no links yet) returns an empty map, so those entities still get no chunks rather than implying a link that does not exist — the property `test_unmatched_entity_does_not_inherit_query_chunks` pins.

### Verified

- `test_selecting_chunk_survives_the_capped_entity_lookup` — 20 older links returned by the capped query, none of them the retrieved chunk; the entity now comes back with that chunk and a non-empty summary. Fails on `main`.
- `test_unlinked_entity_still_gets_no_chunks_with_the_map` — a map keyed for a *different* entity must not leak a chunk into this one. Guards the union against over-attaching.
- The two `TestSelectExploreEntities` tests are updated for the tuple return and now also assert the map's contents, including that the fallback path reports `{}`.
- `pytest tests/test_two_phase_aggregation.py tests/test_composite_wiring.py tests/test_torch_optional.py` — 38 passed.

Both changed functions are module-private and called from one place; `tests/test_composite_wiring.py` calls `_build_knowledge_map` positionally and is unaffected, since the new parameter is keyword-with-default.
