### PR TITLE
fix(graph): reuse entity-chunk map in memory_explore instead of re-querying with limit=20

### DIFF
--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -23,7 +23,7 @@ Provides graph database operations including:
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from mcp import types
 from ...scoring import composite_score, score_components
@@ -644,17 +644,24 @@ async def _select_explore_entities(
     graph: Any,
     chunk_pool: List[Dict[str, Any]],
     max_entities: int,
-) -> List[Dict[str, Any]]:
+) -> Tuple[List[Dict[str, Any]], Dict[str, List[str]]]:
     """Select entities linked to the highest-relevance retrieved chunks.
+
+    Returns ``(entities, entity_chunk_map)`` where *entity_chunk_map* maps
+    each entity name to the hashes from *chunk_pool* that link to it.
+    The knowledge-map builder uses this map so the chunk that caused an
+    entity to be selected is always among its chunks (avoids the
+    ``find_memories_by_entity(limit=20)`` truncation in #1152).
 
     Keep the historical global list as a fallback for stores whose retrieved
     memories have no entity links yet. The knowledge-map builder still leaves
     those fallback entities' chunks empty instead of implying a false link.
     """
     if not graph or max_entities <= 0:
-        return []
+        return [], {}
 
     entities = []
+    entity_chunk_map: Dict[str, List[str]] = {}
     seen = set()
     ranked_chunks = sorted(
         chunk_pool,
@@ -669,29 +676,36 @@ async def _select_explore_entities(
             if not name:
                 continue
             entity_id = normalize_entity_id(name)
-            if entity_id in seen:
-                continue
-            seen.add(entity_id)
-            entities.append({"entity_name": name})
-            if len(entities) >= max_entities:
-                return entities
+            if entity_id not in seen:
+                seen.add(entity_id)
+                entities.append({"entity_name": name})
+                if len(entities) >= max_entities:
+                    return entities, entity_chunk_map
+            # Track which chunks link to each entity
+            entity_chunk_map.setdefault(name, []).append(memory_hash)
 
     if entities:
-        return entities
-    return await graph.list_entities(limit=max_entities)
+        return entities, entity_chunk_map
+    fallback = await graph.list_entities(limit=max_entities)
+    return fallback, entity_chunk_map
 
 
-async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entity, scoring=None):
+async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entity, scoring=None, entity_chunk_map=None):
     """Assemble the memory_explore response shape from discovered entities.
 
     Phase-1 aggregation (standalone, no composite scoring):
-      - Entity-specific chunk filtering via graph.find_memories_by_entity
+      - Entity-specific chunk filtering via entity_chunk_map (from
+        _select_explore_entities) so the chunk that selected the entity is
+        always present (#1152).  Falls back to graph.find_memories_by_entity
+        only for fallback entities not in the map.
       - Extractive (LLM-free) summary from top chunks
       - Per-entity top_chunks ranking by relevance score
 
     When scoring="composite": enrich chunks with composite_score + score_components
     and re-rank by composite score (opt-in, Issue #55).
     """
+    if entity_chunk_map is None:
+        entity_chunk_map = {}
     chunk_by_hash = {c["hash"]: c for c in chunk_pool}
     knowledge_map = []
     for ent in entities_raw:
@@ -702,7 +716,11 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
         # Entity-specific chunk filtering
         entity_chunks = []
         if graph:
-            entity_hashes = await graph.find_memories_by_entity(name)
+            # Prefer the map built during entity selection (avoids limit=20 truncation)
+            entity_hashes = entity_chunk_map.get(name)
+            if entity_hashes is None:
+                # Fallback entity not discovered from chunks — query directly
+                entity_hashes = await graph.find_memories_by_entity(name)
             entity_chunks = [chunk_by_hash[h] for h in entity_hashes if h in chunk_by_hash]
 
         # Rank by relevance descending, take top N
@@ -795,12 +813,13 @@ async def handle_memory_explore(server, arguments: dict) -> List[types.TextConte
 
         # 2. Entity discovery — scoped to entities linked from retrieved chunks.
         graph = await get_graph_storage()
-        entities_raw = await _select_explore_entities(
+        entities_raw, entity_chunk_map = await _select_explore_entities(
             graph, chunk_pool, max_entities
         )
 
         knowledge_map = await _build_knowledge_map(
-            graph, entities_raw, chunk_pool, chunks_per_entity, scoring=scoring
+            graph, entities_raw, chunk_pool, chunks_per_entity,
+            scoring=scoring, entity_chunk_map=entity_chunk_map,
         )
         knowledge_map = knowledge_map[:max_entities]
 

--- a/tests/test_two_phase_aggregation.py
+++ b/tests/test_two_phase_aggregation.py
@@ -140,13 +140,17 @@ class TestSelectExploreEntities:
             {"hash": "high", "relevance": 0.9},
         ]
 
-        result = await _select_explore_entities(graph, chunks, max_entities=4)
+        result, entity_chunk_map = await _select_explore_entities(graph, chunks, max_entities=4)
 
         assert result == [
             {"entity_name": "Python"},
             {"entity_name": "Testing"},
             {"entity_name": "SQLite"},
         ]
+        # entity_chunk_map tracks which chunks link to each entity
+        assert "Python" in entity_chunk_map
+        assert "Testing" in entity_chunk_map
+        assert "SQLite" in entity_chunk_map
         graph.list_entities.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -157,11 +161,12 @@ class TestSelectExploreEntities:
         graph.get_entities_for_memory = AsyncMock(return_value=[])
         graph.list_entities = AsyncMock(return_value=[{"entity_name": "Global", "count": 3}])
 
-        result = await _select_explore_entities(
+        result, entity_chunk_map = await _select_explore_entities(
             graph, [{"hash": "query-hash", "relevance": 0.9}], max_entities=1
         )
 
         assert result == [{"entity_name": "Global", "count": 3}]
+        assert entity_chunk_map == {}  # no chunks linked to any entity
         graph.list_entities.assert_awaited_once_with(limit=1)
 
 


### PR DESCRIPTION
## What this changes

`_select_explore_entities` now returns the entity-to-chunk mapping it already builds during entity discovery. `_build_knowledge_map` uses that map instead of calling `find_memories_by_entity(name)` again with its default `limit=20`.

## Why

An entity with 25 linked memories where the query matches the 21st-oldest would come back with `top_chunks=[]` and `summary=""` because `find_memories_by_entity(limit=20)` silently dropped the matching chunk. The chunk that caused the entity to be selected was not among its returned chunks.

Fixes #1152

## How it was verified

```bash
# Run explore-related tests
python -m pytest tests/ -k "explore" -v --timeout=60
# Result: 5 passed, 10 skipped

# Run full test suite
python -m pytest tests/ --ignore=tests/benchmarks --ignore=tests/consolidation/test_dbscan_eps_estimation.py --ignore=tests/integration/test_http_server_startup.py --timeout=60 -q
# Result: 2871 passed, 0 failed, 105 skipped
```

## Notes for the reviewer

**Architecture**: `_select_explore_entities` returns `Tuple[List[Dict], Dict[str, List[str]]]` — the entity list plus a map from entity name to the hashes from `chunk_pool` that link to it. `_build_knowledge_map` uses the map as the primary source, falling back to `find_memories_by_entity` only for fallback entities not in the map.

**No limit increase**: The fix is NOT a bigger limit. The chunk that caused an entity to be selected is now always present because it came from the same `chunk_pool` that `_select_explore_entities` walked.

**Backward compatible**: `_build_knowledge_map` accepts `entity_chunk_map=None` (default), so any caller that doesn't pass it falls back to the old behavior.