### PR TITLE
fix(scripts): guard maintenance writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Thanks to eunwoo song for the retrieval fix below (#1128) and to timkjr for the 
 
 ### Fixed
 
+- **Maintenance and Cloudflare scripts no longer write on a `--help` smoke test (#1226).** The Cloudflare integration test and ONNX embedding repair now parse arguments before loading storage code, print the backend and database target, and require confirmation unless `--yes` is passed. The SQLite-only repair refuses Cloudflare and other non-local backends; Cloudflare resource setup has the same target/confirmation guard and a bootstrap helper for deliberate setup runs.
+
 - **CLI lifecycle JSON PID metadata parsing (#1210)**: `memory launch` now reads the structured PID file written by `_write_pid()` without eagerly evaluating the legacy integer fallback. A second launch therefore recognizes the live managed process instead of treating it as stale and replacing it. Legacy integer PID files remain supported.
 
 - **Tag search now honors `match_all=True` (#1196).** The MCP `search_by_tag` path applies AND matching through storage instead of returning OR results labelled `ALL`. Default ANY matching, tag normalization, and empty queries retain their existing behavior. Regression tests assert exact result sets against real SQLite storage.
@@ -1361,4 +1363,3 @@ First release published from Codeberg (Forgejo). It bundles the post-migration b
 ### Fixed
 
 - **[#687] `Get-McpApiKey` returned first character of API key instead of full key**: A Gemini-suggested refactor in v10.36.3 replaced a working implementation with `($matches[1], $matches[2], $matches[3] | Where-Object { $_ -ne $null })[0]`. Unmatched regex capture groups are absent from `$matches` (not `$null`), so when only one group matched the comma expression produced a single-element string, which PowerShell enumerated to its `Char` array — making `[0]` return `'b'` instead of `bxvWZwrI...`. This broke `manage_service.ps1 status` for all Windows users: Version and Backend showed `(unavailable - set MCP_API_KEY in .env for details)` even when the key was correctly configured. Fixed by replacing the comma expression with an explicit `if/elseif` chain using `$matches.ContainsKey(N)` and `[string]` casts. Verified live: returns full 43-character key string, `manage_service.ps1 status` correctly displays Version and Backend.
-

--- a/scripts/installation/bootstrap_cloudflare.sh
+++ b/scripts/installation/bootstrap_cloudflare.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Bootstrap Cloudflare backend for MCP Memory Service.
+# Prerequisites: Cloudflare account, API token, and account ID in .env
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+PYTHON="${ROOT}/.venv/bin/python"
+if [[ ! -x "$PYTHON" ]]; then
+  echo "❌ Project venv not found. Run: uv pip install --python .venv/bin/python -e ."
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  cp .env.example .env
+  echo "✅ Created .env from .env.example"
+fi
+
+if grep -q 'CLOUDFLARE_API_TOKEN=your-cloudflare-api-token-here' .env \
+   || grep -q 'CLOUDFLARE_ACCOUNT_ID=your-account-id-here' .env; then
+  echo ""
+  echo "============================================================"
+  echo "  Cloudflare credentials needed in .env"
+  echo "============================================================"
+  echo ""
+  echo "1. Create account:  https://dash.cloudflare.com/sign-up"
+  echo "2. Copy Account ID from the dashboard sidebar"
+  echo "3. Create API token: https://dash.cloudflare.com/profile/api-tokens"
+  echo "   Use Custom Token with:"
+  echo "     - Vectorize: Edit"
+  echo "     - D1: Edit"
+  echo "     - Workers AI: Read"
+  echo "     - R2: Edit (optional)"
+  echo ""
+  echo "4. Edit ${ROOT}/.env and set:"
+  echo "     CLOUDFLARE_API_TOKEN=..."
+  echo "     CLOUDFLARE_ACCOUNT_ID=..."
+  echo ""
+  echo "5. Re-run: bash scripts/installation/bootstrap_cloudflare.sh"
+  echo "============================================================"
+  exit 1
+fi
+
+echo "🚀 Creating Cloudflare resources..."
+"$PYTHON" scripts/installation/setup_cloudflare_resources.py --no-r2 --write-env --yes
+
+echo ""
+echo "🧪 Running integration test..."
+"$PYTHON" scripts/testing/test_cloudflare_backend.py

--- a/scripts/installation/setup_cloudflare_resources.py
+++ b/scripts/installation/setup_cloudflare_resources.py
@@ -4,16 +4,28 @@ Automated Cloudflare resource setup for MCP Memory Service.
 This script creates the required Cloudflare resources using the HTTP API.
 """
 
+import argparse
+import asyncio
+import logging
 import os
 import sys
-import asyncio
-import json
-import logging
-from typing import Dict, Any, Optional
+from pathlib import Path
+from typing import Any
+
 import httpx
+
+# Load .env from project root when present
+_project_root = Path(__file__).resolve().parents[2]
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(_project_root / ".env", override=False)
+except ImportError:
+    pass
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 class CloudflareSetup:
     def __init__(self, api_token: str, account_id: str):
@@ -21,208 +33,314 @@ class CloudflareSetup:
         self.account_id = account_id
         self.base_url = f"https://api.cloudflare.com/client/v4/accounts/{account_id}"
         self.client = None
-    
+
     async def _get_client(self) -> httpx.AsyncClient:
         if self.client is None:
             headers = {
                 "Authorization": f"Bearer {self.api_token}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
             }
             self.client = httpx.AsyncClient(headers=headers, timeout=30.0)
         return self.client
-    
-    async def _make_request(self, method: str, url: str, **kwargs) -> Dict[str, Any]:
+
+    async def _make_request(self, method: str, url: str, **kwargs) -> dict[str, Any]:
         """Make authenticated request to Cloudflare API."""
         client = await self._get_client()
         response = await client.request(method, url, **kwargs)
-        
+
         if response.status_code not in [200, 201]:
-            logger.error(f"API request failed: {response.status_code} {response.text}")
+            logger.error(
+                "API request failed: %s %s", response.status_code, response.text
+            )
             response.raise_for_status()
-        
+
         return response.json()
-    
+
     async def create_vectorize_index(self, name: str = "mcp-memory-index") -> str:
         """Create Vectorize index and return its ID."""
-        logger.info(f"Creating Vectorize index: {name}")
-        
+        logger.info("Creating Vectorize index: %s", name)
+
         # Use Vectorize v2 API
         vectorize_base = f"{self.base_url}/vectorize/v2/indexes"
-        
+
         # Check if index already exists
         try:
             url = f"{vectorize_base}/{name}"
             result = await self._make_request("GET", url)
             if result.get("success"):
-                logger.info(f"Vectorize index {name} already exists")
+                logger.info("Vectorize index %s already exists", name)
                 return name
         except httpx.HTTPStatusError as e:
             if e.response.status_code != 404:
                 raise
-        
+
         # Create new index
         url = vectorize_base
-        payload = {
-            "name": name,
-            "config": {
-                "dimensions": 768,
-                "metric": "cosine"
-            }
-        }
-        
+        payload = {"name": name, "config": {"dimensions": 768, "metric": "cosine"}}
+
         result = await self._make_request("POST", url, json=payload)
         if result.get("success"):
-            logger.info(f"✅ Created Vectorize index: {name}")
+            logger.info("✅ Created Vectorize index: %s", name)
             return name
         else:
             raise ValueError(f"Failed to create Vectorize index: {result}")
-    
+
     async def create_d1_database(self, name: str = "mcp-memory-db") -> str:
         """Create D1 database and return its ID."""
-        logger.info(f"Creating D1 database: {name}")
-        
+        logger.info("Creating D1 database: %s", name)
+
         # List existing databases to check if it exists
         url = f"{self.base_url}/d1/database"
         result = await self._make_request("GET", url)
-        
+
         if result.get("success"):
             for db in result.get("result", []):
                 if db.get("name") == name:
                     db_id = db.get("uuid")
-                    logger.info(f"D1 database {name} already exists with ID: {db_id}")
+                    logger.info(
+                        "D1 database %s already exists with ID: %s", name, db_id
+                    )
                     return db_id
-        
+
         # Create new database
         payload = {"name": name}
         result = await self._make_request("POST", url, json=payload)
-        
+
         if result.get("success"):
             db_id = result["result"]["uuid"]
-            logger.info(f"✅ Created D1 database: {name} (ID: {db_id})")
+            logger.info("✅ Created D1 database: %s (ID: %s)", name, db_id)
             return db_id
         else:
             raise ValueError(f"Failed to create D1 database: {result}")
-    
+
     async def create_r2_bucket(self, name: str = "mcp-memory-content") -> str:
         """Create R2 bucket and return its name."""
-        logger.info(f"Creating R2 bucket: {name}")
-        
+        logger.info("Creating R2 bucket: %s", name)
+
         # Check if bucket already exists
         try:
             url = f"{self.base_url}/r2/buckets/{name}"
             result = await self._make_request("GET", url)
             if result.get("success"):
-                logger.info(f"R2 bucket {name} already exists")
+                logger.info("R2 bucket %s already exists", name)
                 return name
         except httpx.HTTPStatusError as e:
             if e.response.status_code != 404:
                 raise
-        
+
         # Create new bucket
         url = f"{self.base_url}/r2/buckets"
         payload = {"name": name}
-        
+
         result = await self._make_request("POST", url, json=payload)
         if result.get("success"):
-            logger.info(f"✅ Created R2 bucket: {name}")
+            logger.info("✅ Created R2 bucket: %s", name)
             return name
         else:
             raise ValueError(f"Failed to create R2 bucket: {result}")
-    
+
     async def verify_workers_ai_access(self) -> bool:
         """Verify Workers AI access and embedding model."""
         logger.info("Verifying Workers AI access...")
-        
+
         # Test embedding generation
         url = f"{self.base_url}/ai/run/@cf/baai/bge-base-en-v1.5"
         payload = {"text": ["test embedding"]}
-        
+
         try:
             result = await self._make_request("POST", url, json=payload)
             if result.get("success"):
                 logger.info("✅ Workers AI access verified")
                 return True
             else:
-                logger.warning(f"Workers AI test failed: {result}")
+                logger.warning("Workers AI test failed: %s", result)
                 return False
-        except Exception as e:
-            logger.warning(f"Workers AI verification failed: {e}")
+        except (
+            Exception  # noqa: BLE001 - optional capability must not abort setup
+        ) as e:
+            logger.warning("Workers AI verification failed: %s", e)
             return False
-    
-    async def close(self):
+
+    async def close(self) -> None:
         """Close HTTP client."""
         if self.client:
             await self.client.aclose()
 
-async def main():
+
+def _write_env_file(
+    api_token: str,
+    account_id: str,
+    vectorize_index: str,
+    d1_database_id: str,
+    r2_bucket: str | None = None,
+) -> None:
+    """Update .env in the project root with Cloudflare resource IDs."""
+    env_path = _project_root / ".env"
+    if not env_path.exists():
+        example = _project_root / ".env.example"
+        env_path.write_text(example.read_text(encoding="utf-8"), encoding="utf-8")
+
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    updates = {
+        "CLOUDFLARE_API_TOKEN": api_token,
+        "CLOUDFLARE_ACCOUNT_ID": account_id,
+        "CLOUDFLARE_VECTORIZE_INDEX": vectorize_index,
+        "CLOUDFLARE_D1_DATABASE_ID": d1_database_id,
+        "MCP_MEMORY_STORAGE_BACKEND": "cloudflare",
+    }
+    if r2_bucket:
+        updates["CLOUDFLARE_R2_BUCKET"] = r2_bucket
+
+    seen = set()
+    new_lines = []
+    for line in lines:
+        key = (
+            line.split("=", 1)[0]
+            if "=" in line and not line.strip().startswith("#")
+            else None
+        )
+        if key in updates:
+            new_lines.append(f"{key}={updates[key]}")
+            seen.add(key)
+        else:
+            new_lines.append(line)
+
+    for key, value in updates.items():
+        if key not in seen:
+            new_lines.append(f"{key}={value}")
+
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    print(f"\n✅ Wrote Cloudflare settings to {_project_root / '.env'}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create Cloudflare resources for MCP Memory Service."
+    )
+    parser.add_argument(
+        "--no-r2",
+        action="store_true",
+        help="Skip optional R2 bucket creation",
+    )
+    parser.add_argument(
+        "--write-env",
+        action="store_true",
+        help="Write resource IDs into the project .env file",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Create resources without confirmation",
+    )
+    return parser.parse_args(argv)
+
+
+def _confirm_resource_creation(skip_confirmation: bool) -> bool:
+    if skip_confirmation:
+        return True
+
+    try:
+        answer = input("Create these Cloudflare resources? [y/N]: ")
+    except EOFError:
+        return False
+
+    return answer.strip().lower() in {"y", "yes"}
+
+
+async def main(args: argparse.Namespace) -> bool:
     """Main setup routine."""
     print("🚀 Cloudflare Backend Setup for MCP Memory Service")
     print("=" * 55)
-    
+
     # Check for required environment variables
     api_token = os.getenv("CLOUDFLARE_API_TOKEN")
     account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
-    
-    if not api_token:
-        print("❌ CLOUDFLARE_API_TOKEN environment variable not set")
-        print("Please create an API token at: https://dash.cloudflare.com/profile/api-tokens")
-        print("Required permissions: Vectorize:Edit, D1:Edit, Workers AI:Edit, R2:Edit")
+    placeholder = "your-cloudflare-api-token-here"
+
+    if not api_token or api_token == placeholder:
+        print("❌ CLOUDFLARE_API_TOKEN not set in environment or .env")
+        print("1. Sign up: https://dash.cloudflare.com/sign-up")
+        print("2. Create token: https://dash.cloudflare.com/profile/api-tokens")
+        print("   Permissions: Vectorize:Edit, D1:Edit, Workers AI:Read")
+        print("3. Add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID to .env")
         return False
-    
-    if not account_id:
-        print("❌ CLOUDFLARE_ACCOUNT_ID environment variable not set")
-        print("You can find your account ID in the Cloudflare dashboard sidebar")
+
+    if not account_id or account_id == "your-account-id-here":
+        print("❌ CLOUDFLARE_ACCOUNT_ID not set in environment or .env")
+        print("Find it in the Cloudflare dashboard right sidebar after login.")
         return False
-    
+
+    print("\nTarget configuration:")
+    print("  Backend: Cloudflare")
+    print(f"  Account ID: {account_id}")
+    print("  Vectorize index: mcp-memory-index")
+    print("  D1 database: mcp-memory-db")
+    print(f"  R2 bucket: {'skipped' if args.no_r2 else 'optional'}")
+    print()
+
+    if not _confirm_resource_creation(args.yes):
+        print("Setup cancelled by user.")
+        return True
+
     setup = CloudflareSetup(api_token, account_id)
-    
+
     try:
         # Create resources
         vectorize_index = await setup.create_vectorize_index()
         d1_database_id = await setup.create_d1_database()
-        
+
         # R2 bucket is optional
         r2_bucket = None
-        create_r2 = input("\n🪣 Create R2 bucket for large content storage? (y/N): ").lower().strip()
-        if create_r2 in ['y', 'yes']:
+        create_r2 = not args.no_r2 and input(
+            "\n🪣 Create R2 bucket for large content storage? (y/N): "
+        ).lower().strip() in ["y", "yes"]
+        if create_r2:
             try:
                 r2_bucket = await setup.create_r2_bucket()
-            except Exception as e:
-                logger.warning(f"Failed to create R2 bucket: {e}")
+            except Exception as e:  # noqa: BLE001 - R2 is optional
+                logger.warning("Failed to create R2 bucket: %s", e)
                 logger.warning("Continuing without R2 storage...")
-        
+
         # Verify Workers AI
         ai_available = await setup.verify_workers_ai_access()
-        
+
         print("\n🎉 Setup Complete!")
         print("=" * 20)
         print(f"Vectorize Index: {vectorize_index}")
         print(f"D1 Database ID: {d1_database_id}")
         print(f"R2 Bucket: {r2_bucket or 'Not configured'}")
         print(f"Workers AI: {'Available' if ai_available else 'Limited access'}")
-        
+
         print("\n📝 Environment Variables:")
         print("=" * 25)
-        print(f"export CLOUDFLARE_API_TOKEN=\"{api_token[:10]}...\"")
-        print(f"export CLOUDFLARE_ACCOUNT_ID=\"{account_id}\"")
-        print(f"export CLOUDFLARE_VECTORIZE_INDEX=\"{vectorize_index}\"")
-        print(f"export CLOUDFLARE_D1_DATABASE_ID=\"{d1_database_id}\"")
+        print(f'export CLOUDFLARE_API_TOKEN="{api_token[:10]}..."')
+        print(f'export CLOUDFLARE_ACCOUNT_ID="{account_id}"')
+        print(f'export CLOUDFLARE_VECTORIZE_INDEX="{vectorize_index}"')
+        print(f'export CLOUDFLARE_D1_DATABASE_ID="{d1_database_id}"')
         if r2_bucket:
-            print(f"export CLOUDFLARE_R2_BUCKET=\"{r2_bucket}\"")
-        print("export MCP_MEMORY_STORAGE_BACKEND=\"cloudflare\"")
-        
+            print(f'export CLOUDFLARE_R2_BUCKET="{r2_bucket}"')
+        print('export MCP_MEMORY_STORAGE_BACKEND="cloudflare"')
+
+        if args.write_env:
+            _write_env_file(
+                api_token, account_id, vectorize_index, d1_database_id, r2_bucket
+            )
+
         print("\n🧪 Test the setup:")
-        print("python scripts/testing/test_cloudflare_backend.py")
-        
+        print(".venv/bin/python scripts/testing/test_cloudflare_backend.py")
+
         return True
-        
-    except Exception as e:
-        logger.error(f"Setup failed: {e}")
+
+    except (
+        Exception  # noqa: BLE001 - CLI reports API failures without a traceback
+    ) as e:
+        logger.error("Setup failed: %s", e)
         return False
-    
+
     finally:
         await setup.close()
 
+
 if __name__ == "__main__":
-    success = asyncio.run(main())
+    success = asyncio.run(main(parse_args()))
     sys.exit(0 if success else 1)

--- a/scripts/maintenance/repair_missing_embeddings_onnx.py
+++ b/scripts/maintenance/repair_missing_embeddings_onnx.py
@@ -1,57 +1,132 @@
 #!/usr/bin/env python3
 """Fast repair: generate missing embeddings using the project's ONNX pipeline."""
-import asyncio, sys, logging
+
+import argparse
+import asyncio
+import logging
+import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.mcp_memory_service.storage.factory import create_storage_instance
-from src.mcp_memory_service.config import SQLITE_VEC_PATH
-from sqlite_vec import serialize_float32
-
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 BATCH = 64  # ONNX batch size
 
-async def main():
-    storage = await create_storage_instance(SQLITE_VEC_PATH)
-    s = storage.primary if hasattr(storage, 'primary') else storage
-    s.conn.text_factory = lambda b: b.decode('utf-8', errors='replace')
 
-    cur = s.conn.execute('''
-        SELECT id, content FROM memories
-        WHERE id NOT IN (SELECT rowid FROM memory_embeddings)
-    ''')
-    rows = cur.fetchall()
-    log.info(f"Missing embeddings: {len(rows)}")
-    if not rows:
-        log.info("Nothing to do.")
-        return
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate missing embeddings for the configured database."
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Run the repair without confirmation.",
+    )
+    parser.add_argument(
+        "--allow-non-local",
+        action="store_true",
+        help="Allow the local SQLite repair while the hybrid backend is configured.",
+    )
+    return parser.parse_args(argv)
 
-    fixed = 0
-    for i in range(0, len(rows), BATCH):
-        batch = rows[i:i+BATCH]
-        contents = [r[1] for r in batch]
-        # _generate_embedding accepts a single string; call model directly for batch
-        embeddings = s.embedding_model.encode(contents, convert_to_numpy=True)
-        for (mem_id, _), emb in zip(batch, embeddings):
-            s.conn.execute(
-                'INSERT OR IGNORE INTO memory_embeddings(rowid, content_embedding) VALUES (?, ?)',
-                (mem_id, serialize_float32(emb))
+
+def confirm_write(skip_confirmation: bool) -> bool:
+    if skip_confirmation:
+        return True
+
+    try:
+        answer = input("This operation will modify the database. Continue? [y/N]: ")
+    except EOFError:
+        return False
+
+    return answer.strip().lower() in {"y", "yes"}
+
+
+async def repair_missing_embeddings(database_path: str) -> None:
+    from sqlite_vec import serialize_float32
+
+    from src.mcp_memory_service.storage.factory import create_storage_instance
+
+    storage = await create_storage_instance(database_path)
+    try:
+        s = storage.primary if hasattr(storage, "primary") else storage
+        s.conn.text_factory = lambda b: b.decode("utf-8", errors="replace")
+
+        cur = s.conn.execute("""
+            SELECT id, content FROM memories
+            WHERE id NOT IN (SELECT rowid FROM memory_embeddings)
+            """)
+        rows = cur.fetchall()
+        log.info("Missing embeddings: %d", len(rows))
+        if not rows:
+            log.info("Nothing to do.")
+            return
+
+        fixed = 0
+        for i in range(0, len(rows), BATCH):
+            batch = rows[i : i + BATCH]
+            contents = [r[1] for r in batch]
+            # _generate_embedding accepts one string; call the model directly for a batch.
+            embeddings = s.embedding_model.encode(contents, convert_to_numpy=True)
+            for (mem_id, _), emb in zip(batch, embeddings):
+                s.conn.execute(
+                    """
+                    INSERT OR IGNORE INTO memory_embeddings(rowid, content_embedding)
+                    VALUES (?, ?)
+                    """,
+                    (mem_id, serialize_float32(emb)),
+                )
+            s.conn.commit()
+            fixed += len(batch)
+            log.info(
+                "Progress: %d/%d (%d%%)", fixed, len(rows), fixed * 100 // len(rows)
             )
+
+        deleted = s.conn.execute("""
+            DELETE FROM memory_embeddings
+            WHERE rowid NOT IN (SELECT id FROM memories)
+            """).rowcount
         s.conn.commit()
-        fixed += len(batch)
-        log.info(f"Progress: {fixed}/{len(rows)} ({fixed*100//len(rows)}%)")
+        log.info("Orphaned embeddings deleted: %d", deleted)
+        log.info("Done. Fixed %d missing embeddings.", fixed)
+    finally:
+        await storage.close()
 
-    # Orphaned cleanup
-    deleted = s.conn.execute('''
-        DELETE FROM memory_embeddings
-        WHERE rowid NOT IN (SELECT id FROM memories)
-    ''').rowcount
-    s.conn.commit()
-    log.info(f"Orphaned embeddings deleted: {deleted}")
-    log.info(f"Done. Fixed {fixed} missing embeddings.")
-    await storage.close()
 
-asyncio.run(main())
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    from src.mcp_memory_service.config import SQLITE_VEC_PATH, STORAGE_BACKEND
+
+    database_path = SQLITE_VEC_PATH
+    backend = STORAGE_BACKEND
+
+    print("\nTarget configuration:")
+    print(f"  Backend: {backend}")
+    print(f"  Database: {database_path}")
+    print()
+
+    if database_path is None:
+        print(f"Backend {backend!r} has no local SQLite database to repair.")
+        return 2
+
+    if backend != "sqlite_vec" and not args.allow_non_local:
+        print(
+            "Refusing to run while a non-local backend is configured. "
+            "Use --allow-non-local to explicitly repair the hybrid backend's "
+            "local SQLite database."
+        )
+        return 2
+
+    if not confirm_write(args.yes):
+        print("Operation cancelled by user.")
+        return 0
+
+    asyncio.run(repair_missing_embeddings(database_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/testing/test_cloudflare_backend.py
+++ b/scripts/testing/test_cloudflare_backend.py
@@ -4,56 +4,113 @@ Test script for Cloudflare backend integration.
 Run this after setting up your Cloudflare resources.
 """
 
-import os
-import sys
+import argparse
 import asyncio
 import hashlib
 import logging
-from datetime import datetime
+import os
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
-# Add project root to sys.path so 'src' package is importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
-from src.mcp_memory_service.storage.cloudflare import CloudflareStorage
-from src.mcp_memory_service.models.memory import Memory
+# Add project root to sys.path so 'src' package is importable
+sys.path.insert(0, str(PROJECT_ROOT))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-async def test_cloudflare_backend():
-    """Test all Cloudflare backend functionality."""
-    
-    # Check environment variables
-    required_vars = [
-        'CLOUDFLARE_API_TOKEN',
-        'CLOUDFLARE_ACCOUNT_ID', 
-        'CLOUDFLARE_VECTORIZE_INDEX',
-        'CLOUDFLARE_D1_DATABASE_ID'
-    ]
-    
-    missing_vars = [var for var in required_vars if not os.getenv(var)]
-    if missing_vars:
-        logger.error(f"Missing environment variables: {missing_vars}")
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Cloudflare backend integration tests."
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Run tests without confirmation",
+    )
+    return parser.parse_args(argv)
+
+
+def load_project_env() -> None:
+    """Load the repository .env after argparse has handled --help."""
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+
+    load_dotenv(PROJECT_ROOT / ".env", override=False)
+
+
+def confirm_write(skip_confirmation: bool) -> bool:
+    if skip_confirmation:
+        return True
+
+    try:
+        answer = input(
+            "This test will write to your Cloudflare resources. Continue? [y/N]: "
+        )
+    except EOFError:
         return False
-    
+
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def print_target() -> None:
+    print("\nTarget configuration:")
+    print("  Backend: Cloudflare")
+    print(f"  Account ID: {os.getenv('CLOUDFLARE_ACCOUNT_ID')}")
+    print(f"  Vectorize index: {os.getenv('CLOUDFLARE_VECTORIZE_INDEX')}")
+    print(f"  D1 database ID: {os.getenv('CLOUDFLARE_D1_DATABASE_ID')}")
+    print(f"  R2 bucket: {os.getenv('CLOUDFLARE_R2_BUCKET') or '(not configured)'}")
+    print()
+
+
+def missing_configuration() -> list[str]:
+    placeholders = {
+        "CLOUDFLARE_API_TOKEN": "your-cloudflare-api-token-here",
+        "CLOUDFLARE_ACCOUNT_ID": "your-account-id-here",
+        "CLOUDFLARE_VECTORIZE_INDEX": "your-vectorize-index-name",
+        "CLOUDFLARE_D1_DATABASE_ID": "your-d1-database-id-here",
+    }
+    return [
+        name
+        for name, placeholder in placeholders.items()
+        if not os.getenv(name) or os.getenv(name) == placeholder
+    ]
+
+
+async def test_cloudflare_backend() -> bool:
+    """Test all Cloudflare backend functionality."""
+
+    from src.mcp_memory_service.models.memory import Memory
+    from src.mcp_memory_service.storage.cloudflare import CloudflareStorage
+
+    # Check environment variables
+    missing_vars = missing_configuration()
+    if missing_vars:
+        logger.error("Missing environment variables: %s", missing_vars)
+        return False
+
     try:
         # Initialize storage
         logger.info("🔧 Initializing Cloudflare storage...")
         storage = CloudflareStorage(
-            api_token=os.getenv('CLOUDFLARE_API_TOKEN'),
-            account_id=os.getenv('CLOUDFLARE_ACCOUNT_ID'),
-            vectorize_index=os.getenv('CLOUDFLARE_VECTORIZE_INDEX'),
-            d1_database_id=os.getenv('CLOUDFLARE_D1_DATABASE_ID'),
-            r2_bucket=os.getenv('CLOUDFLARE_R2_BUCKET')  # Optional
+            api_token=os.getenv("CLOUDFLARE_API_TOKEN"),
+            account_id=os.getenv("CLOUDFLARE_ACCOUNT_ID"),
+            vectorize_index=os.getenv("CLOUDFLARE_VECTORIZE_INDEX"),
+            d1_database_id=os.getenv("CLOUDFLARE_D1_DATABASE_ID"),
+            r2_bucket=os.getenv("CLOUDFLARE_R2_BUCKET"),  # Optional
         )
-        
+
         # Test initialization
         logger.info("🚀 Testing storage initialization...")
         await storage.initialize()
         logger.info("✅ Storage initialized successfully")
-        
+
         # Test storing a memory
         logger.info("💾 Testing memory storage...")
         test_content = "This is a test memory for Cloudflare backend integration."
@@ -62,79 +119,96 @@ async def test_cloudflare_backend():
             content_hash=hashlib.sha256(test_content.encode()).hexdigest(),
             tags=["test", "cloudflare", "integration"],
             memory_type="test",
-            metadata={"test_run": datetime.now().isoformat()}
+            metadata={"test_run": datetime.now(timezone.utc).isoformat()},
         )
-        
+
         success, message = await storage.store(test_memory)
         if success:
-            logger.info(f"✅ Memory stored: {message}")
+            logger.info("✅ Memory stored: %s", message)
         else:
-            logger.error(f"❌ Failed to store memory: {message}")
+            logger.error("❌ Failed to store memory: %s", message)
             return False
-        
+
         # Test retrieval
         logger.info("🔍 Testing memory retrieval...")
         results = await storage.retrieve("test memory cloudflare", n_results=5)
         if results:
-            logger.info(f"✅ Retrieved {len(results)} memories")
+            logger.info("✅ Retrieved %d memories", len(results))
             for i, result in enumerate(results):
-                logger.info(f"  {i+1}. Score: {result.similarity_score:.3f} - {result.memory.content[:50]}...")
+                logger.info(
+                    "  %d. Score: %.3f - %.50s...",
+                    i + 1,
+                    result.similarity_score,
+                    result.memory.content,
+                )
         else:
             logger.warning("⚠️  No memories retrieved")
-        
+
         # Test tag search
         logger.info("🏷️  Testing tag search...")
         tag_results = await storage.search_by_tag(["test"])
         if tag_results:
-            logger.info(f"✅ Found {len(tag_results)} memories with 'test' tag")
+            logger.info("✅ Found %d memories with 'test' tag", len(tag_results))
         else:
             logger.warning("⚠️  No memories found with 'test' tag")
-        
+
         # Test statistics
         logger.info("📊 Testing statistics...")
         stats = await storage.get_stats()
-        logger.info(f"✅ Stats: {stats['total_memories']} memories, {stats['status']} status")
-        
+        logger.info(
+            "✅ Stats: %s memories, %s status",
+            stats["total_memories"],
+            stats["status"],
+        )
+
         # Test cleanup (optional - uncomment to clean up test data)
         # logger.info("🧹 Cleaning up test data...")
         # deleted_count, delete_message = await storage.delete_by_tag("test")
-        # logger.info(f"✅ Cleaned up: {delete_message}")
-        
+        # logger.info("✅ Cleaned up: %s", delete_message)
+
         logger.info("🎉 All tests passed! Cloudflare backend is working correctly.")
         return True
-        
-    except Exception as e:
-        logger.error(f"❌ Test failed: {e}")
+
+    except (
+        Exception  # noqa: BLE001 - integration test reports all failures cleanly
+    ) as e:
+        logger.error("❌ Test failed: %s", e)
         return False
-    
+
     finally:
-        if 'storage' in locals():
+        if "storage" in locals():
             await storage.close()
             logger.info("🔒 Storage connection closed")
 
-def print_setup_instructions():
+
+def print_setup_instructions(missing_vars: list[str] | None = None) -> None:
     """Print setup instructions if environment is not configured."""
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("🔧 CLOUDFLARE BACKEND SETUP REQUIRED")
-    print("="*60)
+    print("=" * 60)
+    if missing_vars:
+        print(f"Missing or placeholder settings: {', '.join(missing_vars)}")
+        print()
     print()
     print("Please complete these steps:")
     print()
     print("1. Create API token with these permissions:")
     print("   - Vectorize:Edit")
-    print("   - D1:Edit") 
+    print("   - D1:Edit")
     print("   - Workers AI:Edit")
     print("   - R2:Edit (optional)")
     print()
     print("2. Create Cloudflare resources:")
-    print("   wrangler vectorize create mcp-memory-index --dimensions=768 --metric=cosine")
+    print(
+        "   wrangler vectorize create mcp-memory-index --dimensions=768 --metric=cosine"
+    )
     print("   wrangler d1 create mcp-memory-db")
     print("   wrangler r2 bucket create mcp-memory-content  # optional")
     print()
     print("3. Set environment variables:")
     print("   export CLOUDFLARE_API_TOKEN='your-token'")
     print("   export CLOUDFLARE_ACCOUNT_ID='be0e35a26715043ef8df90253268c33f'")
-    print("   export CLOUDFLARE_VECTORIZE_INDEX='mcp-memory-index'") 
+    print("   export CLOUDFLARE_VECTORIZE_INDEX='mcp-memory-index'")
     print("   export CLOUDFLARE_D1_DATABASE_ID='your-d1-id'")
     print("   export CLOUDFLARE_R2_BUCKET='mcp-memory-content'  # optional")
     print()
@@ -142,15 +216,32 @@ def print_setup_instructions():
     print("   python test_cloudflare_backend.py")
     print()
     print("See docs/cloudflare-setup.md for detailed instructions.")
-    print("="*60)
+    print("=" * 60)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    load_project_env()
+
+    missing_vars = missing_configuration()
+    if missing_vars:
+        print_setup_instructions(missing_vars)
+        return 1
+
+    print_target()
+
+    if not confirm_write(args.yes):
+        print("Tests cancelled by user.")
+        return 0
+
+    success = asyncio.run(test_cloudflare_backend())
+    if success:
+        print("\n🎉 Cloudflare backend is ready for production use!")
+        return 0
+
+    print("\n❌ Tests failed. Check the logs above for details.")
+    return 1
+
 
 if __name__ == "__main__":
-    # Check if basic environment is set up
-    if not all(os.getenv(var) for var in ['CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_ACCOUNT_ID']):
-        print_setup_instructions()
-    else:
-        success = asyncio.run(test_cloudflare_backend())
-        if success:
-            print("\n🎉 Cloudflare backend is ready for production use!")
-        else:
-            print("\n❌ Tests failed. Check the logs above for details.")
+    sys.exit(main())

--- a/tests/maintenance/test_script_cli_safety.py
+++ b/tests/maintenance/test_script_cli_safety.py
@@ -1,0 +1,182 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLOUDFLARE_SCRIPT = REPO_ROOT / "scripts" / "testing" / "test_cloudflare_backend.py"
+SETUP_CLOUDFLARE_SCRIPT = (
+    REPO_ROOT / "scripts" / "installation" / "setup_cloudflare_resources.py"
+)
+
+REPAIR_EMBEDDINGS_SCRIPT = (
+    REPO_ROOT / "scripts" / "maintenance" / "repair_missing_embeddings_onnx.py"
+)
+
+CLOUDFLARE_ENV = {
+    "CLOUDFLARE_API_TOKEN": "test-token",
+    "CLOUDFLARE_ACCOUNT_ID": "test-account",
+    "CLOUDFLARE_VECTORIZE_INDEX": "test-index",
+    "CLOUDFLARE_D1_DATABASE_ID": "test-database",
+}
+
+
+def isolated_env(tmp_path: Path, **overrides: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "MCP_MEMORY_BASE_DIR": str(tmp_path / "base"),
+            "MCP_MEMORY_SQLITE_PATH": str(tmp_path / "memory.db"),
+            **overrides,
+        }
+    )
+    return env
+
+
+def test_cloudflare_help_does_not_run_backend() -> None:
+    result = subprocess.run(
+        [sys.executable, str(CLOUDFLARE_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
+    assert "Run Cloudflare backend integration tests." in result.stdout
+    assert "Initializing Cloudflare storage" not in output
+    assert "Testing memory storage" not in output
+
+
+def test_cloudflare_decline_prints_target_without_running_backend(
+    tmp_path: Path,
+) -> None:
+    result = subprocess.run(
+        [sys.executable, str(CLOUDFLARE_SCRIPT)],
+        input="n\n",
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=isolated_env(tmp_path, **CLOUDFLARE_ENV),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Backend: Cloudflare" in result.stdout
+    assert "Account ID: test-account" in result.stdout
+    assert "Vectorize index: test-index" in result.stdout
+    assert "D1 database ID: test-database" in result.stdout
+    assert "Tests cancelled by user." in result.stdout
+    assert "Initializing Cloudflare storage" not in result.stderr
+    assert "Testing memory storage" not in result.stderr
+
+
+def test_repair_embeddings_help_does_not_run_repair() -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPAIR_EMBEDDINGS_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
+    assert "Generate missing embeddings" in result.stdout
+    assert "Missing embeddings:" not in output
+    assert "Progress:" not in output
+
+
+def test_repair_embeddings_decline_prints_target_without_running_repair(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "memory.db"
+    result = subprocess.run(
+        [sys.executable, str(REPAIR_EMBEDDINGS_SCRIPT)],
+        input="n\n",
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=isolated_env(
+            tmp_path,
+            MCP_MEMORY_STORAGE_BACKEND="sqlite_vec",
+            MCP_MEMORY_SQLITE_PATH=str(database_path),
+        ),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Backend: sqlite_vec" in result.stdout
+    assert f"Database: {database_path}" in result.stdout
+    assert "Operation cancelled by user." in result.stdout
+    assert "Missing embeddings:" not in result.stderr
+    assert "Progress:" not in result.stderr
+    assert not database_path.exists()
+
+
+def test_repair_embeddings_refuses_cloudflare_even_with_yes(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPAIR_EMBEDDINGS_SCRIPT), "--yes"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=isolated_env(
+            tmp_path,
+            MCP_MEMORY_STORAGE_BACKEND="cloudflare",
+            **CLOUDFLARE_ENV,
+        ),
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Backend: cloudflare" in result.stdout
+    assert "Database: None" in result.stdout
+    assert "has no local SQLite database to repair" in result.stdout
+    assert "Missing embeddings:" not in result.stderr
+    assert "Progress:" not in result.stderr
+
+
+def test_cloudflare_setup_help_does_not_create_resources() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SETUP_CLOUDFLARE_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
+    assert "Create Cloudflare resources" in result.stdout
+    assert "Creating Vectorize index" not in output
+    assert "Creating D1 database" not in output
+
+
+def test_cloudflare_setup_decline_prints_target_without_creating_resources(
+    tmp_path: Path,
+) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SETUP_CLOUDFLARE_SCRIPT), "--no-r2"],
+        input="n\n",
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=isolated_env(tmp_path, **CLOUDFLARE_ENV),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Backend: Cloudflare" in result.stdout
+    assert "Account ID: test-account" in result.stdout
+    assert "Vectorize index: mcp-memory-index" in result.stdout
+    assert "D1 database: mcp-memory-db" in result.stdout
+    assert "Setup cancelled by user." in result.stdout
+    assert "Creating Vectorize index" not in result.stderr
+    assert "Creating D1 database" not in result.stderr


### PR DESCRIPTION
## What this changes

- Makes `--help` exit before loading storage backends.
- Prints the backend, database, and Cloudflare resource target before writes.
- Requires confirmation or `--yes` for destructive operations.
- Refuses ONNX repairs against non-local backends.
- Adds a guarded Cloudflare bootstrap helper and regression tests.
- Updates the changelog.

## Why

The maintenance and integration scripts could pick up a production `.env` and perform writes during an apparently harmless `--help` invocation.

Fixes #1226.

## How it was verified

- Safety and Cloudflare tests: 49 passed, 1 expected xfail.
- Ruff: passed.
- Black formatting check: passed.
- Python compilation: passed.
- Bootstrap shell syntax: passed.
- Diff validation: passed.
- The pre-PR gate passed all checks relevant to this change. Its repository-wide suite reports one unrelated existing lifecycle-test failure, `test_launch_command_sends_excluded_handles`, which exhausts its mocked file-handle sequence. This branch does not modify lifecycle code or that test.
- The optional AI quality scan was skipped because no local analysis endpoint was available.

## Notes for the reviewer

No live Cloudflare resources were contacted during verification. The regression tests exercise help, cancellation, target display, and non-local refusal paths without writing data.