### PR TITLE
fix(quality): pin the legacy ONNX exporter where torch supports dynamo

### DIFF
--- a/src/mcp_memory_service/quality/onnx_ranker.py
+++ b/src/mcp_memory_service/quality/onnx_ranker.py
@@ -5,6 +5,7 @@ Uses ms-marco-MiniLM-L-6-v2 model for relevance scoring.
 Exports the model from transformers to ONNX format on first use.
 """
 
+import inspect
 import logging
 import os
 import threading
@@ -271,16 +272,28 @@ class ONNXRankerModel:
             dynamic_axes = {name: {0: "batch", 1: "sequence"} for name in input_names}
             dynamic_axes["logits"] = {0: "batch"}
 
+            export_kwargs = {
+                "input_names": input_names,
+                "output_names": ["logits"],
+                "dynamic_axes": dynamic_axes,
+                "opset_version": 14,
+                "do_constant_folding": True,
+                "export_params": True,
+            }
+            # torch 2.9 flipped torch.onnx.export's ``dynamo`` default to True,
+            # routing this legacy argument set through the torch.export-based
+            # exporter, where the DeBERTa export fails (issue #1101, hit on
+            # torch 2.13). Pin the legacy exporter — but only where the
+            # parameter exists: torch < 2.5 has no ``dynamo`` and would raise
+            # TypeError on the keyword, and pyproject allows torch >= 2.0.
+            if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+                export_kwargs["dynamo"] = False
+
             torch.onnx.export(
                 model,
                 model_inputs,
                 str(onnx_path),
-                input_names=input_names,
-                output_names=["logits"],
-                dynamic_axes=dynamic_axes,
-                opset_version=14,
-                do_constant_folding=True,
-                export_params=True
+                **export_kwargs
             )
 
         # Save tokenizer config for loading

--- a/tests/quality/test_onnx_export_dynamo_pin.py
+++ b/tests/quality/test_onnx_export_dynamo_pin.py
@@ -1,0 +1,81 @@
+"""Regression tests for issue #1101: pin the legacy ONNX exporter explicitly.
+
+torch 2.9 changed the default of ``torch.onnx.export``'s ``dynamo`` parameter
+to True, which routes the call through the new ``torch.export``-based exporter.
+``_ensure_onnx_model`` passes the legacy argument set (``dynamic_axes``,
+``opset_version``, ...) and the DeBERTa export fails under the new exporter
+(confirmed on torch 2.13; ``dynamo=False`` makes it work).
+
+The pin has to be conditional: ``dynamo`` only exists as a parameter from
+torch 2.5, and pyproject allows ``torch>=2.0.0`` — passing it unconditionally
+would trade a failure on new torch for a TypeError on old torch.
+
+These tests need no ml extras: torch is replaced by a fake module whose
+``onnx.export`` records what it was called with, so they run everywhere and
+exercise both signature generations.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mcp_memory_service.quality import onnx_ranker
+from mcp_memory_service.quality.onnx_ranker import ONNXRankerModel
+
+
+def _fake_torch(export_fn):
+    return SimpleNamespace(no_grad=contextlib.nullcontext, onnx=SimpleNamespace(export=export_fn))
+
+
+def _ranker_for_export(tmp_path):
+    """A bare instance pointed at an empty dir, so _ensure_onnx_model exports."""
+    ranker = object.__new__(ONNXRankerModel)
+    ranker.MODEL_PATH = tmp_path / "model"
+    ranker.model_config = {"type": "classifier", "hf_name": "some/quality-model"}
+    tokenizer = MagicMock()
+    tokenizer.return_value = {"input_ids": MagicMock(), "attention_mask": MagicMock()}
+    ranker._load_source_model = MagicMock(return_value=(tokenizer, MagicMock()))
+    return ranker
+
+
+class TestDynamoPin:
+    def test_modern_torch_gets_dynamo_false(self, tmp_path, monkeypatch):
+        """On torch >= 2.5 the export must pin dynamo=False explicitly.
+
+        From 2.9 the default is True and the legacy argument set fails on
+        DeBERTa; relying on the default is exactly the bug of #1101.
+        """
+        recorded = {}
+
+        def export(model, args, f, *, input_names, output_names, dynamic_axes,
+                   opset_version, do_constant_folding, export_params, dynamo=True):
+            recorded["dynamo"] = dynamo
+
+        monkeypatch.setattr(onnx_ranker, "torch", _fake_torch(export), raising=False)
+
+        _ranker_for_export(tmp_path)._ensure_onnx_model()
+
+        assert recorded["dynamo"] is False, (
+            "torch.onnx.export was left on its default dynamo setting; on "
+            "torch >= 2.9 that default is True and the DeBERTa export fails "
+            "with this legacy argument set (issue #1101)."
+        )
+
+    def test_legacy_torch_does_not_receive_the_keyword(self, tmp_path, monkeypatch):
+        """On torch < 2.5 there is no ``dynamo`` parameter to pass.
+
+        The fake signature is strict, exactly like the real old one: passing
+        ``dynamo`` unconditionally raises TypeError here, which is what an
+        unguarded pin would do to every torch 2.0-2.4 install.
+        """
+        called = {}
+
+        def export(model, args, f, *, input_names, output_names, dynamic_axes,
+                   opset_version, do_constant_folding, export_params):
+            called["ok"] = True
+
+        monkeypatch.setattr(onnx_ranker, "torch", _fake_torch(export), raising=False)
+
+        _ranker_for_export(tmp_path)._ensure_onnx_model()
+
+        assert called.get("ok"), "export was never reached on a legacy-signature torch"


### PR DESCRIPTION
Closes #1101.

## The bug

`_ensure_onnx_model()` exports the quality model with the legacy argument set
and never passes `dynamo`:

```python
torch.onnx.export(
    model, model_inputs, str(onnx_path),
    input_names=input_names, output_names=["logits"],
    dynamic_axes=dynamic_axes, opset_version=14,
    do_constant_folding=True, export_params=True
)
```

PyTorch changed the default underneath it: since 2.9, `dynamo=True`, so on any
current torch this call goes through the new `torch.export`-based exporter
while still passing `dynamic_axes` and friends — and the DeBERTa export fails.
@tecnobrat hit it on torch 2.13 and confirmed `dynamo=False` fixes it (Codeberg
#170); nothing in `pyproject.toml` bounds the version (`torch>=2.0.0` in the
`ml` extra).

## The fix — and why it is conditional

The obvious one-liner (`dynamo=False` unconditionally) trades a failure on new
torch for a `TypeError` on old torch: the `dynamo` parameter only exists from
torch 2.5, and the `ml` extra allows 2.0.0. So the pin is guarded on the
installed signature:

```python
if "dynamo" in inspect.signature(torch.onnx.export).parameters:
    export_kwargs["dynamo"] = False
```

- torch >= 2.5 (parameter exists): the legacy exporter is pinned explicitly,
  immune to the 2.9 default flip.
- torch 2.0–2.4 (no parameter): nothing is passed; those versions are
  legacy-only anyway.

A signature check rather than a version compare, so it keys on the actual
capability instead of parsing version strings.

## Tests — red without the change

`tests/quality/test_onnx_export_dynamo_pin.py`, two behavioural tests that need
no ml extras (torch is replaced by a fake whose `onnx.export` records its
kwargs, following the pattern of `test_onnx_ranker_cache_resolution.py`):

- `test_modern_torch_gets_dynamo_false` — a modern-signature fake asserts the
  call receives `dynamo=False`. **Red on `main`** (verified: stashing the src
  change alone makes it fail), green with the fix.
- `test_legacy_torch_does_not_receive_the_keyword` — a strict legacy-signature
  fake (no `dynamo` parameter, exactly like real torch < 2.5) would raise
  `TypeError` if the keyword were passed unconditionally; it asserts the export
  is still reached.

Ran locally: `tests/quality/` → 30 passed, 2 skipped. `ruff` on the touched
source file reports exactly the findings already present on `main` (none
introduced); the new test file is ruff-clean.

Honest note on environment: verified without `torch` installed, so I did not
run a real DeBERTa export end-to-end — the failing-on-2.9+ behaviour rests on
@tecnobrat's repeated confirmation in Codeberg #170 and the documented default
change ("Changed in version 2.9: `dynamo` is now True by default").

## Agent Disclosure

This PR was generated by DIADE, an autonomous coding agent. The submitting
account (massimiliano1991) is operated by Massimiliano Guidi.
Human review of this PR: no — fully automated. Every claim above was verified
at the source before submitting (the unpinned call site, the torch signature
history, the red-without-change test run), except the end-to-end export on
torch >= 2.9, which is declared above as resting on the reporter's confirmation.
