### PR TITLE
chore: drop ChromaDB from NOTICE, add PyMilvus

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,10 +5,10 @@ This product includes software developed by Heinrich Krupp.
 
 This project uses the following third-party libraries:
 
-- ChromaDB (Apache License 2.0)
 - sentence-transformers (Apache License 2.0)
 - PyTorch (BSD-style license)
 - SQLite-vec (MIT License)
+- PyMilvus (Apache License 2.0)
 - MCP SDK (MIT License)
 - FastAPI (MIT License)
 - ONNX Runtime (MIT License)


### PR DESCRIPTION
NOTICE still credited ChromaDB, which was removed as a backend in v7.x and is not in pyproject.toml or uv.lock. The only remaining mentions in src/ are an S3 hostname for the ONNX model download and a comment in debug.py, neither an import.

PyMilvus (Apache 2.0) is a real optional dependency via the milvus extra and was missing, so it takes the slot.

Documentation-only change, no code touched.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates third-party attribution metadata in `NOTICE`.
- Removes the obsolete ChromaDB entry.
- Adds Apache-2.0-licensed PyMilvus, which is available through the `milvus` optional dependency group.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The attribution-only change appears safe to merge.

The removed library is not part of the distributed package, while the added library is declared and locked as an optional dependency; no actionable issue remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| NOTICE | Replaces the obsolete ChromaDB attribution with the current optional PyMilvus dependency. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop ChromaDB from NOTICE, add Py..."](https://github.com/doobidoo/mcp-memory-service/commit/fab668560f2b11760f02fb1c32e44a79310768d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62945567)</sub>

<!-- /greptile_comment -->