### PR TITLE
feat(harvest): rate-limit backoff and optional pacing for the LLM classifier (#1111)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -473,6 +473,27 @@ MCP_HYBRID_SEMANTIC_WEIGHT=0.7
 # MCP_NLI_LLM_TIMEOUT=30
 
 # =============================================================================
+# HARVEST LLM CLASSIFIER — rate-limit pacing & backoff
+# =============================================================================
+# The harvest classifier validates candidate memories via the LLM provider
+# chain (HARVEST_LLM_PROVIDERS). On a large candidate set with a free-tier
+# provider it can throttle itself; these knobs pace it and back off on 429.
+# All optional with conservative defaults — leave unset for prior behavior.
+#
+# Max retries against the SAME provider on a 429 before moving to the next.
+# On each retry it waits (backoff base * 2**attempt) seconds. Default 0 keeps
+# the prior behavior (switch provider immediately on 429). Set >0 to opt into
+# exponential backoff:
+# MCP_HARVEST_LLM_MAX_RETRIES=0
+#
+# Base for the exponential backoff, in seconds (1.0 → 1s, 2s, 4s, ...):
+# MCP_HARVEST_LLM_BACKOFF_BASE=1.0
+#
+# Optional inter-request delay (seconds) applied before each classifier call,
+# to pace throughput regardless of provider. 0 = disabled (default):
+# MCP_HARVEST_LLM_REQUEST_DELAY=0.0
+
+# =============================================================================
 # TROUBLESHOOTING
 # =============================================================================
 # Common issues:

--- a/docs/mastery/configuration-guide.md
+++ b/docs/mastery/configuration-guide.md
@@ -87,6 +87,14 @@ Flags contradictions between a newly stored memory and semantically similar exis
 - `MCP_NLI_BACKEND`: `heuristic|cascade|llm` (default `heuristic`). `heuristic` is keyword/pattern-based with no ML deps. `cascade` (alias `llm`) uses the harvest provider chain (`HARVEST_LLM_PROVIDERS`) and degrades gracefully to the heuristic on any error. When unset it resolves to `heuristic`, so no LLM is ever called by accident.
 - `MCP_NLI_LLM_TIMEOUT`: seconds (default `30`). Applied once **per provider attempt** inside the harvest chain, so the worst case for a single pair is roughly `timeout × number of providers` before it falls back to the heuristic.
 
+## Harvest LLM Classifier — Pacing & Backoff (Optional)
+
+Rate-limit handling for the harvest classifier (validates candidate memories via the `HARVEST_LLM_PROVIDERS` chain). All optional; unset = prior behavior (switch provider on 429, no pacing).
+
+- `MCP_HARVEST_LLM_MAX_RETRIES`: int (default `0`). Retries against the **same** provider on a 429 before moving to the next. Default `0` preserves the prior behavior (switch provider immediately); set `>0` to opt into exponential backoff.
+- `MCP_HARVEST_LLM_BACKOFF_BASE`: seconds (default `1.0`). Exponential backoff base — waits `base × 2**attempt` between retries (1s, 2s, 4s, …).
+- `MCP_HARVEST_LLM_REQUEST_DELAY`: seconds (default `0.0` = disabled). Inter-request delay applied before each classifier call, to pace throughput regardless of provider.
+
 ## Machine Identification
 
 - `MCP_MEMORY_INCLUDE_HOSTNAME`: `true|false` to tag memories with `source:<hostname>` and include `hostname` metadata.

--- a/src/mcp_memory_service/harvest/classifier.py
+++ b/src/mcp_memory_service/harvest/classifier.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -17,6 +18,30 @@ from .models import HarvestCandidate
 from .rewriter import load_llm_providers, is_usable_provider
 
 logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    """Read a float env var, clamped to >= minimum, falling back to default on error."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r, using default %s", name, raw, default)
+        return default
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    """Read an int env var, clamped to >= minimum, falling back to default on error."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r, using default %s", name, raw, default)
+        return default
 
 SYSTEM_PROMPT = (
     "You are a memory classifier for an AI coding assistant. "
@@ -93,6 +118,17 @@ class HarvestClassifier:
         self._api_key = groq_api_key or os.environ.get("GROQ_API_KEY")
         self._providers = None
         self._init_attempted = False
+        # Rate-limit pacing/backoff config (#1111). OPT-IN: defaults preserve the
+        # prior behavior (switch provider immediately on 429, no pacing). Henry
+        # can raise the default if he wants backoff on by default.
+        self._max_retries = _env_int("MCP_HARVEST_LLM_MAX_RETRIES", 0, minimum=0)
+        self._backoff_base = _env_float("MCP_HARVEST_LLM_BACKOFF_BASE", 1.0, minimum=0.0)
+        self._request_delay = _env_float("MCP_HARVEST_LLM_REQUEST_DELAY", 0.0, minimum=0.0)
+
+    def _pace(self):
+        """Optional inter-request delay to pace calls (0 = disabled)."""
+        if self._request_delay > 0:
+            time.sleep(self._request_delay)
 
     def _ensure_initialized(self):
         """Lazy-init provider chain, preferring configured providers over legacy Groq-only."""
@@ -126,25 +162,48 @@ class HarvestClassifier:
             return False
 
     def _call_llm(self, prompt: str, system_message: str, max_tokens: int, temperature: float) -> Optional[str]:
-        """Call the configured provider chain (or legacy Groq bridge), return response text or None."""
+        """Call the configured provider chain (or legacy Groq bridge), return response text or None.
+
+        Rate-limit handling (#1111): on a 429 the same provider is retried with
+        exponential backoff (base * 2**attempt) up to MCP_HARVEST_LLM_MAX_RETRIES
+        before moving to the next provider, instead of switching immediately and
+        continuing at full speed. An optional inter-request delay
+        (MCP_HARVEST_LLM_REQUEST_DELAY) paces calls whichever provider is used.
+        Non-rate-limit errors still fall through to the next provider at once.
+        """
         if self._providers:
             for provider in self._providers:
-                try:
-                    return self._call_openai_compatible(
-                        provider.base_url, provider.model, provider.api_key,
-                        prompt, system_message, max_tokens, temperature,
-                    )
-                except Exception as e:
-                    err_str = str(e).lower()
-                    if "rate limit" in err_str or "429" in err_str:
-                        logger.warning("%s rate limited, trying next", _sanitize_log_value(provider.name))
-                    else:
-                        logger.warning(
-                            "%s failed: %s, trying next",
-                            _sanitize_log_value(provider.name),
-                            _sanitize_log_value(str(e)),
+                self._pace()
+                for attempt in range(self._max_retries + 1):
+                    try:
+                        return self._call_openai_compatible(
+                            provider.base_url, provider.model, provider.api_key,
+                            prompt, system_message, max_tokens, temperature,
                         )
-                    continue
+                    except Exception as e:
+                        err_str = str(e).lower()
+                        is_rate_limit = "rate limit" in err_str or "429" in err_str
+                        if is_rate_limit and attempt < self._max_retries:
+                            delay = self._backoff_base * (2 ** attempt)
+                            logger.warning(
+                                "%s rate limited, backing off %.1fs (attempt %d/%d)",
+                                _sanitize_log_value(provider.name), delay,
+                                attempt + 1, self._max_retries,
+                            )
+                            time.sleep(delay)
+                            continue
+                        if is_rate_limit:
+                            logger.warning(
+                                "%s rate limited after %d retries, trying next",
+                                _sanitize_log_value(provider.name), self._max_retries,
+                            )
+                        else:
+                            logger.warning(
+                                "%s failed: %s, trying next",
+                                _sanitize_log_value(provider.name),
+                                _sanitize_log_value(str(e)),
+                            )
+                        break  # move to next provider
             return None
 
         if self._groq_bridge is not None:

--- a/tests/test_harvest_classifier_backoff.py
+++ b/tests/test_harvest_classifier_backoff.py
@@ -1,0 +1,196 @@
+"""Tests for HarvestClassifier rate-limit backoff and pacing (#1111).
+
+The classifier used to react to a 429 by switching provider immediately and
+continuing at full speed. These tests pin the new behavior: exponential
+backoff retries the SAME provider before moving on, and an optional
+inter-request delay paces calls. Red on main (no backoff / no pacing there).
+"""
+
+import pytest
+from unittest.mock import patch
+
+from mcp_memory_service.harvest.classifier import HarvestClassifier
+from mcp_memory_service.harvest.rewriter import LLMProvider
+
+
+def _provider(name, model="m"):
+    return LLMProvider(name=name, base_url=f"http://{name}.local/v1", model=model, api_key="k")
+
+
+def _classifier_with_providers(providers, **env):
+    """Build a classifier with providers injected (skip network init)."""
+    import os
+    for k, v in env.items():
+        os.environ[k] = str(v)
+    try:
+        c = HarvestClassifier()
+    finally:
+        for k in env:
+            os.environ.pop(k, None)
+    c._providers = providers
+    c._init_attempted = True
+    return c
+
+
+def test_backoff_retries_same_provider_on_429_before_switching():
+    """A 429 retries the SAME provider with exponential backoff before the
+    next provider is tried. Red on main (main switches immediately)."""
+    p1, p2 = _provider("p1"), _provider("p2")
+    c = _classifier_with_providers([p1, p2],
+                                   MCP_HARVEST_LLM_MAX_RETRIES=2,
+                                   MCP_HARVEST_LLM_BACKOFF_BASE=1.0)
+
+    calls = []
+
+    def fake_call(base_url, model, api_key, *a, **k):
+        calls.append(base_url)
+        if base_url == p1.base_url:
+            raise Exception("Rate limit exceeded: 429")
+        return "ok from p2"
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", side_effect=fake_call), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        out = c._call_llm("prompt", "sys", max_tokens=10, temperature=0.0)
+
+    # p1 tried 1 + 2 retries = 3 times, then p2 once
+    assert calls.count(p1.base_url) == 3, f"expected 3 attempts on p1, got {calls.count(p1.base_url)}"
+    assert calls.count(p2.base_url) == 1
+    assert out == "ok from p2"
+    # exponential backoff: base*2**0, base*2**1 = 1.0, 2.0 (2 retries → 2 sleeps)
+    assert sleeps == [1.0, 2.0], f"expected exponential backoff [1.0, 2.0], got {sleeps}"
+
+
+def test_backoff_exhausts_then_returns_none_when_all_rate_limited():
+    """If every provider stays rate-limited through all retries, return None
+    (not an infinite loop)."""
+    p1 = _provider("only")
+    c = _classifier_with_providers([p1],
+                                   MCP_HARVEST_LLM_MAX_RETRIES=2,
+                                   MCP_HARVEST_LLM_BACKOFF_BASE=0.5)
+
+    n = {"calls": 0}
+
+    def always_429(*a, **k):
+        n["calls"] += 1
+        raise Exception("429 Too Many Requests")
+
+    with patch.object(c, "_call_openai_compatible", side_effect=always_429), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep"):
+        out = c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+
+    assert out is None
+    assert n["calls"] == 3  # 1 + 2 retries, then give up
+
+
+def test_non_rate_limit_error_switches_provider_immediately():
+    """A non-429 error must NOT trigger backoff — it falls through to the next
+    provider at once (preserves prior behavior)."""
+    p1, p2 = _provider("p1"), _provider("p2")
+    c = _classifier_with_providers([p1, p2], MCP_HARVEST_LLM_MAX_RETRIES=3)
+
+    calls = []
+
+    def fake_call(base_url, *a, **k):
+        calls.append(base_url)
+        if base_url == p1.base_url:
+            raise Exception("connection refused")
+        return "ok"
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", side_effect=fake_call), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        out = c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+
+    assert calls == [p1.base_url, p2.base_url], "non-429 should switch immediately, no retry"
+    assert sleeps == [], "no backoff on non-rate-limit error"
+    assert out == "ok"
+
+
+def test_pacing_delay_applied_before_each_call():
+    """MCP_HARVEST_LLM_REQUEST_DELAY paces calls: sleep(delay) before each
+    provider call. Red on main (no pacing there)."""
+    p1 = _provider("p1")
+    c = _classifier_with_providers([p1], MCP_HARVEST_LLM_REQUEST_DELAY=0.25)
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", return_value="ok"), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        out = c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+
+    assert out == "ok"
+    assert sleeps == [0.25], f"expected one pacing sleep of 0.25, got {sleeps}"
+
+
+def test_pacing_disabled_by_default():
+    """No pacing sleep when REQUEST_DELAY is unset/0 (default)."""
+    p1 = _provider("p1")
+    c = _classifier_with_providers([p1])
+    assert c._request_delay == 0.0
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", return_value="ok"), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+    assert sleeps == []
+
+
+def test_pacing_not_multiplied_by_backoff_retries():
+    """Pacing is applied once per provider call, NOT once per backoff retry —
+    it must not stack with the exponential backoff sleeps. Regression guard for
+    the G5 review on #1111."""
+    p1 = _provider("p1")
+    c = _classifier_with_providers([p1],
+                                   MCP_HARVEST_LLM_MAX_RETRIES=2,
+                                   MCP_HARVEST_LLM_BACKOFF_BASE=1.0,
+                                   MCP_HARVEST_LLM_REQUEST_DELAY=0.5)
+
+    def always_429(*a, **k):
+        raise Exception("429")
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", side_effect=always_429), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+
+    # exactly ONE pacing sleep (0.5) for the provider, plus backoff sleeps (1.0, 2.0)
+    assert sleeps.count(0.5) == 1, f"pacing should fire once per provider, got {sleeps.count(0.5)}"
+    assert [s for s in sleeps if s != 0.5] == [1.0, 2.0], f"backoff sleeps wrong: {sleeps}"
+
+
+def test_default_max_retries_is_zero_no_regression():
+    """With no env config, max_retries defaults to 0 → a 429 switches provider
+    immediately (no backoff), preserving prior behavior. Guards the G5 concern."""
+    p1, p2 = _provider("p1"), _provider("p2")
+    c = _classifier_with_providers([p1, p2])
+    assert c._max_retries == 0
+
+    calls = []
+
+    def fake_call(base_url, *a, **k):
+        calls.append(base_url)
+        if base_url == p1.base_url:
+            raise Exception("429 rate limit")
+        return "ok"
+
+    sleeps = []
+    with patch.object(c, "_call_openai_compatible", side_effect=fake_call), \
+         patch("mcp_memory_service.harvest.classifier.time.sleep", side_effect=sleeps.append):
+        out = c._call_llm("p", "s", max_tokens=10, temperature=0.0)
+
+    assert calls == [p1.base_url, p2.base_url], "default should switch immediately, no retry"
+    assert sleeps == [], "no backoff sleeps with default max_retries=0"
+    assert out == "ok"
+
+
+def test_env_helpers_clamp_and_fallback():
+    """_env_int/_env_float clamp to minimum and fall back on invalid input."""
+    from mcp_memory_service.harvest.classifier import _env_int, _env_float
+    import os
+    os.environ["_T_INT"] = "-5"; os.environ["_T_FLOAT"] = "abc"
+    try:
+        assert _env_int("_T_INT", 3, minimum=0) == 0        # clamped
+        assert _env_float("_T_FLOAT", 1.0, minimum=0.0) == 1.0  # fallback on invalid
+        assert _env_int("_T_MISSING", 7) == 7               # default when unset
+    finally:
+        os.environ.pop("_T_INT", None); os.environ.pop("_T_FLOAT", None)


### PR DESCRIPTION
**Closes #1111.**

The harvest LLM classifier reacted to a 429 by switching provider immediately and continuing at full speed, with no pacing and no backoff. On a large candidate set against a free-tier provider that throttles hard. This adds request-level backoff and optional pacing, composing with the multi-provider chain (`HARVEST_LLM_PROVIDERS`) — not just Groq.

**What changed** (`harvest/classifier.py`, classifier-internal, no protocol change):
- **Backoff on 429** — retry the *same* provider with exponential backoff (`base × 2**attempt`) up to `MCP_HARVEST_LLM_MAX_RETRIES` before moving to the next provider. Non-429 errors still fall through immediately (prior behavior).
- **Optional pacing** — `MCP_HARVEST_LLM_REQUEST_DELAY` sleeps before each provider call, applied once per call (does not stack with backoff sleeps).
- Config via env, parsed by small `_env_int`/`_env_float` helpers (clamp to a minimum, fall back on invalid input).

**Opt-in, no default regression:** `MCP_HARVEST_LLM_MAX_RETRIES` defaults to `0` and `MCP_HARVEST_LLM_REQUEST_DELAY` to `0.0`, so with no config the behavior is exactly as before (switch provider on 429, no delay). Set them to opt into backoff/pacing.

**Scope:** backoff + pacing only. Batching (one call for N candidates) is deliberately left as a follow-up — it changes the prompt shape and deserves its own PR.

**Tests** (`tests/test_harvest_classifier_backoff.py`, 8): backoff retries the same provider before switching (`sleeps == [1.0, 2.0]`); exhausting retries returns `None` (no infinite loop); non-429 switches immediately with no backoff; pacing sleeps once per provider and does **not** stack with backoff; pacing off by default; `max_retries=0` default preserves immediate-switch; env helpers clamp/fallback. Red on main — each behavioral test fails against the current classifier and passes with the change.

Docs: `.env.example` + `docs/mastery/configuration-guide.md`.
