### PR TITLE
fix(scripts): replace src. prefix imports with package path (#1172)

### DIFF
--- a/scripts/backup/backup_memories.py
+++ b/scripts/backup/backup_memories.py
@@ -28,8 +28,8 @@ from pathlib import Path
 # Add parent directory to path so we can import from the src directory
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.mcp_memory_service.storage.chroma import ChromaMemoryStorage
-from src.mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
+from mcp_memory_service.storage.chroma import ChromaMemoryStorage
+from mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/backup/restore_memories.py
+++ b/scripts/backup/restore_memories.py
@@ -28,8 +28,8 @@ from pathlib import Path
 # Add parent directory to path so we can import from the src directory
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.mcp_memory_service.storage.chroma import ChromaMemoryStorage
-from src.mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
+from mcp_memory_service.storage.chroma import ChromaMemoryStorage
+from mcp_memory_service.config import CHROMA_PATH, BACKUPS_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/database/db_health_check.py
+++ b/scripts/database/db_health_check.py
@@ -51,9 +51,9 @@ class HealthChecker:
         """Test all necessary imports."""
         try:
             import sqlite_vec
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             return True
         except ImportError as e:
             print(f"      Import error: {e}")
@@ -65,7 +65,7 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "health_check.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()
             
@@ -94,9 +94,9 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "operations_test.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()
@@ -148,9 +148,9 @@ class HealthChecker:
         db_path = os.path.join(temp_dir, "vector_test.db")
         
         try:
-            from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-            from src.mcp_memory_service.models.memory import Memory
-            from src.mcp_memory_service.utils.hashing import generate_content_hash
+            from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+            from mcp_memory_service.models.memory import Memory
+            from mcp_memory_service.utils.hashing import generate_content_hash
             
             storage = SqliteVecMemoryStorage(db_path)
             await storage.initialize()

--- a/scripts/maintenance/assign_memory_types.py
+++ b/scripts/maintenance/assign_memory_types.py
@@ -45,7 +45,7 @@ import shutil
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/maintenance/discover_harvest_patterns.py
+++ b/scripts/maintenance/discover_harvest_patterns.py
@@ -33,10 +33,10 @@ from typing import List, Optional, Dict, Tuple
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from src.mcp_memory_service.harvest.parser import TranscriptParser, ParsedMessage
-from src.mcp_memory_service.harvest.extractor import PatternExtractor
-from src.mcp_memory_service.harvest.patterns import PATTERNS_DIR
-from src.mcp_memory_service.harvest.models import HARVEST_TYPES
+from mcp_memory_service.harvest.parser import TranscriptParser, ParsedMessage
+from mcp_memory_service.harvest.extractor import PatternExtractor
+from mcp_memory_service.harvest.patterns import PATTERNS_DIR
+from mcp_memory_service.harvest.models import HARVEST_TYPES
 logger = logging.getLogger(__name__)
 LOW_YIELD_MAX_MATCHES = 3
 LOW_YIELD_MIN_MESSAGES = 50

--- a/scripts/maintenance/regenerate_embeddings.py
+++ b/scripts/maintenance/regenerate_embeddings.py
@@ -17,8 +17,8 @@ from pathlib import Path
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from src.mcp_memory_service.storage.factory import create_storage_instance
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.storage.factory import create_storage_instance
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 logging.basicConfig(
     level=logging.INFO,
@@ -113,7 +113,7 @@ async def regenerate_embeddings():
                     memory_id = result[0]
 
                     # Insert embedding
-                    from src.mcp_memory_service.storage.sqlite_vec import serialize_float32
+                    from mcp_memory_service.storage.sqlite_vec import serialize_float32
                     actual_storage.conn.execute(
                         'INSERT OR REPLACE INTO memory_embeddings(rowid, content_embedding) VALUES (?, ?)',
                         (memory_id, serialize_float32(embedding))

--- a/scripts/maintenance/repair_malformed_tags.py
+++ b/scripts/maintenance/repair_malformed_tags.py
@@ -40,7 +40,7 @@ from typing import List, Tuple, Set, Dict
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.config import SQLITE_VEC_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/maintenance/repair_missing_embeddings_onnx.py
+++ b/scripts/maintenance/repair_missing_embeddings_onnx.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from src.mcp_memory_service.storage.factory import create_storage_instance
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
+from mcp_memory_service.storage.factory import create_storage_instance
+from mcp_memory_service.config import SQLITE_VEC_PATH
 from sqlite_vec import serialize_float32
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')

--- a/scripts/sync/check_drift.py
+++ b/scripts/sync/check_drift.py
@@ -32,8 +32,8 @@ from pathlib import Path
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from src.mcp_memory_service.storage.hybrid import HybridMemoryStorage
-from src.mcp_memory_service import config as app_config
+from mcp_memory_service.storage.hybrid import HybridMemoryStorage
+from mcp_memory_service import config as app_config
 
 # Set up logging
 logging.basicConfig(

--- a/scripts/testing/test_cloudflare_backend.py
+++ b/scripts/testing/test_cloudflare_backend.py
@@ -15,8 +15,8 @@ from pathlib import Path
 # Add project root to sys.path so 'src' package is importable
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.mcp_memory_service.storage.cloudflare import CloudflareStorage
-from src.mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.cloudflare import CloudflareStorage
+from mcp_memory_service.models.memory import Memory
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/scripts/testing/test_sqlite_vec_embeddings.py
+++ b/scripts/testing/test_sqlite_vec_embeddings.py
@@ -17,9 +17,9 @@ from datetime import datetime
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src.mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
-from src.mcp_memory_service.models.memory import Memory
-from src.mcp_memory_service.utils.hashing import generate_content_hash
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.utils.hashing import generate_content_hash
 
 # Configure logging
 logging.basicConfig(

--- a/scripts/validation/verify_environment.py
+++ b/scripts/validation/verify_environment.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     # Fallback for scripts directory context
     sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-    from src.mcp_memory_service.utils.gpu_detection import detect_gpu as shared_detect_gpu
+    from mcp_memory_service.utils.gpu_detection import detect_gpu as shared_detect_gpu
 
 class EnvironmentVerifier:
     def __init__(self):

--- a/tests/test_script_imports.py
+++ b/tests/test_script_imports.py
@@ -1,0 +1,33 @@
+"""Verify scripts/ do not import through the src. prefix.
+
+Issue #1172: scripts that import via `src.mcp_memory_service` load a shadow
+copy of the package, bypassing any patches or singleton guards in the test
+suite.  The fix is to import via `mcp_memory_service` directly.
+"""
+
+import subprocess
+import sys
+
+
+def test_no_src_prefix_imports_in_scripts():
+    """No script in scripts/ should import through the src. prefix."""
+    result = subprocess.run(
+        [sys.executable, "-c", r"""
+import pathlib, re, sys
+
+pattern = re.compile(r'^\s*(?:from\s+src\.|import\s+src\.)', re.MULTILINE)
+hits = []
+for p in sorted(pathlib.Path('scripts').rglob('*.py')):
+    text = p.read_text(errors='replace')
+    for m in pattern.finditer(text):
+        hits.append(f'{p}:{text[:m.start()].count(chr(10))+1}: {m.group().strip()}')
+
+if hits:
+    print('\n'.join(hits))
+    sys.exit(1)
+"""],
+        capture_output=True, text=True, cwd=".",
+    )
+    assert result.returncode == 0, (
+        f"scripts/ still contain src. prefix imports:\n{result.stdout}"
+    )


### PR DESCRIPTION
## Summary

Fixes #1172 — 12 maintenance scripts imported through `src.mcp_memory_service` which loads a shadow copy of the package, bypassing test guards and patches.

## Changes

Replaced all `from src.mcp_memory_service` / `import src.mcp_memory_service` with `from mcp_memory_service` / `import mcp_memory_service` in:

- `scripts/backup/backup_memories.py`
- `scripts/backup/restore_memories.py`
- `scripts/database/db_health_check.py`
- `scripts/maintenance/assign_memory_types.py`
- `scripts/maintenance/discover_harvest_patterns.py`
- `scripts/maintenance/regenerate_embeddings.py`
- `scripts/maintenance/repair_malformed_tags.py`
- `scripts/maintenance/repair_missing_embeddings_onnx.py`
- `scripts/sync/check_drift.py`
- `scripts/testing/test_cloudflare_backend.py`
- `scripts/testing/test_sqlite_vec_embeddings.py`
- `scripts/validation/verify_environment.py`

## Test

Added `tests/test_script_imports.py` that scans `scripts/` for any remaining `src.` prefix imports and fails if any are found.

## Verification

```bash
# Before: 33 hits
$ grep -rcn "from src\.\|import src\." scripts/ --include="*.py" | grep -v ':0$'
scripts/backup/backup_memories.py:2
...

# After: 0 hits
$ grep -rcn "from src\.\|import src\." scripts/ --include="*.py" | grep -v ':0$'
(no output)
```

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)