### PR TITLE
feat(nli): LLM backend via harvest provider chain (cascade fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -441,6 +441,38 @@ MCP_HYBRID_SEMANTIC_WEIGHT=0.7
 #   memory_consolidate(action="run", horizon="daily")
 
 # =============================================================================
+# NLI CONTRADICTION DETECTION
+# =============================================================================
+# Optional Natural-Language-Inference pass that flags contradictions between a
+# newly stored memory and semantically similar existing ones (4-stage pipeline:
+# entity overlap -> embedding band -> NLI classify -> conflict registration).
+#
+# Master switch. Off by default; nothing runs unless this is truthy
+# (1/true/yes):
+# MCP_NLI_ENABLED=false
+#
+# Also run the pass inline on every store (not just on-demand). Only takes
+# effect when MCP_NLI_ENABLED is on:
+# MCP_NLI_ON_STORE=false
+#
+# Minimum NLI confidence for a pair to be registered as a contradiction:
+# MCP_NLI_CONFIDENCE_THRESHOLD=0.4
+#
+# Classifier backend:
+#   heuristic  keyword/pattern fallback, no ML deps. This is the default.
+#   cascade    LLM via the harvest provider chain (HARVEST_LLM_PROVIDERS) with
+#              graceful fallback to the heuristic on any error.
+#   llm        alias of cascade.
+# When unset it resolves to 'heuristic', so no LLM is ever called by accident.
+# MCP_NLI_BACKEND=heuristic
+#
+# Per-attempt timeout (seconds) for the LLM backend. NOTE: this is applied once
+# PER PROVIDER attempt inside the harvest chain, so the worst case for a single
+# pair is roughly (timeout x number of providers) before it degrades to the
+# heuristic.
+# MCP_NLI_LLM_TIMEOUT=30
+
+# =============================================================================
 # TROUBLESHOOTING
 # =============================================================================
 # Common issues:

--- a/docs/mastery/configuration-guide.md
+++ b/docs/mastery/configuration-guide.md
@@ -77,6 +77,16 @@ TLS:
 - Scheduling (APScheduler-ready):
   - `MCP_SCHEDULE_DAILY` (default `02:00`), `MCP_SCHEDULE_WEEKLY` (default `SUN 03:00`), `MCP_SCHEDULE_MONTHLY` (default `01 04:00`), `MCP_SCHEDULE_QUARTERLY` (default `disabled`), `MCP_SCHEDULE_YEARLY` (default `disabled`).
 
+## Contradiction Detection / NLI (Optional)
+
+Flags contradictions between a newly stored memory and semantically similar existing ones.
+
+- `MCP_NLI_ENABLED`: `true|false` (default `false`). Master switch; nothing runs unless truthy.
+- `MCP_NLI_ON_STORE`: `true|false` (default `false`). Also run the pass inline on every store, not just on demand. Only takes effect when `MCP_NLI_ENABLED` is on.
+- `MCP_NLI_CONFIDENCE_THRESHOLD`: float (default `0.4`). Minimum NLI confidence for a pair to be registered as a contradiction.
+- `MCP_NLI_BACKEND`: `heuristic|cascade|llm` (default `heuristic`). `heuristic` is keyword/pattern-based with no ML deps. `cascade` (alias `llm`) uses the harvest provider chain (`HARVEST_LLM_PROVIDERS`) and degrades gracefully to the heuristic on any error. When unset it resolves to `heuristic`, so no LLM is ever called by accident.
+- `MCP_NLI_LLM_TIMEOUT`: seconds (default `30`). Applied once **per provider attempt** inside the harvest chain, so the worst case for a single pair is roughly `timeout × number of providers` before it falls back to the heuristic.
+
 ## Machine Identification
 
 - `MCP_MEMORY_INCLUDE_HOSTNAME`: `true|false` to tag memories with `source:<hostname>` and include `hostname` metadata.

--- a/src/mcp_memory_service/consolidation/quarantine.py
+++ b/src/mcp_memory_service/consolidation/quarantine.py
@@ -59,7 +59,7 @@ async def check_beliefs_on_store(storage, belief_service, content: str, content_
     if not beliefs:
         return None
 
-    classifier = NLIClassifier(backend="heuristic")
+    classifier = NLIClassifier(backend="auto")
 
     for belief in beliefs[:20]:
         result = await classifier.classify(belief["content"], content)

--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -11,6 +11,7 @@ Install with `pip install .[nli]` when the transformers backend lands.
 
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import List, Tuple
 
@@ -78,9 +79,14 @@ class NLIClassifier:
             if not response or not response.strip():
                 return self._heuristic_classify(premise, hypothesis)
 
-            label = response.strip().lower().split()[0]
+            # Parse the label: take the first alphabetic token, stripped of
+            # punctuation (so "Contradiction." -> "contradiction"). An unknown
+            # or garbled label falls back to the heuristic classifier rather
+            # than being returned as a (wrong) answer — see PR description.
+            first = response.strip().lower().split()[0] if response.strip().split() else ""
+            label = re.sub(r"[^a-z]", "", first)
             if label not in ("entailment", "contradiction", "neutral"):
-                label = "neutral"
+                return self._heuristic_classify(premise, hypothesis)
             return NLIResult(label=label, confidence=0.9 if label != "neutral" else 0.3)
         except Exception as e:
             logger.debug("LLM NLI failed (%s); falling back to heuristic", e)
@@ -198,7 +204,7 @@ async def detect_contradictions_nli(
         return result
 
     # Stage 3: NLI classification
-    classifier = NLIClassifier(backend="heuristic")
+    classifier = NLIClassifier(backend="auto")
     confidence_threshold = float(os.environ.get("MCP_NLI_CONFIDENCE_THRESHOLD", "0.4"))
 
     contradictions = []

--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -44,14 +44,47 @@ class NLIClassifier:
         """Classify relationship between two texts."""
         if self.backend == "heuristic":
             return self._heuristic_classify(premise, hypothesis)
+        if self.backend in ("cascade", "llm"):
+            return await self._llm_classify(premise, hypothesis)
         if not self._warned_unimplemented:
             logger.warning(
                 "NLI backend '%s' is not implemented; returning neutral. "
-                "Only 'heuristic' is currently supported.",
+                "Only 'heuristic' and 'cascade' are supported.",
                 self.backend,
             )
             self._warned_unimplemented = True
         return NLIResult(label="neutral", confidence=0.0)
+
+    async def _llm_classify(self, premise: str, hypothesis: str) -> NLIResult:
+        """LLM-based NLI via the harvest provider chain (cascade fallback).
+
+        Reuses HarvestRewriter._call_llm, which resolves the configured
+        provider chain (HARVEST_LLM_PROVIDERS) with fallback. Any failure
+        degrades gracefully to the heuristic classifier.
+        """
+        try:
+            from ..harvest.rewriter import HarvestRewriter
+
+            rewriter = HarvestRewriter()
+            prompt = (
+                "Classify the relationship between Statement A and Statement B.\n"
+                "Answer with EXACTLY one word: entailment, contradiction, or neutral.\n\n"
+                f"Statement A: {premise[:500]}\n"
+                f"Statement B: {hypothesis[:500]}\n\n"
+                "Classification:"
+            )
+            timeout = float(os.environ.get("MCP_NLI_LLM_TIMEOUT", "30"))
+            response = await rewriter._call_llm(prompt, timeout)
+            if not response or not response.strip():
+                return self._heuristic_classify(premise, hypothesis)
+
+            label = response.strip().lower().split()[0]
+            if label not in ("entailment", "contradiction", "neutral"):
+                label = "neutral"
+            return NLIResult(label=label, confidence=0.9 if label != "neutral" else 0.3)
+        except Exception as e:
+            logger.debug("LLM NLI failed (%s); falling back to heuristic", e)
+            return self._heuristic_classify(premise, hypothesis)
 
     async def classify_batch(self, pairs: List[Tuple[str, str]]) -> List[NLIResult]:
         """Batch classification."""

--- a/src/mcp_memory_service/reasoning/nli.py
+++ b/src/mcp_memory_service/reasoning/nli.py
@@ -32,6 +32,49 @@ class NLIResult:
     confidence: float  # 0.0-1.0
 
 
+_NLI_LABELS = ("entailment", "contradiction", "neutral")
+
+
+def _parse_nli_label(response: str):
+    """Parse an LLM NLI answer into one of the three labels, or None.
+
+    Rules (see review on PR #1215):
+    - Anchor on the FIRST token (word-boundary matching over the whole answer
+      would misread "there is no contradiction" / "not a contradiction" as
+      ``contradiction``; the first-token anchor sends those to the heuristic).
+    - Strip an optional leading ``classification:`` prefix, so a prefixed
+      answer like "Classification: contradiction" still parses.
+    - Reject the whole answer (return None) if a SECOND distinct label appears
+      anywhere in it — a hedged answer like "contradiction, but really neutral"
+      is unparseable and must fall back to the heuristic, not be acted on at
+      0.9 confidence.
+    - Any unknown/garbled first token also returns None.
+
+    Returns the label string, or None when the caller should fall back to the
+    heuristic classifier.
+    """
+    if not response or not response.strip():
+        return None
+
+    text = response.strip().lower()
+
+    # Reject if more than one distinct label is mentioned anywhere (hedging).
+    mentioned = {lbl for lbl in _NLI_LABELS if re.search(rf"\b{lbl}\b", text)}
+    if len(mentioned) > 1:
+        return None
+
+    # Strip an optional leading "classification:" prefix before anchoring.
+    text = re.sub(r"^\s*classification\s*:\s*", "", text)
+
+    tokens = text.split()
+    if not tokens:
+        return None
+    first = re.sub(r"[^a-z]", "", tokens[0])
+    if first not in _NLI_LABELS:
+        return None
+    return first
+
+
 class NLIClassifier:
     """NLI-based contradiction detection with multiple backends."""
 
@@ -76,16 +119,8 @@ class NLIClassifier:
             )
             timeout = float(os.environ.get("MCP_NLI_LLM_TIMEOUT", "30"))
             response = await rewriter._call_llm(prompt, timeout)
-            if not response or not response.strip():
-                return self._heuristic_classify(premise, hypothesis)
-
-            # Parse the label: take the first alphabetic token, stripped of
-            # punctuation (so "Contradiction." -> "contradiction"). An unknown
-            # or garbled label falls back to the heuristic classifier rather
-            # than being returned as a (wrong) answer — see PR description.
-            first = response.strip().lower().split()[0] if response.strip().split() else ""
-            label = re.sub(r"[^a-z]", "", first)
-            if label not in ("entailment", "contradiction", "neutral"):
+            label = _parse_nli_label(response)
+            if label is None:
                 return self._heuristic_classify(premise, hypothesis)
             return NLIResult(label=label, confidence=0.9 if label != "neutral" else 0.3)
         except Exception as e:
@@ -122,6 +157,25 @@ class NLIClassifier:
                     return NLIResult(label="contradiction", confidence=0.55)
 
         return NLIResult(label="neutral", confidence=0.3)
+
+
+async def _classify_band(
+    classifier, source_content, band_hashes, band_memories, confidence_threshold, result
+):
+    """Stage 3 helper: run NLI over the similarity band and collect contradictions.
+
+    Extracted from detect_contradictions_nli to keep that function under the
+    complexity gate (see review on PR #1215). Mutates ``result['nli_calls']``
+    and returns the list of (hash, mem_b_data, nli_result) contradictions.
+    """
+    contradictions = []
+    for h in band_hashes:
+        mem_b_data = band_memories[h]
+        nli_result = await classifier.classify(source_content, mem_b_data["content"])
+        result["nli_calls"] += 1
+        if nli_result.label == "contradiction" and nli_result.confidence >= confidence_threshold:
+            contradictions.append((h, mem_b_data, nli_result))
+    return contradictions
 
 
 async def detect_contradictions_nli(
@@ -206,16 +260,9 @@ async def detect_contradictions_nli(
     # Stage 3: NLI classification
     classifier = NLIClassifier(backend="auto")
     confidence_threshold = float(os.environ.get("MCP_NLI_CONFIDENCE_THRESHOLD", "0.4"))
-
-    contradictions = []
-    for h in band_hashes:
-        mem_b_data = band_memories[h]
-        nli_result = await classifier.classify(mem_a.content, mem_b_data["content"])
-        result["nli_calls"] += 1
-
-        if nli_result.label == "contradiction" and nli_result.confidence >= confidence_threshold:
-            contradictions.append((h, mem_b_data, nli_result))
-
+    contradictions = await _classify_band(
+        classifier, mem_a.content, band_hashes, band_memories, confidence_threshold, result
+    )
     result["pairs_detected"] = len(contradictions)
 
     # Stage 4: Register conflicts (unless dry_run)

--- a/tests/test_nli_llm.py
+++ b/tests/test_nli_llm.py
@@ -1,0 +1,72 @@
+"""Tests for NLIClassifier._llm_classify method."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from mcp_memory_service.reasoning.nli import NLIClassifier, NLIResult
+
+
+@pytest.fixture
+def classifier():
+    return NLIClassifier(backend="llm")
+
+
+@pytest.mark.asyncio
+async def test_returns_contradiction_with_high_confidence(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="contradiction")
+        result = await classifier._llm_classify("A is true", "A is false")
+    assert result.label == "contradiction"
+    assert result.confidence == 0.9
+
+
+@pytest.mark.asyncio
+async def test_returns_entailment_with_high_confidence(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="entailment")
+        result = await classifier._llm_classify("sky is blue", "sky is blue")
+    assert result.label == "entailment"
+    assert result.confidence == 0.9
+
+
+@pytest.mark.asyncio
+async def test_returns_neutral_with_low_confidence(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="neutral")
+        result = await classifier._llm_classify("cats are nice", "weather is warm")
+    assert result.label == "neutral"
+    assert result.confidence == 0.3
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_heuristic_on_empty_response(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="")
+        result = await classifier._llm_classify("redis enabled", "redis disabled")
+    # Heuristic detects enabled/disabled antonym pair
+    assert result.label == "contradiction"
+    assert result.confidence <= 0.6
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_heuristic_on_exception(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+        result = await classifier._llm_classify("feature enabled", "feature disabled")
+    assert result.label == "contradiction"
+    assert result.confidence <= 0.6
+
+
+@pytest.mark.asyncio
+async def test_garbled_output_returns_neutral(classifier):
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="xyzzy blorp 42 random garbage")
+        result = await classifier._llm_classify("some premise", "some hypothesis")
+    assert result.label == "neutral"
+    assert result.confidence == 0.3

--- a/tests/test_nli_llm.py
+++ b/tests/test_nli_llm.py
@@ -63,10 +63,81 @@ async def test_falls_back_to_heuristic_on_exception(classifier):
 
 
 @pytest.mark.asyncio
-async def test_garbled_output_returns_neutral(classifier):
+async def test_garbled_output_falls_back_to_heuristic(classifier):
+    """Unknown/garbled label must fall back to the heuristic classifier,
+    not be returned as a (wrong) answer. Regression for the review on #1215."""
     with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
         instance = MockRewriter.return_value
         instance._call_llm = AsyncMock(return_value="xyzzy blorp 42 random garbage")
-        result = await classifier._llm_classify("some premise", "some hypothesis")
-    assert result.label == "neutral"
-    assert result.confidence == 0.3
+        # heuristic on unrelated texts → neutral; the point is it went through
+        # _heuristic_classify, not that the label happens to be neutral.
+        with patch.object(classifier, "_heuristic_classify",
+                          return_value=NLIResult(label="entailment", confidence=0.42)) as heur:
+            result = await classifier._llm_classify("some premise", "some hypothesis")
+    heur.assert_called_once()
+    assert result.label == "entailment"
+    assert result.confidence == 0.42
+
+
+@pytest.mark.asyncio
+async def test_label_with_trailing_punctuation_is_parsed(classifier):
+    """'Contradiction.' (with a period) must parse as contradiction, not neutral.
+    Regression for the review on #1215 (one-word parser dropped punctuation)."""
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="Contradiction.")
+        result = await classifier._llm_classify("feature enabled", "feature disabled")
+    assert result.label == "contradiction"
+    assert result.confidence == 0.9
+
+
+@pytest.mark.asyncio
+async def test_env_backend_reaches_pipeline(monkeypatch):
+    """INTEGRATION: MCP_NLI_BACKEND=cascade must actually reach the pipeline.
+    Regression for the review on #1215 — detect_contradictions_nli hardcoded
+    NLIClassifier(backend='heuristic'), so the env switch changed nothing.
+
+    This drives the REAL detect_contradictions_nli (not a locally-built
+    classifier), mocking storage+graph up to Stage 3, and asserts the LLM
+    backend selected by the env is the one that runs. Without the fix
+    (backend='auto' at the call-site) the LLM is never called → red on main."""
+    from mcp_memory_service.reasoning import nli as nli_mod
+
+    monkeypatch.setenv("MCP_NLI_ENABLED", "true")
+    monkeypatch.setenv("MCP_NLI_BACKEND", "cascade")
+    called = {"llm": 0}
+
+    async def fake_call_llm(prompt, timeout=30):
+        called["llm"] += 1
+        return "contradiction"
+
+    ha, hb = "hashA", "hashB"
+    mem_a = MagicMock()
+    mem_a.content = "the feature is enabled"
+    mem_a.metadata = {"entities": ["feature"]}
+
+    storage = MagicMock()
+    storage.get_by_hash = AsyncMock(return_value=mem_a)
+    storage.search_memories = AsyncMock(return_value={
+        "memories": [{"content_hash": hb, "content": "the feature is disabled",
+                      "similarity_score": 0.6}]
+    })
+    graph = MagicMock()
+    graph.find_memories_by_entity = AsyncMock(return_value=[ha, hb])
+    graph.store_association = AsyncMock()
+
+    import sys, types
+    # Stub the graph handler module so the in-function import resolves without
+    # triggering the lazy-loaded server package.
+    graph_mod = types.ModuleType("mcp_memory_service.server.handlers.graph")
+    graph_mod.get_graph_storage = AsyncMock(return_value=graph)
+    monkeypatch.setitem(sys.modules, "mcp_memory_service.server.handlers.graph", graph_mod)
+
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        MockRewriter.return_value._call_llm = AsyncMock(side_effect=fake_call_llm)
+        res = await nli_mod.detect_contradictions_nli(storage, memory_hash=ha, dry_run=True)
+
+    assert res["nli_calls"] >= 1, "pipeline never reached NLI classification"
+    assert called["llm"] >= 1, "env backend did not reach the pipeline (LLM never called)"
+
+

--- a/tests/test_nli_llm.py
+++ b/tests/test_nli_llm.py
@@ -92,6 +92,49 @@ async def test_label_with_trailing_punctuation_is_parsed(classifier):
 
 
 @pytest.mark.asyncio
+async def test_hedged_multilabel_falls_back_to_heuristic(classifier):
+    """A hedged answer mentioning two distinct labels is unparseable and must
+    fall back to the heuristic — NOT be acted on at 0.9 confidence.
+    Regression for the second-round review on #1215."""
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="contradiction, but really neutral")
+        with patch.object(classifier, "_heuristic_classify",
+                          return_value=NLIResult(label="neutral", confidence=0.3)) as heur:
+            result = await classifier._llm_classify("some premise", "some hypothesis")
+    heur.assert_called_once()
+    assert result.confidence <= 0.6
+
+
+@pytest.mark.asyncio
+async def test_negated_contradiction_falls_back_to_heuristic(classifier):
+    """'there is no contradiction' must NOT parse as contradiction — the
+    first-token anchor sends it to the heuristic. Regression for #1215
+    (a word-boundary match would wrongly read it as contradiction@0.9)."""
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="there is no contradiction")
+        with patch.object(classifier, "_heuristic_classify",
+                          return_value=NLIResult(label="neutral", confidence=0.3)) as heur:
+            result = await classifier._llm_classify("some premise", "some hypothesis")
+    heur.assert_called_once()
+    assert result.confidence <= 0.6
+
+
+@pytest.mark.asyncio
+async def test_classification_prefix_is_parsed(classifier):
+    """'Classification: contradiction' must parse as contradiction — the
+    optional leading 'classification:' prefix is stripped before anchoring.
+    Regression for the second-round review on #1215."""
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        instance = MockRewriter.return_value
+        instance._call_llm = AsyncMock(return_value="Classification: contradiction")
+        result = await classifier._llm_classify("feature enabled", "feature disabled")
+    assert result.label == "contradiction"
+    assert result.confidence == 0.9
+
+
+@pytest.mark.asyncio
 async def test_env_backend_reaches_pipeline(monkeypatch):
     """INTEGRATION: MCP_NLI_BACKEND=cascade must actually reach the pipeline.
     Regression for the review on #1215 — detect_contradictions_nli hardcoded
@@ -126,7 +169,7 @@ async def test_env_backend_reaches_pipeline(monkeypatch):
     graph.find_memories_by_entity = AsyncMock(return_value=[ha, hb])
     graph.store_association = AsyncMock()
 
-    import sys, types
+    import sys, types  # inline import
     # Stub the graph handler module so the in-function import resolves without
     # triggering the lazy-loaded server package.
     graph_mod = types.ModuleType("mcp_memory_service.server.handlers.graph")
@@ -139,5 +182,43 @@ async def test_env_backend_reaches_pipeline(monkeypatch):
 
     assert res["nli_calls"] >= 1, "pipeline never reached NLI classification"
     assert called["llm"] >= 1, "env backend did not reach the pipeline (LLM never called)"
+
+
+@pytest.mark.asyncio
+async def test_env_backend_reaches_quarantine_call_site(monkeypatch):
+    """INTEGRATION: MCP_NLI_BACKEND=cascade must also reach the SECOND call site,
+    quarantine.check_beliefs_on_store. Regression for the second-round review on
+    #1215 — that call site builds its own NLIClassifier, so it needs its own
+    proof that the env switch is honored there too (the nli.py integration test
+    does not cover it). Red on main if quarantine.py:62 were hardcoded to
+    'heuristic' (LLM never called)."""
+    from mcp_memory_service.consolidation import quarantine as q_mod
+
+    monkeypatch.setenv("MCP_NLI_BACKEND", "cascade")
+    called = {"llm": 0}
+
+    async def fake_call_llm(prompt, timeout=30):
+        called["llm"] += 1
+        return "contradiction"
+
+    belief_service = MagicMock()
+    belief_service.get_beliefs = AsyncMock(return_value=[
+        {"content": "the feature is enabled", "belief_hash": "beliefA"}
+    ])
+    belief_service.challenge_belief = AsyncMock()
+
+    storage = MagicMock()
+    storage.update_memory_metadata = AsyncMock()
+    storage.search_by_tag = AsyncMock(return_value=[])
+
+    with patch("mcp_memory_service.harvest.rewriter.HarvestRewriter") as MockRewriter:
+        MockRewriter.return_value._call_llm = AsyncMock(side_effect=fake_call_llm)
+        res = await q_mod.check_beliefs_on_store(
+            storage, belief_service, "the feature is disabled", "hashNew"
+        )
+
+    assert called["llm"] >= 1, "env backend did not reach the quarantine call site (LLM never called)"
+    assert res is not None and res.get("status") == "quarantined", \
+        "contradiction@0.9 from cascade should have quarantined the memory"
 
 


### PR DESCRIPTION
Toward #1098.

## Section implemented
The NLI backend from the RFC: an LLM-based classifier for contradiction detection, reusing the harvest provider chain (`HARVEST_LLM_PROVIDERS`) so it inherits the configured providers and fallback rather than adding a second config surface.

## What it does
Adds a `cascade`/`llm` backend to `NLIClassifier`. On `classify()`, it prompts the LLM (via `HarvestRewriter._call_llm`) for a one-word relationship (`entailment`/`contradiction`/`neutral`), with confidence 0.9 for definite labels and 0.3 for neutral. **Any failure — empty response, unknown label, exception — degrades gracefully to the existing heuristic classifier.** Opt-in via `MCP_NLI_BACKEND=cascade`; timeout via `MCP_NLI_LLM_TIMEOUT` (default 30s). Premise/hypothesis are truncated to 500 chars.

Default behavior is unchanged (`heuristic` remains the default).

## Tests
6 unit tests: contradiction, entailment, neutral, empty response, exception path, garbled output.

## Red on main
The tests fail without the change (the method does not exist):
```
tests/test_nli_llm.py:19: AttributeError: 'NLIClassifier' object has no attribute '_llm_classify'
```
With the change: `6 passed`.
