### PR TITLE
fix: recover ONNX embeddings after CoreML inference failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,14 @@ MCP_SEMANTIC_DEDUP_THRESHOLD=0.85            # Similarity threshold 0.0-1.0 (def
 # Large content threshold for R2 storage (bytes)
 # CLOUDFLARE_LARGE_CONTENT_THRESHOLD=1048576
 
+# Local ONNX embedding providers (unset or empty: automatic accelerator selection)
+# Comma-separated ONNX Runtime provider names, in priority order. Names must be
+# available in the installed runtime. Restart the service after changing this.
+# Pin CPU on Apple Silicon to avoid CoreML dynamic-sequence failures:
+# MCP_MEMORY_ONNX_PROVIDERS=CPUExecutionProvider
+# CoreML inference errors automatically retry once on CPU and keep using CPU.
+# This controls local embeddings only, not the ONNX quality scorer.
+
 # Quality System - Local ONNX model location
 # Parent directory holding one subdirectory of exported ONNX artifacts per model;
 # the loader appends /<model_name>. Default: ~/.cache/mcp_memory/onnx_models

--- a/.env.example
+++ b/.env.example
@@ -100,8 +100,9 @@ MCP_SEMANTIC_DEDUP_THRESHOLD=0.85            # Similarity threshold 0.0-1.0 (def
 
 # Local ONNX embedding providers (unset or empty: automatic accelerator selection)
 # Comma-separated ONNX Runtime provider names, in priority order. Names must be
-# available in the installed runtime. Restart the service after changing this.
-# Pin CPU on Apple Silicon to avoid CoreML dynamic-sequence failures:
+# available in the installed runtime; invalid names prevent ONNX initialization.
+# Restart the service after changing this.
+# Pin CPU on Apple Silicon to avoid CoreML runtime failures:
 # MCP_MEMORY_ONNX_PROVIDERS=CPUExecutionProvider
 # CoreML inference errors automatically retry once on CPU and keep using CPU.
 # This controls local embeddings only, not the ONNX quality scorer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Thanks to eunwoo song for the retrieval fix below (#1128) and to timkjr for the 
 
 ### Fixed
 
+- **Recover local ONNX embeddings from CoreML runtime failures (#1105).** A failing
+  CoreML session is rebuilt with `CPUExecutionProvider`, retries the same batch
+  once, and stays on CPU for subsequent store and search calls. The model and
+  embedding dimension are unchanged. `MCP_MEMORY_ONNX_PROVIDERS` also lets users
+  pin an available provider list without editing installed files; for example,
+  `CPUExecutionProvider` avoids CoreML entirely. Restart after changing the setting.
+
 - **fix(storage): apply eligibility filters before the nearest-neighbour limit (#1128, eunwoo song, closes #1077).** `recall()` and `retrieve()` asked sqlite-vec for the k nearest embeddings first and filtered afterwards, so soft-deleted rows, rows outside the requested time window, and rows excluded by tag or supersession consumed the candidate budget before a valid match could be seen. With enough excluded neighbours the result set came back short or empty even though matching memories existed. Both queries now restrict the KNN scan to eligible rowids, so k counts only memories that can actually be returned. The tests run against real sqlite-vec with 4,100 excluded neighbours crowding five valid ones, which is what distinguishes a fix here from a fix that merely reorders the same failure.
 - **fix(consolidation): map recommendation values onto the API's public contract (#1087, timkjr).** `/api/consolidation/recommendations/{time_horizon}` sanitized its output against an allowlist of uppercase values, but `DreamInspiredConsolidator.get_consolidation_recommendations()` has always returned lowercase snake_case ones (`consolidation_beneficial`, `optional`, `no_action`, `error`). Nothing ever matched, so every call returned `"recommendation": "UNKNOWN"` regardless of the consolidator's actual assessment. The values are now mapped explicitly, with the CWE-209 fallback kept for anything unrecognised. Traces back to Codeberg #328, ported here from Codeberg PR #339.
 - **fix(consolidation): derive DBSCAN's eps from the data's own k-distance curve (#1088, timkjr).** `eps` was computed from dataset size alone (`0.5 - n/10000`, clamped), which bakes in an assumption about how far apart an embedding model puts unrelated text. all-MiniLM-L6-v2 keeps unrelated content at a narrow, elevated baseline similarity, so density-reachability chained memories into one giant cluster — observed at 989 of 1,104 memories in a single cluster with coherence 0.461. `eps` now comes from the knee of the sorted k-distance curve (Ester et al., 1996), computed with `NearestNeighbors` rather than a full n×n distance matrix. Ported from Codeberg PR #340.

--- a/src/mcp_memory_service/embeddings/onnx_embeddings.py
+++ b/src/mcp_memory_service/embeddings/onnx_embeddings.py
@@ -10,7 +10,10 @@ import os
 import tarfile
 from pathlib import Path
 from typing import List, Optional, Union
+
 import numpy as np
+
+from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +208,25 @@ class ONNXEmbeddingModel:
             "token_type_ids": token_type_ids,
         }
         
-        outputs = self._model.run(None, ort_inputs)
+        session = self._model
+        try:
+            outputs = session.run(None, ort_inputs)
+        except Exception as exc:
+            if "CoreMLExecutionProvider" not in session.get_providers():
+                raise
+            # CPU in the provider list handles unsupported nodes, not CoreML
+            # runtime failures. Rebuild without CoreML and retry this batch once.
+            logger.warning(
+                "CoreML inference failed; retrying with CPUExecutionProvider: %s",
+                _sanitize_log_value(exc),
+            )
+            model_path = self.DOWNLOAD_PATH / self.EXTRACTED_FOLDER_NAME / "model.onnx"
+            session = ort.InferenceSession(
+                str(model_path), providers=["CPUExecutionProvider"]
+            )
+            self._model = session
+            self._preferred_providers = ["CPUExecutionProvider"]
+            outputs = session.run(None, ort_inputs)
         
         # Extract embeddings (using mean pooling)
         last_hidden_states = outputs[0]
@@ -227,6 +248,29 @@ class ONNXEmbeddingModel:
         return "cpu"  # ONNX runtime handles device selection internally
 
 
+def _get_preferred_providers() -> list[str]:
+    """Use an explicit provider pin, or prefer available accelerators."""
+    available = ort.get_available_providers()
+    configured = os.environ.get("MCP_MEMORY_ONNX_PROVIDERS", "").strip()
+    if configured:
+        providers = [provider.strip() for provider in configured.split(",")]
+        if set(providers) - set(available):
+            raise ValueError(
+                "MCP_MEMORY_ONNX_PROVIDERS must contain comma-separated available "
+                f"provider names. Available: {available}"
+            )
+        return providers
+    return [
+        provider
+        for provider in (
+            "CUDAExecutionProvider",
+            "DirectMLExecutionProvider",
+            "CoreMLExecutionProvider",
+        )
+        if provider in available
+    ] + ["CPUExecutionProvider"]
+
+
 def get_onnx_embedding_model(model_name: str = "all-MiniLM-L6-v2") -> Optional[ONNXEmbeddingModel]:
     """
     Get ONNX embedding model if available.
@@ -246,24 +290,13 @@ def get_onnx_embedding_model(model_name: str = "all-MiniLM-L6-v2") -> Optional[O
         return None
     
     try:
-        # Detect best available providers
-        available_providers = ort.get_available_providers()
-        preferred_providers = []
-        
-        # Prefer GPU providers if available
-        if 'CUDAExecutionProvider' in available_providers:
-            preferred_providers.append('CUDAExecutionProvider')
-        if 'DirectMLExecutionProvider' in available_providers:
-            preferred_providers.append('DirectMLExecutionProvider')
-        if 'CoreMLExecutionProvider' in available_providers:
-            preferred_providers.append('CoreMLExecutionProvider')
-        
-        # Always include CPU as fallback
-        preferred_providers.append('CPUExecutionProvider')
-        
-        logger.info(f"Creating ONNX model with providers: {preferred_providers}")
+        preferred_providers = _get_preferred_providers()
+        logger.info(
+            "Creating ONNX model with providers: %s",
+            _sanitize_log_value(preferred_providers),
+        )
         return ONNXEmbeddingModel(model_name, preferred_providers)
     
     except Exception as e:
-        logger.error(f"Failed to create ONNX embedding model: {e}")
+        logger.error("Failed to create ONNX embedding model: %s", _sanitize_log_value(e))
         return None

--- a/src/mcp_memory_service/embeddings/onnx_embeddings.py
+++ b/src/mcp_memory_service/embeddings/onnx_embeddings.py
@@ -157,7 +157,10 @@ class ONNXEmbeddingModel:
             raise FileNotFoundError(f"Tokenizer not found at {tokenizer_path}")
         
         # Initialize ONNX session
-        logger.info(f"Loading ONNX model with providers: {self._preferred_providers}")
+        logger.info(
+            "Loading ONNX model with providers: %s",
+            _sanitize_log_value(self._preferred_providers),
+        )
         self._model = ort.InferenceSession(
             str(model_path),
             providers=self._preferred_providers
@@ -280,6 +283,9 @@ def get_onnx_embedding_model(model_name: str = "all-MiniLM-L6-v2") -> Optional[O
         
     Returns:
         ONNXEmbeddingModel instance or None if ONNX is not available
+
+    Raises:
+        ValueError: If MCP_MEMORY_ONNX_PROVIDERS contains unavailable provider names.
     """
     if not ONNX_AVAILABLE:
         logger.warning("ONNX Runtime not available")
@@ -289,8 +295,8 @@ def get_onnx_embedding_model(model_name: str = "all-MiniLM-L6-v2") -> Optional[O
         logger.warning("Tokenizers not available")
         return None
     
+    preferred_providers = _get_preferred_providers()
     try:
-        preferred_providers = _get_preferred_providers()
         logger.info(
             "Creating ONNX model with providers: %s",
             _sanitize_log_value(preferred_providers),

--- a/src/mcp_memory_service/storage/mixins/embeddings.py
+++ b/src/mcp_memory_service/storage/mixins/embeddings.py
@@ -252,6 +252,8 @@ class EmbeddingsMixin:
                         logger.warning("ONNX model creation failed, falling back to SentenceTransformer")
                 except ImportError as e:
                     logger.warning(f"ONNX dependencies not available: {e}")
+                except ValueError as e:
+                    raise RuntimeError(f"Invalid ONNX embedding configuration: {e}") from e
                 except Exception as e:
                     logger.warning(f"Failed to initialize ONNX embeddings: {e}")
 

--- a/tests/test_onnx_provider_fallback.py
+++ b/tests/test_onnx_provider_fallback.py
@@ -1,0 +1,168 @@
+"""CoreML failure recovery with real ONNX inference and sqlite-vec storage.
+
+Only the unavailable CoreML hardware boundary is fault-injected. The tiny ONNX
+graph casts input_ids and attention_mask to float, unsqueezes them, and
+concatenates them into [batch, sequence, 2] hidden states (IR 8, opset 13).
+Embedding pooling, CPU inference, and database operations all run normally.
+The serialized graph avoids a model download or an extra onnx test dependency.
+"""
+
+import base64
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mcp_memory_service.embeddings.onnx_embeddings import (
+    ONNXEmbeddingModel,
+    get_onnx_embedding_model,
+)
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.utils.hashing import generate_content_hash
+
+ort = pytest.importorskip("onnxruntime")
+tokenizers = pytest.importorskip("tokenizers")
+
+CPU = "CPUExecutionProvider"
+COREML = "CoreMLExecutionProvider"
+MODEL = (
+    "CAg6lwQKLQoJaW5wdXRfaWRzEg9pbnB1dF9pZHNfZmxvYXQiBENhc3QqCQoCdG8YAaABAgo2Cg9p"
+    "bnB1dF9pZHNfZmxvYXQKBGF4ZXMSEmlucHV0X2lkc19leHBhbmRlZCIJVW5zcXVlZXplCjcKDmF0"
+    "dGVudGlvbl9tYXNrEhRhdHRlbnRpb25fbWFza19mbG9hdCIEQ2FzdCoJCgJ0bxgBoAECCkAKFGF0"
+    "dGVudGlvbl9tYXNrX2Zsb2F0CgRheGVzEhdhdHRlbnRpb25fbWFza19leHBhbmRlZCIJVW5zcXVl"
+    "ZXplClUKEmlucHV0X2lkc19leHBhbmRlZAoXYXR0ZW50aW9uX21hc2tfZXhwYW5kZWQSEWxhc3Rf"
+    "aGlkZGVuX3N0YXRlIgZDb25jYXQqCwoEYXhpcxgCoAECEg90ZXN0X2VtYmVkZGluZ3MqDQgBEAc6"
+    "AQJCBGF4ZXNaKAoJaW5wdXRfaWRzEhsKGQgHEhUKBxIFYmF0Y2gKChIIc2VxdWVuY2VaLQoOYXR0"
+    "ZW50aW9uX21hc2sSGwoZCAcSFQoHEgViYXRjaAoKEghzZXF1ZW5jZVotCg50b2tlbl90eXBlX2lk"
+    "cxIbChkIBxIVCgcSBWJhdGNoCgoSCHNlcXVlbmNlYjQKEWxhc3RfaGlkZGVuX3N0YXRlEh8KHQgB"
+    "EhkKBxIFYmF0Y2gKChIIc2VxdWVuY2UKAggCQgIQDQ=="
+)
+
+
+@pytest.fixture
+def onnx_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    model_dir = tmp_path / "onnx"
+    model_dir.mkdir()
+    (model_dir / "model.onnx").write_bytes(base64.b64decode(MODEL))
+    tokenizer = tokenizers.Tokenizer(
+        tokenizers.models.WordLevel({"[UNK]": 0, "short": 1, "long": 2}, "[UNK]")
+    )
+    tokenizer.pre_tokenizer = tokenizers.pre_tokenizers.Whitespace()
+    tokenizer.save(str(model_dir / "tokenizer.json"))
+    monkeypatch.setattr(ONNXEmbeddingModel, "DOWNLOAD_PATH", tmp_path)
+    monkeypatch.setenv("MCP_MEMORY_USE_ONNX", "1")
+    monkeypatch.setenv("MCP_MEMORY_ALLOW_HASH_EMBEDDINGS", "0")
+    monkeypatch.delenv("MCP_MEMORY_ONNX_PROVIDERS", raising=False)
+    monkeypatch.delenv("MCP_EXTERNAL_EMBEDDING_URL", raising=False)
+    return model_dir
+
+
+@pytest.fixture
+def failing_coreml(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    create_session = ort.InferenceSession
+    attempts = []
+
+    def create(path: str, providers: list[str]) -> ort.InferenceSession:
+        attempts.append(list(providers))
+        session = create_session(path, providers=[CPU])
+        if COREML in providers:
+            monkeypatch.setattr(session, "get_providers", lambda: list(providers))
+
+            def fail(*args: object, **kwargs: object) -> None:
+                raise RuntimeError("CoreML dynamic sequence resize error -6\nretry")
+
+            monkeypatch.setattr(session, "run", fail)
+        return session
+
+    monkeypatch.setattr(ort, "get_available_providers", lambda: [COREML, CPU])
+    monkeypatch.setattr(ort, "InferenceSession", create)
+    return attempts
+
+
+@pytest.mark.asyncio
+async def test_coreml_failure_stores_and_retrieves(
+    onnx_cache: Path,
+    failing_coreml: list[list[str]],
+    temp_db_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    storage = SqliteVecMemoryStorage(f"{temp_db_path}/coreml.db")
+    await storage.initialize()
+    try:
+        assert isinstance(storage.embedding_model, ONNXEmbeddingModel)
+        for content in ("short", "long short long"):
+            memory = Memory(
+                content=content, content_hash=generate_content_hash(content)
+            )
+            success, message = await storage.store(memory)
+            assert success, message
+        results = await storage.retrieve("short long", n_results=2)
+        assert {result.memory.content for result in results} == {
+            "short",
+            "long short long",
+        }
+        assert storage.embedding_dimension == 2
+        assert storage.embedding_model._model.get_providers() == [CPU]
+        assert failing_coreml == [[COREML, CPU], [CPU]]
+        warnings = [
+            r.getMessage() for r in caplog.records if "CoreML" in r.getMessage()
+        ]
+        assert any("CPUExecutionProvider" in message for message in warnings)
+        assert all("\n" not in message for message in warnings)
+    finally:
+        await storage.close()
+
+
+def test_fallback_preserves_batched_embeddings(
+    onnx_cache: Path, failing_coreml: list[list[str]]
+) -> None:
+    reference = ONNXEmbeddingModel(preferred_providers=[CPU])
+    model = get_onnx_embedding_model()
+    assert model is not None
+    texts = ["short", "long short long"]
+    np.testing.assert_allclose(model.encode(texts), reference.encode(texts))
+    np.testing.assert_allclose(model.encode("short"), reference.encode("short"))
+    assert failing_coreml == [[CPU], [COREML, CPU], [CPU]]
+
+
+@pytest.mark.parametrize("providers", [CPU, f"  {CPU}  "])
+def test_cpu_pin_skips_coreml(
+    onnx_cache: Path,
+    failing_coreml: list[list[str]],
+    monkeypatch: pytest.MonkeyPatch,
+    providers: str,
+) -> None:
+    monkeypatch.setenv("MCP_MEMORY_ONNX_PROVIDERS", providers)
+    model = get_onnx_embedding_model()
+    assert model is not None
+    assert model._model.get_providers() == [CPU]
+    assert np.isfinite(model.encode(["short", "long short"])).all()
+    assert failing_coreml == [[CPU]]
+
+
+@pytest.mark.parametrize("providers", ["MissingExecutionProvider", f"{CPU},", ","])
+def test_invalid_provider_pin_is_rejected(
+    onnx_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    providers: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MCP_MEMORY_ONNX_PROVIDERS", providers)
+    assert get_onnx_embedding_model() is None
+    assert "MCP_MEMORY_ONNX_PROVIDERS" in caplog.text
+
+
+def test_cpu_errors_are_not_retried(
+    onnx_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    model = ONNXEmbeddingModel(preferred_providers=[CPU])
+    session = model._model
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("CPU inference failed")
+
+    monkeypatch.setattr(session, "run", fail)
+    with pytest.raises(RuntimeError, match="CPU inference failed"):
+        model.encode("short")
+    assert model._model is session

--- a/tests/test_onnx_provider_fallback.py
+++ b/tests/test_onnx_provider_fallback.py
@@ -146,11 +146,28 @@ def test_invalid_provider_pin_is_rejected(
     onnx_cache: Path,
     monkeypatch: pytest.MonkeyPatch,
     providers: str,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setenv("MCP_MEMORY_ONNX_PROVIDERS", providers)
-    assert get_onnx_embedding_model() is None
-    assert "MCP_MEMORY_ONNX_PROVIDERS" in caplog.text
+    with pytest.raises(ValueError, match="MCP_MEMORY_ONNX_PROVIDERS"):
+        get_onnx_embedding_model()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("providers", ["MissingExecutionProvider", f"{CPU},", ","])
+async def test_invalid_provider_pin_stops_storage_initialization(
+    onnx_cache: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    providers: str,
+    temp_db_path: str,
+) -> None:
+    monkeypatch.setenv("MCP_MEMORY_ONNX_PROVIDERS", providers)
+    monkeypatch.setenv("MCP_MEMORY_ALLOW_HASH_EMBEDDINGS", "1")
+    storage = SqliteVecMemoryStorage(f"{temp_db_path}/invalid-provider.db")
+    try:
+        with pytest.raises(RuntimeError, match="MCP_MEMORY_ONNX_PROVIDERS"):
+            await storage.initialize()
+    finally:
+        await storage.close()
 
 
 def test_cpu_errors_are_not_retried(


### PR DESCRIPTION
## What this changes

Recover from CoreML embedding inference failures by rebuilding the same ONNX model with `CPUExecutionProvider`, retrying the current batch once, and retaining that CPU session. Model, pooling, normalization, and embedding dimension stay the same. CPU-only errors still propagate.

`MCP_MEMORY_ONNX_PROVIDERS` accepts an ordered, comma-separated list of available provider names; `CPUExecutionProvider` pins CPU, while unset or empty preserves automatic selection. Invalid names raise `ValueError` from the factory and `RuntimeError` during storage initialization, stopping startup even when hash fallback is allowed. The setting is documented in `.env.example`, and provider logs use `_sanitize_log_value`.

## Why

Fixes #1105. A CPU provider listed after CoreML does not recover an already-assigned CoreML node that fails during inference. This adds the explicit provider pin and CPU session rebuild requested by the maintainer.

## How it was verified

The same regression file was run against an isolated upstream `d0d79d9` checkout and this revision (`133c124`):

```text
python -m pytest tests/test_onnx_provider_fallback.py -q
# upstream main: 10 failed, 1 passed
# this revision: 11 passed
```

The tests execute a small real ONNX graph, real tokenization and CPU inference, and real sqlite-vec storage through `temp_db_path`. Only the unavailable CoreML boundary is fault-injected. Startup tests explicitly allow hash fallback so a silently degraded startup cannot pass.

- Related ONNX/embedding selection: `107 passed, 25 skipped, 2894 deselected, 3 xfailed` locally.
- Real MiniLM acceptance: three varying-length memories, 384-dimensional CPU reference equivalence, persistence, and nearest-neighbor retrieval passed after one injected CoreML failure; hash fallback was disabled.
- Ruff on the regression file and `git diff --check` passed.
- [Full Linux CI](https://github.com/2160039878-cyber/mcp-memory-service/actions/runs/34557996681) passed: base suite `2908 passed, 93 skipped, 8 deselected, 15 xfailed, 5 xpassed`, coverage `67.91%`; ML extras suite `2784 passed, 62 skipped, 8 deselected, 15 xfailed, 2 xpassed`. JS, shell, version, and bundled-config jobs also passed.
- [CodeQL on the PR commit](https://github.com/2160039878-cyber/mcp-memory-service/actions/runs/34557998951) passed.

Fork validation commit `61dc4e1` has exactly the same source and tests as PR commit `133c124`; its only tree difference is a `workflow_dispatch` trigger in `ci.yml`. That trigger is not included in this PR. The manual run skips the PR-only `tests-prove-fix` job; the independently executed main/branch regression results are above. [Upstream CI](https://github.com/doobidoo/mcp-memory-service/actions/runs/34557959716) and [upstream CodeQL](https://github.com/doobidoo/mcp-memory-service/actions/runs/34557959704) still await maintainer approval and have not executed on this revision.

## Notes for the reviewer

Apple Silicon was unavailable locally. Recovery was tested by injection, not by reproducing a native CoreML failure. As confirmed in the maintainer's review, the shipped tokenizer pads to 128 and CoreML did not fail natively on their current runtime either; the documentation therefore says "CoreML runtime failures" without asserting a dynamic-sequence mechanism.

Merged current main to resolve the conflict and removed the contributor changelog entry; `CHANGELOG.md` has no PR diff, per the review request. The separate ONNX quality scorer is unchanged.

## Agent Disclosure

This PR was generated by Codex. The submitting account is operated by the human owner of @2160039878-cyber, who requested this contribution.
Human review of this PR: no — fully automated preparation on the submitting side. Maintainer review and hardware validation are recorded separately in this PR.
