### PR TITLE
fix(quality): run evaluator init off the event loop (#1123)

### DIFF
--- a/src/mcp_memory_service/quality/ai_evaluator.py
+++ b/src/mcp_memory_service/quality/ai_evaluator.py
@@ -39,6 +39,7 @@ class QualityEvaluator:
         self._groq_bridge = None
         self._httpx_client: Optional[httpx.AsyncClient] = None
         self._initialized = False
+        self._init_lock = asyncio.Lock()
 
     def _load_fallback_rankers(self):
         """Load the comma-separated model list used by fallback scoring."""
@@ -143,6 +144,25 @@ class QualityEvaluator:
 
         self._initialized = True
 
+    async def _ensure_initialized_async(self):
+        """Run _ensure_initialized off the event loop.
+
+        On first use with a local provider, _ensure_initialized performs a real
+        torch.onnx.export of DeBERTa — synchronous and minutes long. Called
+        directly from an async method it blocks the whole loop: nothing else on
+        it runs, and AsyncQualityScorer.stop()'s own ``wait_for`` timeout cannot
+        fire because a blocked loop cannot schedule it. Running the load in a
+        worker thread keeps the loop free. The lock stops two concurrent callers
+        from each starting an export; the flag is re-checked inside it so only
+        the first pays the cost.
+        """
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            await asyncio.to_thread(self._ensure_initialized)
+
     async def evaluate_quality(self, query: str, memory: Memory) -> float:
         """
         Evaluate memory quality using multi-tier approach.
@@ -159,7 +179,7 @@ class QualityEvaluator:
             # initialization, not after — see _ensure_initialized.
             return 0.5
 
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         # Try tiers in order based on configuration
         provider_used = None
@@ -260,7 +280,7 @@ class QualityEvaluator:
         if not self.config.enabled:
             return [0.5] * len(memories)
 
-        self._ensure_initialized()
+        await self._ensure_initialized_async()
 
         # Tier 1: Local ONNX batched scoring
         if self.config.ai_provider in ['local', 'auto']:

--- a/tests/test_quality_system.py
+++ b/tests/test_quality_system.py
@@ -916,6 +916,62 @@ class TestQualityAPILayer:
         finally:
             await scorer.stop()
 
+    @pytest.mark.asyncio
+    async def test_initialization_does_not_block_event_loop(self):
+        """Model initialization runs off the loop, so other tasks keep running.
+
+        The previous test disables the evaluator to keep the minutes-long
+        torch.onnx.export out of CI. This one keeps the evaluator ENABLED and
+        replaces only the leaf load (get_onnx_ranker_model) with a slow, blocking
+        stub, so the real async init path runs — the fix under test is that this
+        path no longer freezes the event loop.
+
+        A heartbeat task ticks every 10ms while a batch evaluation triggers first
+        init. If init ran synchronously on the loop (the bug) the heartbeat cannot
+        tick during the stub's sleep; running it in a thread lets the heartbeat
+        advance. This is red without the change: the stub blocks the loop and the
+        tick count is 0.
+        """
+        def slow_get_ranker(model_name=None, device="auto"):
+            time.sleep(0.5)  # stands in for the real torch.onnx.export of DeBERTa
+
+            class _Ranker:
+                def score_quality_batch(self, pairs):
+                    return [0.5] * len(pairs)
+
+                def score_quality(self, query, content):
+                    return 0.5
+
+            return _Ranker()
+
+        evaluator = QualityEvaluator(
+            QualityConfig(enabled=True, ai_provider='local', fallback_enabled=False)
+        )
+
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        try:
+            with patch(
+                'mcp_memory_service.quality.ai_evaluator.get_onnx_ranker_model',
+                slow_get_ranker,
+            ):
+                memories = [Memory(content="x", content_hash="h", metadata={})]
+                await evaluator.evaluate_quality_batch("query", memories)
+        finally:
+            heartbeat_task.cancel()
+
+        # The loop kept scheduling the heartbeat through the 0.5s init. 20 ticks
+        # is a wide margin below the ~50 a free loop manages, above the 0 a
+        # blocked loop allows.
+        assert ticks >= 20, f"event loop was blocked during init: {ticks} ticks"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Closes #1123.

## The bug

`QualityEvaluator._ensure_initialized()` is synchronous and, on first use with a
local provider, performs a real `torch.onnx.export` of DeBERTa — minutes long
with `onnxscript` installed. Both async entry points called it directly on the
event loop:

- `evaluate_quality()` → `self._ensure_initialized()`
- `evaluate_quality_batch()` → `self._ensure_initialized()`

So the export ran *on the loop*. The two consequences from #1123, confirmed
against the code:

1. **Nothing else on the loop runs during init.** In the HTTP server the first
   background scoring after startup stalls request handling for the whole export.
2. **`AsyncQualityScorer.stop()` cannot recover.** It guards the worker with
   `await asyncio.wait_for(self._worker_task, timeout=5.0)`, but a blocked loop
   cannot schedule that timeout, and cancellation cannot interrupt a synchronous
   C call — a graceful shutdown waits for the whole export.

## The fix

A new `_ensure_initialized_async()` runs the sync init in a worker thread via
`asyncio.to_thread`, under a lock, double-checked so only the first caller pays
the cost:

```python
async def _ensure_initialized_async(self):
    if self._initialized:
        return
    async with self._init_lock:
        if self._initialized:
            return
        await asyncio.to_thread(self._ensure_initialized)
```

Both async methods now `await self._ensure_initialized_async()`. The synchronous
`_ensure_initialized()` is left untouched — its direct callers (the fallback
tests, `test_disabled_skips_model_load`) keep working. Fixing init also restores
`stop()`: once the export is off-loop, the loop can fire the `wait_for` timeout.

### Scope / a design choice to flag

This PR moves **initialization** off the loop, which is the minutes-long,
shutdown-breaking part #1123 is about. Synchronous ONNX **scoring**
(`score_quality`, `score_quality_batch`) still runs on the loop — seconds, not
minutes. #1123 says "model initialization, and possibly scoring itself"; I kept
scoring on the loop to keep this change focused and low-risk, and I'm happy to
move scoring into the executor here or in a follow-up if you'd prefer.

## Test — red without the change

`tests/test_quality_system.py::TestQualityAPILayer::test_initialization_does_not_block_event_loop`
keeps the evaluator **enabled** and replaces only the leaf load
(`get_onnx_ranker_model`) with a slow blocking stub, so the real async init path
runs. A heartbeat task ticks every 10ms while a batch evaluation triggers first
init; the test asserts the loop kept scheduling it.

- Without the change (sync init on the loop): **0 ticks** during the 0.5s stub →
  `AssertionError: event loop was blocked during init: 0 ticks`.
- With the change: **~46 ticks** → pass.

This companion sits next to `test_async_background_scoring`, which disables the
evaluator to keep the export out of CI; this one exercises the real init path
with only the leaf stubbed, per #1175 ("a test that is red without the change").

## Verification run

```
python -m pytest tests/test_quality_system.py tests/test_fallback_quality.py \
                 tests/quality/ tests/harvest/ -m "not benchmark"
→ 195 passed, 13 skipped, 2 deselected
```

That covers the blast radius of the change (quality + harvest). Honest note on
environment: this was run without `torch`/`pymilvus`/`pytest-benchmark`
installed, so the *full* suite (milvus, benchmark, integration paths) was not
run locally — CI covers those. `ruff` on the two touched files reports only
issues that are already present on `main` (I introduced none, and left the
pre-existing ones alone to keep the diff scoped).

## Agent Disclosure

This PR was generated by DIADE, an autonomous coding agent. The submitting
account (massimiliano1991) is operated by Massimiliano Guidi.
Human review of this PR: no — fully automated. Every claim above was verified at
the source before submitting (the blocking call path, all `_ensure_initialized`
callers, the red-without-change test run); the maintainer's review is the
intended check on the design choice (init-only vs. init+scoring).
