### PR TITLE
fix: read JSON PID metadata correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Thanks to eunwoo song for the retrieval fix below (#1128) and to timkjr for the 
 
 ### Fixed
 
+- **CLI lifecycle JSON PID metadata parsing (#1210)**: `memory launch` now reads the structured PID file written by `_write_pid()` without eagerly evaluating the legacy integer fallback. A second launch therefore recognizes the live managed process instead of treating it as stale and replacing it. Legacy integer PID files remain supported.
+
 - **Tag search now honors `match_all=True` (#1196).** The MCP `search_by_tag` path applies AND matching through storage instead of returning OR results labelled `ALL`. Default ANY matching, tag normalization, and empty queries retain their existing behavior. Regression tests assert exact result sets against real SQLite storage.
 
 - **fix(storage): apply eligibility filters before the nearest-neighbour limit (#1128, eunwoo song, closes #1077).** `recall()` and `retrieve()` asked sqlite-vec for the k nearest embeddings first and filtered afterwards, so soft-deleted rows, rows outside the requested time window, and rows excluded by tag or supersession consumed the candidate budget before a valid match could be seen. With enough excluded neighbours the result set came back short or empty even though matching memories existed. Both queries now restrict the KNN scan to eligible rowids, so k counts only memories that can actually be returned. The tests run against real sqlite-vec with 4,100 excluded neighbours crowding five valid ones, which is what distinguishes a fix here from a fix that merely reorders the same failure.

--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -73,10 +73,17 @@ def _read_pid() -> int | None:
         # Support both old format (just an int) and new format (JSON with metadata)
         try:
             pid_info = json.loads(content)
-            pid = pid_info.get("pid", int(content)) if isinstance(pid_info, dict) else int(pid_info)
         except (ValueError, TypeError):
-            pid = int(content)
-    except (ValueError, OSError):
+            pid_info = content
+
+        if isinstance(pid_info, dict):
+            pid_value = pid_info.get("pid")
+            if pid_value is None:
+                return None
+        else:
+            pid_value = pid_info
+        pid = int(pid_value)
+    except (ValueError, TypeError, OSError):
         return None
     if _is_process_alive(pid):
         # Validate against stale PID files (PID reuse after reboot)

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -307,3 +307,49 @@ def test_launch_help_text_security_warning():
     assert '--host' in result.output, "Help should show --host option"
     # Check that the help text mentions security concerns
     # The fix adds a warning about binding to non-loopback hosts
+
+
+
+def test_read_pid_accepts_json_metadata_for_live_process(tmp_path, monkeypatch):
+    """A live managed child must survive JSON PID metadata validation."""
+    import json
+    import subprocess
+
+    from mcp_memory_service.cli import lifecycle
+
+    # Match the launcher's stable command-line prefix without importing the
+    # real uvicorn application: a tiny temporary module keeps the child alive.
+    (tmp_path / "uvicorn.py").write_text("import time\ntime.sleep(60)\n")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "mcp_memory_service.web.app:app"],
+        cwd=tmp_path,
+        env=env,
+    )
+
+    pid_path = tmp_path / "server.pid"
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_path)
+    monkeypatch.setattr(lifecycle, "_ensure_dirs", lambda: None)
+
+    try:
+        lifecycle._write_pid(proc.pid)
+        metadata_text = pid_path.read_text()
+        metadata = json.loads(metadata_text)
+        assert metadata["pid"] == proc.pid
+        assert lifecycle._is_stale_pid(pid_path) is False
+        assert lifecycle._read_pid() == proc.pid
+
+        # The structured format must not regress support for pre-metadata PID files.
+        pid_path.write_text(str(proc.pid))
+        assert lifecycle._read_pid() == proc.pid
+        pid_path.write_text(metadata_text)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert lifecycle._is_stale_pid(pid_path) is True


### PR DESCRIPTION
## What this changes

Fixes PID metadata parsing so a second `memory launch` correctly recognizes the already-running managed process instead of treating it as stale.

Legacy integer-only PID files remain supported.

## Why

`_write_pid()` stores structured JSON metadata, but `_read_pid()` eagerly evaluated `int(content)` while reading that JSON. This caused valid metadata to be rejected and `_read_pid()` to return `None` even while the managed process was alive.

Fixes #1210

## How it was verified

A real subprocess regression test was added that writes the same structured PID metadata used by the launcher.

On the base code, the regression test fails as expected:

```text
FAILED tests/unit/test_cli_lifecycle.py::test_read_pid_accepts_json_metadata_for_live_process
AssertionError: assert None == <live process pid>
1 failed
```

With this change, the same regression test passes:

```text
tests/unit/test_cli_lifecycle.py::test_read_pid_accepts_json_metadata_for_live_process
1 passed
```

The test also verifies compatibility with legacy integer-only PID files and confirms that the process is considered stale after it exits.

`python -m py_compile` also completed successfully for the modified source and test files.

## Notes for the reviewer

The fix is intentionally limited to `_read_pid()` parsing. The existing `create_time` and `cmdline_hint` stale-process validation remains unchanged.

## Agent Disclosure

This PR was generated with ChatGPT (GPT-5.6 Sol). The submitting account is operated by Ton (@TonMtt).

Human review of this PR: yes — Ton reviewed the issue context, intended behavior, and test results. The implementation and automated verification were prepared with ChatGPT.