### PR TITLE
test(milvus): round-trip a tag ending in a backslash through Milvus Lite

### DIFF
--- a/tests/storage/test_milvus.py
+++ b/tests/storage/test_milvus.py
@@ -249,6 +249,39 @@ async def test_search_by_tag_exact_not_substring(storage):
 
 
 @pytest.mark.asyncio
+async def test_search_by_tag_with_trailing_backslash(storage):
+    """Regression for #1107: a tag ending in a backslash must survive the filter.
+
+    Escaping only the quote let a trailing backslash consume the closing quote
+    of the interpolated literal, so Milvus rejected the whole expression. This
+    drives the real tag filter through Milvus Lite, which a test that only
+    inspects the expression string cannot.
+    """
+    mem_backslash = Memory(
+        content="Backslash tag memory",
+        content_hash=generate_content_hash("Backslash tag memory"),
+        tags=["foo\\", "C:\\Users\\hkr"],
+    )
+    mem_plain = Memory(
+        content="Plain tag memory",
+        content_hash=generate_content_hash("Plain tag memory"),
+        tags=["foo"],
+    )
+    for m in (mem_backslash, mem_plain):
+        ok, msg = await storage.store(m, skip_semantic_dedup=True)
+        assert ok, msg
+
+    hits = {m.content_hash for m in await storage.search_by_tag(["foo\\"])}
+    assert hits == {mem_backslash.content_hash}
+
+    hits = {m.content_hash for m in await storage.search_by_tag(["C:\\Users\\hkr"])}
+    assert hits == {mem_backslash.content_hash}
+
+    hits = {m.content_hash for m in await storage.search_by_tag(["foo"])}
+    assert hits == {mem_plain.content_hash}
+
+
+@pytest.mark.asyncio
 async def test_search_by_tags_and_or(storage):
     a = Memory(
         content="Memory A", content_hash=generate_content_hash("Memory A"),


### PR DESCRIPTION
## What this changes

Adds the Milvus Lite integration case #1107 asked for: store a memory tagged `foo\` and `C:\Users\hkr` next to one tagged `foo`, then find each again through `search_by_tag`. Test only; no change under `src/`.

## Why

Closes #1107

The helper itself (`storage/milvus_expr.py::escape_expr_value`, backslash first, then quote) and the unit tests on the expression string already landed in e4772db1 on 2026-08-22, before the issue was migrated from Codeberg. I checked the 13 sites listed in the issue and they all route through it now. What was still missing from the scope in the issue comment is the case that drives the real tag filter through Milvus Lite - the failure was Milvus rejecting the expression, which a test that only inspects the string cannot observe.

## How it was verified

pymilvus 2.6.17 / milvus-lite 3.2.1 (what `uv.lock` pins), Python 3.12, macOS arm64.

```
# src/ swapped to 8ed7a7c0 (parent of e4772db1, quote-only escaping): must fail
$ .venv/bin/pytest tests/storage/test_milvus.py::test_search_by_tag_with_trailing_backslash -q
E           pymilvus.exceptions.MilvusException: <MilvusException: (code=6, message=unknown escape sequence \, at column 17
E             tags like "%,foo\,%"
E                             ^^)>
1 failed, 6 warnings in 2.20s

# on this branch: must pass
$ .venv/bin/pytest tests/storage/test_milvus.py::test_search_by_tag_with_trailing_backslash -q
1 passed, 9 warnings in 2.12s
```

Before the helper it is the store path that fails, not the search - `store()` runs a tag filter of its own - so the test dies at `assert ok, msg` with the expression error above.

While checking whether the `like` path needs a second layer of escaping on top of the expression one, I ran the raw patterns against Milvus Lite: `tags like "%,foo\\,%"` matches a stored `,foo\,` and `tags like "%,foo\\\\,%"` does not, so the single `escape_expr_value` pass is the right amount for both `like` and `==`.

`bash scripts/pr/pre_pr_check.sh` came back red, on things I did not touch:

- `[2/9]` quality_gate.sh: SKIP, no local analysis model here.
- `[3/9]` test suite: `4 failed, 3058 passed, 58 skipped, 27 errors` (the new test passes). None of the failures touch what this PR changes:
  - `tests/storage/test_milvus.py::test_embedding_cache_bounded` / `::test_embedding_cache_does_not_collide` - `AttributeError: module 'mcp_memory_service.storage.milvus' has no attribute '_EMBEDDING_CACHE_LOCK'`, same on the upstream copy of the file.
  - `tests/test_milvus_graph.py` - every test errors in the `graph` fixture: `scalar index_type 'TRIE' is not implemented; supported: INVERTED`. That is milvus-lite 3.2.1 (what `uv.lock` resolves) refusing the index the graph store requests; probably relevant to the Milvus CI job in #1112.
  - `tests/integration/test_api_tag_time_search.py` - two tag/time filter tests, sqlite-vec path, not looked into.
- `[5/9]` import ordering: flags the existing inline imports in `tests/storage/test_milvus.py` (lines 475, 757, 1174); I did not add any.
- Everything else passed.

## Notes for the reviewer

`memory_type` cannot carry a backslash to the `==` sites: `Memory.__post_init__` canonicalises it through the ontology and falls back to `observation`, so I left that path to the existing expression-level unit tests rather than assert on a value the model rewrites.

## Agent Disclosure
This PR was generated by Claude Code (Claude Fable 5.1). The submitting account is operated by 7487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
