### PR TITLE
fix(cli): prevent stopping unrelated processes without --force

### DIFF
--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -221,6 +221,46 @@ def _find_process_on_port(port: int) -> int | None:
     return None
 
 
+def _process_command_line(pid: int) -> list[str]:
+    """Return a process command line, or an empty list when unavailable."""
+    import psutil  # inline import: keep lifecycle module startup lightweight
+
+    try:
+        return psutil.Process(pid).cmdline()
+    except (psutil.Error, OSError):
+        return []
+
+
+def _is_memory_server_command(command_line: list[str]) -> bool:
+    """Return whether a command line matches the detached launcher."""
+    return any(
+        command_line[index : index + 2] == ["-m", "uvicorn"]
+        and command_line[index + 2].startswith("mcp_memory_service.")
+        for index in range(len(command_line) - 2)
+    )
+
+
+def _stop_process_on_port(port: int, pid: int, force: bool) -> bool:
+    """Stop a listener only when it is ours or the user explicitly forces it."""
+    command_line = _process_command_line(pid)
+    command_display = " ".join(command_line) if command_line else "<unavailable>"
+
+    if not force and not _is_memory_server_command(command_line):
+        raise click.ClickException(
+            f"Refusing to stop PID {pid} on port {port}: its command line "
+            f"does not match MCP Memory Service:\n  {command_display}\n"
+            "Use --force only if you intend to terminate this process."
+        )
+
+    click.echo(f"Freeing port {port} (PID {pid}): {command_display}")
+    if _kill_process(pid):
+        click.echo("Process terminated.")
+        return True
+
+    click.echo(f"Could not terminate PID {pid}.", err=True)
+    return False
+
+
 def _kill_process(pid: int) -> bool:
     """Terminate a process gracefully, then forcefully if needed."""
     try:
@@ -744,7 +784,12 @@ def launch(ctx, http_host, http_port, detach, storage_backend, debug):
 @click.command()
 @click.option("--host", "http_host", default=None, help="Host to check")
 @click.option("--port", "http_port", default=None, type=int, help="Port to check")
-def stop(http_host, http_port):
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Terminate a port owner even when it is not MCP Memory Service",
+)
+def stop(http_host, http_port, force):
     """Stop a background memory server."""
     host = http_host or os.environ.get("MCP_HTTP_HOST", "127.0.0.1")
     port = http_port or int(os.environ.get("MCP_HTTP_PORT", "8000"))
@@ -763,10 +808,7 @@ def stop(http_host, http_port):
         stopped = True
 
     if port_pid and port_pid != pid:
-        click.echo(f"Freeing port {port} (PID {port_pid})...")
-        if _kill_process(port_pid):
-            click.echo("Process terminated.")
-        stopped = True
+        stopped = _stop_process_on_port(port, port_pid, force) or stopped
 
     if stopped:
         time.sleep(0.5)
@@ -775,11 +817,11 @@ def stop(http_host, http_port):
         base_url = _base_url(host, port)
         health, tls_blocked = _probe_health(f"{base_url}/api/health")
         if health:
-            click.echo("Server responds but no managed PID found. Force-stopping by port...")
+            click.echo("Server responds but no managed PID found. Checking port owner...")
             port_pid_now = _find_process_on_port(port)
             if port_pid_now:
-                _kill_process(port_pid_now)
-                click.echo("Server stopped.")
+                if _stop_process_on_port(port, port_pid_now, force):
+                    click.echo("Server stopped.")
             else:
                 click.echo("Could not find process on port. Stop manually.")
         elif tls_blocked:

--- a/src/mcp_memory_service/cli/main.py
+++ b/src/mcp_memory_service/cli/main.py
@@ -497,7 +497,12 @@ def launch(http_host, http_port, detach, storage_backend, debug):
 @cli.command()
 @click.option("--host", "http_host", default=None, help="Host to check")
 @click.option("--port", "http_port", default=None, type=int, help="Port to check")
-def stop(http_host, http_port):
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Terminate a port owner even when it is not MCP Memory Service",
+)
+def stop(http_host, http_port, force):
     """Stop a background memory server."""
     from .lifecycle import stop as _stop
     args = []
@@ -505,6 +510,8 @@ def stop(http_host, http_port):
         args.extend(["--host", str(http_host)])
     if http_port is not None:
         args.extend(["--port", str(http_port)])
+    if force:
+        args.append("--force")
     _stop.main(args=args, prog_name="memory stop", standalone_mode=False)
 
 

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -19,10 +19,19 @@ Tests verify the new launch/stop/restart/info/health/logs commands
 are properly registered and functional.
 """
 
-import sys
 import os
-from unittest.mock import patch, MagicMock
+import socket
+import subprocess
+import sys
+import textwrap
+from unittest.mock import MagicMock
+
 from click.testing import CliRunner
+
+from mcp_memory_service.cli import lifecycle
+
+
+_REAL_KILL_PROCESS = lifecycle._kill_process
 
 # The _kill_process real-signal guard and MCP_HTTP_PORT/HOST pinning live
 # in conftest.py's autouse _lifecycle_process_safety_net fixture -- it
@@ -68,6 +77,157 @@ def test_stop_command_structure():
     param_names = [p.name for p in stop.params]
     assert 'http_host' in param_names
     assert 'http_port' in param_names
+    assert 'force' in param_names
+
+
+def _unused_local_port():
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def _start_listener(command, env=None):
+    proc = subprocess.Popen(
+        command,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert proc.stdout.readline().strip() == "ready"
+    return proc
+
+
+def _foreign_listener(port):
+    code = textwrap.dedent(
+        """
+        import socket
+        import time
+
+        listener = socket.socket()
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", PORT))
+        listener.listen()
+        print("ready", flush=True)
+        time.sleep(60)
+        """
+    ).replace("PORT", str(port))
+    return _start_listener([sys.executable, "-c", code])
+
+
+def _memory_server_listener(tmp_path, port):
+    module_dir = tmp_path / "uvicorn"
+    module_dir.mkdir()
+    (module_dir / "__init__.py").write_text("")
+    (module_dir / "__main__.py").write_text(
+        textwrap.dedent(
+            """
+            import socket
+            import sys
+            import time
+
+            port = int(sys.argv[sys.argv.index("--port") + 1])
+            listener = socket.socket()
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind(("127.0.0.1", port))
+            listener.listen()
+            print("ready", flush=True)
+            time.sleep(60)
+            """
+        )
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path)
+    return _start_listener(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "mcp_memory_service.web.app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        env=env,
+    )
+
+
+def test_memory_server_command_requires_launcher_app_position():
+    """An unrelated Uvicorn process must not match on a later argument."""
+    assert lifecycle._is_memory_server_command(
+        [sys.executable, "-m", "uvicorn", "mcp_memory_service.web.app:app"]
+    )
+    assert not lifecycle._is_memory_server_command(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "unrelated.web:app",
+            "--app-dir",
+            "mcp_memory_service.fake",
+        ]
+    )
+
+
+def test_stop_refuses_to_kill_foreign_listener_without_force(monkeypatch, tmp_path):
+    """A missing PID file must not make stop kill an unrelated service."""
+    port = _unused_local_port()
+    proc = _foreign_listener(port)
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+
+    try:
+        result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
+
+        assert result.exit_code != 0
+        assert str(proc.pid) in result.output
+        assert sys.executable in result.output
+        assert "Refusing to stop" in result.output
+        assert "--force" in result.output
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_stop_kills_untracked_memory_server_listener(monkeypatch, tmp_path):
+    """The lost-PID recovery path still stops a launcher-shaped process."""
+    port = _unused_local_port()
+    proc = _memory_server_listener(tmp_path, port)
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+    monkeypatch.setattr(lifecycle, "_kill_process", _REAL_KILL_PROCESS)
+
+    try:
+        result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
+
+        assert result.exit_code == 0, result.output
+        proc.wait(timeout=5)
+        assert "Server stopped" in result.output
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+def test_stop_force_kills_foreign_listener(monkeypatch, tmp_path):
+    """The explicit force escape hatch can terminate a foreign listener."""
+    port = _unused_local_port()
+    proc = _foreign_listener(port)
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+    monkeypatch.setattr(lifecycle, "_kill_process", _REAL_KILL_PROCESS)
+
+    try:
+        result = CliRunner().invoke(
+            lifecycle.stop, ["--port", str(port), "--force"]
+        )
+
+        assert result.exit_code == 0, result.output
+        proc.wait(timeout=5)
+        assert "Server stopped" in result.output
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
     
 
 


### PR DESCRIPTION
## What this changes

I updated `memory stop` so the missing-PID-file recovery path does not terminate an unrelated process just because it owns the configured port.

The command now checks the listener's command line and only stops it automatically when it matches the MCP Memory Service launcher (`-m uvicorn mcp_memory_service...`). Otherwise, it reports the PID and command, exits non-zero, and suggests `--force`. I also added the `--force` override for intentional termination.

## Why

Previously, a bare `memory stop` could kill any process listening on port 8000 when there was no managed PID. This keeps the lost-PID recovery behavior while making it fail safely for foreign processes.

Fixes #1211.

## How it was verified

I added regression tests using real child processes bound to real free ports. The process detection and termination path under test is not mocked.

With the source changes stashed (tests run against `main`):

```text
3 failed, 1 passed, 11 deselected
```

The failures showed that the original code did not expose `--force` and attempted to terminate the foreign listener.

On this branch, the lifecycle-related suite passed:

```text
94 passed, 1 warning
```

The CI-equivalent project suite also passed:

```text
2897 passed, 100 skipped, 8 deselected, 13 xfailed, 4 xpassed
```

The regression coverage verifies that:

- a foreign listener is refused and remains alive;
- the refusal names the PID and command and suggests `--force`;
- an untracked launcher-shaped MCP Memory Service process is stopped;
- `--force` deliberately stops a foreign listener;
- an unrelated Uvicorn app cannot match through a later argument.

## Notes for the reviewer

If a process command line cannot be read, the command fails safely unless `--force` is supplied.

I also ran `scripts/pr/pre_pr_check.sh`. Its functional test checks passed. The optional AI quality endpoint was unavailable locally, and the import-order check reported existing inline imports in the touched legacy files; I avoided an unrelated broad import refactor.

## Agent Disclosure

This PR was generated with assistance from OpenAI Codex. The submitting account is operated by Vijay Sreekar.

Human review of this PR: yes — I reviewed the issue requirements, implementation approach, diff, safety behavior, and test results before submission.