### PR TITLE
fix: route REST search endpoints through on_retrieve plugin hook (#1151)

### DIFF
--- a/src/mcp_memory_service/web/api/search.py
+++ b/src/mcp_memory_service/web/api/search.py
@@ -26,9 +26,10 @@ from pydantic import BaseModel, Field
 
 from ...storage.base import MemoryStorage
 from ...models.memory import Memory, MemoryQueryResult
+from ...services.memory_service import MemoryService
 # OAuth config no longer needed - auth is always enabled
 from ...utils.time_parser import parse_time_expression
-from ..dependencies import get_storage
+from ..dependencies import get_storage, get_memory_service
 from .memories import MemoryResponse, memory_to_response
 from ..sse import sse_manager, create_search_completed_event
 
@@ -45,6 +46,39 @@ logger = logging.getLogger(__name__)
 def _sanitize_log_value(value: object) -> str:
     """Sanitize a user-provided value for safe inclusion in log messages."""
     return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\x1b", "\\x1b")
+
+
+def _memory_to_plugin_dict(memory: Memory) -> dict:
+    """Convert a Memory object to the dict format used by retrieve plugins."""
+    return {
+        "content": memory.content,
+        "content_hash": memory.content_hash,
+        "tags": memory.tags,
+        "memory_type": memory.memory_type,
+        "metadata": memory.metadata,
+        "created_at": memory.created_at,
+        "updated_at": memory.updated_at,
+        "created_at_iso": memory.created_at_iso,
+        "updated_at_iso": memory.updated_at_iso,
+    }
+
+
+def _memory_from_plugin_dict(d: dict) -> Memory:
+    """Reconstruct a Memory object from a plugin-modified dict."""
+    return Memory(
+        content=d.get("content", ""),
+        content_hash=d.get("content_hash", ""),
+        tags=d.get("tags", []),
+        memory_type=d.get("memory_type"),
+        metadata={k: v for k, v in d.items()
+                  if k not in ("content", "content_hash", "tags",
+                               "memory_type", "created_at", "updated_at",
+                               "created_at_iso", "updated_at_iso")},
+        created_at=d.get("created_at"),
+        created_at_iso=d.get("created_at_iso"),
+        updated_at=d.get("updated_at"),
+        updated_at_iso=d.get("updated_at_iso"),
+    )
 
 
 # Request Models
@@ -110,6 +144,7 @@ def memory_to_search_result(memory: Memory, reason: str = None) -> SearchResult:
 async def semantic_search(
     request: SemanticSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
+    memory_service: MemoryService = Depends(get_memory_service),
     user: AuthenticationResult = Depends(require_read_access)
 ):
     """
@@ -160,6 +195,19 @@ async def semantic_search(
             # Take top N after reranking
             query_results = query_results[:request.n_results]
 
+        # Apply retrieve plugins (rerank / augment) before serialization
+        plugin_dicts = [
+            {**_memory_to_plugin_dict(r.memory), "similarity_score": r.relevance_score}
+            for r in query_results
+        ]
+        plugin_dicts = await memory_service.apply_retrieve_plugins(request.query, plugin_dicts)
+        query_results = [
+            MemoryQueryResult(
+                memory=_memory_from_plugin_dict(d),
+                relevance_score=d.get("similarity_score"),
+            )
+            for d in plugin_dicts
+        ]
 
         # Convert to search results
         search_results = []
@@ -205,6 +253,7 @@ async def semantic_search(
 async def tag_search(
     request: TagSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
+    memory_service: MemoryService = Depends(get_memory_service),
     user: AuthenticationResult = Depends(require_read_access)
 ):
     """
@@ -239,6 +288,12 @@ async def tag_search(
                 memory for memory in memories
                 if tag_set.issubset(set(memory.tags))
             ]
+
+        # Apply retrieve plugins (rerank / augment) before serialization
+        plugin_query = f"Tags: {', '.join(request.tags)}"
+        plugin_dicts = [_memory_to_plugin_dict(m) for m in memories]
+        plugin_dicts = await memory_service.apply_retrieve_plugins(plugin_query, plugin_dicts)
+        memories = [_memory_from_plugin_dict(d) for d in plugin_dicts]
 
         # Convert to search results
         match_type = "ALL" if request.match_all else "ANY"
@@ -287,6 +342,7 @@ async def tag_search(
 async def time_search(
     request: TimeSearchRequest,
     storage: MemoryStorage = Depends(get_storage),
+    memory_service: MemoryService = Depends(get_memory_service),
     user: AuthenticationResult = Depends(require_read_access)
 ):
     """
@@ -326,6 +382,20 @@ async def time_search(
         # Limit results
         filtered_memories = query_results[:request.n_results]
 
+        # Apply retrieve plugins (rerank / augment) before serialization
+        plugin_dicts = [
+            {**_memory_to_plugin_dict(r.memory), "similarity_score": r.relevance_score}
+            for r in filtered_memories
+        ]
+        plugin_dicts = await memory_service.apply_retrieve_plugins(request.query, plugin_dicts)
+        filtered_memories = [
+            MemoryQueryResult(
+                memory=_memory_from_plugin_dict(d),
+                relevance_score=d.get("similarity_score"),
+            )
+            for d in plugin_dicts
+        ]
+
         # Convert to search results
         search_results = [
             memory_query_result_to_search_result(result)
@@ -357,6 +427,7 @@ async def find_similar(
     content_hash: str,
     n_results: int = Query(default=10, ge=1, le=100, description="Number of similar memories to find"),
     storage: MemoryStorage = Depends(get_storage),
+    memory_service: MemoryService = Depends(get_memory_service),
     user: AuthenticationResult = Depends(require_read_access)
 ):
     """
@@ -389,6 +460,21 @@ async def find_similar(
             result for result in similar_results
             if result.memory.content_hash != content_hash
         ][:n_results]
+
+        # Apply retrieve plugins (rerank / augment) before serialization
+        plugin_query = f"Similar to: {target_memory.content[:80]}"
+        plugin_dicts = [
+            {**_memory_to_plugin_dict(r.memory), "similarity_score": r.relevance_score}
+            for r in filtered_results
+        ]
+        plugin_dicts = await memory_service.apply_retrieve_plugins(plugin_query, plugin_dicts)
+        filtered_results = [
+            MemoryQueryResult(
+                memory=_memory_from_plugin_dict(d),
+                relevance_score=d.get("similarity_score"),
+            )
+            for d in plugin_dicts
+        ]
 
         # Convert to search results
         search_results = [

--- a/tests/web/api/test_search_plugin_hook.py
+++ b/tests/web/api/test_search_plugin_hook.py
@@ -1,0 +1,146 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wiring tests: REST search endpoints route through on_retrieve plugin hook.
+
+Each test registers a recording plugin via MemoryService, seeds a memory,
+calls one search endpoint, and asserts the plugin fired once with the final
+result set.
+"""
+
+import pytest
+import pytest_asyncio
+import tempfile
+import os
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from mcp_memory_service.web.dependencies import set_storage
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.models.memory import Memory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield os.path.join(tmpdir, "test_search_plugin.db")
+
+
+@pytest_asyncio.fixture
+async def initialized_storage(temp_db, monkeypatch):
+    monkeypatch.setenv('MCP_SEMANTIC_DEDUP_ENABLED', 'false')
+    storage = SqliteVecMemoryStorage(temp_db)
+    await storage.initialize()
+    # Seed a test memory
+    memory = Memory(
+        content="test memory for plugin wiring",
+        content_hash="test_plugin_hash_001",
+        tags=["test", "plugin"],
+        memory_type="note",
+        metadata={},
+    )
+    await storage.store(memory)
+    yield storage
+    await storage.close()
+
+
+@pytest.fixture
+def recording_plugin_calls():
+    """Shared list that the recording plugin appends to."""
+    return []
+
+
+@pytest.fixture
+def test_app(initialized_storage, recording_plugin_calls, monkeypatch):
+    monkeypatch.setenv('MCP_API_KEY', '')
+    monkeypatch.setenv('MCP_OAUTH_ENABLED', 'false')
+    monkeypatch.setenv('MCP_ALLOW_ANONYMOUS_ACCESS', 'true')
+    monkeypatch.setenv('INCLUDE_HOSTNAME', 'false')
+
+    from mcp_memory_service.web.app import app
+    from mcp_memory_service.web.oauth.middleware import (
+        get_current_user, require_write_access, require_read_access,
+        AuthenticationResult
+    )
+    from mcp_memory_service.services.memory_service import MemoryService
+    from mcp_memory_service.web.dependencies import get_memory_service
+
+    set_storage(initialized_storage)
+
+    # Create a single MemoryService with a recording plugin
+    ms = MemoryService(initialized_storage)
+
+    async def recording_plugin(query, results, **kwargs):
+        recording_plugin_calls.append({"query": query, "count": len(results)})
+        return results  # pass through unchanged
+
+    ms._plugin_registry.ctx.on("on_retrieve", recording_plugin)
+
+    def override_memory_service():
+        return ms
+
+    async def mock_get_current_user():
+        return AuthenticationResult(
+            authenticated=True,
+            client_id="test_client",
+            scope="read write admin",
+            auth_method="test"
+        )
+
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    app.dependency_overrides[require_write_access] = mock_get_current_user
+    app.dependency_overrides[require_read_access] = mock_get_current_user
+    app.dependency_overrides[get_memory_service] = override_memory_service
+
+    client = TestClient(app)
+    yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.integration
+def test_semantic_search_routes_through_plugin(test_app, recording_plugin_calls):
+    """POST /api/search fires on_retrieve plugin once."""
+    resp = test_app.post("/api/search", json={"query": "test memory", "n_results": 5})
+    assert resp.status_code == 200
+    assert len(recording_plugin_calls) == 1
+    assert recording_plugin_calls[0]["count"] >= 1
+
+
+@pytest.mark.integration
+def test_tag_search_routes_through_plugin(test_app, recording_plugin_calls):
+    """POST /api/search/by-tag fires on_retrieve plugin once."""
+    resp = test_app.post("/api/search/by-tag", json={"tags": ["test"]})
+    assert resp.status_code == 200
+    assert len(recording_plugin_calls) == 1
+    assert recording_plugin_calls[0]["count"] >= 1
+
+
+@pytest.mark.integration
+def test_time_search_routes_through_plugin(test_app, recording_plugin_calls):
+    """POST /api/search/by-time fires on_retrieve plugin once."""
+    resp = test_app.post("/api/search/by-time", json={"query": "today", "n_results": 5})
+    assert resp.status_code == 200
+    assert len(recording_plugin_calls) == 1
+
+
+@pytest.mark.integration
+def test_similar_search_routes_through_plugin(test_app, recording_plugin_calls):
+    """GET /api/search/similar/{hash} fires on_retrieve plugin once."""
+    resp = test_app.get("/api/search/similar/test_plugin_hash_001?n_results=5")
+    assert resp.status_code == 200
+    assert len(recording_plugin_calls) == 1
+    # count may be 0 when embeddings are unavailable (hash fallback);
+    # the important assertion is that the plugin was called at all.


### PR DESCRIPTION
## Problem

#1142 routed MCP `memory_search` through `MemoryService.apply_retrieve_plugins`, but the four REST search endpoints bypass it:

- `POST /api/search`
- `POST /api/search/by-tag`
- `POST /api/search/by-time`
- `GET /api/search/similar/{content_hash}`

A plugin that reranks or augments results applies only to Claude Desktop, not to the dashboard or HTTP API.

## Solution

Added `get_memory_service` dependency to all four endpoints. After computing results, each endpoint:

1. Converts `Memory`/`MemoryQueryResult` objects to the plugin dict format
2. Calls `memory_service.apply_retrieve_plugins(query, dicts)`
3. Reconstructs objects from the plugin-modified dicts

**Wiring test** (`test_search_plugin_hook.py`): registers a recording plugin on a shared `MemoryService`, seeds a memory, calls each endpoint, and asserts the plugin fired once.

Fixes #1151