### PR TITLE
fix(api): preserve async-context storage guard

### DIFF
--- a/src/mcp_memory_service/api/client.py
+++ b/src/mcp_memory_service/api/client.py
@@ -164,13 +164,15 @@ def get_storage() -> MemoryStorage:
         # Check if we're already in an async context
         try:
             asyncio.get_running_loop()
-            # We're in an async context, but we can't use run_until_complete
-            # This shouldn't happen in normal usage, but handle it gracefully
-            logger.error("get_storage() called from async context - use get_storage_async() instead")
-            raise RuntimeError("get_storage() cannot be called from async context")
         except RuntimeError:
             # No running loop, we can proceed with synchronous initialization
             pass
+        else:
+            # We're in an async context, where run_until_complete cannot be used.
+            logger.error(
+                "get_storage() called from async context - use get_storage_async() instead"
+            )
+            raise RuntimeError("get_storage() cannot be called from async context")
 
         # Get or create event loop
         try:

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -1,0 +1,30 @@
+"""Regression tests for the code-execution API storage client."""
+
+import pytest
+
+from mcp_memory_service.api import client
+
+
+@pytest.mark.asyncio
+async def test_get_storage_rejects_async_context_with_actionable_error(monkeypatch):
+    """The sync accessor must direct async callers to its async counterpart."""
+    monkeypatch.setattr(client, "_storage_instance", None)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"get_storage\(\) cannot be called from async context",
+    ):
+        client.get_storage()
+
+
+def test_get_storage_initializes_from_sync_context(monkeypatch):
+    """The sync accessor still initializes storage when no loop is running."""
+    storage = object()
+
+    async def fake_get_storage_async():
+        return storage
+
+    monkeypatch.setattr(client, "_storage_instance", None)
+    monkeypatch.setattr(client, "_get_storage_async", fake_get_storage_async)
+
+    assert client.get_storage() is storage


### PR DESCRIPTION
## What this changes

`get_storage()` now rejects calls made from an active event loop with its
documented guidance to use `get_storage_async()`. It no longer continues into
`run_until_complete()` or creates a coroutine that cannot be awaited.

## Why

The active-loop guard raised its own `RuntimeError` inside the same `try` whose
`except RuntimeError` represented "no running loop." That handler swallowed the
guard, so async callers received the generic `This event loop is already
running` error and emitted an unawaited-coroutine warning instead of the
actionable API error.

## How it was verified

The tests exercise the real `get_storage()` control flow. The async regression
test is red against `main` and green with this change; the synchronous case
confirms normal initialization still works.

```text
# main source + new tests
.venv/bin/pytest tests/api/test_client.py -q
1 failed, 1 passed, 1 warning

# this branch
.venv/bin/pytest tests/api/test_client.py -q
2 passed in 0.35s

.venv/bin/pytest tests/api -q
43 passed, 1 skipped, 204 warnings in 0.40s
```

The full repository test suite also passed inside
`scripts/pr/pre_pr_check.sh`. The gate's final status remained red because its
whole-file log-injection check flags five f-string logger calls already present
in `api/client.py`; this patch does not modify or add any of them. The optional
AI analysis check was skipped because no local model endpoint was available.

Focused Black, Ruff, `py_compile`, and `git diff --check` checks pass for the
changed lines and new test. Whole-file Ruff has 12 pre-existing findings in
`api/client.py`; the changed logic adds none.

## Notes for the reviewer

GitNexus classified the change as medium risk and mapped two storage flows
through `_get_storage_async`; the full suite and focused API suite cover those
paths. No protected storage, OAuth, MCP transport, server-registration, or CI
path is changed.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by
Divyam Talwar.
Human review of this PR: no — fully automated.
