### PR TITLE
fix: guard lifecycle process ownership

### DIFF
--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -455,6 +455,28 @@ def _recorded_port() -> int | None:
     return port if 1 <= port <= 65535 else None
 
 
+def _resolve_lifecycle_port(http_port: int | None) -> int:
+    """Resolve the port for commands that operate on an existing server."""
+    if http_port is not None:
+        return http_port
+    configured_port = os.environ.get("MCP_HTTP_PORT")
+    if configured_port is not None:
+        return int(configured_port)
+    return _recorded_port() or 8000
+
+
+def _refuse_recorded_port_mismatch(pid: int | None, port: int) -> bool:
+    """Report and reject a lifecycle operation targeting the wrong port."""
+    recorded_port = _recorded_port()
+    if pid and recorded_port is not None and recorded_port != port:
+        click.echo(
+            f"Refusing to stop PID {pid}: PID file records port "
+            f"{recorded_port}, not requested port {port}."
+        )
+        return True
+    return False
+
+
 def _base_url(host: str, port: int, scheme: str | None = None) -> str:
     scheme = scheme or _recorded_scheme() or ("https" if _is_https_enabled() else "http")
     return f"{scheme}://{host}:{port}"
@@ -826,19 +848,16 @@ def launch(ctx, http_host, http_port, detach, storage_backend, debug):
 def stop(http_host, http_port, force):
     """Stop a background memory server."""
     host = http_host or os.environ.get("MCP_HTTP_HOST", "127.0.0.1")
-    port = http_port or int(os.environ.get("MCP_HTTP_PORT", "8000"))
+    port = _resolve_lifecycle_port(http_port)
 
     pid = _read_pid()
-    recorded_port = _recorded_port()
+    if _refuse_recorded_port_mismatch(pid, port):
+        return False
+
     port_pid = _find_process_on_port(port)
     stopped = False
 
-    if pid and recorded_port is not None and recorded_port != port:
-        click.echo(
-            f"Refusing to stop PID {pid}: PID file records port "
-            f"{recorded_port}, not requested port {port}."
-        )
-    elif pid and port_pid in (None, pid):
+    if pid and port_pid in (None, pid):
         click.echo(f"Stopping PID {pid}...")
         if _stop_process_on_port(port, pid, force):
             _remove_pid()
@@ -896,7 +915,10 @@ def restart(ctx, http_host, http_port, storage_backend, debug):
     server's health endpoint before restarting.
     """
     host = http_host or os.environ.get("MCP_HTTP_HOST", "127.0.0.1")
-    port = http_port or int(os.environ.get("MCP_HTTP_PORT", "8000"))
+    port = _resolve_lifecycle_port(http_port)
+    pid = _read_pid()
+    if _refuse_recorded_port_mismatch(pid, port):
+        return
     base_url = _base_url(host, port)
     
     # If storage_backend not specified, try to read it from the running server
@@ -919,9 +941,11 @@ def restart(ctx, http_host, http_port, storage_backend, debug):
             )
     
     click.echo("Restarting server...")
-    ctx.invoke(stop, http_host=http_host, http_port=http_port)
+    stopped = ctx.invoke(stop, http_host=http_host, http_port=port)
+    if stopped is False:
+        return
     time.sleep(1)
-    ctx.invoke(launch, http_host=http_host, http_port=http_port,
+    ctx.invoke(launch, http_host=http_host, http_port=port,
                detach=True, storage_backend=storage_backend, debug=debug)
 
 

--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -804,7 +804,7 @@ def stop(http_host, http_port, force):
     port_pid = _find_process_on_port(port)
     stopped = False
 
-    if pid and port_pid == pid:
+    if pid and port_pid in (None, pid):
         click.echo(f"Stopping PID {pid}...")
         if _stop_process_on_port(port, pid, force):
             _remove_pid()

--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -652,8 +652,7 @@ def launch(ctx, http_host, http_port, detach, storage_backend, debug):
     # Kill stale process on the port if any
     port_pid = _find_process_on_port(port)
     if port_pid and port_pid != existing_pid:
-        click.echo(f"Freeing port {port} (stale PID {port_pid})...")
-        _kill_process(port_pid)
+        _stop_process_on_port(port, port_pid, force=False)
         time.sleep(0.5)
 
     if not detach:
@@ -805,14 +804,15 @@ def stop(http_host, http_port, force):
     port_pid = _find_process_on_port(port)
     stopped = False
 
-    if pid:
+    if pid and port_pid == pid:
         click.echo(f"Stopping PID {pid}...")
-        if _kill_process(pid):
-            click.echo("Process terminated.")
-        else:
-            click.echo(f"Could not terminate PID {pid}.", err=True)
-        _remove_pid()
-        stopped = True
+        if _stop_process_on_port(port, pid, force):
+            _remove_pid()
+            stopped = True
+    elif pid:
+        click.echo(
+            f"Refusing to stop PID {pid}: it does not own port {port}."
+        )
 
     if port_pid and port_pid != pid:
         stopped = _stop_process_on_port(port, port_pid, force) or stopped

--- a/src/mcp_memory_service/cli/lifecycle.py
+++ b/src/mcp_memory_service/cli/lifecycle.py
@@ -95,13 +95,18 @@ def _read_pid() -> int | None:
     return None
 
 
-def _write_pid(pid: int, scheme: str = "http") -> None:
+def _write_pid(
+    pid: int, scheme: str = "http", port: int | None = None
+) -> None:
     _ensure_dirs()
-    # Record PID alongside process creation time and cmdline hint to detect
-    # stale PID files after reboot or PID reuse. The scheme records what the
-    # server was actually launched with, so later commands probe the right
-    # one instead of re-deriving it -- see _recorded_scheme().
+    # Record PID alongside the port, process creation time, and cmdline hint.
+    # The port is ground truth for stop: a PID file must not make a process
+    # serving a different port look like the requested server. The scheme
+    # records what the server was actually launched with, so later commands
+    # probe the right one instead of re-deriving it -- see _recorded_scheme().
     pid_info = {"pid": pid, "scheme": scheme}
+    if port is not None:
+        pid_info["port"] = port
     try:
         import psutil  # inline import: deferred so this third-party dependency doesn't load at module import time, matching this module's fast-load design
         proc = psutil.Process(pid)
@@ -427,6 +432,29 @@ def _recorded_scheme() -> str | None:
     return scheme if scheme in ("http", "https") else None
 
 
+def _recorded_port() -> int | None:
+    """Return the server port recorded in the PID file, if available.
+
+    Older PID files do not contain a port. Returning None for those files
+    preserves the legacy command-line ownership fallback in ``stop``.
+    """
+    pid_path = _pid_file()
+    try:
+        pid_info = json.loads(pid_path.read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(pid_info, dict):
+        return None
+    port = pid_info.get("port")
+    if isinstance(port, bool) or port is None:
+        return None
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        return None
+    return port if 1 <= port <= 65535 else None
+
+
 def _base_url(host: str, port: int, scheme: str | None = None) -> str:
     scheme = scheme or _recorded_scheme() or ("https" if _is_https_enabled() else "http")
     return f"{scheme}://{host}:{port}"
@@ -725,7 +753,7 @@ def launch(ctx, http_host, http_port, detach, storage_backend, debug):
         log_err_handle.close()
         raise
 
-    _write_pid(proc.pid, scheme=tls.scheme)
+    _write_pid(proc.pid, scheme=tls.scheme, port=port)
 
     # Poll health endpoint until server is ready
     click.echo("Waiting for server to start...")
@@ -801,10 +829,16 @@ def stop(http_host, http_port, force):
     port = http_port or int(os.environ.get("MCP_HTTP_PORT", "8000"))
 
     pid = _read_pid()
+    recorded_port = _recorded_port()
     port_pid = _find_process_on_port(port)
     stopped = False
 
-    if pid and port_pid in (None, pid):
+    if pid and recorded_port is not None and recorded_port != port:
+        click.echo(
+            f"Refusing to stop PID {pid}: PID file records port "
+            f"{recorded_port}, not requested port {port}."
+        )
+    elif pid and port_pid in (None, pid):
         click.echo(f"Stopping PID {pid}...")
         if _stop_process_on_port(port, pid, force):
             _remove_pid()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,7 +21,7 @@ def _refuse_real_kill(pid):
 
 
 @pytest.fixture(autouse=True)
-def _lifecycle_process_safety_net(monkeypatch):
+def _lifecycle_process_safety_net(monkeypatch, tmp_path):
     """Structural guard, not per-test discipline: any test anywhere under
     tests/unit/ that reaches lifecycle._kill_process without mocking it
     gets a loud AssertionError instead of a real signal -- this is the
@@ -42,6 +42,7 @@ def _lifecycle_process_safety_net(monkeypatch):
     lifecycle.py's own commands never read that cached value, they call
     os.environ.get("MCP_HTTP_PORT", "8000") directly at call time, which
     is exactly when this fixture's monkeypatch.setenv is in effect."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     from mcp_memory_service.cli import lifecycle
     monkeypatch.setattr(lifecycle, "_kill_process", _refuse_real_kill)
     monkeypatch.setenv("MCP_HTTP_HOST", "127.0.0.1")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,6 +43,7 @@ def _lifecycle_process_safety_net(monkeypatch, tmp_path):
     os.environ.get("MCP_HTTP_PORT", "8000") directly at call time, which
     is exactly when this fixture's monkeypatch.setenv is in effect."""
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     from mcp_memory_service.cli import lifecycle
     monkeypatch.setattr(lifecycle, "_kill_process", _refuse_real_kill)
     monkeypatch.setenv("MCP_HTTP_HOST", "127.0.0.1")

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -236,7 +236,12 @@ def test_stop_does_not_kill_pid_file_process_on_different_port(monkeypatch, tmp_
     kill_process = MagicMock(return_value=True)
     monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
     monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
-    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: 9876)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_command_line",
+        lambda pid: [sys.executable, "-c", "foreign listener"],
+    )
     monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
     monkeypatch.setattr(
         lifecycle, "_probe_health", lambda *args, **kwargs: (None, False)
@@ -244,9 +249,30 @@ def test_stop_does_not_kill_pid_file_process_on_different_port(monkeypatch, tmp_
 
     result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
 
-    assert result.exit_code == 0, result.output
-    assert "does not own port" in result.output
+    assert result.exit_code != 0, result.output
+    assert "Refusing to stop PID 9876" in result.output
     kill_process.assert_not_called()
+
+
+def test_stop_falls_back_to_pid_file_when_port_owner_is_unknown(monkeypatch, tmp_path):
+    """A known MCP server PID can be stopped when port probing is unavailable."""
+    port = _unused_local_port()
+    kill_process = MagicMock(return_value=True)
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_command_line",
+        lambda pid: [sys.executable, "-m", "uvicorn", "mcp_memory_service.web.app:app"],
+    )
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+
+    result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
+
+    assert result.exit_code == 0, result.output
+    assert "Server stopped" in result.output
+    kill_process.assert_called_once_with(4321)
 
 
 def test_launch_refuses_to_kill_foreign_listener(monkeypatch):

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -228,6 +228,57 @@ def test_stop_force_kills_foreign_listener(monkeypatch, tmp_path):
         if proc.poll() is None:
             proc.terminate()
             proc.wait(timeout=5)
+
+
+def test_stop_does_not_kill_pid_file_process_on_different_port(monkeypatch, tmp_path):
+    """A PID file must not override the requested port ownership check."""
+    port = _unused_local_port()
+    kill_process = MagicMock(return_value=True)
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+    monkeypatch.setattr(
+        lifecycle, "_probe_health", lambda *args, **kwargs: (None, False)
+    )
+
+    result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
+
+    assert result.exit_code == 0, result.output
+    assert "does not own port" in result.output
+    kill_process.assert_not_called()
+
+
+def test_launch_refuses_to_kill_foreign_listener(monkeypatch):
+    """Launch must use the same command-line ownership check as stop."""
+    port = _unused_local_port()
+    kill_process = MagicMock(return_value=True)
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: None)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: 4321)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_command_line",
+        lambda pid: [sys.executable, "-c", "foreign listener"],
+    )
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+    monkeypatch.setattr(lifecycle, "_ensure_dirs", lambda: None)
+    monkeypatch.setattr(lifecycle, "_log_file", lambda: MagicMock())
+    monkeypatch.setattr("builtins.open", lambda *args, **kwargs: MagicMock())
+    monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+    monkeypatch.setattr(
+        lifecycle.subprocess, "Popen", MagicMock(return_value=MagicMock(pid=1234))
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_probe_health",
+        lambda *args, **kwargs: ({"status": "healthy"}, False),
+    )
+
+    result = CliRunner().invoke(lifecycle.launch, ["--port", str(port)])
+
+    assert result.exit_code != 0
+    assert "Refusing to stop" in result.output
+    kill_process.assert_not_called()
     
 
 

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -278,6 +278,32 @@ def test_stop_stops_pid_file_process_when_recorded_port_matches(monkeypatch, tmp
     kill_process.assert_called_once_with(4321)
 
 
+def test_stop_uses_recorded_port_when_no_cli_or_environment_port(monkeypatch, tmp_path):
+    """A fresh shell can stop a server launched on its recorded port."""
+    recorded_port = 8443
+    kill_process = MagicMock(return_value=True)
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(
+        json.dumps({"pid": 4321, "scheme": "http", "port": recorded_port})
+    )
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_command_line",
+        lambda pid: [sys.executable, "-m", "uvicorn", "mcp_memory_service.web.app:app"],
+    )
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+    monkeypatch.delenv("MCP_HTTP_PORT", raising=False)
+
+    result = CliRunner().invoke(lifecycle.stop, [])
+
+    assert result.exit_code == 0, result.output
+    assert "Server stopped" in result.output
+    kill_process.assert_called_once_with(4321)
+
+
 def test_stop_refuses_pid_file_process_when_recorded_port_differs(monkeypatch, tmp_path):
     """A PID file for another port must not terminate its recorded process."""
     requested_port = 8765
@@ -291,9 +317,8 @@ def test_stop_refuses_pid_file_process_when_recorded_port_differs(monkeypatch, t
     monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
     monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
     monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
-    monkeypatch.setattr(
-        lifecycle, "_probe_health", lambda *args, **kwargs: (None, False)
-    )
+    probe_health = MagicMock(return_value=(None, False))
+    monkeypatch.setattr(lifecycle, "_probe_health", probe_health)
 
     result = CliRunner().invoke(lifecycle.stop, ["--port", str(requested_port)])
 
@@ -302,7 +327,85 @@ def test_stop_refuses_pid_file_process_when_recorded_port_differs(monkeypatch, t
         f"PID file records port {recorded_port}, not requested port {requested_port}"
         in result.output
     )
+    assert "Server is not running" not in result.output
     kill_process.assert_not_called()
+    probe_health.assert_not_called()
+
+
+def test_lifecycle_port_precedence(monkeypatch, tmp_path):
+    """Lifecycle ports prefer CLI, set environment, PID file, then default."""
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "port": 8443}))
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+
+    monkeypatch.setenv("MCP_HTTP_PORT", "9443")
+    assert lifecycle._resolve_lifecycle_port(7443) == 7443
+    assert lifecycle._resolve_lifecycle_port(None) == 9443
+
+    monkeypatch.delenv("MCP_HTTP_PORT")
+    assert lifecycle._resolve_lifecycle_port(None) == 8443
+
+    pid_file.write_text(json.dumps({"pid": 4321}))
+    assert lifecycle._resolve_lifecycle_port(None) == 8000
+
+
+def test_restart_refuses_recorded_port_mismatch_before_health_probe(
+    monkeypatch, tmp_path
+):
+    """Restart must not probe or stop when its requested port mismatches the PID file."""
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "port": 8443}))
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    probe_health = MagicMock(return_value=({"status": "healthy"}, False))
+    monkeypatch.setattr(lifecycle, "_probe_health", probe_health)
+    stop = MagicMock()
+    monkeypatch.setattr(lifecycle, "stop", stop)
+
+    result = CliRunner().invoke(lifecycle.restart, ["--port", "8000"])
+
+    assert result.exit_code == 0, result.output
+    assert "Refusing to stop PID 4321" in result.output
+    probe_health.assert_not_called()
+    stop.assert_not_called()
+
+
+def test_restart_uses_recorded_port_when_no_cli_or_environment_port(
+    monkeypatch, tmp_path
+):
+    """Restart carries the recorded port through both stop and launch."""
+    recorded_port = 8443
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(
+        json.dumps({"pid": 4321, "scheme": "http", "port": recorded_port})
+    )
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+    monkeypatch.setattr(
+        lifecycle, "_probe_health", lambda *args, **kwargs: (None, False)
+    )
+    monkeypatch.delenv("MCP_HTTP_PORT", raising=False)
+
+    calls = []
+
+    from click import command
+
+    @command("fake-stop")
+    def fake_stop(**kwargs):
+        calls.append(("stop", kwargs))
+        return True
+
+    @command("fake-launch")
+    def fake_launch(**kwargs):
+        calls.append(("launch", kwargs))
+        return True
+
+    monkeypatch.setattr(lifecycle, "stop", fake_stop)
+    monkeypatch.setattr(lifecycle, "launch", fake_launch)
+    result = CliRunner().invoke(lifecycle.restart, [])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0][1]["http_port"] == recorded_port
+    assert calls[1][1]["http_port"] == recorded_port
 
 
 def test_stop_legacy_pid_file_keeps_command_line_fallback(monkeypatch, tmp_path):

--- a/tests/unit/test_cli_lifecycle.py
+++ b/tests/unit/test_cli_lifecycle.py
@@ -19,6 +19,7 @@ Tests verify the new launch/stop/restart/info/health/logs commands
 are properly registered and functional.
 """
 
+import json
 import os
 import socket
 import subprocess
@@ -254,11 +255,63 @@ def test_stop_does_not_kill_pid_file_process_on_different_port(monkeypatch, tmp_
     kill_process.assert_not_called()
 
 
-def test_stop_falls_back_to_pid_file_when_port_owner_is_unknown(monkeypatch, tmp_path):
-    """A known MCP server PID can be stopped when port probing is unavailable."""
+def test_stop_stops_pid_file_process_when_recorded_port_matches(monkeypatch, tmp_path):
+    """A matching recorded port permits the PID-file fallback."""
     port = _unused_local_port()
     kill_process = MagicMock(return_value=True)
-    monkeypatch.setattr(lifecycle, "_pid_file", lambda: tmp_path / "server.pid")
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "scheme": "http", "port": port}))
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(
+        lifecycle,
+        "_process_command_line",
+        lambda pid: [sys.executable, "-m", "uvicorn", "mcp_memory_service.web.app:app"],
+    )
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+
+    result = CliRunner().invoke(lifecycle.stop, ["--port", str(port)])
+
+    assert result.exit_code == 0, result.output
+    assert "Server stopped" in result.output
+    kill_process.assert_called_once_with(4321)
+
+
+def test_stop_refuses_pid_file_process_when_recorded_port_differs(monkeypatch, tmp_path):
+    """A PID file for another port must not terminate its recorded process."""
+    requested_port = 8765
+    recorded_port = 8000
+    kill_process = MagicMock(return_value=True)
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(
+        json.dumps({"pid": 4321, "scheme": "http", "port": recorded_port})
+    )
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
+    monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
+    monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
+    monkeypatch.setattr(lifecycle, "_kill_process", kill_process)
+    monkeypatch.setattr(
+        lifecycle, "_probe_health", lambda *args, **kwargs: (None, False)
+    )
+
+    result = CliRunner().invoke(lifecycle.stop, ["--port", str(requested_port)])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        f"PID file records port {recorded_port}, not requested port {requested_port}"
+        in result.output
+    )
+    kill_process.assert_not_called()
+
+
+def test_stop_legacy_pid_file_keeps_command_line_fallback(monkeypatch, tmp_path):
+    """PID files without a port retain the pre-port-recording behavior."""
+    port = _unused_local_port()
+    kill_process = MagicMock(return_value=True)
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text(json.dumps({"pid": 4321, "scheme": "http"}))
+    monkeypatch.setattr(lifecycle, "_pid_file", lambda: pid_file)
     monkeypatch.setattr(lifecycle, "_read_pid", lambda: 4321)
     monkeypatch.setattr(lifecycle, "_find_process_on_port", lambda value: None)
     monkeypatch.setattr(
@@ -290,7 +343,9 @@ def test_launch_refuses_to_kill_foreign_listener(monkeypatch):
     monkeypatch.setattr(lifecycle, "_ensure_dirs", lambda: None)
     monkeypatch.setattr(lifecycle, "_log_file", lambda: MagicMock())
     monkeypatch.setattr("builtins.open", lambda *args, **kwargs: MagicMock())
-    monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+    monkeypatch.setattr(
+        lifecycle, "_write_pid", lambda pid, scheme="http", port=None: None
+    )
     monkeypatch.setattr(
         lifecycle.subprocess, "Popen", MagicMock(return_value=MagicMock(pid=1234))
     )
@@ -570,10 +625,11 @@ def test_read_pid_accepts_json_metadata_for_live_process(tmp_path, monkeypatch):
     monkeypatch.setattr(lifecycle, "_ensure_dirs", lambda: None)
 
     try:
-        lifecycle._write_pid(proc.pid)
+        lifecycle._write_pid(proc.pid, port=8123)
         metadata_text = pid_path.read_text()
         metadata = json.loads(metadata_text)
         assert metadata["pid"] == proc.pid
+        assert metadata["port"] == 8123
         assert lifecycle._is_stale_pid(pid_path) is False
         assert lifecycle._read_pid() == proc.pid
 

--- a/tests/unit/test_cli_lifecycle_launch_tls.py
+++ b/tests/unit/test_cli_lifecycle_launch_tls.py
@@ -298,6 +298,7 @@ class TestLaunchRecordsScheme:
         assert captured["write_pid"].called
         _, kwargs = captured["write_pid"].call_args
         assert kwargs.get("scheme") == "https", f"scheme not recorded: {kwargs}"
+        assert kwargs.get("port") == 8000, f"port not recorded: {kwargs}"
 
     def test_pidfile_records_http_by_default(self):
         captured = {}
@@ -305,6 +306,7 @@ class TestLaunchRecordsScheme:
         assert result.exit_code == 0, f"{result.output}\n{result.exception}"
         _, kwargs = captured["write_pid"].call_args
         assert kwargs.get("scheme") == "http"
+        assert kwargs.get("port") == 8000
 
     def test_recorded_scheme_drives_the_base_url(self, tmp_path, monkeypatch):
         """A recorded https server is probed over https even though

--- a/tests/unit/test_cli_lifecycle_tls.py
+++ b/tests/unit/test_cli_lifecycle_tls.py
@@ -558,6 +558,7 @@ class TestLaunchDoesNotClobberTlsBlockedServer:
         # 424242 on whatever machine runs this test. Never let a unit test
         # call the real _kill_process with a fabricated PID.
         monkeypatch.setattr(lifecycle, "_kill_process", mock.Mock(return_value=True))
+        monkeypatch.setattr(lifecycle, "_stop_process_on_port", mock.Mock(return_value=True))
         monkeypatch.setattr(lifecycle, "_probe_health", lambda url, timeout=3: (None, True))
 
         runner = CliRunner()

--- a/tests/unit/test_cli_lifecycle_tls.py
+++ b/tests/unit/test_cli_lifecycle_tls.py
@@ -430,7 +430,9 @@ class TestLaunchDoesNotClobberTlsBlockedServer:
             lifecycle, "_log_file", lambda: mock.MagicMock(with_suffix=lambda s: mock.MagicMock())
         )
         monkeypatch.setattr("builtins.open", lambda *a, **k: mock.MagicMock())
-        monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+        monkeypatch.setattr(
+            lifecycle, "_write_pid", lambda pid, scheme="http", port=None: None
+        )
         monkeypatch.setattr(lifecycle.time, "sleep", lambda s: None)
 
         proc = mock.Mock()
@@ -490,7 +492,9 @@ class TestLaunchDoesNotClobberTlsBlockedServer:
             lifecycle, "_log_file", lambda: mock.MagicMock(with_suffix=lambda s: mock.MagicMock())
         )
         monkeypatch.setattr("builtins.open", lambda *a, **k: mock.MagicMock())
-        monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+        monkeypatch.setattr(
+            lifecycle, "_write_pid", lambda pid, scheme="http", port=None: None
+        )
         monkeypatch.setattr(lifecycle.time, "sleep", lambda s: None)
 
         proc = mock.Mock()
@@ -540,7 +544,9 @@ class TestLaunchDoesNotClobberTlsBlockedServer:
             lifecycle, "_log_file", lambda: mock.MagicMock(with_suffix=lambda s: mock.MagicMock())
         )
         monkeypatch.setattr("builtins.open", lambda *a, **k: mock.MagicMock())
-        monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+        monkeypatch.setattr(
+            lifecycle, "_write_pid", lambda pid, scheme="http", port=None: None
+        )
         monkeypatch.setattr(lifecycle.time, "sleep", lambda s: None)
 
         proc = mock.Mock()
@@ -585,7 +591,9 @@ class TestLaunchDoesNotClobberTlsBlockedServer:
             lifecycle, "_log_file", lambda: mock.MagicMock(with_suffix=lambda s: mock.MagicMock())
         )
         monkeypatch.setattr("builtins.open", lambda *a, **k: mock.MagicMock())
-        monkeypatch.setattr(lifecycle, "_write_pid", lambda pid, scheme="http": None)
+        monkeypatch.setattr(
+            lifecycle, "_write_pid", lambda pid, scheme="http", port=None: None
+        )
         monkeypatch.setattr(lifecycle.time, "sleep", lambda s: None)
 
         proc = mock.Mock()


### PR DESCRIPTION
## Summary

- Record the server port in the lifecycle PID file together with the PID and scheme.
- Make `memory stop --port` refuse a PID-file process when the recorded port differs from the requested port.
- Preserve the command-line ownership fallback for legacy PID files that have no recorded port.
- Reuse the existing process-command ownership check for foreign listeners and isolate lifecycle tests from developer-local PID files.

## Tests

- `uv run python -m pytest -q tests/unit/test_cli_lifecycle.py::test_stop_does_not_kill_pid_file_process_on_different_port tests/unit/test_cli_lifecycle.py::test_stop_stops_pid_file_process_when_recorded_port_matches tests/unit/test_cli_lifecycle.py::test_stop_refuses_pid_file_process_when_recorded_port_differs tests/unit/test_cli_lifecycle.py::test_stop_legacy_pid_file_keeps_command_line_fallback tests/unit/test_cli_lifecycle.py::test_launch_refuses_to_kill_foreign_listener tests/unit/test_cli_lifecycle_launch_tls.py::TestLaunchRecordsScheme::test_pidfile_records_https_when_launched_with_tls tests/unit/test_cli_lifecycle_launch_tls.py::TestLaunchRecordsScheme::test_pidfile_records_http_by_default tests/unit/test_cli_lifecycle_tls.py` — 57 passed in the Python 3.13 Linux container; 58 passed in the Windows environment.
- `uv run python -m compileall -q src/mcp_memory_service/cli tests/unit` — passed.
- `git diff --check` — passed for the staged change.

## Compatibility / Known limitations

- PID files without a port field retain the legacy process-command ownership fallback.
- GitHub Actions CI and CodeQL for the current fork head require upstream approval before jobs can run.

Fixes #1224