### PR TITLE
fix(storage): apply stale_days on D1 and order stale pages deterministically

### DIFF
--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -1923,6 +1923,13 @@ class CloudflareStorage(MemoryStorage):
                 where_conditions.append("m.memory_type = ?")
                 params.append(memory_type)
 
+            if stale_days is not None and stale_days > 0:
+                where_conditions.append(
+                    "COALESCE(CAST(json_extract(m.metadata_json, "
+                    "'$.last_accessed_at') AS REAL), m.created_at) < ?"
+                )
+                params.append(time.time() - stale_days * 86400)
+
             tag_count = 0
             if tags:
                 tag_count = len(tags)
@@ -1949,7 +1956,7 @@ class CloudflareStorage(MemoryStorage):
                 else:
                     sql += " GROUP BY m.id"
 
-            sql += " ORDER BY m.created_at DESC"
+            sql += " ORDER BY m.created_at DESC, m.id DESC"
 
             if limit is not None:
                 sql += " LIMIT ?"

--- a/src/mcp_memory_service/storage/milvus.py
+++ b/src/mcp_memory_service/storage/milvus.py
@@ -3154,19 +3154,25 @@ class MilvusMemoryStorage(MemoryStorage):
         active_hashes = {row.get("id") for row in active_rows if row.get("id")}
 
         # Collect stale hashes (not recently accessed AND created_at < threshold)
-        stale_hashes: List[str] = []
+        stale_rows: List[Dict[str, Any]] = []
         for row in all_rows:
             rid = row.get("id")
             if rid and rid not in active_hashes:
                 created_at = row.get("created_at", 0)
                 if created_at < threshold:
-                    stale_hashes.append(rid)
+                    stale_rows.append(row)
 
-        if not stale_hashes:
+        if not stale_rows:
             return []
 
+        stale_rows.sort(
+            key=lambda row: (row.get("created_at", 0), row.get("id", "")),
+            reverse=True,
+        )
+        stale_hashes = [row["id"] for row in stale_rows]
+
         # Apply pagination to the stale set
-        # Sort by created_at desc is implicit from _drain_main_ids_and_created_at order
+        # Pagination follows the explicit deterministic stale ordering above.
         paginated = stale_hashes[offset:]
         if limit is not None:
             paginated = paginated[:limit]

--- a/src/mcp_memory_service/storage/mixins/retrieve.py
+++ b/src/mcp_memory_service/storage/mixins/retrieve.py
@@ -583,7 +583,7 @@ class RetrieveMixin:
             self._apply_stale_days_filter(where_conditions, params, stale_days, table_alias="m")
 
             query += ' WHERE ' + ' AND '.join(where_conditions)
-            query += ' ORDER BY m.created_at DESC'
+            query += ' ORDER BY m.created_at DESC, m.content_hash DESC'
 
             if limit is not None:
                 query += ' LIMIT ?'

--- a/tests/storage/test_stale_pagination.py
+++ b/tests/storage/test_stale_pagination.py
@@ -1,0 +1,121 @@
+"""Deterministic ordering and stale filtering in the storage backends."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.cloudflare import CloudflareStorage
+from mcp_memory_service.storage.milvus import MilvusMemoryStorage
+from mcp_memory_service.storage.sqlite_vec import SqliteVecMemoryStorage
+from mcp_memory_service.utils.hashing import generate_content_hash
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_stale_query_filters_before_deterministic_pagination():
+    """D1 applies stale cutoff before deterministic limit and offset."""
+    storage = CloudflareStorage.__new__(CloudflareStorage)
+    storage.d1_url = "https://d1.example"
+    captured = {}
+
+    async def retry(method, url, json):
+        captured.update(method=method, url=url, payload=json)
+        return type(
+            "Response",
+            (),
+            {"json": lambda self: {"success": True, "result": [{"results": []}]}},
+        )()
+
+    storage._retry_request = AsyncMock(side_effect=retry)
+    await storage.get_all_memories(limit=5, offset=10, stale_days=90)
+
+    sql = captured["payload"]["sql"]
+    params = captured["payload"]["params"]
+    assert "json_extract(m.metadata_json, '$.last_accessed_at')" in sql
+    assert " < ?" in sql
+    assert "ORDER BY m.created_at DESC, m.id DESC" in sql
+    assert "LIMIT ?" in sql and "OFFSET ?" in sql
+    assert params[-2:] == [5, 10]
+    assert params[-3] == pytest.approx(time.time() - 90 * 86400, abs=2)
+
+
+@pytest.mark.asyncio
+async def test_milvus_stale_page_sorts_created_at_and_id_before_offset():
+    """Milvus pages stale rows deterministically instead of iterator order."""
+    storage = MilvusMemoryStorage.__new__(MilvusMemoryStorage)
+    storage._write_lock = asyncio.Lock()
+    storage.client = object()
+    storage._has_access_collection = False
+    storage._drain_main_ids_and_created_at = lambda _filter: [
+        {"id": "a", "created_at": 1},
+        {"id": "c", "created_at": 2},
+        {"id": "b", "created_at": 2},
+    ]
+    storage._query_memories = AsyncMock(return_value=[])
+
+    await storage._get_stale_memories(
+        "", stale_days=1, limit=1, offset=1, include_embeddings=True
+    )
+
+    query = storage._query_memories.await_args.kwargs
+    assert 'id == "b"' in query["filter_expr"]
+    assert query["limit"] == 1
+    assert query["include_embeddings"] is True
+
+
+@pytest.mark.asyncio
+async def test_sqlite_vec_stale_page_breaks_created_at_ties_by_content_hash(
+    temp_db_path,
+):
+    """sqlite-vec pages tied timestamps in one fixed order, and covers the tail.
+
+    Six memories share a single ``created_at``. ``ORDER BY m.created_at DESC``
+    alone leaves their relative order up to the scan, so a page boundary can
+    fall in a different place on the next fetch and step over a row. The
+    tie-breaker pins it: the expected order below is content-hash descending,
+    which is deliberately not the insertion order.
+    """
+    storage = SqliteVecMemoryStorage(f"{temp_db_path}/tie_break.db")
+    await storage.initialize()
+    try:
+        shared_created_at = time.time() - 400 * 86400
+        contents = [f"tie-break candidate {index}" for index in range(6)]
+        hashes = []
+        for content in contents:
+            memory = Memory(
+                content=content,
+                content_hash=generate_content_hash(content),
+                tags=["stale-tail"],
+            )
+            success, message = await storage.store(memory)
+            assert success, message
+            hashes.append(memory.content_hash)
+            storage.conn.execute(
+                "UPDATE memories SET created_at = ?, last_accessed = NULL "
+                "WHERE content_hash = ?",
+                (shared_created_at, memory.content_hash),
+            )
+        storage.conn.commit()
+
+        expected = sorted(hashes, reverse=True)
+        # The fix is only observable if the contract order is not the order the
+        # rows were written in; otherwise a scan in rowid order would satisfy
+        # the assertions by accident.
+        assert expected != hashes
+
+        whole = await storage.get_all_memories(stale_days=90)
+        assert [memory.content_hash for memory in whole] == expected
+
+        pages = []
+        for offset in (0, 2, 4):
+            page = await storage.get_all_memories(limit=2, offset=offset, stale_days=90)
+            pages.append([memory.content_hash for memory in page])
+        assert pages == [expected[0:2], expected[2:4], expected[4:6]]
+
+        # Every row seen exactly once across the walk: no skips, no repeats.
+        walked = [content_hash for page in pages for content_hash in page]
+        assert sorted(walked) == sorted(hashes)
+    finally:
+        await storage.close()


### PR DESCRIPTION
Split out of #1205 at your request:

> Split the storage fixes into their own PR now: Cloudflare accepting and ignoring `stale_days`, the `created_at` tie-breakers in sqlite-vec and D1, the explicit Milvus sort. Those stand on their own and get reviewed straight away. Each needs a test that is red on main.

That is all this PR contains. No consolidator changes, no `CHANGELOG.md` edit. It touches three source files and adds one test file, and is based on current `main`.

## The three defects

**1. D1 accepted `stale_days` and ignored it.** `CloudflareStorage.get_all_memories` takes `stale_days` and threads it through the signature, but no WHERE clause was ever built from it. A caller asking for stale memories got the whole table back with no signal that filtering had not happened.

**2. Stale pages were ordered by a non-total ordering.** sqlite-vec and D1 both ordered by `created_at DESC` alone. When rows share a timestamp their relative order is left to the scan, so a page boundary can land in a different place between two fetches and step over a row that is then never returned. This is easy to hit because bulk-ingested memories routinely share a timestamp.

**3. Milvus paginated over iterator order.** `_get_stale_memories` sliced whatever order `_drain_main_ids_and_created_at` happened to yield. The old comment said the ordering was "implicit" from that call; it is not guaranteed, so the same walk could skip or repeat rows.

## What changed

- `storage/cloudflare.py` — filter on `COALESCE(CAST(json_extract(m.metadata_json, '$.last_accessed_at') AS REAL), m.created_at) < ?` before LIMIT/OFFSET, so the cutoff is applied by D1 rather than after the page is cut. Order becomes `created_at DESC, m.id DESC`.
- `storage/mixins/retrieve.py` — order becomes `created_at DESC, m.content_hash DESC`.
- `storage/milvus.py` — sort stale rows explicitly on `(created_at, id)` descending before applying offset and limit.

Callers that do not pass `stale_days` are unaffected. The tie-breakers only decide order among rows whose relative order was previously arbitrary, so nothing that had a defined order changes.

## Each test is red on main

```
$ .venv/bin/python -m pytest tests/storage/test_stale_pagination.py -q
3 passed, 42 warnings in 0.14s
```

Reverting all three source files to `main` while keeping the tests:

```
FAILED tests/storage/test_stale_pagination.py::test_cloudflare_stale_query_filters_before_deterministic_pagination
FAILED tests/storage/test_stale_pagination.py::test_milvus_stale_page_sorts_created_at_and_id_before_offset
FAILED tests/storage/test_stale_pagination.py::test_sqlite_vec_stale_page_breaks_created_at_ties_by_content_hash
3 failed
```

Reverting them one at a time fails exactly the matching test and nothing else:

| reverted file | tests failing |
|---|---|
| `storage/cloudflare.py` | 1 failed, 2 passed — the D1 test |
| `storage/milvus.py` | 1 failed, 2 passed — the Milvus test |
| `storage/mixins/retrieve.py` | 1 failed, 2 passed — the sqlite-vec test |

The sqlite-vec case runs against a real `SqliteVecMemoryStorage`, writes six memories sharing one `created_at`, asserts the expected order is deliberately *not* insertion order (otherwise a rowid scan would satisfy it by accident), then walks it in three pages of two and asserts every row is seen exactly once.

No regressions in the surrounding suite:

```
$ .venv/bin/python -m pytest tests/storage/ -q
246 passed, 13 skipped, 4 xfailed, 1 xpassed, 1864 warnings in 2.99s
```

## What was not verified

- **No live Cloudflare D1 or remote Milvus was called.** The D1 test asserts on the SQL and bound parameters at the `_retry_request` boundary; the Milvus test drives `_get_stale_memories` with a stubbed drain and asserts the filter expression handed to `_query_memories`. Only the sqlite-vec path touches a real database.
- **`ruff` on these three source files goes from 506 findings to 507.** The one added is `UP006` (`Dict` vs `dict`) from `stale_rows: List[Dict[str, Any]]` in `milvus.py`, which matches the 79 existing `Dict` annotations in that file. I kept the file's own convention rather than mixing styles in one function; say the word if you would rather have `list[dict[str, Any]]`. The new test file is clean under `ruff check` and `ruff format --check`.
- I did not touch the hybrid delegation contract. A test for it exists but passes on `main`, so it does not belong in this PR; it can go with the consolidator work.

## Still to come, per your comment on #1205

The `RunTracker` cursor work waits for #1167 to land, then rebases onto its `_get_forgetting_candidates` and adopts `forgetting_min_age_days` instead of `access_threshold_days`. Archive-only forgetting will be raised as a proposal issue rather than folded into a pagination fix.

## Agent Disclosure

This PR was generated by an autonomous Claude Code agent. The submitting account is operated by Divyam Talwar.
Human review of this PR: no — fully automated. The reproduction, the per-file revert matrix and the test counts above were produced by running the commands in this repository; the surrounding claims have not been reviewed by a human.
