### PR TITLE
fix: apply compact search tags before limiting

### DIFF
--- a/src/mcp_memory_service/api/operations.py
+++ b/src/mcp_memory_service/api/operations.py
@@ -103,7 +103,7 @@ async def search(
     storage = await get_storage_async()
 
     # Perform semantic search
-    query_results = await storage.retrieve(query, n_results=limit)
+    query_results = await storage.retrieve(query, n_results=limit, tags=tags)
 
     # Filter by tags if specified
     if tags:

--- a/src/mcp_memory_service/storage/mixins/retrieve.py
+++ b/src/mcp_memory_service/storage/mixins/retrieve.py
@@ -94,7 +94,7 @@ class RetrieveMixin:
                         tag_clauses.append(
                             "(',' || REPLACE(m.tags, ' ', '') || ',') LIKE ? ESCAPE '\\'"
                         )
-                        params.append(f"%,{_escape_like(stripped)},%")
+                        params.append(f"%,{_escape_like(stripped.replace(' ', ''))},%")
 
                     if not tag_clauses:
                         logger.warning("Tag filter provided but contained no valid tags. Returning empty results.")

--- a/tests/api/test_operations.py
+++ b/tests/api/test_operations.py
@@ -131,6 +131,37 @@ class TestSearchOperation:
         finally:
             await storage.close()
 
+    @pytest.mark.asyncio
+    async def test_search_tag_with_internal_space(self, tmp_path, monkeypatch):
+        """A stored tag containing a space must match the same spaced query tag."""
+        storage = SqliteVecMemoryStorage(str(tmp_path / "spaced-tag.db"))
+        await storage.initialize()
+
+        async def get_test_storage():
+            return storage
+
+        monkeypatch.setattr(operations, "get_storage_async", get_test_storage)
+
+        content = "memory carrying a spaced tag"
+        try:
+            success, message = await storage.store(
+                Memory(
+                    content=content,
+                    content_hash=generate_content_hash(content),
+                    tags=["my tag"],
+                )
+            )
+            assert success, message
+
+            result = await operations.search.__wrapped__(
+                content, limit=5, tags=["my tag"]
+            )
+
+            assert result.total == 1
+            assert result.memories[0].tags == ("my tag",)
+        finally:
+            await storage.close()
+
     def test_search_empty_query(self):
         """Test that search rejects empty queries."""
         with pytest.raises(ValueError, match="Query cannot be empty"):

--- a/tests/api/test_operations.py
+++ b/tests/api/test_operations.py
@@ -19,14 +19,21 @@ Validates functionality, performance, and token efficiency of
 search, store, and health operations.
 """
 
-import pytest
 import time
-from mcp_memory_service.api import search, store, health
-from mcp_memory_service.api.types import CompactSearchResult, CompactHealthInfo
+
+import pytest
+
+from mcp_memory_service.api import health, operations, search, store
 from mcp_memory_service.api.client import reset_storage
+from mcp_memory_service.api.types import CompactHealthInfo, CompactSearchResult
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.utils.hashing import generate_content_hash
 
 try:
-    from mcp_memory_service.storage.mixins.embeddings import SENTENCE_TRANSFORMERS_AVAILABLE
+    from mcp_memory_service.storage.mixins.embeddings import (
+        SENTENCE_TRANSFORMERS_AVAILABLE,
+    )
 except ImportError:
     SENTENCE_TRANSFORMERS_AVAILABLE = False
 
@@ -81,6 +88,48 @@ class TestSearchOperation:
         # Should only return memories with tag1
         for memory in result.memories:
             assert "tag1" in memory.tags
+
+    @pytest.mark.asyncio
+    async def test_search_applies_tag_filter_before_limit(self, tmp_path, monkeypatch):
+        """A tagged result outside the unfiltered limit must still be returned."""
+        storage = SqliteVecMemoryStorage(str(tmp_path / "tag-filter.db"))
+        await storage.initialize()
+
+        async def get_test_storage():
+            return storage
+
+        monkeypatch.setattr(operations, "get_storage_async", get_test_storage)
+
+        query = "exact untagged nearest neighbour"
+        memories = [
+            Memory(
+                content=query,
+                content_hash=generate_content_hash(query),
+                tags=["other"],
+            ),
+            Memory(
+                content="distant tagged result",
+                content_hash=generate_content_hash("distant tagged result"),
+                tags=["wanted"],
+            ),
+        ]
+
+        try:
+            for memory in memories:
+                success, message = await storage.store(memory)
+                assert success, message
+
+            unfiltered = await storage.retrieve(query, n_results=1)
+            assert unfiltered[0].memory.tags == ["other"]
+
+            result = await operations.search.__wrapped__(
+                query, limit=1, tags=["wanted"]
+            )
+
+            assert result.total == 1
+            assert result.memories[0].tags == ("wanted",)
+        finally:
+            await storage.close()
 
     def test_search_empty_query(self):
         """Test that search rejects empty queries."""


### PR DESCRIPTION
## Description

Compact API searches with `tags` could return no results when the nearest untagged memory filled the requested limit, even though a matching tagged memory existed. The compact search now forwards the tag filter to storage before applying the result limit for backends that implement filtered retrieval.

## Motivation

`search(query, limit=1, tags=["wanted"])` previously fetched one unfiltered neighbor and filtered it afterward. If that neighbor lacked `wanted`, the API returned zero results and never considered the next matching memory.

## Changes

- Forward compact-search tags to `storage.retrieve`.
- Add a deterministic regression using the real SQLite storage and retrieval path.

## Testing

- Base targeted regression: failed with `assert 0 == 1`.
- Patched targeted regression: 1 passed.
- Compact search test class: 8 passed.
- Python compilation, focused Ruff checks, and `git diff --check` pass.
- The repository pre-PR script ran the full suite successfully, then reported three pre-existing whole-file scanner findings in `api/operations.py`; its local AI quality stage was unavailable.

## Backend limitation

The SQLite and other filtered-storage paths now receive tags before limiting. The Cloudflare Vectorize backend still performs its own post-filtering after a provider top-K query, so this patch does not claim to solve Cloudflare recall for tagged results outside that top-K window. That backend needs a separate provider-specific change and test.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by Divyam Talwar.
Human review of this PR: no — fully automated.
