### PR TITLE
fix: try all listed models before declaring LLM endpoint unusable (#1170)

### DIFF
--- a/.claude/directives/code-quality-workflow.md
+++ b/.claude/directives/code-quality-workflow.md
@@ -90,6 +90,26 @@ bash scripts/quality/weekly_quality_review.sh
 - **PR Quality Gate**: `--with-pyscn` flag for comprehensive analysis
 - **Periodic**: Weekly pyscn analysis with trend tracking
 
+## Quality Gate LLM Configuration
+
+The PR quality gate (`quality_gate.sh`) uses `scripts/pr/lib/llm_prompt.py` for
+complexity and security analysis.  It talks to a local OpenAI-compatible endpoint
+(default `http://127.0.0.1:11437/v1`).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MCP_QUALITY_LLM_URL` | `http://127.0.0.1:11437/v1` | Base URL of the LLM endpoint |
+| `MCP_QUALITY_LLM_MODEL` | *(auto)* | Pin a specific model id. **Set this if the endpoint hosts a mix of working and broken models** — e.g. oMLX returning HTTP 507 for a quantisation that cannot load. |
+| `MCP_QUALITY_LLM_API_KEY` | *(none)* | Bearer token for authenticated endpoints |
+| `MCP_QUALITY_LLM_TIMEOUT` | `180` | Seconds per request |
+
+When `MCP_QUALITY_LLM_MODEL` is not set, the helper tries every model the
+endpoint advertises (in listed order) until one succeeds.  This avoids a single
+broken model silently disabling the gate.
+
+**Symptom:** Gate exits 3 and prints `unusable` — check the model name on stderr;
+if it is the first listed model, pin a working one with `MCP_QUALITY_LLM_MODEL`.
+
 ## Pre-commit Hook Setup
 
 ```bash

--- a/scripts/pr/lib/llm_prompt.py
+++ b/scripts/pr/lib/llm_prompt.py
@@ -20,15 +20,22 @@ shell quality gates so complexity and security analysis run against a local
 model instead of a paid API, and so a missing backend is reported as skipped
 rather than passed.
 
+When MCP_QUALITY_LLM_MODEL is not set, the helper tries every model the
+endpoint advertises (in listed order) until one succeeds.  This avoids a
+single broken model (e.g. oMLX returning 507 Insufficient Storage for a
+quantisation that cannot load) silently disabling the entire gate.
+
 Environment:
     MCP_QUALITY_LLM_URL      base URL, default http://127.0.0.1:11437/v1
-    MCP_QUALITY_LLM_MODEL    model id; default is the first one the endpoint lists
+    MCP_QUALITY_LLM_MODEL    model id; if unset, tries all listed models.
+                              Pin this when the endpoint hosts a mix of
+                              working and broken models (e.g. oMLX 507s).
     MCP_QUALITY_LLM_API_KEY  optional bearer token
     MCP_QUALITY_LLM_TIMEOUT  seconds per request, default 180
 
 Exit codes:
-    0  reply printed on stdout
-    3  no usable backend (unreachable endpoint, no model, empty reply)
+    0  reply printed on stdout (model name on stderr)
+    3  no usable backend (unreachable endpoint, no model, all candidates failed)
 """
 
 import json
@@ -64,15 +71,15 @@ def _request(path: str, payload=None):
         return json.load(response)
 
 
-def resolve_model() -> str:
-    """Configured model, else the first one the endpoint advertises."""
+def resolve_model() -> list[str]:
+    """Return candidate models to try: configured model first, then all listed."""
     configured = os.environ.get("MCP_QUALITY_LLM_MODEL")
     if configured:
-        return configured
+        return [configured]
     listed = _request("/models").get("data") or []
     if not listed:
         raise RuntimeError("endpoint lists no models")
-    return listed[0]["id"]
+    return [m["id"] for m in listed]
 
 
 def _chat(payload: dict) -> dict:
@@ -106,16 +113,24 @@ def main() -> int:
         print("llm_prompt: empty prompt on stdin", file=sys.stderr)
         return EXIT_NO_BACKEND
     try:
-        model = resolve_model()
-        reply = complete(prompt, model)
+        candidates = resolve_model()
     except Exception as exc:  # noqa: BLE001 - any failure means "no backend"
         print(f"llm_prompt: {_base_url()} unusable: {exc}", file=sys.stderr)
         return EXIT_NO_BACKEND
-    if not reply:
-        print(f"llm_prompt: {model} returned an empty reply", file=sys.stderr)
-        return EXIT_NO_BACKEND
-    print(reply)
-    return 0
+    last_exc = None
+    for model in candidates:
+        try:
+            reply = complete(prompt, model)
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+            continue
+        if reply:
+            print(f"llm_prompt: using model {model}", file=sys.stderr)
+            print(reply)
+            return 0
+    err = last_exc or "empty reply from all candidates"
+    print(f"llm_prompt: {_base_url()} unusable: {err}", file=sys.stderr)
+    return EXIT_NO_BACKEND
 
 
 if __name__ == "__main__":

--- a/scripts/pr/quality_gate.sh
+++ b/scripts/pr/quality_gate.sh
@@ -67,7 +67,7 @@ if [ "$LLM_BACKEND" = "gemini" ]; then
         echo "   Skipped, NOT passed: complexity and security were not evaluated."
         exit $EXIT_SKIPPED
     fi
-elif ! echo "reply with READY" | python3 "$LLM_HELPER" > /dev/null 2>&1; then
+elif ! _ready_stderr=$(echo "reply with READY" | python3 "$LLM_HELPER" 2>&1 1>/dev/null); then
     echo "WARNING: no local analysis model reachable - skipping AI-based quality checks."
     echo "   Tried ${MCP_QUALITY_LLM_URL:-http://127.0.0.1:11437/v1} via $LLM_HELPER."
     echo "   Skipped, NOT passed: complexity and security were not evaluated."
@@ -77,6 +77,9 @@ elif ! echo "reply with READY" | python3 "$LLM_HELPER" > /dev/null 2>&1; then
     # the status code, and pre_pr_check.sh used to report this as a green check.
     exit $EXIT_SKIPPED
 fi
+
+# Extract model name from the READY probe's stderr
+_llm_model_used=$(echo "$_ready_stderr" | grep -o 'using model .*' | head -1 | sed 's/using model //')
 
 # analyze <prompt> - one model call, empty output on failure so callers stay simple.
 analyze() {
@@ -92,7 +95,11 @@ if [ "$MODE" = "staged" ]; then
 else
     echo "=== PR Quality Gate for #$PR_NUMBER ==="
 fi
-echo "Analysis backend: $LLM_BACKEND"
+if [ -n "$_llm_model_used" ]; then
+    echo "Analysis backend: $LLM_BACKEND ($_llm_model_used)"
+else
+    echo "Analysis backend: $LLM_BACKEND"
+fi
 echo ""
 
 exit_code=0


### PR DESCRIPTION
## Problem

`scripts/pr/lib/llm_prompt.py` picks `listed[0]` from `GET /v1/models` as the analysis model. When that model fails (e.g. oMLX returning HTTP 507 Insufficient Storage for a quantisation that cannot load), the helper treats it as "endpoint unusable" and exits 3, silently skipping complexity and security analysis for every PR.

## Solution

**`llm_prompt.py`**:
- `resolve_model()` now returns a **list** of candidate models (configured model first, then all listed models)
- `main()` iterates through candidates until one succeeds, printing the chosen model to stderr
- Updated docstring to document the fallback behavior and `MCP_QUALITY_LLM_MODEL` env var

**`quality_gate.sh`**:
- Captures model name from the READY probe's stderr
- Displays it in the "Analysis backend" line: `Analysis backend: local (Qwen3.6-35B-A3B-oQ6-mtp)`

**`code-quality-workflow.md`**:
- Added "Quality Gate LLM Configuration" section documenting all env vars and the 507 symptom

## Behavior Change

| Before | After |
|---|---|
| Tries first listed model only | Tries all listed models in order |
| Silent skip on 507 | Falls back to next model |
| No model name in output | Shows model name in gate output |

Fixes #1170