### PR TITLE
fix: count tags when limiting responses

### DIFF
--- a/src/mcp_memory_service/server/utils/response_limiter.py
+++ b/src/mcp_memory_service/server/utils/response_limiter.py
@@ -49,6 +49,17 @@ if raw_value:
 MEMORY_OVERHEAD_CHARS = 200
 
 
+def _estimate_memory_size(memory: Dict[str, Any]) -> int:
+    """Estimate formatted memory size, including variable-length tag text."""
+    content_size = len(memory.get("content") or "")
+    tags = memory.get("tags") or []
+    if isinstance(tags, list):
+        tags_size = sum(len(tag) for tag in tags) + max(0, len(tags) - 1) * 2
+    else:
+        tags_size = len(tags)
+    return content_size + tags_size + MEMORY_OVERHEAD_CHARS
+
+
 def truncate_memories(
     memories: List[Dict[str, Any]],
     max_chars: int = 0,
@@ -95,7 +106,7 @@ def truncate_memories(
         return [], empty_meta
 
     # Calculate estimated size for each memory, including overhead
-    memory_sizes = [(len(m.get("content") or "") + MEMORY_OVERHEAD_CHARS) for m in memories]
+    memory_sizes = [_estimate_memory_size(memory) for memory in memories]
     total_estimated_chars = sum(memory_sizes)
     total_results = len(memories)
 

--- a/tests/integration/test_response_limit_tags.py
+++ b/tests/integration/test_response_limit_tags.py
@@ -1,0 +1,79 @@
+"""Integration coverage for tag-aware MCP response limits."""
+
+import uuid
+
+import pytest
+
+from mcp_memory_service.server import MemoryServer
+
+
+class TestSearchByTagResponseLimit:
+    """Exercise response limiting through real storage and the MCP handler."""
+
+    async def _store_memories(self, unique_content):
+        server = MemoryServer()
+        shared_tag = f"response-limit-{uuid.uuid4().hex}"
+        large_tags = [shared_tag]
+        large_tags.extend(f"tag-{i}-" + "x" * 70 for i in range(8))
+
+        large_content = unique_content("Memory with many valid tags")
+        small_content = unique_content("Memory with one lookup tag")
+        for content, tags in (
+            (large_content, large_tags),
+            (small_content, [shared_tag]),
+        ):
+            stored = await server.handle_store_memory(
+                {
+                    "content": content,
+                    "metadata": {"tags": tags, "type": "note"},
+                }
+            )
+            assert "successfully" in stored[0].text.lower()
+
+        return server, shared_tag, small_content, large_content
+
+    @pytest.mark.asyncio
+    async def test_limit_counts_tags_before_including_later_memory(
+        self, unique_content
+    ):
+        """Valid tag text participates in the real handler's size limit."""
+        server, shared_tag, small_content, large_content = await self._store_memories(
+            unique_content
+        )
+
+        result = await server.handle_search_by_tag(
+            {"tags": [shared_tag], "max_response_chars": 800}
+        )
+
+        text = result[0].text
+        assert "RESPONSE TRUNCATED" in text
+        assert "Showing 1 of 2" in text
+        assert small_content in text
+        assert large_content not in text
+
+    @pytest.mark.asyncio
+    async def test_no_limit_preserves_memories_with_many_valid_tags(
+        self, unique_content
+    ):
+        """Tag-size accounting does not truncate an unbounded response."""
+        server, shared_tag, small_content, large_content = await self._store_memories(
+            unique_content
+        )
+
+        result = await server.handle_search_by_tag({"tags": [shared_tag]})
+
+        text = result[0].text
+        assert "RESPONSE TRUNCATED" not in text
+        assert small_content in text
+        assert large_content in text
+
+    @pytest.mark.asyncio
+    async def test_empty_tags_still_return_handler_error(self):
+        """Response-limit arguments do not bypass tag validation."""
+        server = MemoryServer()
+
+        result = await server.handle_search_by_tag(
+            {"tags": [], "max_response_chars": 800}
+        )
+
+        assert result[0].text == "Error: Tags are required"

--- a/tests/test_response_limiter.py
+++ b/tests/test_response_limiter.py
@@ -144,6 +144,23 @@ class TestTruncateMemories:
         for i, memory in enumerate(result):
             assert memory["content_hash"] == large_memories[i]["content_hash"]
 
+    def test_counts_tag_text_when_deciding_which_memories_fit(self):
+        """Large tags should not let later memories overflow the response limit."""
+        memories = [
+            {"content": "small", "content_hash": "first", "tags": ["short"]},
+            {
+                "content": "small",
+                "content_hash": "second",
+                "tags": [f"tag-{i}-" + "x" * 70 for i in range(8)],
+            },
+        ]
+
+        result, meta = truncate_memories(memories, max_chars=500)
+
+        assert result == memories[:1]
+        assert meta["shown_results"] == 1
+        assert meta["omitted_count"] == 1
+
 
 # ============================================
 # format_truncated_response() Tests


### PR DESCRIPTION
## What this changes

Response limiting now includes rendered tag text when estimating which memories fit within `max_response_chars`. A memory with a very large tag can no longer make a supposedly bounded response include later memories beyond the configured limit.

## Why

`truncate_memories()` counted content plus a fixed metadata allowance, but a normalized memory may contain up to 100 tags of up to 100 characters each, and that text is rendered into the response. Two short-content memories could therefore be classified as fitting even when one carried hundreds or thousands of valid tag characters. The formatter would then return both and defeat the context-window guard.

## How it was verified

The integration regression stores two memories through `MemoryServer` and real SQLite storage, then searches them through the MCP tag-search handler. Every test tag is within the service's 100-character limit. On the base source, both memories are returned under an 800-character limit even though the second has eight long valid tags. With this change, the second memory is omitted at the memory boundary.

```text
# base source, integration regression plus controls
1 failed, 2 passed, 16 warnings

# fixed branch, response-limiter unit and handler integration files
33 passed, 16 warnings

bash scripts/pr/pre_pr_check.sh
Test suite: PASS
Handler coverage: PASS
Import validation: PASS
Import ordering: PASS
No debug code: PASS
Log injection guard: PASS
Hooks configuration checks: PASS
Active documentation references: PASS
Docstring coverage: PASS
```

The integration file includes the bounded behavior, an unbounded-response control, and the handler's invalid-tag error path. The pre-PR script skipped its local-model complexity/security scan because no analysis endpoint was running. Repository coverage was 67.26%; that check is advisory. Focused Ruff fatal-error checks, Python compilation, and `git diff --check` pass. GitNexus classified the source change as low risk and identified `handle_memory_search()` and `_get_truncated_response_if_needed()` as direct callers of the limiter.

## Notes for the reviewer

The fixed per-memory overhead remains as the allowance for labels and ordinary metadata. The estimate now adds tag characters because that field is variable-length and rendered verbatim. The existing contract to always return at least one memory is unchanged.

## Agent Disclosure

This PR was generated by OpenAI Codex. The submitting account is operated by Divyam Talwar.
Human review of this PR: no — fully automated.
