### PR TITLE
chore: remove four unused imports flagged by CodeQL

### DIFF
--- a/src/mcp_memory_service/storage/mixins/base.py
+++ b/src/mcp_memory_service/storage/mixins/base.py
@@ -10,7 +10,7 @@ import time
 import random
 import threading
 import asyncio
-from typing import List, Any, Optional, Set, Callable
+from typing import List, Optional, Callable
 
 try:
     import sqlite_vec

--- a/src/mcp_memory_service/storage/mixins/migrations.py
+++ b/src/mcp_memory_service/storage/mixins/migrations.py
@@ -8,12 +8,6 @@ import os
 import asyncio
 from pathlib import Path
 
-try:
-    import sqlite_vec
-    from sqlite_vec import serialize_float32
-except ImportError:
-    pass
-
 from ..migration_runner import MigrationRunner
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_memory_service/utils/port_detection.py
+++ b/src/mcp_memory_service/utils/port_detection.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import socket
-import asyncio
 import logging
 from typing import Optional
 from ..config import HTTP_PORT


### PR DESCRIPTION
Clears four of the five open `py/unused-import` code-scanning alerts (563, 561, 522, 521).

Each one was checked for a re-export or a side-effect import before removing it:

- `storage/mixins/base.py:13` — `Any` and `Set` have no use in the file, and the only module importing from `.base` takes `deserialize_embedding`.
- `storage/mixins/migrations.py:12-13` — `sqlite_vec` and `serialize_float32` are unused, and the whole `try/except ImportError` around them goes with them. The extension is loaded in `mixins/base.py`, and the availability contract the rest of the code reads is `SQLITE_VEC_AVAILABLE` there, so this block only shadowed that contract with a local name nothing used.
- `utils/port_detection.py:16` — `asyncio` unused.

Verification: `ruff check --select F401,F841,F811,F821` is clean on the three files (before the change it reported exactly these names); `mcp_memory_service.storage.sqlite_vec`, `.utils.port_detection` and `.storage.mixins.migrations` all import; `pytest tests/storage tests/unit` gives 817 passed, 19 skipped, 5 xfailed, 1 xpassed.

Alert 500 (`py/unused-global-variable`, `_HASH_FALLBACK_WARNED` in `storage/mixins/embeddings.py:382`) is deliberately left alone. The value is read on the next `_initialize_embedding_model()` call, which the intra-procedural check cannot follow; the reads were wired on purpose in #1163 under the decision in #1156. It is dismissed as a false positive rather than patched.

Noticed on the way, not addressed here: `utils/port_detection.py` has no consumer anywhere under `src/`, `tests/`, `scripts/`, `claude-hooks/` or `docs/`. The whole module looks dead and is worth its own issue.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes four unused imports identified by static analysis without changing runtime behavior.
- Removes unused typing imports from the storage base mixin.
- Removes a redundant optional `sqlite_vec` import block from the migrations mixin.
- Removes the unused `asyncio` import from port detection utilities.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the removed imports are unused and no runtime initialization, export, or consumer depends on them.

No actionable failures remain; sqlite-vec initialization still occurs explicitly before migrations, and the other removed names have no internal or external references.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/mcp_memory_service/storage/mixins/base.py | Safely removes unused `Any` and `Set` typing imports with no consumers or runtime annotation dependencies. |
| src/mcp_memory_service/storage/mixins/migrations.py | Safely removes redundant sqlite-vec imports while preserving the existing availability check and explicit extension-loading path. |
| src/mcp_memory_service/utils/port_detection.py | Safely removes an unused `asyncio` import; async syntax does not require the module binding. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove four unused imports flagge..."](https://github.com/doobidoo/mcp-memory-service/commit/d99fb7594e701b8f73c7315619a7a55fb15cb852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63038621)</sub>

<!-- /greptile_comment -->