### PR TITLE
fix: select the most recent completed season

### DIFF
--- a/src/mcp_memory_service/utils/time_parser.py
+++ b/src/mcp_memory_service/utils/time_parser.py
@@ -403,36 +403,17 @@ def get_last_period_range(period: str) -> Tuple[float, float]:
         start_dt = datetime(last_year, 1, 1, 0, 0, 0)
         end_dt = datetime(last_year, 12, 31, 23, 59, 59)
     elif period in ["summer", "spring", "winter", "fall", "autumn"]:
-        # Last season
+        # Select the most recent occurrence that has fully ended. Starting from
+        # this year's occurrence also handles winter's year boundary without
+        # treating the current or upcoming season as "last".
         season_info = NAMED_PERIODS[period]
-        current_year = today.year
-        
-        # Determine if we're currently in this season
-        current_month = today.month
-        current_day = today.day
-        is_current_season = False
-        
-        # Check if today falls within the season's date range
-        if period in ["winter"]:  # Winter spans year boundary
-            if (current_month >= season_info["start_month"] or 
-                (current_month <= season_info["end_month"] and 
-                 current_day <= season_info["end_day"])):
-                is_current_season = True
-        else:
-            if (current_month >= season_info["start_month"] and current_month <= season_info["end_month"] and
-                current_day >= season_info["start_day"] if current_month == season_info["start_month"] else True and
-                current_day <= season_info["end_day"] if current_month == season_info["end_month"] else True):
-                is_current_season = True
-        
-        # If we're currently in the season, get last year's season
-        if is_current_season:
-            year = current_year - 1
-        else:
-            year = current_year
-            
-        # Calculate season date range (handles winter's year boundary)
-        context_month = current_month if is_current_season else None
-        start_dt, end_dt = _calculate_season_date_range(period, season_info, year, context_month)
+        year = today.year
+        start_dt, end_dt = _calculate_season_date_range(period, season_info, year)
+        while end_dt.date() >= today:
+            year -= 1
+            start_dt, end_dt = _calculate_season_date_range(
+                period, season_info, year
+            )
     else:
         # Fallback - last 24 hours
         end_dt = now

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -126,6 +126,39 @@ class TestTimeParser:
         # Summer is roughly June 21 to September 22
         assert start_dt.month == 6
         assert end_dt.month == 9
+
+    @pytest.mark.parametrize(
+        ("season", "expected_start", "expected_end"),
+        [
+            ("spring", date(2026, 3, 20), date(2026, 6, 20)),
+            ("summer", date(2025, 6, 21), date(2025, 9, 22)),
+            ("fall", date(2025, 9, 23), date(2025, 12, 20)),
+            ("winter", date(2025, 12, 21), date(2026, 3, 19)),
+        ],
+    )
+    def test_last_seasons_are_most_recent_completed_occurrences(
+        self, monkeypatch, season, expected_start, expected_end
+    ):
+        """Test that "last" never selects a future or stale season."""
+        today = date(2026, 9, 8)
+
+        class FixedDate(date):
+            @classmethod
+            def today(cls):
+                return cls.fromordinal(today.toordinal())
+
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2026, 9, 8, 12, tzinfo=tz)
+
+        monkeypatch.setitem(parse_time_expression.__globals__, "date", FixedDate)
+        monkeypatch.setitem(parse_time_expression.__globals__, "datetime", FixedDateTime)
+
+        start_ts, end_ts = parse_time_expression(f"last {season}")
+
+        assert datetime.fromtimestamp(start_ts).date() == expected_start  # noqa: DTZ006
+        assert datetime.fromtimestamp(end_ts).date() == expected_end  # noqa: DTZ006
     
     def test_holidays(self):
         """Test parsing holiday names"""


### PR DESCRIPTION
# fix: select the most recent completed season

## What this changes

Seasonal `last` filters now select the most recent occurrence that has fully ended. For example, on 8 September 2026, `last spring` resolves to spring 2026, while `last fall` and `last winter` resolve to their 2025–2026 occurrences rather than future dates.

## Why

The previous current-season condition combined chained boolean expressions with conditional expressions. Depending on the current month, it could classify an already completed season as current or select an upcoming season. That made natural-language time searches omit the expected memories and sometimes search a future time range.

## How it was verified

The regression drives `parse_time_expression` with a fixed local date and covers spring, summer, fall, and winter.

```text
# source fix stashed (base behavior)
3 failed, 1 passed, 1 warning

# fixed branch
4 passed, 1 warning
```

Additional checks:

```text
pytest tests/test_time_parser.py tests/integration/test_api_tag_time_search.py -q
27 passed, 99 warnings

bash scripts/pr/pre_pr_check.sh
Test suite: PASS
Handler coverage: PASS
Import validation: PASS
No debug code: PASS
Log injection guard: PASS
```

The pre-PR quality model scan was skipped because no local analysis endpoint was available. Repository coverage was 67.15%; the gate treats the 80% target as advisory.

## Notes for the reviewer

The implementation starts with the occurrence beginning in the current calendar year and moves backward until its end date precedes today. This also handles winter's year boundary through the existing season-range helper.

The changed legacy files are not fully Black/Ruff clean on `main`. Ruff reports the same 117 whole-file findings before and after this patch, so this change adds no Ruff finding. The patch deliberately avoids a broad formatting-only diff.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by Divyam Talwar.
Human review of this PR: no — fully automated

