### PR TITLE
fix: preserve tag-filtered Cloudflare retrieval results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Thanks to eunwoo song for the retrieval fix below (#1128) and to timkjr for the 
 ### Fixed
 
 - **CLI lifecycle JSON PID metadata parsing (#1210)**: `memory launch` now reads the structured PID file written by `_write_pid()` without eagerly evaluating the legacy integer fallback. A second launch therefore recognizes the live managed process instead of treating it as stale and replacing it. Legacy integer PID files remain supported.
+- **Cloudflare tag-filtered retrieval now over-fetches Vectorize matches (#1209).**
+  Previously, the backend requested only `n_results` nearest matches and applied
+  the tag filter afterward, so closer untagged memories could hide valid tagged
+  results. Tagged searches now fetch a bounded candidate set before filtering and
+  still return at most `n_results` results.
 
 - **Tag search now honors `match_all=True` (#1196).** The MCP `search_by_tag` path applies AND matching through storage instead of returning OR results labelled `ALL`. Default ANY matching, tag normalization, and empty queries retain their existing behavior. Regression tests assert exact result sets against real SQLite storage.
 
@@ -1361,4 +1366,3 @@ First release published from Codeberg (Forgejo). It bundles the post-migration b
 ### Fixed
 
 - **[#687] `Get-McpApiKey` returned first character of API key instead of full key**: A Gemini-suggested refactor in v10.36.3 replaced a working implementation with `($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]`. Unmatched regex capture groups are absent from `$matches` (not `$null`), so when only one group matched the comma expression produced a single-element string, which PowerShell enumerated to its `Char` array — making `[0]` return `'b'` instead of `bxvWZwrI...`. This broke `manage_service.ps1 status` for all Windows users: Version and Backend showed `(unavailable - set MCP_API_KEY in .env for details)` even when the key was correctly configured. Fixed by replacing the comma expression with an explicit `if/elseif` chain using `$matches.ContainsKey(N)` and `[string]` casts. Verified live: returns full 43-character key string, `manage_service.ps1 status` correctly displays Version and Backend.
-

--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -33,6 +33,8 @@ from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
+_MAX_TAG_SEARCH_CANDIDATES = 4096
+
 
 def normalize_tags_for_search(tags: List[str]) -> List[str]:
     """Deduplicate and filter empty tag strings.
@@ -729,7 +731,11 @@ class CloudflareStorage(MemoryStorage):
             # Search Vectorize (without namespace for now)
             search_payload = {
                 "vector": query_embedding,
-                "topK": n_results,
+                "topK": (
+                    min(n_results * 3, _MAX_TAG_SEARCH_CANDIDATES)
+                    if tags
+                    else n_results
+                ),
                 "returnMetadata": "all",
                 "returnValues": False
             }
@@ -760,6 +766,9 @@ class CloudflareStorage(MemoryStorage):
                         relevance_score=match.get("score", 0.0)
                     )
                     results.append(query_result)
+
+            if tags:
+                results = results[:n_results]
 
             # Persist updated metadata for accessed memories
             for result in results:

--- a/tests/storage/test_cloudflare_retrieve.py
+++ b/tests/storage/test_cloudflare_retrieve.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+import httpx
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.cloudflare import CloudflareStorage
+
+
+async def test_retrieve_tag_filter_overfetches_vectorize_matches():
+    storage = CloudflareStorage(
+        api_token="token",
+        account_id="account",
+        vectorize_index="index",
+        d1_database_id="database",
+    )
+    storage._generate_embedding = AsyncMock(return_value=[0.1, 0.2])
+    storage._retry_request = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": {
+                    "matches": [
+                        {"id": "near", "score": 0.9},
+                        {"id": "wanted", "score": 0.8},
+                    ]
+                },
+            },
+        )
+    )
+    storage._load_memory_from_match = AsyncMock(
+        side_effect=[
+            Memory(content="near", content_hash="near", tags=["other"]),
+            Memory(content="wanted", content_hash="wanted", tags=["wanted"]),
+        ]
+    )
+    storage._persist_access_metadata = AsyncMock()
+
+    results = await storage.retrieve("query", n_results=1, tags=["wanted"])
+
+    assert storage._retry_request.call_args.kwargs["json"]["topK"] == 3
+    assert [result.memory.content for result in results] == ["wanted"]


### PR DESCRIPTION
## What this changes

Cloudflare semantic searches with a tag filter now over-fetch up to three times the requested result count before applying the existing tag filter, bounded by 4096 Vectorize candidates. The final result list is still capped at `n_results`.

## Why

`CloudflareStorage.retrieve()` previously requested only `n_results` nearest vectors and filtered tags afterward. Closer untagged memories could therefore consume the entire candidate set and hide matching tagged memories.

Fixes #1209

## How it was verified

- `uv run pytest tests/storage/test_cloudflare_retrieve.py -q` — 1 passed.
- The same regression test against the base branch — failed as expected (`topK` was 1 instead of 3).
- `uv run ruff check tests/storage/test_cloudflare_retrieve.py` — passed.
- `uv run ruff format --check tests/storage/test_cloudflare_retrieve.py` — passed.
- `git diff --check` — passed.
- `bash scripts/pr/pre_pr_check.sh` — full test suite and repository checks passed; local model-backed complexity/security checks were skipped because no local analysis endpoint was available.

## Notes for the reviewer

The test exercises the real `retrieve()` method and mocks only the Vectorize HTTP response plus the subsequent D1/R2 hydration boundary.

## Agent Disclosure
This PR was generated by Codex (GPT-5), an automated coding agent. The submitting account is operated by Louis Deconinck.
Human review of this PR: no — fully automated.