### PR TITLE
fix: record belief stats in the job history and log a failed session-counter reset

### DIFF
--- a/src/mcp_memory_service/consolidation/scheduler.py
+++ b/src/mcp_memory_service/consolidation/scheduler.py
@@ -260,6 +260,7 @@ class ConsolidationScheduler:
                 'clusters_created': report.clusters_created,
                 'memories_compressed': report.memories_compressed,
                 'memories_archived': report.memories_archived,
+                'beliefs': belief_stats,
                 'errors': report.errors
             }
             

--- a/src/mcp_memory_service/server_impl.py
+++ b/src/mcp_memory_service/server_impl.py
@@ -2471,8 +2471,11 @@ class MemoryServer:
                             preserve_timestamps=False,
                         )
                         return
-        except Exception:
-            pass
+        except Exception as e:
+            # A swallowed failure here left the counter unreset, so the fresh-start
+            # trigger fired on every call with nothing in the log to say why.
+            logger.warning("Session counter reset for %s failed: %s",
+                           _sanitize_log_value(agent_id), _sanitize_log_value(e))
 
     async def handle_get_bootstrap_profile(self, arguments: dict) -> List[types.TextContent]:
         """Generate a behavioral bootstrap profile for ephemeral agents."""

--- a/tests/unit/test_silent_failures_are_logged.py
+++ b/tests/unit/test_silent_failures_are_logged.py
@@ -1,0 +1,61 @@
+"""Three places that used to swallow a failure or a result without a trace.
+
+- scheduler: belief derivation ran and its stats were discarded (#1149)
+- server_impl: the session-counter reset failed silently, so the fresh-start
+  trigger kept firing with nothing in the log (#1150)
+"""
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_job_record_carries_belief_stats(monkeypatch):
+    from mcp_memory_service.consolidation import scheduler as sched_mod
+
+    report = SimpleNamespace(
+        memories_processed=4, associations_discovered=1, clusters_created=0,
+        memories_compressed=0, memories_archived=0, errors=[],
+    )
+    consolidator = MagicMock()
+    consolidator.consolidate = AsyncMock(return_value=report)
+    consolidator.storage = MagicMock()
+
+    fake_service = MagicMock()
+    fake_service.derive_beliefs = AsyncMock(return_value={"beliefs_derived": 3})
+    monkeypatch.setattr(sched_mod, "BeliefService", lambda storage: fake_service)
+    monkeypatch.setenv("MCP_BELIEFS_ENABLED", "true")
+
+    scheduler = sched_mod.ConsolidationScheduler(consolidator, schedule_config={}, enabled=False)
+    await scheduler._run_consolidation_job("weekly")
+
+    assert scheduler.job_history[-1]["status"] == "success"
+    assert scheduler.job_history[-1]["beliefs"] == {"beliefs_derived": 3}
+
+
+@pytest.mark.asyncio
+async def test_session_counter_reset_failure_is_logged(caplog):
+    from mcp_memory_service.server import MemoryServer
+
+    fake_self = SimpleNamespace(
+        memory_service=SimpleNamespace(
+            retrieve_memories=AsyncMock(side_effect=RuntimeError("storage offline")),
+        ),
+        storage=MagicMock(),
+    )
+    # server_impl logs through logging_config's own handler and does not propagate,
+    # so attach caplog's handler to that logger for the duration of the call.
+    target = logging.getLogger("mcp_memory_service.server.logging_config")
+    target.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger=target.name):
+            await MemoryServer._reset_session_counter(fake_self, "agent-7\nforged")
+    finally:
+        target.removeHandler(caplog.handler)
+
+    text = caplog.text
+    assert "Session counter reset for agent-7" in text
+    assert "storage offline" in text
+    assert "\nforged" not in text  # the agent id is sanitized before it reaches the log


### PR DESCRIPTION
## What this changes

Two places that swallowed a failure or a result without a trace, found in the CodeQL note triage. Closes #1149, closes #1150.

- `consolidation/scheduler.py`: `belief_stats` from `derive_beliefs()` was computed and discarded; the job record now carries it under `beliefs`, next to the other phase counts.
- `server_impl.py` `_reset_session_counter`: the bare `except Exception: pass` around the persisted metadata update meant a failed reset left the counter high and the fresh-start trigger firing on every call, with nothing in the log. It now logs a warning with the agent id and the error, both through `_sanitize_log_value`.

#1154 (the two `find_connected` swallows in `graph.py`) is deliberately not in here: #1164 and #1168 are rewriting exactly that function right now, and two debug lines are easier folded into whichever of those lands than merged across them.

## Verification

- `tests/unit/test_silent_failures_are_logged.py`, two tests: the job record carries the belief stats; the session-counter failure is logged with the agent id sanitized (a `\n` in the id does not reach the log as a newline). 2 passed.
- `bash scripts/pr/pre_pr_check.sh`: 11 passed, 1 failed - the log-injection guard on five pre-existing f-string logger calls in `scheduler.py` (lines 102-146), all byte-identical on `origin/main`; this diff adds one logger call and it is `%s`-formatted with `_sanitize_log_value`. Part of #1146. Complexity and security ran on the local backend and passed.
- The session-counter test drives the real method with a fake `self`; `server_impl` logs through `logging_config`'s handler and does not propagate, so the test attaches caplog's handler to that logger for the call.
- `bash scripts/pr/pre_pr_check.sh`: result pasted in the first comment (local model backend up; complexity and security evaluated).
