### PR TITLE
fix: increase fullscreen 3D graph legend and controls visibility

### DIFF
--- a/src/mcp_memory_service/web/static/style.css
+++ b/src/mcp_memory_service/web/static/style.css
@@ -5038,11 +5038,12 @@ body.dark-mode .quality-tier-low,
     max-width: 280px;
     max-height: 50vh;
     overflow: auto;
-    background: rgba(10, 12, 20, 0.72);
-    backdrop-filter: blur(6px);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    font-size: 0.78rem;
-    opacity: 0.9;
+    background: rgba(10, 12, 20, 0.88);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 0.82rem;
 }
 
 .graph-legend-overlay.hidden {
@@ -5322,6 +5323,25 @@ body.dark-mode .quality-tier-low,
 #graphFullscreenModal:fullscreen,
 #graphFullscreenModal:-webkit-full-screen {
     background: #01010a;
+}
+#graphFullscreenModal:fullscreen .graph-fullscreen-header,
+#graphFullscreenModal:-webkit-full-screen .graph-fullscreen-header {
+    background: rgba(10, 12, 20, 0.85);
+    backdrop-filter: blur(8px);
+}
+#graphFullscreenModal:fullscreen .graph-fullscreen-filters,
+#graphFullscreenModal:-webkit-full-screen .graph-fullscreen-filters {
+    background: rgba(10, 12, 20, 0.7);
+}
+#graphFullscreenModal:fullscreen .btn-secondary,
+#graphFullscreenModal:-webkit-full-screen .btn-secondary {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+#graphFullscreenModal:fullscreen .btn-secondary:hover,
+#graphFullscreenModal:-webkit-full-screen .btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.25);
 }
 
 .graph-fullscreen-header {


### PR DESCRIPTION
## Summary

In fullscreen 3D graph mode, the legend overlay and controls (Pause, Legend buttons, filter bar) were nearly invisible due to low background opacity and faint borders against the dark graph canvas.

## Changes

- **Legend overlay**: background opacity 0.72→0.88, border opacity 0.12→0.25, added border-radius and padding, removed redundant `opacity: 0.9`
- **Fullscreen header**: added semi-transparent background (`rgba(10, 12, 20, 0.85)`) with backdrop blur
- **Fullscreen filter bar**: increased background opacity to 0.7
- **Fullscreen buttons**: added visible background (`rgba(255, 255, 255, 0.15)`) and border overrides scoped to fullscreen pseudo-class

## Related Issues

Closes #1110