### PR TITLE
fix(cloudflare): over-fetch candidates for tag filter in retrieve() (#1209)

### DIFF
--- a/src/mcp_memory_service/storage/cloudflare.py
+++ b/src/mcp_memory_service/storage/cloudflare.py
@@ -33,6 +33,11 @@ from ..compat import _sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
+# Cloudflare Vectorize caps topK at 50 when a query returns values or metadata
+# (and 100 otherwise); this backend always requests metadata. See
+# https://developers.cloudflare.com/vectorize/platform/limits/
+_VECTORIZE_MAX_TOPK_WITH_METADATA = 50
+
 
 def normalize_tags_for_search(tags: List[str]) -> List[str]:
     """Deduplicate and filter empty tag strings.
@@ -726,10 +731,20 @@ class CloudflareStorage(MemoryStorage):
             # Generate query embedding
             query_embedding = await self._generate_embedding(query)
             
+            # When a tag filter is applied client-side (below), over-fetch
+            # candidates so tag-matching memories outside the unfiltered top-N
+            # are not silently dropped. This mirrors the sqlite-vec backend and
+            # the over-fetch contract documented on BaseStorage.retrieve.
+            # Recall ceiling: Vectorize caps topK at 50 with metadata, so a
+            # tagged memory beyond the 50 nearest neighbours is still unreachable.
+            top_k = n_results
+            if tags:
+                top_k = max(n_results, _VECTORIZE_MAX_TOPK_WITH_METADATA)
+
             # Search Vectorize (without namespace for now)
             search_payload = {
                 "vector": query_embedding,
-                "topK": n_results,
+                "topK": top_k,
                 "returnMetadata": "all",
                 "returnValues": False
             }
@@ -760,6 +775,10 @@ class CloudflareStorage(MemoryStorage):
                         relevance_score=match.get("score", 0.0)
                     )
                     results.append(query_result)
+
+            # Matches arrive ordered by score; after over-fetching for the tag
+            # filter, keep only the n_results nearest survivors.
+            results = results[:n_results]
 
             # Persist updated metadata for accessed memories
             for result in results:

--- a/tests/storage/test_cloudflare_tag_overfetch.py
+++ b/tests/storage/test_cloudflare_tag_overfetch.py
@@ -1,0 +1,130 @@
+# Copyright 2024 Heinrich Krupp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for the Cloudflare retrieve() tag over-fetch (issue #1209).
+
+The bug: retrieve() queried Vectorize with ``topK = n_results`` and applied the
+tag filter afterwards in Python, so a tag-matching memory ranked outside the
+unfiltered top-N was never fetched and the call returned nothing.
+
+The test mocks the Vectorize HTTP layer and lets it honour the ``topK`` the code
+sends: it exposes the tagged memory only when the query over-fetches. It asserts
+both on the request (topK is widened when a tag filter is present) and on the
+returned set (the tagged memory comes back).
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.storage.cloudflare import CloudflareStorage
+
+
+@pytest.fixture
+def cloudflare_storage():
+    return CloudflareStorage(
+        api_token="test-token",
+        account_id="test-account",
+        vectorize_index="test-index",
+        d1_database_id="test-db",
+        r2_bucket="test-bucket",
+        embedding_model="@cf/baai/bge-base-en-v1.5",
+    )
+
+
+def _match(idx, score, tags):
+    """A Vectorize match whose metadata carries the tags for the loader mock."""
+    return {
+        "id": f"mem_{idx}",
+        "score": score,
+        "metadata": {"content_hash": f"hash_{idx}", "tags": tags},
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieve_overfetches_when_tag_filter_present(cloudflare_storage):
+    # Five nearer untagged neighbours, then the tagged memory at rank 6.
+    corpus = [_match(i, 0.99 - i * 0.01, tags=["other"]) for i in range(5)]
+    corpus.append(_match(5, 0.94, tags=["wanted"]))
+
+    captured = {}
+
+    async def fake_retry_request(method, url, **kwargs):
+        # Simulate Vectorize honouring topK: return only the top-K nearest.
+        top_k = kwargs.get("json", {}).get("topK")
+        captured["topK"] = top_k
+        response = Mock()
+        response.json.return_value = {
+            "success": True,
+            "result": {"matches": corpus[:top_k]},
+        }
+        return response
+
+    async def fake_load(match):
+        md = match["metadata"]
+        return Memory(
+            content=f"content {match['id']}",
+            content_hash=md["content_hash"],
+            tags=list(md["tags"]),
+            memory_type="standard",
+        )
+
+    with patch.object(cloudflare_storage, "_generate_embedding", return_value=[0.1, 0.2, 0.3]), \
+         patch.object(cloudflare_storage, "_retry_request", side_effect=fake_retry_request), \
+         patch.object(cloudflare_storage, "_load_memory_from_match", side_effect=fake_load), \
+         patch.object(cloudflare_storage, "_persist_access_metadata", new_callable=AsyncMock):
+        results = await cloudflare_storage.retrieve("q", n_results=5, tags=["wanted"])
+
+    # Request side: a tag filter must widen topK beyond n_results so the tagged
+    # memory is a candidate at all.
+    assert captured["topK"] > 5
+
+    # Result side: the tag-matching memory outside the unfiltered top-5 is returned.
+    assert [r.memory.content_hash for r in results] == ["hash_5"]
+    assert all("wanted" in r.memory.tags for r in results)
+
+
+@pytest.mark.asyncio
+async def test_retrieve_truncates_to_n_results_after_overfetch(cloudflare_storage):
+    # More tag matches than requested: over-fetch must still honour n_results.
+    corpus = [_match(i, 0.99 - i * 0.01, tags=["wanted"]) for i in range(8)]
+
+    async def fake_retry_request(method, url, **kwargs):
+        top_k = kwargs.get("json", {}).get("topK")
+        response = Mock()
+        response.json.return_value = {
+            "success": True,
+            "result": {"matches": corpus[:top_k]},
+        }
+        return response
+
+    async def fake_load(match):
+        md = match["metadata"]
+        return Memory(
+            content=f"content {match['id']}",
+            content_hash=md["content_hash"],
+            tags=list(md["tags"]),
+            memory_type="standard",
+        )
+
+    with patch.object(cloudflare_storage, "_generate_embedding", return_value=[0.1, 0.2, 0.3]), \
+         patch.object(cloudflare_storage, "_retry_request", side_effect=fake_retry_request), \
+         patch.object(cloudflare_storage, "_load_memory_from_match", side_effect=fake_load), \
+         patch.object(cloudflare_storage, "_persist_access_metadata", new_callable=AsyncMock):
+        results = await cloudflare_storage.retrieve("q", n_results=3, tags=["wanted"])
+
+    assert len(results) == 3
+    # The three nearest tag matches, in score order.
+    assert [r.memory.content_hash for r in results] == ["hash_0", "hash_1", "hash_2"]


### PR DESCRIPTION
Fixes #1209.

## Problem

`CloudflareStorage.retrieve()` queried Vectorize with `topK = n_results` (`cloudflare.py:732`) and applied the tag filter afterwards in Python (`cloudflare.py:751`). A tag-matching memory ranked outside the unfiltered top-N is never fetched, so `retrieve(query, n_results=5, tags=["wanted"])` returns nothing when five nearer untagged neighbours exist — even though a matching memory is present. The sqlite-vec backend does not have this gap (it over-fetches to a candidate cap and filters before `LIMIT`), and `BaseStorage.retrieve` documents the over-fetch as the contract; only the pure `cloudflare` backend was wrong.

## Fix

Option 2 from the issue (over-fetch), scoped to `retrieve()`:

- When `tags` are given, request `topK = max(n_results, 50)` so tag-matching memories outside the unfiltered top-N are candidates.
- Post-filter by tag (unchanged), then truncate the score-ordered survivors to `n_results`.

**Recall ceiling (documented in code):** Cloudflare Vectorize caps `topK` at **50** when a query returns values or metadata (100 otherwise), and this backend always requests `returnMetadata: "all"`. So the over-fetch cannot exceed 50 — a tagged memory beyond the 50 nearest neighbours remains unreachable. This is a hard Vectorize limit, not something this change can lift; I used a named constant with a link to the limits doc rather than a bare number. (Option 1 — a server-side Vectorize metadata filter — would remove the ceiling, but tags are stored comma-joined so an exact-match metadata filter would not work, exactly as the issue notes.)

Scope note: the `recall()` path (`cloudflare.py:~1806`) sends `topK = n_results` before a *time* post-filter and has the same shape, but the issue is about the tag filter in `retrieve()`, so I left `recall()` untouched — happy to file a follow-up.

## How it was verified

New test in `tests/storage/test_cloudflare_tag_overfetch.py`. It mocks the Vectorize HTTP layer and lets the mock honour the `topK` the code sends (returning only the top-K nearest), so the tagged memory at rank 6 is exposed only when the query over-fetches. It asserts on the request (`topK` is widened past `n_results` when a tag filter is present) and on the returned set.

Red on `main` (fix reverted):

```
>       assert captured["topK"] > 5
E       assert 5 > 5
tests/storage/test_cloudflare_tag_overfetch.py:92: AssertionError
FAILED tests/storage/test_cloudflare_tag_overfetch.py::test_retrieve_overfetches_when_tag_filter_present
1 failed, 1 passed
```

Green on this branch:

```
2 passed
```

No regression in the existing Cloudflare suite:

```
python -m pytest tests/unit/test_cloudflare_storage.py tests/test_hybrid_cloudflare_limits.py tests/storage/test_d1_read_amplification.py
57 passed, 1 xfailed
```

`ruff check` is clean on both touched files; the pre-existing warning count in `cloudflare.py` is unchanged by this diff.

## Agent Disclosure
This PR was generated by DIADE, an autonomous agent built on Claude (Claude Code). The submitting account is operated by Massimiliano Guidi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)