### PR TITLE
fix(consolidation): deduplication deleted every copy instead of the extras

### DIFF
--- a/src/mcp_memory_service/consolidation/forgetting.py
+++ b/src/mcp_memory_service/consolidation/forgetting.py
@@ -293,24 +293,23 @@ class ControlledForgettingEngine(ConsolidationBase):
         if content == other_content:
             return True
 
-        # Very similar content (simple check)
-        if len(content) > 50 and len(other_content) > 50:
-            # Check if one is a substring of the other with high overlap
-            if content in other_content or other_content in content:
-                return True
+        # Very similar content (simple check): only worth testing on longer texts
+        if min(len(content), len(other_content)) <= 50:
+            return False
 
-            # Check word overlap
-            words1 = set(content.split())
-            words2 = set(other_content.split())
+        # Check if one is a substring of the other with high overlap
+        if content in other_content or other_content in content:
+            return True
 
-            if len(words1) > 5 and len(words2) > 5:
-                overlap = len(words1.intersection(words2))
-                union = len(words1.union(words2))
+        # Check word overlap
+        words1 = set(content.split())
+        words2 = set(other_content.split())
+        if min(len(words1), len(words2)) <= 5:
+            return False
 
-                if overlap / union > 0.8:  # 80% word overlap
-                    return True
-
-        return False
+        overlap = len(words1.intersection(words2))
+        union = len(words1.union(words2))
+        return overlap / union > 0.8  # 80% word overlap
 
     @staticmethod
     def _keep_rank(memory: Memory, score_lookup: Dict[str, "RelevanceScore"]):

--- a/src/mcp_memory_service/consolidation/forgetting.py
+++ b/src/mcp_memory_service/consolidation/forgetting.py
@@ -208,8 +208,10 @@ class ControlledForgettingEngine(ConsolidationBase):
                 forgetting_reasons.append("low_quality")
                 archive_priority = min(archive_priority, 2)
             
-            # Duplicate content check
-            if self._appears_to_be_duplicate(memory, memories):
+            # Duplicate content check. Only the *redundant* copies are flagged: the
+            # best-ranked member of a near-duplicate group is never a candidate, so
+            # deduplication always leaves a survivor in storage.
+            if self._is_redundant_copy(memory, memories, score_lookup):
                 forgetting_reasons.append("potential_duplicate")
                 can_be_deleted = True
                 archive_priority = 1
@@ -269,40 +271,80 @@ class ControlledForgettingEngine(ConsolidationBase):
         return False
     
     def _appears_to_be_duplicate(self, memory: Memory, all_memories: List[Memory]) -> bool:
-        """Check if memory appears to be a duplicate of another memory."""
+        """Check if memory appears to be a duplicate of another memory.
+
+        Note this is a *symmetric* relation, so it is true for both members of a pair.
+        Use :meth:`_is_redundant_copy` to decide what may be deleted.
+        """
+        return any(self._is_near_duplicate_of(memory, other) for other in all_memories
+                   if other.content_hash != memory.content_hash)
+
+    def _is_near_duplicate_of(self, memory: Memory, other_memory: Memory) -> bool:
+        """Pairwise near-duplicate test. Symmetric by construction."""
         content = memory.content.strip().lower()
-        
+
         # Skip very short content for duplicate detection
         if len(content) < 20:
             return False
-        
+
+        other_content = other_memory.content.strip().lower()
+
+        # Exact match
+        if content == other_content:
+            return True
+
+        # Very similar content (simple check)
+        if len(content) > 50 and len(other_content) > 50:
+            # Check if one is a substring of the other with high overlap
+            if content in other_content or other_content in content:
+                return True
+
+            # Check word overlap
+            words1 = set(content.split())
+            words2 = set(other_content.split())
+
+            if len(words1) > 5 and len(words2) > 5:
+                overlap = len(words1.intersection(words2))
+                union = len(words1.union(words2))
+
+                if overlap / union > 0.8:  # 80% word overlap
+                    return True
+
+        return False
+
+    @staticmethod
+    def _keep_rank(memory: Memory, score_lookup: Dict[str, "RelevanceScore"]):
+        """Sort key for "which copy is worth keeping" - lower sorts first (kept)."""
+        score = score_lookup.get(memory.content_hash)
+        return (
+            -(score.total_score if score else 0.0),   # best relevance first
+            memory.created_at or 0.0,                  # then the original, not the copy
+            memory.content_hash or "",                 # then a stable tiebreak
+        )
+
+    def _is_redundant_copy(
+        self,
+        memory: Memory,
+        all_memories: List[Memory],
+        score_lookup: Dict[str, "RelevanceScore"],
+    ) -> bool:
+        """True only if a near-duplicate exists that OUTRANKS this memory.
+
+        `_appears_to_be_duplicate` is symmetric, so flagging on it deleted *every*
+        member of a duplicate group instead of the extras. Ranking each candidate
+        against its own duplicates fixes that without needing to build groups first,
+        which matters because near-duplicate matching is not transitive: the
+        best-ranked member of any group is outranked by nobody, so it is never
+        flagged and always survives.
+        """
+        mine = self._keep_rank(memory, score_lookup)
         for other_memory in all_memories:
             if other_memory.content_hash == memory.content_hash:
                 continue
-            
-            other_content = other_memory.content.strip().lower()
-            
-            # Exact match
-            if content == other_content:
+            if not self._is_near_duplicate_of(memory, other_memory):
+                continue
+            if self._keep_rank(other_memory, score_lookup) < mine:
                 return True
-            
-            # Very similar content (simple check)
-            if len(content) > 50 and len(other_content) > 50:
-                # Check if one is a substring of the other with high overlap
-                if content in other_content or other_content in content:
-                    return True
-                
-                # Check word overlap
-                words1 = set(content.split())
-                words2 = set(other_content.split())
-                
-                if len(words1) > 5 and len(words2) > 5:
-                    overlap = len(words1.intersection(words2))
-                    union = len(words1.union(words2))
-                    
-                    if overlap / union > 0.8:  # 80% word overlap
-                        return True
-        
         return False
     
     async def _process_forgetting_candidate(self, candidate: ForgettingCandidate) -> ForgettingResult:

--- a/tests/consolidation/test_forgetting_duplicate_pair.py
+++ b/tests/consolidation/test_forgetting_duplicate_pair.py
@@ -17,6 +17,13 @@ from datetime import datetime, timedelta, timezone
 from mcp_memory_service.consolidation.forgetting import ControlledForgettingEngine
 from mcp_memory_service.consolidation.decay import RelevanceScore
 from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.utils.hashing import generate_content_hash
+
+try:
+    import sqlite_vec  # noqa: F401
+    SQLITE_VEC_AVAILABLE = True
+except ImportError:
+    SQLITE_VEC_AVAILABLE = False
 
 
 ORIGINAL = (
@@ -98,3 +105,71 @@ class TestDuplicatePairSurvivor:
         """Control: a memory with no twin is never deleted as a duplicate."""
         deleted = await self._deleted(engine, [_mem(ORIGINAL, "hash_only")])
         assert deleted == []
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not SQLITE_VEC_AVAILABLE, reason="sqlite-vec not available")
+class TestDuplicateSurvivorInRealStorage:
+    """End-to-end through the real sqlite-vec backend.
+
+    The unit tests above stop at `action_taken == "deleted"`. This change decides what
+    gets deleted from storage, so this test walks the whole path: real
+    `SqliteVecMemoryStorage`, real `generate_content_hash` hashes (storage keys on the
+    real hash and so does the fix), `forgetting_engine.process()` followed by
+    `DreamInspiredConsolidator._apply_forgetting_results()`, then counts what is left.
+    Pre-fix, three stored near-duplicates end as zero rows.
+    """
+
+    async def _survivors_after_forgetting(self, tmp_path, consolidation_config, contents):
+        from mcp_memory_service.consolidation.consolidator import (
+            DreamInspiredConsolidator,
+        )
+        from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+
+        storage = SqliteVecMemoryStorage(str(tmp_path / "t.db"))
+        await storage.initialize()
+        try:
+            # Oldest first, so the survivor-choice on a score tie is exercised too.
+            for days_old, content in enumerate(reversed(contents), start=1):
+                memory = _mem(content, generate_content_hash(content), days_old=days_old)
+                # skip_semantic_dedup: the bug's precondition is near-duplicates that
+                # are already in storage (accumulated outside the dedup time window).
+                success, message = await storage.store(memory, skip_semantic_dedup=True)
+                assert success, message
+
+            consolidator = DreamInspiredConsolidator(storage, consolidation_config)
+            memories = await storage.get_all_memories()
+            assert len(memories) == len(contents)
+            scores = [_score(m.content_hash) for m in memories]
+            results = await consolidator.forgetting_engine.process(
+                memories, scores, access_patterns={}, time_horizon="weekly"
+            )
+            await consolidator._apply_forgetting_results(results)
+            return await storage.get_all_memories()
+        finally:
+            if storage.conn:
+                storage.conn.close()
+
+    @pytest.mark.asyncio
+    async def test_three_near_duplicates_leave_one_row_in_storage(
+        self, tmp_path, consolidation_config
+    ):
+        survivors = await self._survivors_after_forgetting(
+            tmp_path, consolidation_config, [ORIGINAL, FOLLOW_UP, THIRD]
+        )
+        assert len(survivors) == 1, (
+            f"expected exactly one row left in sqlite-vec storage after deduplicating "
+            f"3 near-duplicates, found {len(survivors)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_near_duplicate_pair_leaves_one_row_in_storage(
+        self, tmp_path, consolidation_config
+    ):
+        survivors = await self._survivors_after_forgetting(
+            tmp_path, consolidation_config, [ORIGINAL, FOLLOW_UP]
+        )
+        assert len(survivors) == 1, (
+            f"expected exactly one row left in sqlite-vec storage after deduplicating "
+            f"a near-duplicate pair, found {len(survivors)}"
+        )

--- a/tests/consolidation/test_forgetting_duplicate_pair.py
+++ b/tests/consolidation/test_forgetting_duplicate_pair.py
@@ -1,0 +1,100 @@
+"""Deduplication must leave a survivor.
+
+`_appears_to_be_duplicate` is a *symmetric* predicate: if A is a near-duplicate of B then
+B is a near-duplicate of A. `_identify_forgetting_candidates` asks it once per memory
+against the whole list, so both members of a near-duplicate pair are flagged
+`potential_duplicate`, both get `can_be_deleted=True` (this reason bypasses the
+time-horizon restriction, so it fires at every horizon), and `_apply_forgetting_results`
+calls `storage.delete_memory()` on both.
+
+The realistic shape is a note and its slightly edited follow-up: different content, so
+genuinely different hashes, but >80% word overlap. Deduplicating them deletes *both*.
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from mcp_memory_service.consolidation.forgetting import ControlledForgettingEngine
+from mcp_memory_service.consolidation.decay import RelevanceScore
+from mcp_memory_service.models.memory import Memory
+
+
+ORIGINAL = (
+    "The deployment pipeline retries a failed migration three times before it gives up "
+    "and rolls the release back to the previous known-good revision of the service."
+)
+FOLLOW_UP = ORIGINAL + " Confirmed again on staging."
+THIRD = ORIGINAL + " Confirmed again on staging and in production."
+
+
+def _mem(content, h, days_old=1):
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_old)).timestamp()
+    return Memory(
+        content=content,
+        content_hash=h,
+        tags=["standard"],
+        memory_type="observation",
+        embedding=[0.1] * 8,
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+def _score(h, total=0.9):
+    return RelevanceScore(
+        memory_hash=h, total_score=total, base_importance=1.0, decay_factor=1.0,
+        connection_boost=1.0, access_boost=1.0, metadata={},
+    )
+
+
+@pytest.mark.unit
+class TestDuplicatePairSurvivor:
+
+    @pytest.fixture
+    def engine(self, consolidation_config):
+        return ControlledForgettingEngine(consolidation_config)
+
+    async def _deleted(self, engine, memories):
+        scores = [_score(m.content_hash) for m in memories]
+        results = await engine.process(memories, scores, access_patterns={},
+                                       time_horizon="weekly")
+        return [r.memory_hash for r in results if r.action_taken == "deleted"]
+
+    @pytest.mark.asyncio
+    async def test_near_duplicate_pair_keeps_one_survivor(self, engine):
+        """A note and its edited follow-up: at most one may be deleted."""
+        memories = [_mem(ORIGINAL, "hash_original"), _mem(FOLLOW_UP, "hash_follow_up")]
+        deleted = await self._deleted(engine, memories)
+        assert len(deleted) <= 1, (
+            "deduplication deleted every copy (%s): nothing is left in storage and only a "
+            "JSON backup under the archive path survives" % deleted
+        )
+
+    @pytest.mark.asyncio
+    async def test_three_near_duplicates_keep_exactly_one(self, engine):
+        """Three revisions of the same note: two may go, one must stay."""
+        memories = [_mem(ORIGINAL, "hash_original"), _mem(FOLLOW_UP, "hash_follow_up"),
+                    _mem(THIRD, "hash_third")]
+        deleted = await self._deleted(engine, memories)
+        assert len(deleted) == len(memories) - 1, (
+            "expected exactly one survivor out of %d near-duplicates, %d were deleted (%s)"
+            % (len(memories), len(deleted), deleted)
+        )
+
+    @pytest.mark.asyncio
+    async def test_survivor_is_the_highest_scoring_copy(self, engine):
+        """The copy the system rates highest is the one that stays."""
+        memories = [_mem(ORIGINAL, "hash_low"), _mem(FOLLOW_UP, "hash_high")]
+        scores = [_score("hash_low", 0.30), _score("hash_high", 0.95)]
+        results = await engine.process(memories, scores, access_patterns={},
+                                       time_horizon="weekly")
+        deleted = [r.memory_hash for r in results if r.action_taken == "deleted"]
+        assert "hash_high" not in deleted, (
+            "the best-rated copy was deleted and a worse one kept: %s" % deleted
+        )
+
+    @pytest.mark.asyncio
+    async def test_unique_memory_is_never_a_duplicate(self, engine):
+        """Control: a memory with no twin is never deleted as a duplicate."""
+        deleted = await self._deleted(engine, [_mem(ORIGINAL, "hash_only")])
+        assert deleted == []


### PR DESCRIPTION
## Agent Disclosure

This PR was generated by an autonomous agent (DIADE), running on its own. The submitting account is operated by Massimiliano Guidi. Human review of this PR: **no — fully automated**. Everything below is meant to be checked rather than trusted: the failing test is included so the claim can be reproduced in one command, and the section at the bottom says what I could *not* verify.

---

## The bug

`ControlledForgettingEngine._appears_to_be_duplicate()` is a **symmetric** predicate — if A is a near-duplicate of B, then B is a near-duplicate of A. `_identify_forgetting_candidates()` calls it once per memory against the whole list:

```python
if self._appears_to_be_duplicate(memory, memories):
    forgetting_reasons.append("potential_duplicate")
    can_be_deleted = True
```

So **both** members of a pair are flagged, both get `can_be_deleted=True`, and `potential_duplicate` is one of the two reasons that *bypass* the time-horizon restriction:

```python
if not ('expired_temporary' in forgetting_reasons or 'potential_duplicate' in forgetting_reasons):
    can_delete_final = False
```

`_process_forgetting_candidate()` then routes both to `_delete_memory()`, and `MemoryConsolidator._apply_forgetting_results()` calls `await self.storage.delete_memory(...)` on each.

**Net effect: deduplication deletes every copy of the content instead of the extra ones.** After the run nothing is left in storage; only the JSON written to `~/.mcp_memory_archive/metadata/deleted_*.json` survives, recoverable by hand.

It fires at every time horizon, not just `quarterly`/`yearly`.

### The realistic shape

The exact-match branch is mostly unreachable in practice (identical content usually means an identical `content_hash`), but the fuzzy branches are not. A note and its slightly edited follow-up have genuinely different hashes and >80% word overlap:

```
A: "The deployment pipeline retries a failed migration three times before it gives up
    and rolls the release back to the previous known-good revision of the service."
B: A + " Confirmed again on staging."
```

`_appears_to_be_duplicate(A, [A, B])` → `True`, `_appears_to_be_duplicate(B, [A, B])` → `True`. Both deleted.

## The fix

Rank each candidate against **its own** near-duplicates and flag it only if one of them outranks it:

```python
def _keep_rank(memory, score_lookup):
    return (-(score.total_score if score else 0.0),  # best relevance first
            memory.created_at or 0.0,                # then the original, not the copy
            memory.content_hash or "")               # then a stable tiebreak
```

The best-ranked member of a group is outranked by nobody, so it is never flagged and always survives. This is deliberately a **local** rule rather than a grouping pass: near-duplicate matching here is not transitive (A ≈ B and B ≈ C does not give A ≈ C under the 80%-overlap rule), so "the group" is not well defined, while "nothing outranks me" is, and it still guarantees a survivor per connected component.

`_appears_to_be_duplicate()` keeps its signature and meaning — it is now a thin wrapper over a new pairwise `_is_near_duplicate_of()`, with a docstring saying it is symmetric and pointing at `_is_redundant_copy()` for the deletion decision. The matching thresholds are unchanged.

## Tests

`tests/consolidation/test_forgetting_duplicate_pair.py` — four cases, run through the full `engine.process()` path:

| test | asserts |
|---|---|
| `test_near_duplicate_pair_keeps_one_survivor` | at most one of a pair is deleted |
| `test_three_near_duplicates_keep_exactly_one` | three revisions → exactly two deleted |
| `test_survivor_is_the_highest_scoring_copy` | the best-rated copy is the one kept |
| `test_unique_memory_is_never_a_duplicate` | control: a memory with no twin is untouched |

Red without the change, green with it, as `tests-prove-fix` requires:

```
$ git stash -- src/ && .venv/bin/pytest tests/consolidation/test_forgetting_duplicate_pair.py -q
3 failed, 1 passed
  AssertionError: deduplication deleted every copy (['hash_original', 'hash_follow_up'])
  AssertionError: expected exactly one survivor out of 3 near-duplicates, 3 were deleted
  AssertionError: the best-rated copy was deleted and a worse one kept: ['hash_high', 'hash_low']

$ git stash pop && .venv/bin/pytest tests/consolidation/test_forgetting_duplicate_pair.py -q
4 passed
```

Full suite on this branch: `tests/consolidation/` **306 passed, 1 skipped, 7 xfailed**; `tests/` (minus `performance`/`benchmarks`) **562 passed, 15 skipped, 8 xfailed**, plus one failure in `tests/integration/test_cli_interfaces.py::test_memory_command_exists` that is **pre-existing** — it fails identically with `src/` stashed, and looks like a console-script that isn't on PATH in my venv.

## What I did not verify

- **No end-to-end run against a real storage backend.** The proof stops at `engine.process()` returning `action_taken == "deleted"` for every copy; that `_apply_forgetting_results()` then calls `storage.delete_memory()` on each is read from the source, not executed.
- **I have not measured how often this fires in practice.** It needs two memories that survive `_is_protected_memory` and cross the fuzzy threshold; how common that is in a real store is your data, not mine.
- **The ranking policy is a choice, not a derivation.** Relevance → age → hash keeps the best-scored copy. If you would rather always keep the *newest* revision (arguably right for an edited note), that is a one-line change to `_keep_rank` and I would rather you pick it than me.
