### PR TITLE
ci: skip the suite for NOTICE and .github markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore: ['docs/**', '*.md', 'LICENSE', '.gitignore']
+    paths-ignore: ['docs/**', '*.md', '.github/**/*.md', 'LICENSE', 'NOTICE', '.gitignore']
   pull_request:
     branches: [main]
-    paths-ignore: ['docs/**', '*.md', 'LICENSE', '.gitignore']
+    paths-ignore: ['docs/**', '*.md', '.github/**/*.md', 'LICENSE', 'NOTICE', '.gitignore']
 
 jobs:
   version-drift-check:


### PR DESCRIPTION
Follow-up to #1221, which ran the full suite plus ML extras for a one-line change to NOTICE.

paths-ignore covered LICENSE but not NOTICE. And '*.md' only matches the repository root, so .github/PULL_REQUEST_TEMPLATE.md was not covered either. Both added on push and pull_request.

Checked the ProtectMain ruleset: no required status checks, so a PR that touches only ignored paths can still be merged. CodeQL has no paths filter and keeps running on every PR, which is intended.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the CI workflow so documentation-only changes under `.github/` and changes limited to `NOTICE` do not run the full test suite.
- Adds `.github/**/*.md` and `NOTICE` to `paths-ignore` for pushes to `main`.
- Applies the same exclusions to pull request events.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule issues identified.

The workflow exclusions are valid and symmetrical across push and pull-request events, and the subsequent NOTICE dependency correction accurately reflects the packaged dependencies.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Consistently extends push and pull-request path exclusions to cover GitHub Markdown files and NOTICE. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ci/paths-ignore..."](https://github.com/doobidoo/mcp-memory-service/commit/446fd6f200ef43be731c7e98e1c7eed8b383ea4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62946893)</sub>

<!-- /greptile_comment -->