### PR TITLE
fix(graph): log the two swallowed proximity lookups at debug (closes #1154)

### DIFF
--- a/src/mcp_memory_service/server/handlers/graph.py
+++ b/src/mcp_memory_service/server/handlers/graph.py
@@ -720,8 +720,16 @@ async def _build_knowledge_map(graph, entities_raw, chunk_pool, chunks_per_entit
                     try:
                         connected = await graph.find_connected(first_hash, max_hops=3)
                         proximity_map = {h: d for h, d in connected}
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        # Not a defect: hop stays None a few lines down and the
+                        # proximity term drops out of the composite score. Logged
+                        # because when it fails for every entity the score looks
+                        # like relevance alone, with nothing saying why.
+                        logger.debug(
+                            "Proximity lookup failed for entity %s: %s",
+                            _sanitize_log_value(name),
+                            _sanitize_log_value(exc),
+                        )
             for c in top_chunks:
                 rel = c.get("relevance") or 0.0
                 hop = proximity_map.get(c.get("hash"))
@@ -860,8 +868,14 @@ async def _hydrate_chunks(storage, memory_hashes, scoring=None, graph=None, enti
             try:
                 connected = await graph.find_connected(chunks[0]["hash"], max_hops=3)
                 proximity_map = {h: d for h, d in connected}
-            except Exception:
-                pass
+            except Exception as exc:
+                # Same as in _build_knowledge_map: the proximity term drops out
+                # rather than the call failing, so this only needs to be visible.
+                logger.debug(
+                    "Proximity lookup failed for chunk %s: %s",
+                    _sanitize_log_value(chunks[0]["hash"]),
+                    _sanitize_log_value(exc),
+                )
         for c in chunks:
             rel = c["relevance"] if c["relevance"] is not None else 0.0
             hop = proximity_map.get(c["hash"])

--- a/tests/test_composite_wiring.py
+++ b/tests/test_composite_wiring.py
@@ -1,5 +1,7 @@
 """Tests for composite scoring opt-in wiring in memory_explore/memory_detail."""
 
+import logging
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -71,6 +73,49 @@ class TestBuildKnowledgeMapScoring:
         for chunk in result[0]["top_chunks"]:
             assert "composite_score" in chunk
             assert chunk["score_components"]["proximity"] == 0.0
+
+
+class TestProximityFailureIsVisible:
+    """A failed proximity lookup drops a scoring term; it must not be silent."""
+
+    @pytest.mark.asyncio
+    async def test_build_knowledge_map_logs_the_failure_at_debug(
+        self, mock_graph, sample_entities, sample_chunks, caplog
+    ):
+        mock_graph.find_connected = AsyncMock(side_effect=RuntimeError("graph offline"))
+
+        with caplog.at_level(
+            logging.DEBUG, logger="mcp_memory_service.server.handlers.graph"
+        ):
+            result = await _build_knowledge_map(
+                mock_graph, sample_entities, sample_chunks, 3, scoring="composite"
+            )
+
+        # Still scores, just without the proximity term.
+        assert all("composite_score" in c for c in result[0]["top_chunks"])
+        assert any(
+            "Proximity lookup failed" in r.message and "python" in r.message
+            for r in caplog.records
+        ), caplog.text
+
+    @pytest.mark.asyncio
+    async def test_log_value_is_sanitized(
+        self, mock_graph, sample_chunks, caplog
+    ):
+        """An entity name is user-controlled, so it cannot forge a log line."""
+        mock_graph.find_connected = AsyncMock(side_effect=RuntimeError("graph offline"))
+        entities = [{"entity_name": "py\nINFO: forged", "count": 5}]
+
+        with caplog.at_level(
+            logging.DEBUG, logger="mcp_memory_service.server.handlers.graph"
+        ):
+            await _build_knowledge_map(
+                mock_graph, entities, sample_chunks, 3, scoring="composite"
+            )
+
+        records = [r for r in caplog.records if "Proximity lookup failed" in r.message]
+        assert records
+        assert "\n" not in records[0].message
 
 
 class TestHydrateChunksScoring:


### PR DESCRIPTION
Closes #1154.

## What changed

The two `except Exception: pass` around `find_connected` in `server/handlers/graph.py` -- CodeQL 548 and 549, in `_build_knowledge_map` and its twin in `_hydrate_chunks` -- now log at debug and keep swallowing.

Agreed with the issue that neither is a defect: `hop` is handled as `None` a few lines down and only the composite score's proximity term drops out. The problem is only that when the lookup fails for every entity, a composite score is indistinguishable from plain relevance and nothing says why.

Each site logs the identifier it has -- the entity name in `_build_knowledge_map`, the chunk hash in `_hydrate_chunks` -- plus the exception, through the module's existing `_sanitize_log_value`.

## Tests

Two, in a new `TestProximityFailureIsVisible`:

- `test_build_knowledge_map_logs_the_failure_at_debug` -- `find_connected` raises; scoring still completes (`composite_score` present on every chunk) and a `Proximity lookup failed` record naming the entity appears at DEBUG. **Fails on main**: no such record.
- `test_log_value_is_sanitized` -- the entity name is user-controlled, so an entity called `py\nINFO: forged` must not put a newline in the record. This is why the name goes through `_sanitize_log_value` rather than straight into the format arguments; it is also the class of thing #1146 is tracking.

Measured locally:

```
tests/test_composite_wiring.py -k ProximityFailure     2 passed, 7 deselected
tests/test_composite_wiring.py tests/test_two_phase_aggregation.py    23 passed
```

## On the pre-PR gate

`scripts/pr/pre_pr_check.sh` does not complete in this checkout: steps 3.5 and 4 exit with `Python was not found` / `No suitable Python found. Activate a venv or set VIRTUAL_ENV`, and the broad collection errors are optional backends (`sqlite-vec is not available`) rather than anything from this change. Both are environment, not the diff. I ran the focused suites above instead; happy to paste a full gate run if you can point at what the script expects on a Windows checkout.