### PR TITLE
fix(scripts): import mcp_memory_service via editable install, not src. prefix

### DIFF
--- a/scripts/backup/backup_memories.py
+++ b/scripts/backup/backup_memories.py
@@ -26,10 +26,10 @@ import datetime
 from pathlib import Path
 
 # Add parent directory to path so we can import from the src directory
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
-from src.mcp_memory_service.storage.chroma import ChromaMemoryStorage
-from src.mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
+from mcp_memory_service.storage.chroma import ChromaMemoryStorage
+from mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/backup/restore_memories.py
+++ b/scripts/backup/restore_memories.py
@@ -26,10 +26,10 @@ import argparse
 from pathlib import Path
 
 # Add parent directory to path so we can import from the src directory
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
-from src.mcp_memory_service.storage.chroma import ChromaMemoryStorage
-from src.mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
+from mcp_memory_service.storage.chroma import ChromaMemoryStorage
+from mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/database/db_health_check.py
+++ b/scripts/database/db_health_check.py
@@ -51,9 +51,9 @@ class HealthChecker:
         """Test all necessary imports."""
         try:
             import sqlite_vec
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             return True
         except ImportError as e:
             print(f"      Import error: {e}")
@@ -65,7 +65,7 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "health_check.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()
             
@@ -94,9 +94,9 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "operations_test.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()
@@ -148,9 +148,9 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "vector_test.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()
@@ -289,7 +289,7 @@ async def main():
         print("\n🎉 Database Health Check: PASSED")
         print("   SQLite-vec backend is fully functional and ready for production use!")
         print("\n🚀 Ready for Claude Code integration:")
-        print("   - Start server: python -m src.mcp_memory_service.server")
+        print("   - Start server: python -m mcp_memory_service.server")
         print("   - Database: ~/.local/share/mcp-memory/sqlite_vec.db")
         print("   - 75% memory reduction vs ChromaDB")
         return 0

--- a/scripts/maintenance/assign_memory_types.py
+++ b/scripts/maintenance/assign_memory_types.py
@@ -43,9 +43,9 @@ from collections import defaultdict, Counter
 import shutil
 
 # Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
 
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/maintenance/discover_harvest_patterns.py
+++ b/scripts/maintenance/discover_harvest_patterns.py
@@ -30,13 +30,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Dict, Tuple
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = Path(__file__).resolve().parents[2] / 'src'
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from src.mcp_memory_service.harvest.parser import TranscriptParser, ParsedMessage
-from src.mcp_memory_service.harvest.extractor import PatternExtractor
-from src.mcp_memory_service.harvest.patterns import PATTERNS_DIR
-from src.mcp_memory_service.harvest.models import HARVEST_TYPES
+from mcp_memory_service.harvest.parser import TranscriptParser, ParsedMessage
+from mcp_memory_service.harvest.extractor import PatternExtractor
+from mcp_memory_service.harvest.patterns import PATTERNS_DIR
+from mcp_memory_service.harvest.models import HARVEST_TYPES
 logger = logging.getLogger(__name__)
 LOW_YIELD_MAX_MATCHES = 3
 LOW_YIELD_MIN_MESSAGES = 50

--- a/scripts/maintenance/regenerate_embeddings.py
+++ b/scripts/maintenance/regenerate_embeddings.py
@@ -15,10 +15,10 @@ import logging
 from pathlib import Path
 
 # Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
 
-from src.mcp_memory_service.storage.factory import create_storage_instance
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.storage.factory import create_storage_instance
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 logging.basicConfig(
     level=logging.INFO,
@@ -113,7 +113,7 @@ async def regenerate_embeddings():
                     memory_id = result[0]
 
                     # Insert embedding
-                    from src.mcp_memory_service.storage.sqlite_vec import serialize_float32
+                    from mcp_memory_service.storage.sqlite_vec import serialize_float32
                     actual_storage.conn.execute(
                         'INSERT OR REPLACE INTO memory_embeddings(rowid, content_embedding) VALUES (?, ?)',
                         (memory_id, serialize_float32(embedding))

--- a/scripts/maintenance/repair_malformed_tags.py
+++ b/scripts/maintenance/repair_malformed_tags.py
@@ -38,9 +38,9 @@ from datetime import datetime
 from typing import List, Tuple, Set, Dict
 
 # Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
 
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/maintenance/repair_missing_embeddings_onnx.py
+++ b/scripts/maintenance/repair_missing_embeddings_onnx.py
@@ -3,10 +3,10 @@
 import asyncio, sys, logging
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
 
-from src.mcp_memory_service.storage.factory import create_storage_instance
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.storage.factory import create_storage_instance
+from mcp_memory_service.config import SQLITE_VEC_PATH
 from sqlite_vec import serialize_float32
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')

--- a/scripts/sync/check_drift.py
+++ b/scripts/sync/check_drift.py
@@ -30,10 +30,10 @@ import argparse
 from pathlib import Path
 
 # Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
 
-from src.mcp_memory_service.storage.hybrid import HybridMemoryStorage
-from src.mcp_memory_service import config as app_config
+from mcp_memory_service.storage.hybrid import HybridMemoryStorage
+from mcp_memory_service import config as app_config
 
 # Set up logging
 logging.basicConfig(

--- a/scripts/testing/test_cloudflare_backend.py
+++ b/scripts/testing/test_cloudflare_backend.py
@@ -13,10 +13,10 @@ from datetime import datetime
 from pathlib import Path
 
 # Add project root to sys.path so 'src' package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
 
-from src.mcp_memory_service.storage.cloudflare import CloudflareStorage
-from src.mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.cloudflare import CloudflareStorage
+from mcp_memory_service.models.memory import Memory
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/scripts/testing/test_sqlite_vec_embeddings.py
+++ b/scripts/testing/test_sqlite_vec_embeddings.py
@@ -15,11 +15,11 @@ import traceback
 from datetime import datetime
 
 # Add parent directory to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
 
-from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-from src.mcp_memory_service.models.memory import Memory
-from src.mcp_memory_service.utils.hashing import generate_content_hash
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.utils.hashing import generate_content_hash
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/validation/verify_environment.py
+++ b/scripts/validation/verify_environment.py
@@ -34,8 +34,8 @@ try:
     from mcp_memory_service.utils.gpu_detection import detect_gpu as shared_detect_gpu
 except ImportError:
     # Fallback for scripts directory context
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    from src.mcp_memory_service.utils.gpu_detection import detect_gpu as shared_detect_gpu
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent / 'src'))
+    from mcp_memory_service.utils.gpu_detection import detect_gpu as shared_detect_gpu
 
 class EnvironmentVerifier:
     def __init__(self):


### PR DESCRIPTION
## Summary

Closes #1172. Twelve maintenance scripts imported the package through the `src.` prefix, which constructs a second copy of every module with its own module-level state (caches, singletons). With `tests/conftest.py` now setting `sys.modules['src'] = None`, those imports would fail under pytest; outside pytest they silently aliased a shadow copy.

## Fix

- Point `sys.path` at the repo's `src/` directory and import `mcp_memory_service` directly in all 12 affected scripts
- The editable install (`pip install -e`) resolves the package identically, but with a single shared module set
- Also fixes a stale help-string in `db_health_check.py` that still referenced `python -m src.mcp_memory_service.server`

## Files changed

- `scripts/backup/backup_memories.py`
- `scripts/backup/restore_memories.py`
- `scripts/database/db_health_check.py`
- `scripts/maintenance/assign_memory_types.py`
- `scripts/maintenance/discover_harvest_patterns.py`
- `scripts/maintenance/regenerate_embeddings.py`
- `scripts/maintenance/repair_malformed_tags.py`
- `scripts/maintenance/repair_missing_embeddings_onnx.py`
- `scripts/sync/check_drift.py`
- `scripts/testing/test_cloudflare_backend.py`
- `scripts/testing/test_sqlite_vec_embeddings.py`
- `scripts/validation/verify_environment.py`

## Verification

- All 12 files compile cleanly (`py_compile`)
- `from mcp_memory_service.config import SQLITE_VEC_PATH` resolves correctly under the editable install
- `grep -rn "src\.mcp_memory_service" scripts/` returns no matches in Python files (only `.sh`/`.bat` references remain, which are out of scope — those invoke the package via `-m` and are not affected by this import-path issue)

## Agent Disclosure

This PR was generated by Yunaremaia Agent (an AI coding assistant). The submitting account is operated by Yunaremaia. Human review of this PR: no — fully automated. All changes are mechanical (path + import string substitution) and verified by compilation check.
